### PR TITLE
[CI][CodeChecker] Update skip-list

### DIFF
--- a/.github/codechecker/skipfile.txt
+++ b/.github/codechecker/skipfile.txt
@@ -1,4 +1,7 @@
 -/usr/include/*
-+*/Build/3rdparty/libunicode/*
--*/Build/3rdparty/*
+-/usr/lib/llvm*/lib/clang/*/include/*
++*/Build/_deps/libunicode-src/*
++*/Build/_deps/termbenchpro-src/*
+-*/Build/_deps/*
 -*/Build/src/contour/contour_autogen/*
+-*/Build/src/contour/opengl/contour_frontend_opengl_autogen/*


### PR DESCRIPTION
At some point the past two-ish months the layout of the build changed and the previous skip-list did not properly ignore not-to-be-analysed third-parties anymore, resulting in 340-ish analysis actions, compared to the 150-ish that should have been.