### PR TITLE
improve debug state dumping (also for SEGV)

### DIFF
--- a/src/crispy/App.h
+++ b/src/crispy/App.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <crispy/CLI.h>
+#include <crispy/stdfs.h>
 
 #include <functional>
 #include <map>
@@ -27,7 +28,9 @@ class App
 {
   public:
     App(std::string _appName, std::string _appTitle, std::string _appVersion);
-    virtual ~App() = default;
+    virtual ~App();
+
+    static App* instance() noexcept { return instance_; }
 
     virtual crispy::cli::Command parameterDefinition() const = 0;
     crispy::cli::FlagStore const& parameters() const noexcept { return flags_.value(); }
@@ -38,6 +41,7 @@ class App
 
     std::string const& appName() const noexcept { return appName_; }
     std::string const& appVersion() const noexcept { return appVersion_; }
+    FileSystem::path const& localStateDir() const noexcept { return localStateDir_; }
 
   protected:
     void listDebugTags();
@@ -46,9 +50,12 @@ class App
     int versionAction();
     int helpAction();
 
+    static App* instance_;
+
     std::string appName_;
     std::string appTitle_;
     std::string appVersion_;
+    FileSystem::path localStateDir_;
     std::optional<crispy::cli::Command> syntax_;
     std::optional<crispy::cli::FlagStore> flags_;
     std::map<std::string, std::function<int()>> handlers_;

--- a/src/terminal/Grid.h
+++ b/src/terminal/Grid.h
@@ -277,7 +277,7 @@ class Cell {
 
     constexpr int width() const noexcept { return width_; }
 
-    constexpr GraphicsAttributes attributes() const noexcept { return attributes_; }
+    constexpr GraphicsAttributes const& attributes() const noexcept { return attributes_; }
 
 #if defined(LIBTERMINAL_IMAGES)
     std::optional<ImageFragment> const& imageFragment() const noexcept { return imageFragment_; }

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -348,7 +348,7 @@ class Screen : public capabilities::StaticDatabase {
                      ImageResize _resizePolicy,
                      bool _autoScroll);
 
-    void dumpState(std::string const& _message) const;
+    void dumpState(std::string const& _message, std::ostream& _os) const;
 
     // reset screen
     void resetSoft();


### PR DESCRIPTION
- [x] better state base directory (`.local/state/contour`)
- [x] check for`XDG_STATE_HOME` first
- [x] On windows use `%LOCALAPPDATA%/contour` instead
- [x] SEGV to be stored at `.../crash/$TIMESTAMP.log`
- [x] state dumps stores at `.../dump/$TIMESTAMP/...`
- [ ] have an FD opened at process startup already and all memory pre-allocated to reduce mwlloc() calls on SEGV.
- [ ] also first write via `backtrace_symbols_fd()` and then the more high-level one to ensure we at least have something.


