### PR TITLE
[CI][Ubuntu] Test `dpkg --install` the `.deb` output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,9 @@ jobs:
         path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
         if-no-files-found: error
         retention-days: 7
+    - name: "Attempt installing the created .deb"
+      run: |
+        sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
 
   test_ubuntu2004_valgrind:
     name: "Run tests via valgrind"
@@ -290,6 +293,9 @@ jobs:
         path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64"
         if-no-files-found: error
         retention-days: 7
+    - name: "Attempt installing the created .deb"
+      run: |
+        sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.deb"
 
   osx_qt5:
     name: "OS/X (Qt5)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,9 @@ jobs:
           path: contour-dbgsym_${{ steps.set_vars.outputs.version }}-ubuntu_18_04_amd64.ddeb
           if-no-files-found: error
           retention-days: 7
+      - name: "Attempt installing the created .deb"
+        run: |
+          sudo dpkg --install "contour_${{ steps.set_vars.outputs.version }}-ubuntu_18_04_amd64.deb"
 
   build_ubuntu2004:
     name: Build on Ubuntu 20.04
@@ -168,6 +171,9 @@ jobs:
         with:
           path: contour-dbgsym_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.ddeb
           retention-days: 7
+      - name: "Attempt installing the created .deb"
+        run: |
+          sudo dpkg --install "contour_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.deb"
 
   build_osx:
     name: Build on OS/X


### PR DESCRIPTION
Currently, the Ubuntu 18.04 `.deb` is broken because the control file
doesn't match what is installable (and for the CI itself, installed)
from the system packages.

This new test job ensures that the build only passes if the package
created by the CI can actually be installed on the system.