### PR TITLE
feat(ci): add RPM packaging

### DIFF
--- a/.github/fedora/Dockerfile
+++ b/.github/fedora/Dockerfile
@@ -1,16 +1,15 @@
-FROM fedora:35
+FROM fedora:latest
 
 WORKDIR /app
 
-# Update packages and install RPM development tools
-RUN dnf upgrade -y
+# Install Git and RPM development tools
 RUN dnf install -y \
-        gcc rpm-build rpm-devel make coreutils diffutils patch rpmdevtools
+        git gcc rpm-build rpm-devel make coreutils diffutils patch rpmdevtools desktop-file-utils
 
 # Install contour dependencies
 RUN dnf install -y \
         cmake extra-cmake-modules ninja-build gcc-c++ pkgconf freetype-devel harfbuzz-devel \
-        qt5-qtbase-devel qt5-qtbase-gui kf5-kwindowsystem-devel
+        qt5-qtbase-devel qt5-qtbase-gui kf5-kwindowsystem-devel fontconfig-devel
 
 RUN useradd -d /app builder
 RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
@@ -22,12 +21,12 @@ RUN sudo chown builder:builder .
 RUN mkdir -p /app/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 # Clone contour, copy tarball and spec file to rpmbuild directories
-RUN git clone https://github.com/contour.git . \
+RUN git clone https://github.com/NTBBloodbath/contour.git \
     && cd contour \
     && export version="$(cat .github/fedora/contour.spec | awk -F: '$1=="Version" { print $2 }' | tr -d ' ')" \
-    && git archive --output=/app/rpmbuild/SOURCES/contour-${version}.tar.gz --prefix=contour-${version}/ HEAD \
-    && cp .github/fedora/contour.spec /app/rpmbuild/SPECS/contour.spec
+    && cp .github/fedora/contour.spec /app/rpmbuild/SPECS/contour.spec \
+    && git archive --output=/app/rpmbuild/SOURCES/contour-${version}.tar.gz --prefix=contour-${version}/ HEAD
 
 # Build contour
 RUN cd /app/rpmbuild \
-    && rpmbuild --define "_topdir $(pwd)" -v -bb SPECS/contour.spec
+    && rpmbuild --define "_topdir $(pwd)" -v -ba SPECS/contour.spec

--- a/.github/fedora/Dockerfile
+++ b/.github/fedora/Dockerfile
@@ -1,0 +1,33 @@
+FROM fedora:35
+
+WORKDIR /app
+
+# Update packages and install RPM development tools
+RUN dnf upgrade -y
+RUN dnf install -y \
+        gcc rpm-build rpm-devel make coreutils diffutils patch rpmdevtools
+
+# Install contour dependencies
+RUN dnf install -y \
+        cmake extra-cmake-modules ninja-build gcc-c++ pkgconf freetype-devel harfbuzz-devel \
+        qt5-qtbase-devel qt5-qtbase-gui kf5-kwindowsystem-devel
+
+RUN useradd -d /app builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER builder
+
+RUN sudo chown builder:builder .
+
+# Setup RPM build directories
+RUN mkdir -p /app/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# Clone contour, copy tarball and spec file to rpmbuild directories
+RUN git clone https://github.com/contour.git . \
+    && cd contour \
+    && export version="$(cat .github/fedora/contour.spec | awk -F: '$1=="Version" { print $2 }' | tr -d ' ')" \
+    && git archive --output=/app/rpmbuild/SOURCES/contour-${version}.tar.gz --prefix=contour-${version}/ HEAD \
+    && cp .github/fedora/contour.spec /app/rpmbuild/SPECS/contour.spec
+
+# Build contour
+RUN cd /app/rpmbuild \
+    && rpmbuild --define "_topdir $(pwd)" -v -bb SPECS/contour.spec

--- a/.github/fedora/Dockerfile
+++ b/.github/fedora/Dockerfile
@@ -1,4 +1,7 @@
-FROM fedora:latest
+FROM fedora:latest AS base
+
+ARG VERSION_STRING
+ARG CONTOUR_VERSION=$VERSION_STRING
 
 WORKDIR /app
 
@@ -23,9 +26,8 @@ RUN mkdir -p /app/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 # Clone contour, copy tarball and spec file to rpmbuild directories
 RUN git clone https://github.com/NTBBloodbath/contour.git \
     && cd contour \
-    && export version="$(cat .github/fedora/contour.spec | awk -F: '$1=="Version" { print $2 }' | tr -d ' ')" \
     && cp .github/fedora/contour.spec /app/rpmbuild/SPECS/contour.spec \
