### PR TITLE
Rework input bindings to properly support mode matching.

### DIFF
--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -89,11 +89,11 @@ class TerminalSession: public terminal::Terminal::Events
 
     // Input Events
     using Timestamp = std::chrono::steady_clock::time_point;
-    void sendKeyPressEvent(terminal::KeyInputEvent const& _event, Timestamp _now);
-    void sendCharPressEvent(terminal::CharInputEvent const& _event, Timestamp _now);
-    void sendMousePressEvent(terminal::MousePressEvent const& _event, Timestamp _now);
-    void sendMouseMoveEvent(terminal::MouseMoveEvent const& _event, Timestamp _now);
-    void sendMouseReleaseEvent(terminal::MouseReleaseEvent const& _event, Timestamp _now);
+    void sendKeyPressEvent(terminal::Key _key, terminal::Modifier _modifier, Timestamp _now);
+    void sendCharPressEvent(char32_t _value, terminal::Modifier _modifier, Timestamp _now);
+    void sendMousePressEvent(terminal::MouseButton _button, terminal::Modifier _modifier, Timestamp _now);
+    void sendMouseMoveEvent(int _row, int _column, terminal::Modifier _modifier, Timestamp _now);
+    void sendMouseReleaseEvent(terminal::MouseButton _button, terminal::Modifier _modifier, Timestamp _now);
     void sendFocusInEvent();
     void sendFocusOutEvent();
 
@@ -157,6 +157,7 @@ class TerminalSession: public terminal::Terminal::Events
     config::TerminalProfile& profile() noexcept { return profile_; }
     void configureTerminal();
     void configureDisplay();
+    uint8_t matchModeFlags() const;
 
     // private data
     //

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -265,7 +265,7 @@ color_schemes:
 # Additionally one can filter input mappings based on special terminal modes using the `modes` option:
 # - Alt       : The terminal is currently in alternate screen buffer, otherwise it is in primary screen buffer.
 # - AppCursor : The application key cursor mode is enabled (otherwise it's normal cursor mode).
-# - AppKeyPad : The application keypad mode is enabled (otherwise it's the numeric keypad mode).
+# - AppKeypad : The application keypad mode is enabled (otherwise it's the numeric keypad mode).
 #
 # You can combine these modes by concatenating them via | and negate a single one
 # by prefixing with ~.

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -136,13 +136,6 @@ constexpr inline terminal::MouseButton makeMouseButton(Qt::MouseButton _button)
     }
 }
 
