### PR TITLE
Fixes off-by-one bug in builtin box drawing.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Fixes XTSMGRAPHICS for invalid SetValue actions and setting Sixel image size limits (#422).
 - Fixes internal pixel width/height tracking in VT screen, which did affect sizes of rendered Sixel images (#408).
 - Fixes configuring a custom shell on OS/X (#425).
+- Fixes off-by-one bug in builtin box drawing (#424).
 - Changes DECSDM such that it works like a real VT340; also xterm, as of version 369, changed that recently (#287).
 
 ### 0.2.0 (2021-08-17)

--- a/src/terminal_renderer/BoxDrawingRenderer.cpp
+++ b/src/terminal_renderer/BoxDrawingRenderer.cpp
@@ -720,7 +720,7 @@ optional<atlas::Buffer> BoxDrawingRenderer::build(uint8_t _id, ImageSize _size,
             {
                 auto const x = int(double(y) * aInv);
                 for (auto const xi: iota(-_lineThickness / 2, _lineThickness / 2))
-                    image[y * *width + max(0, min(x + xi, unbox<int>(width)))] = 0xFF;
+                    image[y * *width + max(0, min(x + xi, unbox<int>(width) - 1))] = 0xFF;
             }
         }
         if (unsigned(box.diagonal_) & unsigned(Diagonal::Backward))
@@ -729,7 +729,7 @@ optional<atlas::Buffer> BoxDrawingRenderer::build(uint8_t _id, ImageSize _size,
             {
                 auto const x = int(double(*height - y - 1) * aInv);
                 for (auto const xi: iota(-_lineThickness / 2, _lineThickness / 2))
-                    image[y * *width + max(0, min(x + xi, unbox<int>(width)))] = 0xFF;
+                    image[y * *width + max(0, min(x + xi, unbox<int>(width) - 1))] = 0xFF;
             }
         }
     }


### PR DESCRIPTION
Fixes at least the SEGV as triggered by `notcurses-info`  (#424, box drawing for diagonals could sometimes be writing one byte passt the buffer.