### PR TITLE
[contour] config: Changes font locator engine default on Windows to DirectWrite (#452).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Unicode data updated to version 14.0 (release). See [Announcing The Unicode® Standard, Version 14.0](https://home.unicode.org/announcing-the-unicode-standard-version-14-0).
 - Do not force OpenGL ES on Linux anymore.
 - Changes default (Sixel) image size limits to the primary screen's pixel dimensions (#408).
+- Changes font locator engine default on Windows to DirectWrite (#452).
 - Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.
 - Fixes SGR 24 to remove any kind of underline (#451).
 - Fixes font fallback for `open_shaper` where in rare cases the text was not rendered at all.

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1144,6 +1144,15 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
         terminal::renderer::TextShapingEngine::OpenShaper;
 #endif
 
+    auto constexpr NativeFontLocator =
+#if defined(_WIN32)
+        terminal::renderer::FontLocatorEngine::DWrite;
+#elif defined(__APPLE__)
+        terminal::renderer::FontLocatorEngine::CoreText;
+#else
+        terminal::renderer::FontLocatorEngine::FontConfig;
+#endif
+
     strValue = fmt::format("{}", profile.fonts.textShapingEngine);
     if (tryLoadChild(_usedKeys, _doc, basePath, "font.text_shaping.engine", strValue))
     {
@@ -1161,6 +1170,7 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
                     basePath, strValue);
     }
 
+    profile.fonts.fontLocator = NativeFontLocator;
     strValue = fmt::format("{}", profile.fonts.fontLocator);
     if (tryLoadChild(_usedKeys, _doc, basePath, "font.locator", strValue))
     {
@@ -1171,6 +1181,8 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
             profile.fonts.fontLocator = terminal::renderer::FontLocatorEngine::CoreText;
         else if (lwrValue == "dwrite" || lwrValue == "directwrite")
             profile.fonts.fontLocator = terminal::renderer::FontLocatorEngine::DWrite;
+        else if (lwrValue == "native")
+            profile.fonts.fontLocator = NativeFontLocator;
         else
             debuglog(ConfigTag).write("Invalid value for configuration key {}.font.locator: {}",
                                       basePath, strValue);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -133,7 +133,8 @@ profiles:
             # Possible values are:
             # - fontconfig      : uses fontconfig to select fonts
             # - CoreText        : uses OS/X CoreText to select fonts (currently not implemented).
-            locator: fontconfig
+            # - DirectWrite     : selects DirectWrite engine (Windows only)
+            locator: native
 
             # Text shaping related settings
             text_shaping:


### PR DESCRIPTION
Addresses #452.