### PR TITLE
Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Adds support for building with embedded FreeType and HarfBuzz (experimental, disabled by default).
 - Do not force OpenGL ES on Linux anymore.
 - Changes default (Sixel) image size limits to the primary screen's pixel dimensions (#408).
+- Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.
 - Fixes CPU load going up on mouse move inside terminal window (#407).
 - Fixes terminfo entries accidentally double-escaping `\E` to `\\E` (#399).
 - Fixes RGB color parsing via ':2::Pr:Pg:Pb' syntax and also adapt setrgbf & setrgbb accordingly.

--- a/src/terminal/Capabilities.cpp
+++ b/src/terminal/Capabilities.cpp
@@ -433,7 +433,7 @@ string StaticDatabase::terminfo() const
 
     std::stringstream output;
 
-    output << "contour-latest|xterm-contour|ContourTTY,\n";
+    output << "contour|contour-latest|Contour Terminal Emulator,\n";
 
     for (auto const& cap: move(booleans) | actions::sort)
         if (!cap.name.empty() && cap.value)


### PR DESCRIPTION
also helps OS/X's terminfo issue (primitively at least)