### PR TITLE
Don't use absolute path to contour in contour.desktop

### DIFF
--- a/src/contour/contour.desktop
+++ b/src/contour/contour.desktop
@@ -5,7 +5,7 @@
 [Desktop Entry]
 Type=Application
 TryExec=contour
-Exec=/usr/bin/contour
+Exec=contour
 Icon=contour
 Terminal=false
 Categories=Qt;System;TerminalEmulator;
@@ -193,5 +193,3 @@ Name[uk]=Відкрити нове вікно
 Name[x-test]=xxOpen a New Windowxx
 Name[zh_CN]=打开新窗口
 Name[zh_TW]=開啟新視窗
-Icon=window-new
-Exec=konsole


### PR DESCRIPTION
Many apps uses this way.
E.g. I **always** install my compiled binaries to `/usr/local/bin`.