### PR TITLE
Always sanitize font description

### DIFF
--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -340,6 +340,15 @@ terminal::renderer::PageMargin computeMargin(terminal::ImageSize _cellSize,
     return {leftMargin, bottomMargin};
 }
 
+terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point screenDPI)
+{
+    if (_fonts.dpi.x <= 0 || _fonts.dpi.y <= 0)
+        _fonts.dpi = screenDPI;
+    if (std::fabs(_fonts.size.pt) <= std::numeric_limits<double>::epsilon())
+        _fonts.size.pt = 12;
+    return _fonts;
+}
+
 bool applyFontDescription(terminal::ImageSize _cellSize,
                           terminal::PageSize _screenSize,
                           terminal::ImageSize _pixelSize,
@@ -352,10 +361,7 @@ bool applyFontDescription(terminal::ImageSize _cellSize,
 
     auto const windowMargin = computeMargin(_cellSize, _screenSize, _pixelSize);
 
-    if (_fontDescriptions.dpi == Zero<Point>)
-        _fontDescriptions.dpi = _screenDPI;
-
-    _renderer.setFonts(_fontDescriptions);
+    _renderer.setFonts(sanitizeFontDescription(_fontDescriptions, _screenDPI));
     _renderer.setMargin(windowMargin);
     _renderer.updateFontMetrics();
 

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -340,10 +340,10 @@ terminal::renderer::PageMargin computeMargin(terminal::ImageSize _cellSize,
     return {leftMargin, bottomMargin};
 }
 
-terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point screenDPI)
+terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point _screenDPI)
 {
     if (_fonts.dpi.x <= 0 || _fonts.dpi.y <= 0)
-        _fonts.dpi = screenDPI;
+        _fonts.dpi = _screenDPI;
     if (std::fabs(_fonts.size.pt) <= std::numeric_limits<double>::epsilon())
         _fonts.size.pt = 12;
     return _fonts;

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -173,6 +173,8 @@ terminal::renderer::PageMargin computeMargin(terminal::ImageSize _cellSize,
                                              terminal::PageSize _charCells,
                                              terminal::ImageSize _pixels) noexcept;
 
+terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point screenDPI);
+
 bool applyFontDescription(
     terminal::ImageSize _cellSize,
     terminal::PageSize _screenSize,

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -173,7 +173,7 @@ terminal::renderer::PageMargin computeMargin(terminal::ImageSize _cellSize,
                                              terminal::PageSize _charCells,
                                              terminal::ImageSize _pixels) noexcept;
 
-terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point screenDPI);
+terminal::renderer::FontDescriptions sanitizeFontDescription(terminal::renderer::FontDescriptions _fonts, crispy::Point _screenDPI);
 
 bool applyFontDescription(
     terminal::ImageSize _cellSize,

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -253,13 +253,6 @@ namespace // {{{
     }
 } // }}}
 
-terminal::renderer::FontDescriptions TerminalWidget::sanitizeDPI(terminal::renderer::FontDescriptions _fonts)
-{
-    if (_fonts.dpi.x <= 0 || _fonts.dpi.y <= 0)
-        _fonts.dpi = screenDPI();
-    return _fonts;
-}
-
 TerminalWidget::TerminalWidget(
     config::TerminalProfile const& _profile,
     TerminalSession& _session,
@@ -273,7 +266,7 @@ TerminalWidget::TerminalWidget(
     enableBackgroundBlur_{ std::move(_enableBackgroundBlur) },
     renderer_{
         terminal().screenSize(),
-        sanitizeDPI(profile_.fonts),
+        sanitizeFontDescription(profile_.fonts, screenDPI()),
         terminal().screen().colorPalette(),
         profile_.backgroundOpacity,
         profile_.hyperlinkDecoration.normal,

--- a/src/contour/opengl/TerminalWidget.h
+++ b/src/contour/opengl/TerminalWidget.h
@@ -179,8 +179,6 @@ public:
     /// either DirtyIdle if no painting is currently in progress, DirtyPainting otherwise.
     std::atomic<State> state_ = State::CleanIdle;
 
-    terminal::renderer::FontDescriptions sanitizeDPI(terminal::renderer::FontDescriptions _fonts);
-
     /// Flags the screen as dirty.
     ///
     /// @returns boolean indicating whether the screen was clean before and made dirty (true), false otherwise.


### PR DESCRIPTION
This fixes a crash when `_fonts.size.pt` is somehow zero.