### PR TITLE
OpenGL version related cleanups and hard-dependency drop.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,7 +20,6 @@ exec cmake "${ROOTDIR}" \
            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
            -DCMAKE_EXPORT_COMPILE_COMMANDS="ON" \
-           -DOpenGL_GL_PREFERENCE="GLVND" \
            -DYAML_CPP_BUILD_CONTRIB="OFF" \
            -DYAML_CPP_BUILD_TOOLS="OFF" \
            -DLIBTERMINAL_LOG_RAW="ON" \

--- a/src/contour/opengl/CMakeLists.txt
+++ b/src/contour/opengl/CMakeLists.txt
@@ -1,15 +1,8 @@
-if("${OpenGL_GL_PREFERENCE}" STREQUAL "")
-    # possible values are: GLVND, LEGACY
-    set(OpenGL_GL_PREFERENCE "GLVND")
-endif()
-
 if(CONTOUR_BUILD_WITH_QT6)
-   find_package(Qt6 COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets REQUIRED)
+   find_package(Qt6 COMPONENTS Core Gui OpenGLWidgets Widgets REQUIRED)
 else()
    find_package(Qt5 COMPONENTS Gui Widgets REQUIRED)  # apt install qtbase5-dev libqt5gui5
 endif()
-
-find_package(OpenGL REQUIRED)
 
 CIncludeMe(shaders/background.frag "${CMAKE_CURRENT_BINARY_DIR}/background_frag.h" "background_frag" "default_shaders")
 CIncludeMe(shaders/background.vert "${CMAKE_CURRENT_BINARY_DIR}/background_vert.h" "background_vert" "default_shaders")
@@ -31,7 +24,7 @@ if(CONTOUR_PERF_STATS)
 endif()
 
 target_include_directories(contour_frontend_opengl PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../..")
-target_link_libraries(contour_frontend_opengl terminal_renderer OpenGL::GL)
+target_link_libraries(contour_frontend_opengl terminal_renderer)
 if(CONTOUR_BUILD_WITH_QT6)
    target_link_libraries(contour_frontend_opengl Qt6::Core Qt6::Gui Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Widgets)
 else()

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -305,15 +305,11 @@ QSurfaceFormat TerminalWidget::surfaceFormat()
     );
 
     if (forceOpenGLES || QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES)
-    {
-        format.setVersion(3, 0);
         format.setRenderableType(QSurfaceFormat::OpenGLES);
-    }
     else
-    {
-        format.setVersion(3, 0);
         format.setRenderableType(QSurfaceFormat::OpenGL);
-    }
+
+    format.setVersion(3, 0);
     format.setProfile(QSurfaceFormat::CoreProfile);
     format.setAlphaBufferSize(8);
     format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);


### PR DESCRIPTION
Minor OpenGL version related cleanups, and remove hard dependency on OenGL at compile time.

Related to #166.

This is an attempt to make it possible to use the OpenGL software rasterizer. However, setting `Qt::AA_UseSoftwareOpenGL` (even before Q(Gui)Application was created) did not automatically enable the use of the OpenGL software rasterizer on Linux (Gentoo).

I still had to force it via environment variable  `LIBGL_ALWAYS_SOFTWARE=1`