### PR TITLE
[contour] Extents CLI parameters to support those that Qt supports by default.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 - Fixes off-by-one bug in builtin box drawing (#424).
 - Fixes assertion in text renderer with regards to colored glyphs.
 - Fixes Sixel background select to support transparency (#450).
+- Fixes session resuming on KDE desktop envionment which is respawing all Contour instances upon re-login but failed due to invalid command line parameters (#461).
 - Changes DECSDM such that it works like a real VT340; also xterm, as of version 369, changed that recently (#287).
 
 ### 0.2.0 (2021-08-17)


### PR DESCRIPTION
This is:
- session resuming (fixes #461)
- QPA platform setting
- X11 display setting



Mind, this does not provide fully fledged session management. It simply makes sure resmed contour instances via session ID will work (i.e. not crash).