### PR TITLE
VT: RGB parsing fix, termcap fix, curly underline beautification, ...

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Fixes Qt-related CLI options that that were largely ignored.
 - Fixes crash caused by VT sequence PM and SOS (#513).
 - Fixes parsing VT sequence RGB color parsing for cell decoratioins (e.g. underline).
+- Fixes double-underline to not look like a very thick line on small font sizes.
 - Changes `contour` exit code to reflect the shell's exit code of the last closed window.
 - Improves text cursor rendering and extends cursor configuration accordingly (#526).
 - Adds CLI option `terminal early-exit-threshold SECS` (defaulting to 6) to only report and wait if the process did exit below this threshold seconds.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Fixes Sixel image rendering when scrolling is needed and ANSI cursor is not on left margin.
 - Fixes Qt-related CLI options that that were largely ignored.
 - Fixes crash caused by VT sequence PM and SOS (#513).
+- Fixes parsing VT sequence RGB color parsing for cell decoratioins (e.g. underline).
 - Changes `contour` exit code to reflect the shell's exit code of the last closed window.
 - Improves text cursor rendering and extends cursor configuration accordingly (#526).
 - Adds CLI option `terminal early-exit-threshold SECS` (defaulting to 6) to only report and wait if the process did exit below this threshold seconds.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,14 @@
 ### 0.3.0 (unreleased)
 
+**Important: It is recommended to also use the latest `contour` termcap file if you are already using one
+from a previous release.**
+
 - Fixes Sixel image rendering when scrolling is needed and ANSI cursor is not on left margin.
 - Fixes Qt-related CLI options that that were largely ignored.
 - Fixes crash caused by VT sequence PM and SOS (#513).
 - Fixes parsing VT sequence RGB color parsing for cell decoratioins (e.g. underline).
 - Fixes double-underline to not look like a very thick line on small font sizes.
+- Applies antialiasing to curly underline.
 - Changes `contour` exit code to reflect the shell's exit code of the last closed window.
 - Improves text cursor rendering and extends cursor configuration accordingly (#526).
 - Adds CLI option `terminal early-exit-threshold SECS` (defaulting to 6) to only report and wait if the process did exit below this threshold seconds.

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -885,6 +885,9 @@ void TerminalWidget::setFonts(terminal::renderer::FontDescriptions _fontDescript
 
 bool TerminalWidget::setFontSize(text::font_size _size)
 {
+    LOGSTORE(DisplayLog)("Setting display font size and recompute metrics: {}pt",
+            _size.pt);
+
     if (!renderer_.setFontSize(_size))
         return false;
 

--- a/src/terminal/Capabilities.cpp
+++ b/src/terminal/Capabilities.cpp
@@ -182,8 +182,8 @@ namespace
         String{ Undefined, "Sync"sv, "\033[?2026%?%p1%{1}%-%tl%eh"sv },
 
         // non-standard: used by NeoVIM
-        String{ Undefined, "setrgbf"sv, "\033[38:2::%p1%d:%p2%d:%p3%dm"sv }, // setrgbf: Set RGB foreground color
-        String{ Undefined, "setrgbb"sv, "\033[48:2::%p1%d:%p2%d:%p3%dm"sv }, // setrgbb: Set RGB background color
+        String{ Undefined, "setrgbf"sv, "\033[38:2:%p1%d:%p2%d:%p3%dm"sv }, // setrgbf: Set RGB foreground color
+        String{ Undefined, "setrgbb"sv, "\033[48:2:%p1%d:%p2%d:%p3%dm"sv }, // setrgbb: Set RGB background color
 
         // Inputs (TODO: WIP!)
 	    String{ "*4"_tcap, "kDC"sv, "\033[3;2~"sv },
@@ -345,9 +345,9 @@ namespace
         String{ Undefined, "Smulx"sv, "\033[4:%p1%dm"sv },
 
         // Set underscore color.
-        String{ Undefined, "Setulc"sv, "\033[58:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m"sv },
+        String{ Undefined, "Setulc"sv, "\033[58:2:%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m"sv },
         // NB: the following would work, too.
-        // String{ Undefined, "Setulc"sv, "\033[58:2::%p1%d:%p2%d:%p3%dm"sv },
+        // String{ Undefined, "Setulc"sv, "\033[58:2:%p1%d:%p2%d:%p3%dm"sv },
         // }}}
 
         // RGB for the ncurses direct-color extension.

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -233,13 +233,15 @@ namespace impl // {{{ some command generator helpers
         {
             switch (_seq.subparam(i, 0))
             {
-                case 2: // ":2::R:G:B"
-                    if (_seq.subParameterCount(i) == 5)
+                case 2: // ":2::R:G:B" and ":2:R:G:B"
+                {
+                    auto const len = _seq.subParameterCount(i);
+                    if (len == 4 || len == 5)
                     {
-                        // NB: subparam(i, 1) ignored
-                        auto const r = _seq.subparam(i, 2);
-                        auto const g = _seq.subparam(i, 3);
-                        auto const b = _seq.subparam(i, 4);
+                        // NB: subparam(i, 1) may be ignored
+                        auto const r = _seq.subparam(i, len - 3);
+                        auto const g = _seq.subparam(i, len - 2);
+                        auto const b = _seq.subparam(i, len - 1);
                         if (r <= 255 && g <= 255 && b <= 255)
                         {
                             *pi = i + 1;
@@ -247,6 +249,7 @@ namespace impl // {{{ some command generator helpers
                         }
                     }
                     break;
+                }
                 case 3: // ":3:F:C:M:Y" (TODO)
                 case 4: // ":4:F:C:M:Y:K" (TODO)
                     break;

--- a/src/terminal_renderer/CMakeLists.txt
+++ b/src/terminal_renderer/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(terminal_renderer STATIC
     DecorationRenderer.cpp DecorationRenderer.h
     GridMetrics.h
     ImageRenderer.cpp ImageRenderer.h
+    Pixmap.cpp Pixmap.h
     Renderer.cpp Renderer.h
     TextRenderer.cpp TextRenderer.h
     utils.cpp utils.h

--- a/src/terminal_renderer/DecorationRenderer.cpp
+++ b/src/terminal_renderer/DecorationRenderer.cpp
@@ -116,8 +116,8 @@ void DecorationRenderer::rebuild()
     } // }}}
     { // {{{ double underline
         auto const thickness_half = max(1, int(ceil(underlineThickness() / 3.0)));
-        auto const thickness = max(1, thickness_half * 2);
-        auto const y1 = max(0, underlinePosition() - thickness_half);
+        auto const thickness = max(1, int(ceil(double(underlineThickness()) * 2.0) / 3.0));
+        auto const y1 = max(0, underlinePosition() + thickness);
         auto const y0 = max(0, y1 - 2 * thickness);
         auto const height = Height(y1 + thickness);
         auto image = atlas::Buffer(*width * *height, 0);

--- a/src/terminal_renderer/Pixmap.cpp
+++ b/src/terminal_renderer/Pixmap.cpp
@@ -1,0 +1,159 @@
+/**
+ * This file is part of the "contour" project.
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <terminal_renderer/Pixmap.h>
+#include <terminal_renderer/utils.h>
+
+using std::clamp;
+using std::min;
+using std::max;
+using std::move;
+using std::swap;
+
+namespace terminal::renderer
+{
+
+namespace
+{
+    struct From { int value; };
+    struct To { int value; };
+    struct BaseOffset { int value; };
+    enum class Orientation { Horizontal, Vertical };
+
+    Pixmap& segment_line(Pixmap& pixmap, Orientation orientation, BaseOffset base, From from, To to)
+    {
+        // If the font size is very very small, line length calculation might cause negative values.
+        // Be sensible here then to not cause an infinite loop.
+        to.value = max(from.value, to.value);
+
+        switch (orientation)
+        {
+            case Orientation::Horizontal:
+                for (auto const y: ranges::views::iota(base.value - 1, base.value + 1))
+                    for (auto const x: ranges::views::iota(from.value, to.value))
+                        pixmap.paint(x, y);
+                break;
+            case Orientation::Vertical:
+                for (auto const y: ranges::views::iota(from.value, to.value))
+                    for (auto const x: ranges::views::iota(base.value - 1, base.value + 1))
+                        pixmap.paint(x, y);
+                break;
+        }
+        return pixmap;
+    }
+}
+
+atlas::Buffer Pixmap::take()
+{
+    if (_size != _downsampledSize)
+        return downsample(_buffer, 1, _size, _downsampledSize);
+    else
+        return move(_buffer);
+}
+
+Pixmap& Pixmap::line(Ratio _from, Ratio _to)
+{
+    if (_from.y > _to.y)
+        swap(_from, _to);
+    auto const from = _size * _from;
+    auto const to = _size * _to;
+    auto const z = max(1, _lineThickness / 2);
+    if (from.x != to.x)
+    {
+        auto const f = linearEq(from, to);
+        for (auto const x: ranges::views::iota(0, unbox<int>(_size.width)))
+            if (auto const y = f(x); from.y <= y && y <= to.y)
+                for (auto const i: ranges::views::iota(-z, z))
+                    paint(x, y + i);
+    }
+    else
+    {
+        for (auto const y: ranges::views::iota(from.y, to.y))
+            for (auto const i: ranges::views::iota(-z, z))
+                paint(from.x, y + i);
+    }
+    return *this;
+}
+
+Pixmap& Pixmap::halfFilledCircleLeft()
+{
+    auto const w = unbox<int>(_size.width);
+    auto const h = unbox<int>(_size.height);
+    auto const putpixel = [&](int x, int y)
+    {
+        auto const xf = clamp(x, 0, w - 1);
+        auto const yf = clamp(y, 0, h - 1);
+        for (int xi = xf; xi < w; ++xi)
+            paint(xi, yf, 0xFF);
+    };
+    auto const putAbove = [&](int x, int y) { putpixel(x, y - h/2); };
+    auto const putBelow = [&](int x, int y) { putpixel(x, y + h/2); };
+    auto const radius   = crispy::Point{ w, h / 2 };
+    drawEllipseArc(putAbove, _size, radius, Arc::BottomLeft);
+    drawEllipseArc(putBelow, _size, radius, Arc::TopLeft);
+    return *this;
+}
+
+Pixmap& Pixmap::halfFilledCircleRight()
+{
+    auto const w = unbox<int>(_size.width);
+    auto const h = unbox<int>(_size.height);
+    auto const putpixel = [&](int x, int y)
+    {
+        auto const fx = min(w - 1, x);
+        for (int x = 0; x < fx; ++x)
+            paint(x, y, 0xFF);
+    };
+    auto const putAbove = [&](int x, int y) { putpixel(x, y - h/2); };
+    auto const putBelow = [&](int x, int y) { putpixel(x, y + h/2); };
+    auto const radius   = crispy::Point{ w, h / 2 };
+    drawEllipseArc(putAbove, _size, radius, Arc::BottomRight);
+    drawEllipseArc(putBelow, _size, radius, Arc::TopRight);
+    return *this;
+}
+
+Pixmap& Pixmap::segment_bar(int which)
+{
+    assert(1 <= which && which <= 7);
+
+    //   --1--
+    //  4     2
+    //   --3--
+    //  7     5
+    //   --6--
+
+    auto const Z = _lineThickness;
+
+    auto const L = 2 * Z;
+    auto const R = unbox<int>(_size.width) - Z;
+
+    auto const T = static_cast<int>(ceil(unbox<double>(_size.height) * 1/8_th)); // Z;
+    auto const B = unbox<int>(_size.height) - _baseLine - Z / 2;
+    auto const M = T + (B - T) / 2;
+
+    switch (which)
+    {
+        case 1: return segment_line(*this, Orientation::Horizontal, BaseOffset{T}, From{L},   To{R});
+        case 2: return segment_line(*this, Orientation::Vertical,   BaseOffset{R}, From{T+Z}, To{M-Z});
+        case 3: return segment_line(*this, Orientation::Horizontal, BaseOffset{M}, From{L},   To{R});
+        case 4: return segment_line(*this, Orientation::Vertical,   BaseOffset{L}, From{T+Z}, To{M-Z});
+        case 5: return segment_line(*this, Orientation::Vertical,   BaseOffset{R}, From{M+Z}, To{B-Z});
+        case 6: return segment_line(*this, Orientation::Horizontal, BaseOffset{B}, From{L},   To{R});
+        case 7: return segment_line(*this, Orientation::Vertical,   BaseOffset{L}, From{M+Z}, To{B-Z});
+    }
+
+    assert(false);
+    return *this;
+}
+
+} // end namespace terminal::renderer

--- a/src/terminal_renderer/Pixmap.h
+++ b/src/terminal_renderer/Pixmap.h
@@ -1,0 +1,281 @@
+/**
+ * This file is part of the "contour" project.
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <terminal_renderer/Atlas.h>
+#include <terminal/primitives.h>
+
+#include <range/v3/view/iota.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <functional>
+
+namespace terminal::renderer
+{
+
+// Helper to write ratios like 1/8_th
+struct Ratio1 { double value; };
+constexpr Ratio1 operator "" _th(unsigned long long ratio) { return Ratio1{static_cast<double>(ratio)}; }
+constexpr double operator/(int a, Ratio1 b) noexcept { return static_cast<double>(a) / b.value; }
+
+// ratio between 0.0 and 1.0 for x (horizontal) and y (vertical).
+struct Ratio { double x; double y; };
+
+struct RatioBlock { Ratio from{}; Ratio to{}; };
+constexpr RatioBlock lower(double r) noexcept { return RatioBlock{{0, 1 - r}, {1, 1}}; }
+constexpr RatioBlock upper(double r) noexcept { return RatioBlock{{0, 0}, {1, r}}; }
+constexpr RatioBlock left(double r)  noexcept { return RatioBlock{{0, 0}, {r, 1}}; }
+constexpr RatioBlock right(double r) noexcept { return RatioBlock{{1.f - r, 0.f}, {1.f, 1.f}}; }
+
+constexpr crispy::Point operator*(ImageSize a, Ratio b) noexcept
+{
+    return crispy::Point{
+        static_cast<int>(a.width.as<double>() * b.x),
+        static_cast<int>(a.height.as<double>() * b.y)
+    };
+}
+
+constexpr auto linearEq(crispy::Point p1, crispy::Point p2) noexcept
+{
+    // Expects(p2.x != p1.x);
+    auto const m = double(p2.y - p1.y) / double(p2.x - p1.x);
+    auto const n = double(p1.y) - m * double(p1.x);
+    return [m, n](int x) -> int { return int(double(m) * double(x) + n); };
+}
+
+enum class Dir { Top, Right, Bottom, Left };
+enum class Inverted { No, Yes };
+
+enum Arc
+{
+    NoArc, TopLeft, TopRight, BottomRight, BottomLeft
+};
+
+template <typename F>
+auto makeDraw4WaySymmetric(Arc arc, ImageSize size, F putpixel)
+{
+    return [=](int x, int y)
+    {
+        auto const w = unbox<int>(size.width);
+        auto const h = unbox<int>(size.height);
+        switch (arc)
+        {
+            case Arc::TopLeft:     putpixel(w - x,     y); break;
+            case Arc::TopRight:    putpixel(    x,     y); break;
+            case Arc::BottomLeft:  putpixel(w - x, h - y); break;
+            case Arc::BottomRight: putpixel(    x, h - y); break;
+            case Arc::NoArc:       break;
+        }
+    };
+}
+
+template <typename F>
+constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::Point radius)
+{
+    auto const rx = radius.x;
+    auto const ry = radius.y;
+
+    double dx{}, dy{}, d1{}, d2{};
+    double x {0};
+    double y {static_cast<double>(ry)};
+
+    // Initial decision parameter of region 1
+    d1 = (ry * ry) - (rx * rx * ry) +
+                     (0.25 * rx * rx);
+    dx = 2 * ry * ry * x;
+    dy = 2 * rx * rx * y;
+
+    while (dx < dy)
+    {
+        doDraw4WaySymmetric(x, y);
+
+        // Checking and updating value of decision parameter based on algorithm
+        if (d1 < 0)
+        {
+            x++;
+            dx = dx + (2 * ry * ry);
+            d1 = d1 + dx + (ry * ry);
+        }
+        else
+        {
+            x++;
+            y--;
+            dx = dx + (2 * ry * ry);
+            dy = dy - (2 * rx * rx);
+            d1 = d1 + dx - dy + (ry * ry);
+        }
+    }
+
+    // Decision parameter of region 2
+    d2 = ((ry * ry) * ((x + 0.5) * (x + 0.5))) +
+         ((rx * rx) * ((y - 1) * (y - 1))) -
+          (rx * rx * ry * ry);
+
+    while (y >= 0)
+    {
+        doDraw4WaySymmetric(x, y);
+
+        // Checking and updating parameter value based on algorithm
+        if (d2 > 0)
+        {
+            y--;
+            dy = dy - (2 * rx * rx);
+            d2 = d2 + (rx * rx) - dy;
+        }
+        else
+        {
+            y--;
+            x++;
+            dx = dx + (2 * ry * ry);
+            dy = dy - (2 * rx * rx);
+            d2 = d2 + dx - dy + (rx * rx);
+        }
+    }
+}
+
+template <typename PutPixel>
+constexpr void drawEllipseArc(PutPixel putpixel,
+                              ImageSize imageSize,
+                              crispy::Point radius,
+                              Arc arc)
+{
+    drawEllipse(makeDraw4WaySymmetric(arc, imageSize, std::move(putpixel)), radius);
+}
+
+/// Alpha-channel 2D image.
+struct Pixmap
+{
+    atlas::Buffer _buffer{};
+    ImageSize _size{};
+    ImageSize _downsampledSize{};
+    std::function<int(int, int)> _filler = [](int, int) { return 0xFF; };
+    int _lineThickness = 1;
+    int _baseLine = 0;  // baseline position relative to cell bottom.
+
+    constexpr ImageSize downsampledSize() const noexcept { return _downsampledSize; }
+
+    Pixmap& halfFilledCircleLeft();
+    Pixmap& halfFilledCircleRight();
+    Pixmap& lineThickness(int n) noexcept { _lineThickness = n; return *this; }
+    Pixmap& baseline(int n) noexcept { _baseLine = n; return *this; }
+    Pixmap& line(Ratio _from, Ratio _to);
+
+    Pixmap& segment_bar(int which);
+    template <typename... More> Pixmap& segment_bar(int which, More... more);
+
+    Pixmap& fill() { return fill(_filler); }
+    template <typename F> Pixmap& fill(F const& filler);
+
+    void paint(int x, int y, uint8_t value = 0xFF);
+    void paintOver(int x, int y, uint8_t intensity);
+
+    atlas::Buffer take();
+
+    operator atlas::Buffer () { return take(); }
+};
+
+template <std::size_t SupersamplingFactor = 1>
+inline Pixmap blockElement(ImageSize size)
+{
+    auto const superSize = size * SupersamplingFactor;
+    return Pixmap{
+        atlas::Buffer(superSize.width.as<size_t>() * superSize.height.as<size_t>(), 0x00),
+        superSize,
+        size
+    };
+}
+
+template <size_t N, typename F>
+Pixmap blockElement(ImageSize size, F f)
+{
+    auto p = blockElement<N>(size);
+    p._filler = f;
+    return p;
+}
+
+// {{{ Pixmap inlines
+inline void Pixmap::paint(int x, int y, uint8_t _value)
+{
+    auto const w = unbox<int>(_size.width);
+    auto const h = unbox<int>(_size.height) - 1;
+    if (!(0 <= y && y <= h))
+        return;
+    if (!(0 <= x && x < w))
+        return;
+    _buffer.at((h - y) * w + x) = _value;
+}
+
+inline void Pixmap::paintOver(int x, int y, uint8_t intensity)
+{
+    auto const w = unbox<int>(_size.width);
+    auto const h = unbox<int>(_size.height) - 1;
+    if (!(0 <= y && y <= h))
+        return;
+    if (!(0 <= x && x < w))
+        return;
+    auto& target = _buffer.at((h - y) * w + x);
+    target = static_cast<uint8_t>(std::min(
+        static_cast<int>(target) + static_cast<int>(intensity),
+        255
+    ));
+}
+
+template <typename F>
+Pixmap& Pixmap::fill(F const& filler)
+{
+    auto const h = unbox<int>(_size.height) - 1;
+    for (auto const y: ranges::views::iota(0, unbox<int>(_size.height)))
+        for (auto const x: ranges::views::iota(0, unbox<int>(_size.width)))
+            _buffer[(h - y) * *_size.width + x] = filler(x, y);
+    return *this;
+}
+
+template <typename... More>
+Pixmap& Pixmap::segment_bar(int which, More... more)
+{
+    segment_bar(which);
+    return segment_bar(more...);
+}
+// }}}
+
+} // end namespace terminal::renderer
+
+namespace fmt // {{{
+{
+    template <>
+    struct formatter<terminal::renderer::Arc> {
+        template <typename ParseContext>
+        constexpr auto parse(ParseContext& ctx)
+        {
+            return ctx.begin();
+        }
+        template <typename FormatContext>
+        auto format(terminal::renderer::Arc value, FormatContext& ctx)
+        {
+            using terminal::renderer::Arc;
+            switch (value)
+            {
+                case Arc::NoArc: return format_to(ctx.out(), "NoArc");
+                case Arc::TopLeft: return format_to(ctx.out(), "TopLeft");
+                case Arc::TopRight: return format_to(ctx.out(), "TopRight");
+                case Arc::BottomLeft: return format_to(ctx.out(), "BottomLeft");
+                case Arc::BottomRight: return format_to(ctx.out(), "BottomRight");
+            }
+            return format_to(ctx.out(), "?");
+        }
+    };
+} // }}}
+


### PR DESCRIPTION
commute-hacking :dagger: 

- Fixes parsing VT sequence RGB color parsing for cell decoratioins (e.g. underline).
- Fixes double-underline to not look like a very thick line on small font sizes.
- curly underline antialiasing