### PR TITLE
[contour] Adds config key `renderer` to choose a renderer: default, software, OpenGL.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Adds new configuration option `mouse_block_selection_modifier`.
 - Adds new configuration option `profiles.*.copy_last_mark_range_offset` (default `0`) to adjust where to start looking upwards for the `CopyPreviousMarkRange` action. This is useful for multi-line prompts.
 - Adds new configuration option `platform_plugin`.
+- Adds new configuration option `renderer` for explicitly setting renderer to one of: `OpenGL`, `software`, `default`.
 
 ### 0.2.3 (2021-12-12)
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1473,6 +1473,18 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     if (_config.platformPlugin == "auto")
         _config.platformPlugin = ""; // Mapping "auto" to its internally equivalent "".
 
+    string renderingBackendStr;
+    if (tryLoadValue(usedKeys, doc, "renderer", renderingBackendStr))
+    {
+        renderingBackendStr = toUpper(renderingBackendStr);
+        if (renderingBackendStr == "OPENGL")
+            _config.renderingBackend = RenderingBackend::OpenGL;
+        else if (renderingBackendStr == "SOFTWARE")
+            _config.renderingBackend = RenderingBackend::Software;
+        else if (renderingBackendStr != "" && renderingBackendStr != "DEFAULT")
+            errorlog()("Unknown renderer: {}.", renderingBackendStr);
+    }
+
     tryLoadValue(usedKeys, doc, "read_buffer_size", _config.ptyReadBufferSize);
     if ((_config.ptyReadBufferSize % 16) != 0)
     {

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -169,6 +169,13 @@ struct TerminalProfile
 using opengl::ShaderClass;
 using opengl::ShaderConfig;
 
+enum class RenderingBackend
+{
+    Default,
+    Software,
+    OpenGL,
+};
+
 // NB: All strings in here must be UTF8-encoded.
 struct Config
 {
@@ -177,6 +184,8 @@ struct Config
     /// Qt platform plugin to be loaded.
     /// This is equivalent to QT_QPA_PLATFORM.
     std::string platformPlugin;
+
+    RenderingBackend renderingBackend = RenderingBackend::Default;
 
     // Configures the size of the PTY read buffer.
     // Changing this value may result in better or worse throughput performance.

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -258,6 +258,19 @@ int ContourGuiApp::terminalGuiAction()
     if (!loadConfig())
         return EXIT_FAILURE;
 
+    switch (config_.renderingBackend)
+    {
+    case config::RenderingBackend::OpenGL:
+        QGuiApplication::setAttribute(Qt::AA_UseSoftwareOpenGL, false);
+        break;
+    case config::RenderingBackend::Software:
+        QGuiApplication::setAttribute(Qt::AA_UseSoftwareOpenGL, true);
+        break;
+    case config::RenderingBackend::Default:
+        // Don't do anything.
+        break;
+    }
+
     auto appName = QString::fromStdString(config_.profile(profileName())->wmClass);
     QCoreApplication::setApplicationName(appName);
     QCoreApplication::setOrganizationName("contour");

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -291,7 +291,6 @@ int ContourGuiApp::terminalGuiAction()
     {
         if (!config_.platformPlugin.empty())
         {
-            printf("using config key\n");
             static constexpr auto platformArg = string_view("-platform");
             qtArgsPtr.push_back(platformArg.data());
             qtArgsPtr.push_back(config_.platformPlugin.c_str());

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -12,6 +12,14 @@
 # Default: auto
 platform_plugin: auto
 
+# Backend to use for rendering the terminal onto the screen
+#
+# Possible values are:
+# - default     Uses the default rendering option as decided by the terminal.
+# - software    Uses software-based rendering.
+# - OpenGL      Use (possibly) hardware accelerated OpenGL
+renderer: OpenGL
+
 # Word delimiters when selecting word-wise.
 word_delimiters: " /\\()\"'-.,:;<>~!@#$%^&*+=[]{}~?|│"
 


### PR DESCRIPTION
Not sure how this is possible with Qt, but it would be useful (for customers) to determine if the underlying hardware OpenGL implementation is prior 3.0 and then just default-select software rendering.

Note, the current "software" renderer is making use of the system provided OpenGL software renderer.

Why is `Apple Software Renderer` causing a SEGV? ;-(