### PR TITLE
Add option to set a custom `WM_CLASS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for power users with a modern feature mindset.
   Usage:
 
     contour [terminal] [config STRING] [profile STRING] [debug STRING] [live-config]
-                       [working-directory STRING] [PROGRAM ARGS...]
+                       [working-directory STRING] [class STRING] [PROGRAM ARGS...]
     contour help
     contour version
     contour parser-table
@@ -61,6 +61,7 @@ for power users with a modern feature mindset.
             [debug STRING]              Enables debug logging, using a comma seperated list of tags.
             [live-config]               Enables live config reloading. [default: false]
             [working-directory STRING]  Sets initial working directory. [default: .]
+            [class STRING]              Sets the WM_CLASS property of the window. [default: contour]
             [PROGRAM ARGS...]           Executes given program instead of the configuration provided one.
 
 ```

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1031,6 +1031,8 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
     tryLoadChild(_usedKeys, _doc, basePath, "fullscreen", profile.fullscreen);
     tryLoadChild(_usedKeys, _doc, basePath, "refresh_rate", profile.refreshRate);
 
+    tryLoadChild(_usedKeys, _doc, basePath, "wm_class", profile.wmClass);
+
     if (auto args = _doc["profiles"][_name]["arguments"]; args && args.IsSequence())
     {
         _usedKeys.emplace(fmt::format("{}.arguments", basePath));

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -124,6 +124,8 @@ struct TerminalProfile {
     bool fullscreen = false;
     double refreshRate = 0.0; // 0=auto
 
+    std::string wmClass;
+
     terminal::PageSize terminalSize = {terminal::LineCount(10), terminal::ColumnCount(40)};
     terminal::VTType terminalId = terminal::VTType::VT525;
 

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -67,6 +67,7 @@ crispy::cli::Command ContourGuiApp::parameterDefinition() const
                 CLI::Option{"debug", CLI::Value{""s}, "Enables debug logging, using a comma (,) seperated list of tags.", "TAGS"},
                 CLI::Option{"live-config", CLI::Value{false}, "Enables live config reloading."},
                 CLI::Option{"working-directory", CLI::Value{""s}, "Sets initial working directory (overriding config).", "DIRECTORY"},
+                CLI::Option{"class", CLI::Value{""s}, "Sets the class part of the WM_CLASS property for the window (overriding config).", "WM_CLASS"},
             },
             CLI::CommandList{},
             CLI::CommandSelect::Implicit,
@@ -162,7 +163,12 @@ int terminalGUI(int argc, char const* argv[], CLI::FlagStore const& _flags)
              shell.arguments.push_back(string(_flags.verbatim.at(i)));
     }
 
-    QCoreApplication::setApplicationName("contour");
+
+    if (auto const wmClass = _flags.get<string>("contour.terminal.class"); !wmClass.empty())
+        config.profile(profileName)->wmClass = wmClass;
+
+    auto appName = QString::fromStdString(config.profile(profileName)->wmClass);
+    QCoreApplication::setApplicationName(appName);
     QCoreApplication::setOrganizationName("contour");
     QCoreApplication::setApplicationVersion(CONTOUR_VERSION_STRING);
 

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -61,6 +61,9 @@ profiles:
         # whether or not to put the window into maximized mode.
         maximized: false
 
+        # Defines the class part of the WM_CLASS property of the window.
+        wm_class: "contour"
+
         # Environment variables to be passed to the shell.
         environment:
             TERM: xterm-256color


### PR DESCRIPTION
Add the CLI option `class` and the configuration option `wm_class` to set the user-defined `WM_CLASS` property of the terminal window.

This could be tested using `xprop` utility, to test if we really modified `WM_CLASS`:
```
WM_CLASS(STRING) = "contour", "contour_ex"
```

I additionally tried to use this feature with my `i3wm` as it described in #376, using the following configuration:
```
for_window [class="contour_ex"] floating enable
```

It works as expected in both cases: when set using the CLI option or using a configuration file.