### PR TITLE
Initial work on improving ASCII text throughput performance.

### DIFF
--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -137,6 +137,9 @@ if(LIBTERMINAL_TESTING)
     )
     target_link_libraries(terminal_test fmt::fmt-header-only Catch2::Catch2 terminal)
     add_test(terminal_test ./terminal_test)
+
+    add_executable(bench-headless bench-headless.cpp)
+    target_link_libraries(bench-headless fmt::fmt-header-only terminal)
 endif(LIBTERMINAL_TESTING)
 
 message(STATUS "[libterminal] Compile unit tests: ${LIBTERMINAL_TESTING}")

--- a/src/terminal/Parser.cpp
+++ b/src/terminal/Parser.cpp
@@ -25,13 +25,85 @@
 #include <cstdio>
 #include <map>
 #include <ostream>
+#include <string_view>
 
 #include <fmt/format.h>
+
+#if defined(__SSE2__)
+#include <immintrin.h>
+#endif
 
 namespace terminal::parser {
 
 using namespace std;
 
+inline int countTrailingZeroBits(unsigned int _value)
+{
+#if defined(_WIN32)
+    return _tzcnt_u32(_value);
+#else
+    return __builtin_ctz(_value);
+#endif
+}
+
+inline size_t countAsciiTextChars(uint8_t const* _begin, uint8_t const* _end) noexcept
+{
+    // TODO: Do move this functionality into libunicode?
+
+    auto input = _begin;
+
+#if 0 // TODO: defined(__AVX2__)
+    // AVX2 to be implemented directly in NASM file.
+
+#elif defined(__SSE2__)
+    __m128i const ControlCodeMax = _mm_set1_epi8(0x20);  // 0..0x1F
+    __m128i const Complex = _mm_set1_epi8(static_cast<char>(0x80));
+
+    while (input < _end - sizeof(__m128i))
+    {
+        __m128i batch = _mm_loadu_si128((__m128i *)input);
+        __m128i isControl = _mm_cmplt_epi8(batch, ControlCodeMax);
+        __m128i isComplex = _mm_and_si128(batch, Complex);
+        __m128i testPack = _mm_or_si128(isControl, isComplex);
+        if (int const check = _mm_movemask_epi8(testPack); check != 0)
+        {
+            int advance = countTrailingZeroBits(check);
+            input += advance;
+            break;
+        }
+        input += 16;
+    }
+
+    return static_cast<size_t>(std::distance(_begin, input));
+#else
+    return 0;
+#endif
+}
+
+void Parser::parseFragment(iterator _begin, iterator _end)
+{
+    if (state_ == State::Ground)
+    {
+        if (auto count = countAsciiTextChars(_begin, _end); count > 0)
+        {
+            eventListener_.print(string_view{reinterpret_cast<char const*>(_begin), count});
+            _begin += count;
+        }
+    }
+
+    static constexpr char32_t ReplacementCharacter {0xFFFD};
+
+    for (auto const current : crispy::range(_begin, _end))
+    {
+        unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState_, current);
+        if (std::holds_alternative<unicode::Success>(r))
+            processInput(std::get<unicode::Success>(r).value);
+        else if (std::holds_alternative<unicode::Invalid>(r))
+            processInput(ReplacementCharacter);
+    }
+}
+
+// {{{ dot
 using Transition = pair<State, State>;
 using Range = ParserTable::Range;
 using RangeSet = std::vector<Range>;
@@ -118,5 +190,6 @@ void dot(std::ostream& _os, ParserTable const& _table)
 
     _os << "}\n";
 }
+// }}}
 
 }  // namespace terminal

--- a/src/terminal/Parser.h
+++ b/src/terminal/Parser.h
@@ -762,37 +762,6 @@ class Parser {
     ParserEvents& eventListener_;
 };
 
