### PR TITLE
(#536) Fix SIGFPE on FreeBSD

### DIFF
--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -399,7 +399,7 @@ namespace // {{{ helper
         FT_Pos maxAdvance = 0;
         for (FT_ULong i = 32; i < 128; i++)
         {
-            if (auto ci = FT_Get_Char_Index(_face, i); ci == FT_Err_Ok)
+            if (auto ci = FT_Get_Char_Index(_face, i); ci != 0)
                 if (FT_Load_Glyph(_face, ci, FT_LOAD_DEFAULT) == FT_Err_Ok)
                     maxAdvance = max(maxAdvance, _face->glyph->metrics.horiAdvance);
         }


### PR DESCRIPTION
FT_Get_Char_Index as per documentation at https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_get_char_index returns 0 in case of an error. It does not return a Freetype2 error code. Thus checking for FT_Err_Ok which is defined to 0 does not really make any sense.

Fixes #536 