### PR TITLE
Using mimalloc (experimental, optionally)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(CONTOUR_FRONTEND_GUI "Enables GUI frontend." ON)
 option(CONTOUR_COVERAGE "Builds with codecov [default: OFF]" OFF)
 option(CONTOUR_SANITIZE "Builds with Address sanitizer enabled [default: OFF]" OFF)
 option(CONTOUR_STACKTRACE_ADDR2LINE "Uses addr2line to pretty-print SEGV stacktrace." ${ADDR2LINE_DEFAULT})
-
+option(CONTOUR_BUILD_WITH_MIMALLOC "Builds with mimalloc [default: OFF]" OFF)
 # ----------------------------------------------------------------------------
 # code coverage
 
@@ -89,6 +89,7 @@ message(STATUS "Build unit tests:                   ${CONTOUR_TESTING}")
 message(STATUS "Enable with code coverage:          ${CONTOUR_CODE_COVERAGE_ENABLED}")
 message(STATUS "Build contour frontend GUI:         ${CONTOUR_FRONTEND_GUI}")
 message(STATUS "Build contour using Qt 6:           ${CONTOUR_BUILD_WITH_QT6}")
+message(STATUS "Build contour using mimalloc:       ${CONTOUR_BUILD_WITH_MIMALLOC}")
 message(STATUS "|> Enable blur effect on KWin:      ${CONTOUR_BLUR_PLATFORM_KWIN}")
 message(STATUS "|> Enable performance metrics:      ${CONTOUR_PERF_STATS}")
 message(STATUS "Using filesystem API:               ${USING_FILESYSTEM_API_STRING}")

--- a/Changelog.md
+++ b/Changelog.md
@@ -58,6 +58,7 @@
 - Adds new CLI command: `contour generate integration shell SHELL output OUTPUT_FILE` to create the shell integreation file for the given shell (only zsh supported for now). Also adds a pre-generated shell integration file for Linux (and OS/X) to `/usr/share/contour/shell-integration.zsh`.
 - Unicode data updated to version 14.0 beta. See https://home.unicode.org/unicode-14-0-beta-review.
 - Adds support for building with Qt 6 (disabled by default).
+- Adds support for building with mimalloc (experimental, disabled by default).
 
 ### 0.1.1 (2020-12-31)
 

--- a/cmake/ThirdParties.cmake
+++ b/cmake/ThirdParties.cmake
@@ -3,6 +3,7 @@ include(CPM)
 set(3rdparty_catch2_version "bf61a418cbc4d3b430e3d258c5287780944ad505" CACHE STRING "catch2: commit hash")
 set(3rdparty_fmt_version "561834650aa77ba37b15f7e5c9d5726be5127df9" CACHE STRING "fmt: commit hash")
 set(3rdparty_libunicode_version "a0f72919e4520ee1a02890ea77f19ff16c92d4f8" CACHE STRING "libunicode: commit hash")
+set(3rdparty_mimalloc_version "v2.0.2" CACHE STRING "mimalloc: release tag")
 set(3rdparty_range_v3_version "0487cca29e352e8f16bbd91fda38e76e39a0ed28" CACHE STRING "range_v3: commit hash")
 set(3rdparty_yaml_cpp_version "79aa6d53e5718ca44bc01ef05fdda7a849d353e0" CACHE STRING "yaml-cpp: commit hash")
 set(3rdparty_termbenchpro_version "c2312fc2ebadf45adc724295951d078b1adb7ffe" CACHE STRING "termbench-pro: version")
@@ -78,3 +79,14 @@ CPMAddPackage(
   EXCLUDE_FROM_ALL YES
 )
 
+if(CONTOUR_BUILD_WITH_MIMALLOC)
+  set(MI_BUILD_SHARED OFF CACHE INTERNAL "")
+  set(MI_BUILD_TESTS OFF CACHE INTERNAL "")
+  CPMAddPackage(
+    NAME mimalloc
+    VERSION ${3rdparty_mimalloc_version}
+    URL https://github.com/microsoft/mimalloc/archive/${3rdparty_mimalloc_version}.zip
+    URL_HASH SHA256=6ccba822e251b8d10f8a63d5d7767bc0cbfae689756a4047cdf3d1e4a9fd33d0
+    EXCLUDE_FROM_ALL YES
+  )
+endif()

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -127,6 +127,10 @@ if(CONTOUR_FRONTEND_GUI)
     endif()
 endif()
 
+if(CONTOUR_BUILD_WITH_MIMALLOC)
+    target_link_libraries(contour mimalloc-static)
+endif()
+
 if(CONTOUR_SANITIZE AND NOT MSVC)
     add_compile_options(-fsanitize=address)
     #add_compile_options(-fsanitize=pointer-compare) # cannot be enabled with -fsanitize=thread


### PR DESCRIPTION
My results with `tbp`.
Without mimalloc:

          many_lines:   3.0420 seconds,   9.357 MB/s (normalized:   2.457 KB/s)
          long_lines:   1.0080 seconds,  29.630 MB/s (normalized:   7.780 KB/s)
        sgr_fg_lines:   0.0585 seconds,  54.701 MB/s (normalized:  14.362 KB/s)
     sgr_fg_bg_lines:   0.0724 seconds,  44.199 MB/s (normalized:  11.605 KB/s)
           all tests:   5.0809 seconds,  22.035 MB/s (normalized:   5.786 KB/s)

With mimalloc:

          many_lines:   3.0456 seconds,   9.259 MB/s (normalized:   2.431 KB/s)
          long_lines:   1.0202 seconds,  26.622 MB/s (normalized:   6.990 KB/s)
        sgr_fg_lines:   0.0526 seconds,  60.837 MB/s (normalized:  15.973 KB/s)
     sgr_fg_bg_lines:   0.0523 seconds,  61.185 MB/s (normalized:  16.065 KB/s)
           all tests:   5.0707 seconds,  22.429 MB/s (normalized:   5.889 KB/s)