-inline void Parser::parseFragment(iterator _begin, iterator _end)
-{
-    static constexpr char32_t ReplacementCharacter {0xFFFD};
-
-    for (auto const current : crispy::range(_begin, _end))
-    {
-#if 0
-        std::visit(
-            overloaded{
-                [&](unicode::Incomplete) {},
-                [&](unicode::Invalid) {
-                    eventListener_.error("Invalid UTF-8 byte sequence received.");
-                    processInput(ReplacementCharacter);
-                },
-                [&](unicode::Success const& success) {
-                    // std::cout << fmt::format("VTParser.parse: ch = {:04X}\n", static_cast<unsigned>(success.value));
-                    processInput(success.value);
-                },
-            },
-            unicode::from_utf8(utf8DecoderState_, current)
-        );
-#else
-        unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState_, current);
-        if (std::holds_alternative<unicode::Success>(r))
-            processInput(std::get<unicode::Success>(r).value);
-        else if (std::holds_alternative<unicode::Invalid>(r))
-            processInput(ReplacementCharacter);
-#endif
-    }
-}
-
 inline void Parser::processInput(char32_t _ch)
 {
     auto const s = static_cast<size_t>(state_);

--- a/src/terminal/ParserEvents.h
+++ b/src/terminal/ParserEvents.h
@@ -39,6 +39,9 @@ class ParserEvents {
      */
     virtual void print(char32_t _text) = 0;
 
+    /// Optimization that passes in ASCII chars between [0x20 .. 0x7F].
+    virtual void print(std::string_view _chars) = 0;
+
     /**
      * The C0 or C1 control function should be executed, which may have any one of a variety of
      * effects, including changing the cursor position, suspending or resuming communications or
@@ -145,6 +148,7 @@ class BasicParserEvents : public ParserEvents {
   public:
     void error(std::string_view const&) override {}
     void print(char32_t) override {}
+    void print(std::string_view) override {};
     void execute(char) override {}
     void clear() override {}
     void collect(char) override {}

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -134,7 +134,8 @@ namespace fmt
                     return format_to(_ctx.out(), "NormalExit:{}", _exit.exitCode);
                 },
                 [&](terminal::Process::SignalExit _exit) {
-                    return format_to(_ctx.out(), "SignalExit:{} ({})", _exit.signum, strerror(_exit.signum));
+                    char buf[256];
+                    return format_to(_ctx.out(), "SignalExit:{} ({})", _exit.signum, strerror_r(_exit.signum, buf, sizeof(buf)));
                 }
             }, _status);
         }

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -550,7 +550,8 @@ void Screen::write(std::u32string_view const& _text)
 void Screen::writeText(char32_t _char)
 {
 #if defined(LIBTERMINAL_LOG_TRACE)
-    debuglog(VTParserTraceTag).write("text: {}", unicode::convert_to<char>(_char));
+    if (debugtag::enabled(VTParserTraceTag))
+        debuglog(VTParserTraceTag).write("text: {}", unicode::convert_to<char>(_char));
 #endif
     bool const consecutiveTextWrite = sequencer_.instructionCounter() == 1;
 

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -547,6 +547,15 @@ void Screen::write(std::u32string_view const& _text)
     eventListener_.screenUpdated();
 }
 
+void Screen::writeText(std::string_view _chars)
+{
+    // TODO: can be optimized.
+    // - This may require Grid/Line/Cell updates first before yielding any impact.
+    // - Also, we could use SIMD to batch-store the grid cell attributes.
+    for (char ch: _chars)
+        writeText(ch);
+}
+
 void Screen::writeText(char32_t _char)
 {
 #if defined(LIBTERMINAL_LOG_TRACE)

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -192,6 +192,7 @@ class Screen : public capabilities::StaticDatabase {
     void write(std::u32string_view const& _text);
 
     void writeText(char32_t _char);
+    void writeText(std::string_view _chars);
 
     /// Renders the full screen by passing every grid cell to the callback.
     template <typename Renderer>

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -1015,6 +1015,16 @@ void Sequencer::print(char32_t _char)
     screen_.writeText(_char);
 }
 
+void Sequencer::print(string_view _chars)
+{
+    if (_chars.empty())
+        return;
+
+    precedingGraphicCharacter_ = _chars.back();
+    instructionCounter_ += _chars.size();
+    screen_.writeText(_chars);
+}
+
 void Sequencer::execute(char _controlCode)
 {
     executeControlFunction(_controlCode);

--- a/src/terminal/Sequencer.h
+++ b/src/terminal/Sequencer.h
@@ -608,6 +608,7 @@ class Sequencer : public ParserEvents {
     //
     void error(std::string_view const& _errorString) override;
     void print(char32_t _text) override;
+    void print(std::string_view _chars) override;
     void execute(char _controlCode) override;
     void clear() override;
     void collect(char _char) override;

--- a/src/terminal/bench-headless.cpp
+++ b/src/terminal/bench-headless.cpp
@@ -1,0 +1,76 @@
+#include <terminal/Terminal.h>
+#include <terminal/pty/MockPty.h>
+#include <iostream>
+#include <optional>
+#include <fmt/format.h>
+#include <random>
+
+class HeadlessBench: public terminal::Terminal::Events
+{
+public:
+    HeadlessBench(terminal::PageSize _pageSize,
+                  int _ptyReadBufferSize,
+                  std::optional<terminal::LineCount> _maxHistoryLineCount);
+
+    void run();
+
+private:
+    std::unique_ptr<terminal::MockPty> pty_;
+    terminal::Terminal vt_;
+    bool running_ = false;
+};
+
+using namespace std;
+
+HeadlessBench::HeadlessBench(terminal::PageSize _pageSize,
+                             int _ptyReadBufferSize,
+                             std::optional<terminal::LineCount> _maxHistoryLineCount):
+    pty_{std::make_unique<terminal::MockPty>(_pageSize)},
+    vt_{
+        *pty_,
+        _ptyReadBufferSize,
+        *this,
+        _maxHistoryLineCount
+    }
+{
+    vt_.screen().setMode(terminal::DECMode::AutoWrap, true);
+}
+
+void HeadlessBench::run()
+{
+    running_ = true;
+
+    std::string text;
+    text.resize(8192);
+
+    std::random_device rand_dev;
+    std::mt19937 generator(rand_dev());
+    std::uniform_int_distribution<char> distr(0x20, 0x7E);
+    for (size_t i = 0; i < text.size(); ++i)
+        text[i] = distr(generator);
+
+    uint64_t i = 0;
+    while (running_)
+    {
+        assert(pty_->stdoutBuffer().size() == 0);
+        pty_->stdoutBuffer().append(text);
+
+        vt_.processInputOnce();
+
+        i++;
+        if (i > 10000)
+            running_ = false;
+    }
+}
+
+int main(int argc, char const* argv[])
+{
+    auto pageSize = terminal::PageSize{terminal::LineCount(25), terminal::ColumnCount(80)};
+    auto const ptyReadBufferSize = 8192;
+    auto maxHistoryLineCount = optional{terminal::LineCount(10000)};
+    auto hb = HeadlessBench{pageSize, ptyReadBufferSize, maxHistoryLineCount};
+
+    hb.run();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
While this could be merged early already, it only makes more sense if almost all points below are satisfied:

### Checklist:

- [x] SIMD: (SSE2) process ASCII text to bypass VT state machine and chunk-pass it all to the Terminal directly.
- [x] eliminate `count` variable to avoid double Inc/dec in hot loop 
- [ ] SIMD: AVX2 version
- [ ] create headless termbench test that pumps 1GB of data (default ASCII) with and without newlines into the Terminal interface (bypassing PTY and avoiding render locks). Have the perf stats printed.
- [ ] refactor `Grid` to have a continuous buffer of Cell elements; &  `Line` can become a view on that then./
- [ ] text writes should not overwrite Sixel (would be equivalent to how Sixel works in xterm and would make notcurses dev happy?)
- [ ] reduce the complexity overhead of writing chunked ASCII text as much as possible. (e.g. defer checks to the end instead of on every char; pre-calc end of line to not test for EOL and linewrap every time).

### Thoughts

- Making Line a view over the `vector<Cell>` would make text reflow almost a no-op.
- Chunked ASCII text appending should be almost as simple as `memcpy`.

### Conclusion

All the above points are nice but would exceed a small PR and fill a dedicated release cycle. Cutting down.