### PR TITLE
Fixes SEGV with overflowing (Sixel) images. 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Do not force OpenGL ES on Linux anymore.
 - Fixes terminfo entries accidentally double-escaping `\E` to `\\E` (#399).
 - Fixes RGB color parsing via ':2::Pr:Pg:Pb' syntax and also adapt setrgbf & setrgbb accordingly.
+- Fixes SEGV with overflowing (Sixel) images (#409).
 
 ### 0.2.0 (2021-08-17)
 

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -2089,7 +2089,8 @@ void Screen::renderImage(std::shared_ptr<Image const> const& _imageRef,
 #else
     auto const linesAvailable = LineCount(1 + *size_.lines - _topLeft.row);
     auto const linesToBeRendered = min(_gridSize.lines, linesAvailable);
-    auto const columnsToBeRendered = ColumnCount(min(*_gridSize.columns, *size_.columns - _topLeft.column - 1));
+    auto const columnsAvailable = *size_.columns - _topLeft.column + 1;
+    auto const columnsToBeRendered = ColumnCount(min(columnsAvailable, *_gridSize.columns));
     auto const gapColor = RGBAColor{}; // TODO: cursor_.graphicsRendition.backgroundColor;
 
     // TODO: make use of _imageOffset and _imageSize


### PR DESCRIPTION
The other problem of #406 is how we want to treat the question of whether or not to append a linefeed at the end of a received and rendered Sixel image... Maybe that should be addressed separately. 