### PR TITLE
Fixes terminfo installation path on OS/X and tries to auto-set `TERMNFO_DIRS` to it on startup.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Changes default (Sixel) image size limits to the primary screen's pixel dimensions (#408).
 - Changes font locator engine default on Windows to DirectWrite (#452).
 - Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.
+- Fixes terminfo installation path on OS/X and tries to auto-set `TERMINFO_DIRS` to it on startup (#443).
 - Fixes SGR 24 to remove any kind of underline (#451).
 - Fixes font fallback for `open_shaper` where in rare cases the text was not rendered at all.
 - Fixes CPU load going up on mouse move inside terminal window (#407).

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -241,8 +241,8 @@ elseif(APPLE)
 
     # Install application icon
     install(FILES "res/images/contour-logo.icns" DESTINATION "${INSTALL_CMAKE_DIR}" RENAME "contour.icns")
-    install(FILES "shell-integration.zsh" DESTINATION "${CMAKE_INSTALL_DATADIR}/contour")
-    install(DIRECTORY "${terminfo_basedir}" DESTINATION "${CMAKE_INSTALL_DATADIR}")
+    install(DIRECTORY "${terminfo_basedir}" DESTINATION "${INSTALL_CMAKE_DIR}")
+    install(FILES "shell-integration.zsh" DESTINATION "${INSTALL_CMAKE_DIR}")
 
     #add_custom_target(Docs SOURCES README.md LICENSE.txt)
     #TODO: install(TARGETS Docs ...)


### PR DESCRIPTION
Fixes #443 