-std::variant<
-    std::monostate,
-    terminal::KeyInputEvent,
-    std::vector<terminal::CharInputEvent>
->
-mapQtToTerminalKeyEvent(QKeyEvent* _event);
-
 class TerminalSession;
 bool sendKeyEvent(QKeyEvent* _keyEvent, TerminalSession& _session);
 void sendWheelEvent(QWheelEvent* _event, TerminalSession& _session);

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -30,7 +30,9 @@ set(terminal_HEADERS
     Hyperlink.h
     Functions.h
     Image.h
+    InputBinding.h
     InputGenerator.h
+    MatchModes.h
     Parser.h
     Process.h
     pty/Pty.h
@@ -57,7 +59,9 @@ set(terminal_SOURCES
     Grid.cpp
     Functions.cpp
     Image.cpp
+    InputBinding.cpp
     InputGenerator.cpp
+    MatchModes.cpp
     Parser.cpp
     Process.cpp
     RenderBuffer.cpp

--- a/src/terminal/InputBinding.h
+++ b/src/terminal/InputBinding.h
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma aonce
+
+#include <terminal/MatchModes.h>
+#include <terminal/InputGenerator.h>
+
+#include <fmt/format.h>
+
+namespace terminal {
+
+template <typename Input, typename Binding>
+struct InputBinding
+{
+    MatchModes modes;
+    Modifier modifier;
+    Input input;
+    Binding binding;
+};
+
+template <typename Input, typename Binding>
+bool match(InputBinding<Input, Binding> const& _binding,
+           MatchModes _modes,
+           Modifier _modifier,
+           Input _input)
+{
+    return _binding.modes == _modes
+        && _binding.modifier == _modifier
+        && _binding.input == _input;
+}
+
+template <typename I, typename O>
+bool operator==(InputBinding<I, O> const& a, InputBinding<I, O> const& b) noexcept
+{
+    return a.modes == b.modes
+        && a.modifier == b.modifier
+        && a.input == b.input;
+}
+
+template <typename I, typename O>
+bool operator!=(InputBinding<I, O> const& a, InputBinding<I, O> const& b) noexcept
+{
+    return !(a == b);
+}
+
+template <typename I, typename O>
+bool operator<(InputBinding<I, O> const& a, InputBinding<I, O> const& b) noexcept
+{
+    if (a.modes < b.modes)
+        return true;
+    if (a.modes != b.modes)
+        return false;
+
+    if (a.modifier < b.modifier)
+        return true;
+    if (a.modifier != b.modifier)
+        return false;
+
+    if (a.input < b.input)
+        return true;
+
+    return false;
+}
+
+}
+
+namespace fmt
+{
+    template <typename I, typename O>
+    struct formatter<terminal::InputBinding<I, O>> {
+        template <typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+        template <typename FormatContext>
+        auto format(terminal::InputBinding<I, O> const& _binding, FormatContext& _ctx)
+        {
+            return format_to(_ctx.out(), "{} {} {}",
+                    _binding.modes,
+                    _binding.modifier,
+                    _binding.input);
+        }
+    };
+}

--- a/src/terminal/MatchModes.cpp
+++ b/src/terminal/MatchModes.cpp
@@ -1,0 +1,40 @@
+#include <terminal/MatchModes.h>
+#include <terminal/Terminal.h>
+
+namespace terminal {
+
+MatchModes constructMatchModes(Terminal const& _terminal)
+{
+    auto mm = MatchModes{};
+    if (_terminal.screen().isAlternateScreen())
+        mm.enable(MatchModes::AlternateScreen);
+    if (_terminal.applicationCursorKeys())
+        mm.enable(MatchModes::AppCursor);
+    if (_terminal.applicationKeypad())
+        mm.enable(MatchModes::AppKeypad);
+    return mm;
+}
+
+bool testMatch(Terminal const& _terminal, MatchModes _mode)
+{
+    switch (_mode.status(MatchModes::AlternateScreen))
+    {
+        case MatchModes::Status::Enabled:
+            if (!_terminal.screen().isAlternateScreen())
+                return false;
+            break;
+        case MatchModes::Status::Disabled:
+            if (_terminal.screen().isAlternateScreen())
+                return false;
+            break;
+        case MatchModes::Status::Any:
+            break;
+    }
+
+    //TODO: _mode.status(MatchModes::AppCursor);
+    //TODO: _mode.status(MatchModes::AppKeypad);
+
+    return false;
+}
+
+}

--- a/src/terminal/MatchModes.h
+++ b/src/terminal/MatchModes.h
@@ -1,0 +1,145 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+
+#include <cstdint>
+
+namespace terminal {
+
+class MatchModes
+{
+public:
+    enum Flag : uint8_t
+    {
+        Default             = 0x00,
+        AlternateScreen     = 0x01,
+        AppCursor           = 0x02,
+        AppKeypad           = 0x04,
+        // future modes
+        ViSearch            = 0x08, // TODO: This mode we want.
+    };
+
+    enum class Status
+    {
+        Any,
+        Enabled,
+        Disabled
+    };
+
+    constexpr Status status(Flag _flag) const noexcept
+    {
+        if (enabled_ & static_cast<uint8_t>(_flag))
+            return Status::Enabled;
+        if (disabled_ & static_cast<uint8_t>(_flag))
+            return Status::Disabled;
+        return Status::Any;
+    }
+
+    constexpr unsigned enabled() const noexcept { return enabled_; }
+    constexpr unsigned disabled() const noexcept { return disabled_; }
+
+    constexpr void enable(Flag _flag) noexcept
+    {
+        enabled_ |= static_cast<uint8_t>(_flag);
+        disabled_ &= ~static_cast<uint8_t>(_flag);
+    }
+
+    constexpr void disable(Flag _flag) noexcept
+    {
+        enabled_ &= ~static_cast<uint8_t>(_flag);
+        disabled_ |= static_cast<uint8_t>(_flag);
+    }
+
+    constexpr bool has_value(Flag _flag) const noexcept
+    {
+        return enabled_ & static_cast<uint8_t>(_flag)
+           || disabled_ & static_cast<uint8_t>(_flag);
+    }
+
+    constexpr void clear(Flag _flag) noexcept
+    {
+        enabled_ &= ~static_cast<uint8_t>(_flag);
+        disabled_ &= ~static_cast<uint8_t>(_flag);
+    }
+
+    constexpr void reset() noexcept
+    {
+        enabled_ = 0;
+        disabled_ = 0;
+    }
+
+    constexpr bool any() const noexcept
+    {
+        return enabled_ || disabled_;
+    }
+
+    constexpr uint16_t hashcode() const noexcept
+    {
+        return (enabled_ << 8) | disabled_;
+    }
+
+private:
+    uint8_t enabled_ = 0;
+    uint8_t disabled_ = 0;
+};
+
+constexpr bool operator==(MatchModes a, MatchModes b) noexcept
+{
+    return a.hashcode() == b.hashcode();
+}
+
+constexpr bool operator!=(MatchModes a, MatchModes b) noexcept
+{
+    return !(a == b);
+}
+
+class Terminal;
+
+MatchModes constructMatchModes(Terminal const& _terminal);
+bool testMatch(Terminal const& _terminal, MatchModes _mode);
+
+}
+
+namespace fmt { // {{{
+    template <>
+    struct formatter<terminal::MatchModes> {
+        template <typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+        template <typename FormatContext>
+        auto format(terminal::MatchModes m, FormatContext& _ctx)
+        {
+            std::string s;
+            auto const advance = [&](terminal::MatchModes::Flag _cond, std::string_view _text) {
+                auto const status = m.status(_cond);
+                if (status == terminal::MatchModes::Status::Any)
+                    return;
+                if (!s.empty())
+                    s += '|';
+                if (status == terminal::MatchModes::Status::Disabled)
+                    s += "~";
+                s += _text;
+            };
+            advance(terminal::MatchModes::AppCursor, "AppCursor");
+            advance(terminal::MatchModes::AppKeypad, "AppKeypad");
+            advance(terminal::MatchModes::AlternateScreen, "AltScreen");
+            advance(terminal::MatchModes::ViSearch, "ViSearch");
+            if (s.empty())
+                s = "Any";
+            return format_to(_ctx.out(), "{}", s);
+        }
+    };
+}
+// }}}

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -96,11 +96,11 @@ class Terminal : public ScreenEvents {
 
     // {{{ input proxy
     using Timestamp = std::chrono::steady_clock::time_point;
-    bool sendKeyPressEvent(KeyInputEvent const& _event, Timestamp _now);
-    bool sendCharPressEvent(CharInputEvent const& _event, Timestamp _now);
-    bool sendMousePressEvent(MousePressEvent const& _event, Timestamp _now);
-    bool sendMouseMoveEvent(MouseMoveEvent const& _event, Timestamp _now);
-    bool sendMouseReleaseEvent(MouseReleaseEvent const& _event, Timestamp _now);
+    bool sendKeyPressEvent(Key _key, Modifier _modifier, Timestamp _now);
+    bool sendCharPressEvent(char32_t _char, Modifier _modifier, Timestamp _now);
+    bool sendMousePressEvent(MouseButton _button, Modifier _modifier, Timestamp _now);
+    bool sendMouseMoveEvent(int _row, int _column, Modifier _modifier, Timestamp _now);
+    bool sendMouseReleaseEvent(MouseButton _button, Modifier _modifier, Timestamp _now);
     bool sendFocusInEvent();
     bool sendFocusOutEvent();
     void sendPaste(std::string_view _text); // Sends verbatim text in bracketed mode to application.

--- a/src/terminal/Terminal_test.cpp
+++ b/src/terminal/Terminal_test.cpp
@@ -171,7 +171,7 @@ TEST_CASE("Terminal.BlinkingCursor", "[terminal]")
 
         // type something into the terminal
         auto const clockAtInputEvent = clockBase + BlinkInterval + chrono::milliseconds(10);
-        terminal.sendCharPressEvent(terminal::CharInputEvent{L'x', terminal::Modifier{}}, clockAtInputEvent);
+        terminal.sendCharPressEvent('x', terminal::Modifier{}, clockAtInputEvent);
 
         // now the cursor is visible before the interval has passed
         terminal.tick(clockBeforeTurn);


### PR DESCRIPTION
Reworks `input_mapping`, implicitly fixing recently added support to match on terminal states (such as alt screen or not alt screen)