### PR TITLE
fixes and improvements to synchronized updates

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,7 +27,7 @@ exec cmake "${ROOTDIR}" \
            -DLIBTERMINAL_LOG_TRACE="ON" \
            -DLIBTERMINAL_EXECUTION_PAR="OFF" \
            -DCONTOUR_COVERAGE="OFF" \
-           -DCONTOUR_PERF_STATS="OFF" \
+           -DCONTOUR_PERF_STATS="ON" \
            -DCONTOUR_BLUR_PLATFORM_KWIN="ON" \
            -GNinja
 

--- a/src/contour/opengl/CMakeLists.txt
+++ b/src/contour/opengl/CMakeLists.txt
@@ -26,6 +26,10 @@ add_library(contour_frontend_opengl
     TerminalWidget.cpp TerminalWidget.h
 )
 
+if(CONTOUR_PERF_STATS)
+    target_compile_definitions(contour_frontend_opengl PRIVATE CONTOUR_PERF_STATS=1)
+endif()
+
 target_include_directories(contour_frontend_opengl PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../..")
 target_link_libraries(contour_frontend_opengl terminal_renderer OpenGL::GL)
 if(CONTOUR_BUILD_WITH_QT6)

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -516,15 +516,21 @@ void TerminalWidget::paintGL()
     {
         [[maybe_unused]] auto const lastState = state_.exchange(State::CleanPainting);
 
-#if 0
-        auto const updateCount = stats_.updatesSinceRendering.exchange(0);
-        auto const renderCount = stats_.consecutiveRenderCount.exchange(0);
-        debuglog(WidgetTag).write(
-            "paintGL#{}: {} updates since last paint (state: {}).",
-            renderCount,
-            updateCount,
-            lastState
-        );
+#if defined(CONTOUR_PERF_STATS)
+        {
+            ++renderCount_;
+            auto const updateCount = stats_.updatesSinceRendering.exchange(0);
+            auto const renderCount = stats_.consecutiveRenderCount.exchange(0);
+            if (crispy::debugtag::enabled(WidgetTag))
+                debuglog(WidgetTag).write(
+                    "paintGL/{}: {} renders, {} updates since last paint ({}/{}).",
+                    renderCount_.load(),
+                    renderCount,
+                    updateCount,
+                    lastState,
+                    to_string(session_.terminal().renderBufferState())
+                );
+        }
 #endif
 
         bool const reverseVideo =

--- a/src/contour/opengl/TerminalWidget.h
+++ b/src/contour/opengl/TerminalWidget.h
@@ -230,6 +230,9 @@ public:
     };
     std::atomic<bool> initialized_ = false;
     Stats stats_;
+#if defined(CONTOUR_PERF_STATS)
+    std::atomic<uint64_t> renderCount_ = 0;
+#endif
 #if defined(CONTOUR_VT_METRICS)
     terminal::Metrics terminalMetrics_{};
 #endif

--- a/src/crispy/debuglog.h
+++ b/src/crispy/debuglog.h
@@ -221,6 +221,7 @@ class logging_sink {
 };
 
 auto const inline ErrorTag = crispy::debugtag::make("error", "Logs general errors.", true);
+auto const inline PerfMetricsTag = crispy::debugtag::make("perf.metrics", "Logs performance metrics.");
 
 }
 

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -104,6 +104,10 @@ endif()
 if(LIBTERMINAL_LOG_TRACE)
     target_compile_definitions(terminal PRIVATE LIBTERMINAL_LOG_TRACE=1)
 endif()
+if(CONTOUR_PERF_STATS)
+    target_compile_definitions(terminal PUBLIC CONTOUR_PERF_STATS=1)
+endif()
+
 
 if(LIBTERMINAL_IMAGES)
     target_compile_definitions(terminal PUBLIC LIBTERMINAL_IMAGES=1)

--- a/src/terminal/RenderBuffer.cpp
+++ b/src/terminal/RenderBuffer.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include <terminal/RenderBuffer.h>
+#include <crispy/debuglog.h>
 
 #include <mutex>
 

--- a/src/terminal/RenderBuffer.h
+++ b/src/terminal/RenderBuffer.h
@@ -46,6 +46,7 @@ struct RenderBuffer
 {
     std::vector<RenderCell> screen{};
     std::optional<RenderCursor> cursor{};
+    uint64_t frameCount{};
 
     void clear() { screen.clear(); cursor.reset(); }
 };
@@ -104,6 +105,8 @@ struct RenderDoubleBuffer
 
     RenderBufferRef frontBuffer() const
     {
+        // if (state == RenderBufferState::TrySwapBuffers)
+        //     const_cast<RenderDoubleBuffer*>(this)->swapBuffers(lastUpdate);
         RenderBuffer const& frontBuffer = buffers.at((currentBackBufferIndex + 1) % 2);
         return RenderBufferRef(frontBuffer, readerLock);
     }

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -533,12 +533,20 @@ void Screen::write(char const * _data, size_t _size)
 #endif
 
     parser_.parseFragment(string_view(_data, _size));
+
+    if (modes_.enabled(DECMode::BatchedRendering))
+        return;
+
     eventListener_.screenUpdated();
 }
 
 void Screen::write(std::u32string_view const& _text)
 {
     parser_.parseFragment(_text);
+
+    if (modes_.enabled(DECMode::BatchedRendering))
+        return;
+
     eventListener_.screenUpdated();
 }
 
@@ -1792,8 +1800,8 @@ void Screen::setMode(DECMode _mode, bool _enable)
             }
             break;
         case DECMode::BatchedRendering:
-            // Only perform batched rendering when NOT in debugging mode.
-            // TODO: also, do I still need this here?
+            if (modes_.enabled(DECMode::BatchedRendering) != _enable)
+                eventListener_.synchronizedOutput(_enable);
             break;
         case DECMode::TextReflow:
             if (isPrimaryScreen())

--- a/src/terminal/ScreenEvents.h
+++ b/src/terminal/ScreenEvents.h
@@ -68,6 +68,7 @@ class ScreenEvents {
     virtual void useApplicationCursorKeys(bool /*_enabled*/) {}
     virtual void hardReset() {}
     virtual void markRegionDirty(LinePosition _line, ColumnPosition _column) {}
+    virtual void synchronizedOutput(bool _enabled) {}
 
     // Invoked by screen buffer when an image is not being referenced by any grid cell anymore.
     virtual void discardImage(Image const&) {}


### PR DESCRIPTION
### checklist

- [x] not flickering
- [x] not lagging
- [x] only refresh render buffer after frame end when last update is `>= refreshRate` to avoid unnecessary read-outs.
- [ ] have a test for the new cases
- [x] clean up commit history for better atomic commits
