### PR TITLE
[contour] Enables TCAP query feature by default, removes experimental flag, not configurable anymore.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Do not force OpenGL ES on Linux anymore.
 - Changes default (Sixel) image size limits to the primary screen's pixel dimensions (#408).
 - Changes font locator engine default on Windows to DirectWrite (#452).
+- Changes tcap-query feature from experimental to always enabled (not configurable anymore).
 - Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.
 - Fixes VT sequences that cause a cursor restore to sometimes crash.
 - Fixes terminfo installation path on OS/X and tries to auto-set `TERMINFO_DIRS` to it on startup (#443).

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1381,8 +1381,8 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
                 doc["bypass_mouse_protocol_modifier"]); opt.has_value())
         _config.bypassMouseProtocolModifier = opt.value();
 
-    auto constexpr KnownExperimentalFeatures = array{
-        "tcap"sv
+    auto constexpr KnownExperimentalFeatures = array<string_view, 0>{
+        // "tcap"sv
     };
 
     if (auto experimental = doc["experimental"]; experimental.IsMap())

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -843,7 +843,6 @@ void TerminalSession::configureTerminal()
 
     LOGSTORE(SessionLog)("Setting terminal ID to {}.", profile_.terminalId);
     screen.setTerminalId(profile_.terminalId);
-    screen.setRespondToTCapQuery(config_.experimentalFeatures.count("tcap"));
     screen.setSixelCursorConformance(config_.sixelCursorConformance);
     screen.setMaxImageColorRegisters(config_.maxImageColorRegisters);
     screen.setMaxImageSize(config_.maxImageSize);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -17,9 +17,10 @@ reflow_on_resize: true
 
 # Section of experimental features.
 # All experimental features are disabled by default and must be explicitely enabled here.
-experimental:
-    # Enables experimental support for termcap/terminfo queries
-    tcap: false
+# NOTE: Contour currently has no experimental features behind this configuration wall.
+# experimental:
+#     # Enables experimental support for feature X/Y/Z
+#     feature_xyz: true
 
 # This keyboard modifier can be used to bypass the terminal's mouse protocol,
 # which can be used to select screen content even if the an application

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -702,7 +702,7 @@ class Screen : public capabilities::StaticDatabase {
 
     // experimental features
     //
-    bool respondToTCapQuery_ = false;
+    bool respondToTCapQuery_ = true;
 };
 
 }  // namespace terminal


### PR DESCRIPTION
no bug reports, nothing found myself. no need to flag it as experimental then.