### PR TITLE
debian: Adds missing terminfo file to .deb file.

### DIFF
--- a/debian/contour-terminfo.install
+++ b/debian/contour-terminfo.install
@@ -1,1 +1,2 @@
+debian/tmp/usr/share/terminfo/c/contour
 debian/tmp/usr/share/terminfo/c/contour-latest

--- a/debian/contour.install
+++ b/debian/contour.install
@@ -6,3 +6,5 @@ debian/tmp/usr/share/contour/README.md
 debian/tmp/usr/share/contour/shell-integration.zsh
 debian/tmp/usr/share/kservices5/ServiceMenus/contour-run.desktop
 debian/tmp/usr/share/pixmaps/contour.png
+debian/tmp/usr/share/terminfo/c/contour
+debian/tmp/usr/share/terminfo/c/contour-latest


### PR DESCRIPTION
Fixes #531 