### PR TITLE
Implements conditional input mappings based on whether or not the user has selected some text. Closes #292.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,7 +25,7 @@
 - Adds experimental text reflow.
 - Adds OpenFileManager action to configuration.
 - Adds terminal identification environment variables `TERMINAL_NAME`, `TERMINAL_VERSION_TRIPLE` and `TERMINAL_VERSION_STRING`.
-- Adds config option `mode` to input modifiers for additionally filtering based on modes (alt screen, app cursor/keypad modes, ...).
+- Adds config option `mode` to input modifiers for additionally filtering based on modes (alt screen, app cursor/keypad, text selection modes, ...).
 - Adds config option `profile.*.terminal_id: STR` to set the terminal identification to one of VT100, VT220, VT340, etc.
 - Adds config option `profile.*.maximized: BOOL` to indicate maximized state during profile activation.
 - Adds config option `profile.*.fullscreen: BOOL` to indicate fullscreen state during profile activation.

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -503,6 +503,8 @@ optional<terminal::MatchModes> parseMatchModes(UsedKeys& _usedKeys,
             flag = MatchModes::AppCursor;
         else if (upperArg == "APPKEYPAD")
             flag = MatchModes::AppKeypad;
+        else if (upperArg == "SELECT")
+            flag = MatchModes::Select;
         else
         {
             errorlog().write("Unknown input_mapping mode: {}", arg);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -266,6 +266,7 @@ color_schemes:
 # - Alt       : The terminal is currently in alternate screen buffer, otherwise it is in primary screen buffer.
 # - AppCursor : The application key cursor mode is enabled (otherwise it's normal cursor mode).
 # - AppKeypad : The application keypad mode is enabled (otherwise it's the numeric keypad mode).
+# - Select    : The terminal has currently an active grid cell selection (such as selected text).
 #
 # You can combine these modes by concatenating them via | and negate a single one
 # by prefixing with ~.

--- a/src/terminal/MatchModes.cpp
+++ b/src/terminal/MatchModes.cpp
@@ -12,6 +12,8 @@ MatchModes constructMatchModes(Terminal const& _terminal)
         mm.enable(MatchModes::AppCursor);
     if (_terminal.applicationKeypad())
         mm.enable(MatchModes::AppKeypad);
+    if (_terminal.selectionAvailable())
+        mm.enable(MatchModes::Select);
     return mm;
 }
 

--- a/src/terminal/MatchModes.h
+++ b/src/terminal/MatchModes.h
@@ -28,8 +28,9 @@ public:
         AlternateScreen     = 0x01,
         AppCursor           = 0x02,
         AppKeypad           = 0x04,
+        Select              = 0x08,
         // future modes
-        ViSearch            = 0x08, // TODO: This mode we want.
+        // ViSearch            = 0x10, // TODO: This mode we want.
     };
 
     enum class Status
@@ -135,7 +136,7 @@ namespace fmt { // {{{
             advance(terminal::MatchModes::AppCursor, "AppCursor");
             advance(terminal::MatchModes::AppKeypad, "AppKeypad");
             advance(terminal::MatchModes::AlternateScreen, "AltScreen");
-            advance(terminal::MatchModes::ViSearch, "ViSearch");
+            advance(terminal::MatchModes::Select, "Select");
             if (s.empty())
                 s = "Any";
             return format_to(_ctx.out(), "{}", s);


### PR DESCRIPTION
Makes it possible to copy to clipboard via Ctrl+C iff some text is selected, otherwise it's forwarded to the app.

Closes #292.