### PR TITLE
[CI] Fixing windows CI. Something must have changed on Github CI env.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,6 +326,9 @@ jobs:
       with:
         path: "**/cpm_modules"
         key: ${{github.workflow}}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+    - name: Avoid conflict with Chocolatey's CPack
+      if: runner.os == 'Windows'
+      run: Rename-Item -Force -Path ${Env:ChocolateyInstall}/bin/cpack.exe  -NewName ${Env:ChocolateyInstall}/bin/cpack-choco.exe
     - name: setup environment
       shell: powershell
       id: set_vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         run: .\scripts\ci-set-vars.ps1
         env:
           REPOSITORY: ${{ github.event.repository.name }}
+      - name: Avoid conflict with Chocolatey's CPack
+        if: runner.os == 'Windows'
+        run: Rename-Item -Force -Path ${Env:ChocolateyInstall}/bin/cpack.exe  -NewName ${Env:ChocolateyInstall}/bin/cpack-choco.exe
       - name: "vcpkg: Install dependencies"
         uses: lukka/run-vcpkg@v5
         id: runvcpkg


### PR DESCRIPTION
I do not call this a fix but a workaround as I simply uninstall something to avoid the name clash.

See https://github.community/t/windows-actions-suddenly-fail-needing-a-nuspec-file/199483