-    && git archive --output=/app/rpmbuild/SOURCES/contour-${version}.tar.gz --prefix=contour-${version}/ HEAD
+    && git archive --output=/app/rpmbuild/SOURCES/contour-${CONTOUR_VERSION}.tar.gz --prefix=contour-${CONTOUR_VERSION}/ HEAD
 
 # Build contour
 RUN cd /app/rpmbuild \

--- a/.github/fedora/contour.spec
+++ b/.github/fedora/contour.spec
@@ -1,0 +1,75 @@
+# This enables cmake to work consistently between pre-f33 and after.
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/#_notes
+%undefine __cmake_in_source_build
+
+Name:           contour
+Version:        0.3.0
+Release:        1%{?dist}
+Summary:        Modern C++ Terminal Emulator
+
+License:        ASL 2.0
+URL:            https://github.com/contour-terminal/%{name}
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  extra-cmake-modules
+BuildRequires:  ninja-build
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconf
+BuildRequires:  freetype-devel
+BuildRequires:  harfbuzz-devel
+BuildRequires:  qt5-qtbase-devel
+BuildRequires:  qt5-qtbase-gui
+BuildRequires:  kf5-kwindowsystem-devel
+
+%description
+contour is a modern terminal emulator, for everyday use.
+It is aiming for power users with a modern feature mindset.
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+
+%build
+BUILD_TYPE=Release ./autogen.sh
+%ninja_build
+
+
+%install
+%ninja_install
+# Create needed directories
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_datadir}/applications
+mkdir -p %{buildroot}%{_datadir}/terminfo
+mkdir -p %{buildroot}%{_datadir}/pixmaps
+mkdir -p %{buildroot}%{_datadir}/contour
+# Move /usr/local files to /usr to follow build standards
+mv %{buildroot}/usr/local/bin/%{name} %{buildroot}%{_bindir}/%{name}
+for _dir in $(ls "%{buildroot}/usr/local/share"); do
+    # Moved directories:
+    # - applications
+    # - terminfo
+    # - pixmaps
+    # - contour
+    mv "%{buildroot}/usr/local/share/$_dir" "%{buildroot}%{_datadir}"
+done
+# Remove non-needed /usr/local directory
+rm -rf %{buildroot}/usr/local
+# verify desktop file
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+
+%check
+
+
+%files
+%license LICENSE.txt
+%doc README.md Changelog.md CONTRIBUTING.md TODO.md
+%{_bindir}/*
+%{_datadir}/*
+
+
+%changelog
+* Sun Dec 05 2021 NTBBloodbath <bloodbathalchemist@protonmail.com> 0.3.0-1
+- Initial RPM package

--- a/.github/fedora/contour.spec
+++ b/.github/fedora/contour.spec
@@ -2,7 +2,7 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/#_notes
 %undefine __cmake_in_source_build
 
-# Shut up rpmbuild complaining about this file hen finishing the build
+# Shut up rpmbuild complaining about this file when finishing the build
 # error: Empty %files file /app/rpmbuild/BUILD/contour-0.3.0/debugsourcefiles.list
 %global debug_package %{nil}
 

--- a/.github/fedora/contour.spec
+++ b/.github/fedora/contour.spec
@@ -6,8 +6,11 @@
 # error: Empty %files file /app/rpmbuild/BUILD/contour-0.3.0/debugsourcefiles.list
 %global debug_package %{nil}
 
+# Get contour version
+%{!?_version: %define _version %{getenv:CONTOUR_VERSION} }
+
 Name:           contour
-Version:        0.3.0
+Version:        %{_version}
 Release:        1%{?dist}
 Summary:        Modern C++ Terminal Emulator
 

--- a/.github/fedora/contour.spec
+++ b/.github/fedora/contour.spec
@@ -2,6 +2,10 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/#_notes
 %undefine __cmake_in_source_build
 
+# Shut up rpmbuild complaining about this file hen finishing the build
+# error: Empty %files file /app/rpmbuild/BUILD/contour-0.3.0/debugsourcefiles.list
+%global debug_package %{nil}
+
 Name:           contour
 Version:        0.3.0
 Release:        1%{?dist}
@@ -16,6 +20,7 @@ BuildRequires:  extra-cmake-modules
 BuildRequires:  ninja-build
 BuildRequires:  gcc-c++
 BuildRequires:  pkgconf
+BuildRequires:  fontconfig-devel
 BuildRequires:  freetype-devel
 BuildRequires:  harfbuzz-devel
 BuildRequires:  qt5-qtbase-devel
@@ -32,11 +37,13 @@ It is aiming for power users with a modern feature mindset.
 
 
 %build
-BUILD_TYPE=Release ./autogen.sh
+./autogen.sh Release
+cd target/Release
 %ninja_build
 
 
 %install
+cd target/Release
 %ninja_install
 # Create needed directories
 mkdir -p %{buildroot}%{_bindir}
@@ -44,20 +51,20 @@ mkdir -p %{buildroot}%{_datadir}/applications
 mkdir -p %{buildroot}%{_datadir}/terminfo
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 mkdir -p %{buildroot}%{_datadir}/contour
-# Move /usr/local files to /usr to follow build standards
-mv %{buildroot}/usr/local/bin/%{name} %{buildroot}%{_bindir}/%{name}
-for _dir in $(ls "%{buildroot}/usr/local/share"); do
+# Move /app/usr/opt files to /usr to follow build standards
+mv %{buildroot}/app/usr/opt/contour/bin/%{name} %{buildroot}%{_bindir}/%{name}
+for _dir in $(ls "%{buildroot}/app/usr/opt/contour/share"); do
     # Moved directories:
     # - applications
     # - terminfo
     # - pixmaps
     # - contour
-    mv "%{buildroot}/usr/local/share/$_dir" "%{buildroot}%{_datadir}"
+    mv "%{buildroot}/app/usr/opt/contour/share/$_dir" "%{buildroot}%{_datadir}"
 done
-# Remove non-needed /usr/local directory
-rm -rf %{buildroot}/usr/local
-# verify desktop file
-desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+# Remove non-needed /usr/opt directory
+rm -rf %{buildroot}/app/usr/opt
+# verify desktop file (not possible in github actions)
+# desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 
 %check
@@ -71,5 +78,5 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 
 %changelog
-* Sun Dec 05 2021 NTBBloodbath <bloodbathalchemist@protonmail.com> 0.3.0-1
+* Sun Dec 07 2021 NTBBloodbath <bloodbathalchemist@protonmail.com> 0.3.0-1
 - Initial RPM package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -495,7 +495,7 @@ jobs:
         --load \
         .
         docker create --name contour-${{ steps.tags.outputs.ARCH }} contour:${{ steps.tags.outputs.ARCH }}
-        docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/*.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
+        docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/contour-${{ steps.set_vars.outputs.VERSION_STRING }}-1.fc35.${{ steps.tags.outputs.ARCH }}.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
         docker container rm contour-${{ steps.tags.outputs.ARCH }}
     - name: "Uploading Fedora RPM package"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,6 +491,7 @@ jobs:
       run: |
         docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
         --tag contour:${{ steps.tags.outputs.ARCH }} \
+        --build-arg VERSION_STRING=${{ steps.set_vars.outputs.VERSION_STRING }} \
         -f .github/fedora/Dockerfile \
         --load \
         .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,3 +454,54 @@ jobs:
         if-no-files-found: error
         retention-days: 7
 
+  fedora:
+    strategy:
+      matrix:
+        arch:
+          [
+            "linux/adm64 x86_64"
+          ]
+    name: "Fedora ${{ matrix.arch }}"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+    - name: Read info
+      id: tags
+      shell: bash
+      run: |
+        arch="${{ matrix.arch }}"
+        echo ::set-output name=PLATFORM::${arch%% *}
+        echo ::set-output name=ARCH::${arch##* }
+    - name: set environment variables
+      id: set_vars
+      run: ./scripts/ci-set-vars.sh
+      env:
+        REPOSITORY: ${{ github.event.repository.name }}
+    - name: Build ${{ matrix.arch }} release
+      shell: bash
+      run: |
+        docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
+        --tag contour:${{ steps.tags.outputs.ARCH }} \
+        -f .github/fedora/Dockerfile \
+        --load \
+        .
+        docker create --name contour-${{ steps.tags.outputs.ARCH }} contour:${{ steps.tags.outputs.ARCH }}
+        docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/*.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
+        docker container rm contour-${{ steps.tags.outputs.ARCH }}
+    - name: "Uploading Fedora RPM package"
+      uses: actions/upload-artifact@v2
+      with:
+        name: "contour_${{ steps.set_vars.outputs.VERSION_STRING }}-fc35_${{ steps.tags.outputs.ARCH }}.rpm"
+        path: "contour-${{ steps.tags.outputs.ARCH }}.rpm"
+        if-no-files-found: error
+        retention-days: 7
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -459,7 +459,7 @@ jobs:
       matrix:
         arch:
           [
-            "linux/adm64 x86_64"
+            "linux/amd64 x86_64"
           ]
     name: "Fedora ${{ matrix.arch }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
           --load \
           .
           docker create --name contour-${{ steps.tags.outputs.ARCH }} contour:${{ steps.tags.outputs.ARCH }}
-          docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/*.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
+          docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/contour-${{ steps.set_vars.outputs.VERSION_STRING }}-1.fc35.${{ steps.tags.outputs.ARCH }}.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
           docker container rm contour-${{ steps.tags.outputs.ARCH }}
           mv "contour-${{ steps.tags.outputs.ARCH }}.rpm" \
               contour_${{ steps.set_vars.outputs.version }}-fedora_${{ steps.tags.outputs.ARCH }}.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,7 @@ jobs:
         run: |
           docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
           --tag contour:${{ steps.tags.outputs.ARCH }} \
+          --build-arg VERSION_STRING=${{ steps.set_vars.outputs.VERSION_STRING }} \
           -f .github/fedora/Dockerfile \
           --load \
           .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,11 +269,62 @@ jobs:
           path: contour_${{ steps.set_vars.outputs.version }}-archlinux_${{ steps.tags.outputs.ARCH }}
           if-no-files-found: error
           retention-days: 7
+  build_fedora:
+    strategy:
+      matrix:
+        arch:
+          [
+              "linux/amd64 x86_64",
+          ]
+    name: "Fedora ${{ matrix.arch }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Read info
+        id: tags
+        shell: bash
+        run: |
+          arch="${{ matrix.arch }}"
+          echo ::set-output name=PLATFORM::${arch%% *}
+          echo ::set-output name=ARCH::${arch##* }
+      - name: set environment variables
+        id: set_vars
+        run: ./scripts/ci-set-vars.sh
+        env:
+          REPOSITORY: ${{ github.event.repository.name }}
+      - name: Build ${{ matrix.arch }} release
+        shell: bash
+        run: |
+          docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
+          --tag contour:${{ steps.tags.outputs.ARCH }} \
+          -f .github/fedora/Dockerfile \
+          --load \
+          .
+          docker create --name contour-${{ steps.tags.outputs.ARCH }} contour:${{ steps.tags.outputs.ARCH }}
+          docker cp contour-${{ steps.tags.outputs.ARCH }}:/app/rpmbuild/RPMS/${{ steps.tags.outputs.ARCH }}/*.rpm contour-${{ steps.tags.outputs.ARCH }}.rpm
+          docker container rm contour-${{ steps.tags.outputs.ARCH }}
+          mv "contour-${{ steps.tags.outputs.ARCH }}.rpm" \
+              contour_${{ steps.set_vars.outputs.version }}-fedora_${{ steps.tags.outputs.ARCH }}.rpm
+      - name: "Uploading Fedora RPM package"
+        uses: actions/upload-artifact@v2
+        with:
+          path: contour_${{ steps.set_vars.outputs.version }}-fedora_${{ steps.tags.outputs.ARCH }}.rpm
+          if-no-files-found: error
+          retention-days: 7
 
   do_release:
     name: Create Github release
     runs-on: ubuntu-latest
-    needs: [build_ubuntu1804, build_ubuntu2004, build_windows, build_osx, build_archlinux]
+    needs: [build_ubuntu1804, build_ubuntu2004, build_windows, build_osx, build_archlinux, build_fedora]
     steps:
       - uses: actions/checkout@v2
       - name: set variables
@@ -373,6 +424,18 @@ jobs:
           asset_path: ./contour_${{ steps.set_vars.outputs.version }}-archlinux_aarch64
           asset_name: contour_${{ steps.set_vars.outputs.version }}-archlinux_aarch64
           asset_content_type: application/x-zstd-compressed-tar
+
+      # -------------------------------------------------------------
+      - name: Upload Fedora package x86_64
+        id: upload-release-asset-archlinux-x86_64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./contour_${{ steps.set_vars.outputs.version }}-fedora_x86_64.rpm
+          asset_name: contour_${{ steps.set_vars.outputs.version }}-fedora_x86_64.rpm
+          asset_content_type: application/x-rpm
 
       # -------------------------------------------------------------
       - name: Upload Windows MSI package


### PR DESCRIPTION
Hey, hope you're doing well! :)

This PR aims to resolve #420 by adding RPM packaging for Fedora (didn't tried in openSUSE which also uses RPM packages but it should work _in theory_). I'm actually using a RPM package produced from my tests and it's working really good btw.

Regarding to structure I tried to keep the same hierarchy as ArchLinux builds, made a directory in `.github/` called `fedora` that contains the following files:
- `Dockerfile` - our Fedora docker container image used to build contour RPM package.
- `contour.spec` - our spec file used to compile contour as a RPM package (contains all the packaging logic).

Also I'm only packaging for `x86_64` arch at the moment, if it's requested then I could also add packaging for `arm64`/`aarch64`.

Please let me know if you want me to change something :)

Cheers