### PR TITLE
Don't use AA_DisableHighDpiScaling with Qt 6

### DIFF
--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -170,7 +170,9 @@ int terminalGUI(int argc, char const* argv[], CLI::FlagStore const& _flags)
     // which makes the text look pixelated on HighDPI screens. We want to apply HighDPI
     // manually in QOpenGLWidget.
     //QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+    #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+    #endif
 
     QApplication app(argc, (char**) argv);
 


### PR DESCRIPTION
Because:
>ContourGuiApp.cpp:173:40: warning: ‘Qt::AA_DisableHighDpiScaling’ is deprecated: High-DPI scaling is always enabled. This attribute no longer has any effect. [-Wdeprecated-declarations]
  173 |     QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);

It's cosmetic change, but I don't like warnings. :)