### PR TITLE
Adds more pixel-perfect graphical codepoints.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Reverts change from 0.2.0: "Changes behaviour when receiving `U+FE0E` (VS15) to not enforce the width of 1 but leave it as is (usually 2). This seems to match what the web browser is doing, too."
 - Adds some more tmux-extension entries to the terminfo database that are supported by contour (`Ss`, `Se`, `Cs`, `Smol`, `Smulx`, `Setulc`).
 - Adds `Sync` capability entry to terminfo file.
+- Adds more pixel-perfect graphical codepoints: U+23A1..U+23A6, U+2580..U+2590, U+2594..U+259F, U+1FB00..U+1FB3B, U+1FB70..U+1FB8B.
 - Unicode data updated to version 14.0 (release). See [Announcing The Unicode® Standard, Version 14.0](https://home.unicode.org/announcing-the-unicode-standard-version-14-0).
 - Adds support for building with embedded FreeType and HarfBuzz (experimental, disabled by default).
 - Do not force OpenGL ES on Linux anymore.

--- a/src/terminal_renderer/BoxDrawingRenderer.h
+++ b/src/terminal_renderer/BoxDrawingRenderer.h
@@ -35,17 +35,20 @@ class BoxDrawingRenderer : public Renderable {
     void setRenderTarget(RenderTarget& _renderTarget) override;
     void clearCache() override;
 
+    bool renderable(char32_t codepoint) const noexcept;
+
     /// Renders boxdrawing character.
     ///
-    /// @param _char the boxdrawing character's codepoint modulo 0x2500 (a value between 0x00 and 0x7F).
-    bool render(LinePosition _line, ColumnPosition _column, uint8_t _id, RGBColor _color);
+    /// @param _char the boxdrawing character's codepoint.
+    bool render(LinePosition _line, ColumnPosition _column, char32_t codepoint, RGBColor _color);
 
   private:
-    using TextureAtlas = atlas::MetadataTextureAtlas<uint8_t, int>;
+    using TextureAtlas = atlas::MetadataTextureAtlas<char32_t, int>;
     using DataRef = TextureAtlas::DataRef;
 
-    std::optional<DataRef> getDataRef(uint8_t _id);
-    std::optional<atlas::Buffer> build(uint8_t _id, ImageSize _size, int _lineThickness);
+    std::optional<DataRef> getDataRef(char32_t codepoint);
+    std::optional<atlas::Buffer> buildBoxElements(char32_t codepoint, ImageSize _size, int _lineThickness);
+    std::optional<atlas::Buffer> buildElements(char32_t codepoint);
 
     // private fields
     //

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -130,20 +130,23 @@ void TextRenderer::renderCell(RenderCell const& _cell)
     bool const isBoxDrawingCharacter =
         fontDescriptions_.builtinBoxDrawing &&
         _cell.codepoints.size() == 1 &&
-        crispy::ascending(char32_t{0x2500}, codepoints[0], char32_t{0x257F});
+        boxDrawingRenderer_.renderable(codepoints[0]);
 
     if (isBoxDrawingCharacter)
     {
-        boxDrawingRenderer_.render(
+        auto const success = boxDrawingRenderer_.render(
             LinePosition::cast_from(_cell.position.row),
             ColumnPosition::cast_from(_cell.position.column),
-            codepoints[0] % 0x2500,
+            codepoints[0],
             _cell.foregroundColor
         );
-        if (!forceCellGroupSplit_)
-            endSequence();
-        forceCellGroupSplit_ = true;
-        return;
+        if (success)
+        {
+            if (!forceCellGroupSplit_)
+                endSequence();
+            forceCellGroupSplit_ = true;
+            return;
+        }
     }
 
     if (forceCellGroupSplit_ || (_cell.flags & CellFlags::CellSequenceStart))


### PR DESCRIPTION
refs #424, #441
closes #437, #419

Update: I am not going to implement all possible box drawings and terminal-alike codepoints in one single PR.
Ticket #441 is used to keep track of the progress.