### PR TITLE
[terminal] Terminal: Fixes skipping grid cell that contained decorati…

### DIFF
--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -326,7 +326,8 @@ void Terminal::refreshRenderBuffer(RenderBuffer& _output)
                                 && !_cell.imageFragment().has_value()
 #endif
                                 ;
-            auto const customBackground = bg != screen_.colorPalette().defaultBackground;
+            auto const customBackground = bg != screen_.colorPalette().defaultBackground
+                                       || !!_cell.attributes().styles;
 
             bool isNewLine = false;
             if (lineNr != _pos.row)

--- a/test/decoration.sh
+++ b/test/decoration.sh
@@ -10,8 +10,9 @@ function decoration() {
     local name="${2}"
     local off="${3}"
     local color="${4:-250:250:70}"
+    local bar="║" # │
     decoration_color "${color}"
-    echo -ne "${on}\t| \033[${on}m${name}\033[${off}m\n"
+    echo -ne "${on}\t${bar} \033[${on}m${name}\033[${off}m\n"
 }
 
 # Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters


### PR DESCRIPTION
…ons but no text (should still be rendered).

found out by accident that underline was not rendered on white-spaces.