### PR TITLE
fixing render cache bloat - prep-work

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -945,21 +945,21 @@ void softLoadFont(UsedKeys& _usedKeys,
             _store.familyName = _node["family"].as<string>();
         }
 
-        if (_node["slant"].IsScalar())
+        if (_node["slant"] && _node["slant"].IsScalar())
         {
             _usedKeys.emplace(fmt::format("{}.{}", _basePath, "slant"));
             if (auto const p = text::make_font_slant(_node["slant"].as<string>()))
                 _store.slant = p.value();
         }
 
-        if (_node["weight"].IsScalar())
+        if (_node["weight"] && _node["weight"].IsScalar())
         {
             _usedKeys.emplace(fmt::format("{}.{}", _basePath, "weight"));
             if (auto const p = text::make_font_weight(_node["weight"].as<string>()))
                 _store.weight = p.value();
         }
 
-        if (_node["features"] && _node["features"].IsSequence())
+        if (_node["features"] && _node["features"] && _node["features"].IsSequence())
         {
             _usedKeys.emplace(fmt::format("{}.{}", _basePath, "features"));
             YAML::Node featuresNode = _node["features"];
@@ -1409,6 +1409,7 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
  */
 void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
 {
+    LOGSTORE(ConfigLog)("Loading configuration from file: {}", _fileName.string());
     _config.backingFilePath = _fileName;
     createFileIfNotExists(_config.backingFilePath);
     auto usedKeys = UsedKeys {};

--- a/src/contour/opengl/OpenGLRenderer.cpp
+++ b/src/contour/opengl/OpenGLRenderer.cpp
@@ -61,7 +61,7 @@ namespace atlas = terminal::renderer::atlas;
         } while (0)
 #endif
 
-namespace // {{{ helper
+namespace
 {
     int glFormat(atlas::Format _format)
     {

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -692,8 +692,9 @@ void TerminalWidget::doDumpState()
         std::cout << screenStateDump;
 
         auto const screenStateDumpFilePath = targetDir / "screen-state-dump.vt";
-        auto fs = ofstream { screenStateDumpFilePath.string(), ios::trunc | ios::binary };
+        auto fs = ofstream { screenStateDumpFilePath.string(), ios::trunc };
         fs << screenStateDump;
+        fs.close();
     }
 
     enum class ImageBufferFormat

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CRISPY_TESTING)
         CLI_test.cpp
         LRUCache_test.cpp
         StrongLRUCache_test.cpp
+        StrongLRUHashtable_test.cpp
         base64_test.cpp
         indexed_test.cpp
         compose_test.cpp

--- a/src/crispy/StrongHash.h
+++ b/src/crispy/StrongHash.h
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the "contour" project.
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <crispy/assert.h>
+
+#include <immintrin.h>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace crispy
+{
+
+struct StrongHash
+{
+    __m128i value;
+};
+
+inline int to_integer(StrongHash hash) noexcept
+{
+    return _mm_cvtsi128_si32(hash.value);
+}
+
+inline bool operator==(StrongHash a, StrongHash b) noexcept
+{
+    return _mm_movemask_epi8(_mm_cmpeq_epi32(a.value, b.value)) == 0xFFFF;
+}
+
+inline bool operator!=(StrongHash a, StrongHash b) noexcept
+{
+    return !(a == b);
+}
+
+template <typename T>
+struct StrongHasher
+{
+    StrongHash operator()(T const&) noexcept; // Specialize and implement me.
+};
+
+// {{{ some standard hash implementations
+namespace detail
+{
+    template <typename T>
+    struct StdHash32
+    {
+        inline StrongHash operator()(T v) noexcept { return StrongHash { _mm_set_epi32(0, 0, 0, v) }; }
+    };
+} // namespace detail
+
+// clang-format off
+template <> struct StrongHasher<char>: public detail::StdHash32<char> { };
+template <> struct StrongHasher<unsigned char>: public detail::StdHash32<char> { };
+template <> struct StrongHasher<short>: public detail::StdHash32<short> { };
+template <> struct StrongHasher<unsigned short>: public detail::StdHash32<unsigned short> { };
+template <> struct StrongHasher<int>: public detail::StdHash32<int> { };
+template <> struct StrongHasher<unsigned int>: public detail::StdHash32<int> { };
+// clang-format on
+// }}}
+
+template <class Char, class Allocator>
+struct StrongHasher<std::basic_string<Char, Allocator>>
+{
+    inline StrongHash operator()(std::basic_string<Char, Allocator> const& v) noexcept
+    {
+        return StrongHasher<int> {}((int) std::hash<std::basic_string<Char, Allocator>> {}(v));
+    }
+};
+
+template <typename U>
+struct StrongHasher<std::basic_string_view<U>>
+{
+    inline StrongHash operator()(std::basic_string_view<U> v) noexcept
+    {
+        return StrongHasher<int> {}((int) std::hash<std::basic_string_view<U>> {}(v));
+    }
+};
+
+} // namespace crispy

--- a/src/crispy/StrongLRUCache_test.cpp
+++ b/src/crispy/StrongLRUCache_test.cpp
@@ -25,9 +25,7 @@ using namespace std::string_view_literals;
 
 TEST_CASE("StrongLRUCache.operator_index", "")
 {
-    auto cachePtr =
-        StrongLRUCache<int, string_view>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string_view>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
 
     cache[1] = "1"sv;
     REQUIRE(cache[1] == "1"sv);
@@ -56,8 +54,7 @@ TEST_CASE("StrongLRUCache.operator_index", "")
 
 TEST_CASE("StrongLRUCache.at", "")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -68,8 +65,7 @@ TEST_CASE("StrongLRUCache.at", "")
 
 TEST_CASE("StrongLRUCache.clear", "[lrucache]")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -81,8 +77,7 @@ TEST_CASE("StrongLRUCache.clear", "[lrucache]")
 
 TEST_CASE("StrongLRUCache.touch", "")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -106,8 +101,7 @@ TEST_CASE("StrongLRUCache.touch", "")
 
 TEST_CASE("StrongLRUCache.contains", "")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -131,21 +125,20 @@ TEST_CASE("StrongLRUCache.contains", "")
 
 TEST_CASE("StrongLRUCache.try_emplace", "")
 {
-    auto cachePtr = StrongLRUCache<int, int>::create(StrongHashCapacity { 4 }, StrongCacheCapacity { 2 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, int>(StrongHashtableSize { 4 }, LRUCapacity { 2 });
 
-    auto rv = cache.try_emplace(2, []() { return 4; });
+    auto rv = cache.try_emplace(2, [](auto) { return 4; });
     CHECK(rv);
     CHECK(joinHumanReadable(cache.keys()) == "2");
     CHECK(cache.at(2) == 4);
 
-    rv = cache.try_emplace(3, []() { return 6; });
+    rv = cache.try_emplace(3, [](auto) { return 6; });
     CHECK(rv);
     CHECK(joinHumanReadable(cache.keys()) == "3, 2");
     CHECK(cache.at(2) == 4);
     CHECK(cache.at(3) == 6);
 
-    rv = cache.try_emplace(2, []() { return -1; });
+    rv = cache.try_emplace(2, [](auto) { return -1; });
     CHECK_FALSE(rv);
     CHECK(joinHumanReadable(cache.keys()) == "2, 3");
     CHECK(cache.at(2) == 4);
@@ -154,8 +147,7 @@ TEST_CASE("StrongLRUCache.try_emplace", "")
 
 TEST_CASE("StrongLRUCache.try_get", "")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -185,27 +177,26 @@ TEST_CASE("StrongLRUCache.try_get", "")
 
 TEST_CASE("StrongLRUCache.get_or_emplace", "[lrucache]")
 {
-    auto cachePtr = StrongLRUCache<int, int>::create(StrongHashCapacity { 4 }, StrongCacheCapacity { 2 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, int>(StrongHashtableSize { 4 }, LRUCapacity { 2 });
 
-    int& a = cache.get_or_emplace(2, []() { return 4; });
+    int& a = cache.get_or_emplace(2, [](auto) { return 4; });
     CHECK(a == 4);
     CHECK(cache.at(2) == 4);
     CHECK(cache.size() == 1);
     CHECK(joinHumanReadable(cache.keys()) == "2"sv);
 
-    int& a2 = cache.get_or_emplace(2, []() { return -4; });
+    int& a2 = cache.get_or_emplace(2, [](auto) { return -4; });
     CHECK(a2 == 4);
     CHECK(cache.at(2) == 4);
     CHECK(cache.size() == 1);
 
-    int& b = cache.get_or_emplace(3, []() { return 6; });
+    int& b = cache.get_or_emplace(3, [](auto) { return 6; });
     CHECK(b == 6);
     CHECK(cache.at(3) == 6);
     CHECK(cache.size() == 2);
     CHECK(joinHumanReadable(cache.keys()) == "3, 2"sv);
 
-    int& c = cache.get_or_emplace(4, []() { return 8; });
+    int& c = cache.get_or_emplace(4, [](auto) { return 8; });
     CHECK(joinHumanReadable(cache.keys()) == "4, 3"sv);
     CHECK(c == 8);
     CHECK(cache.at(4) == 8);
@@ -213,7 +204,7 @@ TEST_CASE("StrongLRUCache.get_or_emplace", "[lrucache]")
     CHECK(cache.contains(3));
     CHECK_FALSE(cache.contains(2)); // thrown out
 
-    int& b2 = cache.get_or_emplace(3, []() { return -3; });
+    int& b2 = cache.get_or_emplace(3, [](auto) { return -3; });
     CHECK(joinHumanReadable(cache.keys()) == "3, 4"sv);
     CHECK(b2 == 6);
     CHECK(cache.at(3) == 6);
@@ -222,8 +213,7 @@ TEST_CASE("StrongLRUCache.get_or_emplace", "[lrucache]")
 
 TEST_CASE("StrongLRUCache.erase", "")
 {
-    auto cachePtr = StrongLRUCache<int, string>::create(StrongHashCapacity { 8 }, StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -260,9 +250,7 @@ struct CollidingHasher
 
 TEST_CASE("StrongLRUCache.insert_with_cache_collision", "")
 {
-    auto cachePtr = StrongLRUCache<int, int, CollidingHasher>::create(StrongHashCapacity { 8 },
-                                                                      StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, int, CollidingHasher>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
 
     cache[1] = 1;
     REQUIRE(joinHumanReadable(cache.keys()) == "1");
@@ -279,9 +267,7 @@ TEST_CASE("StrongLRUCache.insert_with_cache_collision", "")
 
 TEST_CASE("StrongLRUCache.erase_with_hashTable_lookup_collision", "")
 {
-    auto cachePtr = StrongLRUCache<int, int, CollidingHasher>::create(StrongHashCapacity { 8 },
-                                                                      StrongCacheCapacity { 4 });
-    auto& cache = *cachePtr;
+    auto cache = StrongLRUCache<int, int, CollidingHasher>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = 2 * i;
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -1,0 +1,734 @@
+/**
+ * This file is part of the "contour" project.
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <crispy/StrongHash.h>
+#include <crispy/assert.h>
+
+#include <immintrin.h>
+#include <optional>
+#include <ostream>
+#include <stdexcept>
+#include <vector>
+
+#define DEBUG_STRONG_LRU_HASHTABLE 1
+
+#if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_HASHTABLE)
+    #undef DEBUG_STRONG_LRU_HASHTABLE
+#endif
+
+namespace crispy
+{
+
+// {{{ details
+namespace detail
+{
+    static constexpr bool isPowerOfTwo(uint32_t value) noexcept
+    {
+        //.
+        return (value & (value - 1)) == 0;
+    }
+} // namespace detail
+// }}}
+
+struct LRUHashtableStats
+{
+    uint32_t hits;
+    uint32_t misses;
+    uint32_t recycles;
+};
+
+// Defines the number of hashes the hashtable can store.
+struct StrongHashtableSize
+{
+    uint32_t value;
+};
+
+// Number of entries the LRU StrongLRUHashtable can store at most.
+struct LRUCapacity
+{
+    uint32_t value;
+};
+
+// LRU hashtable implementation with the goal to minimize runtime allocations
+// and maximize speed.
+//
+// NOTE!
+//     Cache locality could be further improved by having one single
+//     memory region instead of two.
+//     Or even overloading operator new of StrongLRUHashtable
+//     and put the dynamic data at the end of the primary data.
+template <typename Value>
+class StrongLRUHashtable
+{
+  private:
+    StrongLRUHashtable(StrongHashtableSize hashCount, LRUCapacity entryCount);
+
+  public:
+    ~StrongLRUHashtable();
+
+    using CachePtr = std::unique_ptr<StrongLRUHashtable, std::function<void(StrongLRUHashtable*)>>;
+
+    static constexpr inline size_t requiredMemorySize(StrongHashtableSize hashCount, LRUCapacity entryCount);
+
+    template <typename Allocator = std::allocator<unsigned char>>
+    static CachePtr create(StrongHashtableSize hashCount, LRUCapacity entryCount);
+
+    /// Returns the actual number of entries currently hold in this hashtable.
+    [[nodiscard]] size_t size() const noexcept;
+
+    /// Returns the maximum number of entries that can be stored in this hashtable.
+    [[nodiscard]] size_t capacity() const noexcept;
+
+    /// Returns the total storage sized used by this object.
+    [[nodiscard]] size_t storageSize() const noexcept;
+
+    /// Returns gathered stats and clears the local stats state to start
+    /// counting from zero again.
+    LRUHashtableStats fetchAndClearStats() noexcept;
+
+    /// Clears all entries from the hashtable.
+    void clear();
+
+    // Delets the hash entry and its associated value from the LRU hashtable
+    void erase(StrongHash const& hash);
+
+    /// Touches a given hash key, putting it to the front of the LRU chain.
+    /// Nothing is done if the hash key was not found.
+    void touch(StrongHash const& hash) noexcept;
+
+    /// Returns an ordered list of keys in this hash.
+    /// Ordering is from most recent to least recent access.
+    [[nodiscard]] std::vector<StrongHash> hashes() const;
+
+    /// Tests for the exitence of the given hash key in this hash table.
+    [[nodiscard]] bool contains(StrongHash const& hash) const noexcept;
+
+    /// Returns the value for the given hash key if found, nullptr otherwise.
+    [[nodiscard]] Value* try_get(StrongHash const& hash);
+    [[nodiscard]] Value const* try_get(StrongHash const& hash) const;
+
+    /// Returns the value for the given hash key,
+    /// throwing std::out_of_range if hash key was not found.
+    [[nodiscard]] Value& at(StrongHash const& hash);
+
+    /// like at() but does not change LRU order.
+    [[nodiscard]] Value& peek(StrongHash const& hash);
+    [[nodiscard]] Value const& peek(StrongHash const& hash) const;
+
+    /// Returns the value for the given hash key, default-constructing it in case
+    /// if it wasn't in the hashtable just yet.
+    [[nodiscard]] Value& operator[](StrongHash const& hash) noexcept;
+
+    /// Assignes the given value to the given hash key.
+    /// If the hash key was not found, it is being created,
+    /// otherwise the value will be re-assigned with the new value.
+    Value& emplace(StrongHash const& hash, Value value) noexcept;
+
+    /// Conditionally creates a new item to the LRU-Cache iff its hash key
+    /// was not present yet.
+    ///
+    /// @retval true the hash key did not exist in hashtable yet, a new value was constructed.
+    /// @retval false The hash key is already in the hashtable, no entry was constructed.
+    template <typename ValueConstructFn>
+    [[nodiscard]] bool try_emplace(StrongHash const& hash, ValueConstructFn constructValue);
+
+    /// Always returns either the existing item by the given hash key, if found,
+    /// or a newly created one by invoking constructValue().
+    template <typename ValueConstructFn>
+    [[nodiscard]] Value& get_or_emplace(StrongHash const& hash, ValueConstructFn constructValue);
+
+    void inspect(std::ostream& output) const;
+
+    // {{{ public detail
+    struct NextWithSameHash
+    {
+        explicit NextWithSameHash(uint32_t v): value { v } {}
+        uint32_t value;
+    };
+
+    struct Entry
+    {
+        Entry(Entry const&) = default;
+        Entry(Entry&&) noexcept = default;
+        Entry& operator=(Entry const&) = default;
+        Entry& operator=(Entry&&) noexcept = default;
+        Entry(NextWithSameHash initialNextWithSameHash): nextWithSameHash { initialNextWithSameHash.value } {}
+
+        StrongHash hashValue {};
+
+        uint32_t prevInLRU = 0;
+        uint32_t nextInLRU = 0;
+        uint32_t nextWithSameHash = 0;
+
+        std::optional<Value> value = std::nullopt;
+
+#if defined(DEBUG_STRONG_LRU_HASHTABLE)
+        uint32_t ordering = 0;
+#endif
+    };
+    // }}}
+
+  private:
+    // {{{ details
+    // Maps the given hash hash key to a slot in the hash table.
+    uint32_t* hashTableSlot(StrongHash const& hash);
+
+    // Returns entry index to an unused entry, possibly by evicting
+    // the least recently used entry if no free entries are available.
+    //
+    // This entry is not inserted into the LRU-chain yet.
+    uint32_t allocateEntry();
+
+    // Returns the index to the entry associated with the given hash key.
+    // If the hash key was not found and force is set to true, it'll be created,
+    // otherwise 0 is returned.
+    uint32_t findEntry(StrongHash const& hash, bool force);
+
+    // Evicts the least recently used entry in the LRU chain
+    // and links it to the unused-entries chain.
+    //
+    // Requires the hashtable to be full.
+    void recycle();
+
+    int validateChange(int adj);
+
+    Entry& sentinelEntry() noexcept { return _entries[0]; }
+    Entry const& sentinelEntry() const noexcept { return _entries[0]; }
+    // }}}
+
+    LRUHashtableStats _stats;
+    uint32_t _hashMask;
+    StrongHashtableSize _hashCount;
+    uint32_t _size;
+    LRUCapacity _capacity;
+
+    // The hash table maps hash codes to indices into the entry table.
+    uint32_t* _hashTable;
+    Entry* _entries;
+
+#if defined(DEBUG_STRONG_LRU_HASHTABLE)
+    int _lastLRUCount = 0;
+#endif
+};
+
+// {{{ implementation
+
+template <typename Value>
+StrongLRUHashtable<Value>::StrongLRUHashtable(StrongHashtableSize hashCount, LRUCapacity entryCount):
+    _stats {},
+    _hashMask { hashCount.value - 1 },
+    _hashCount { hashCount },
+    _size { 0 },
+    _capacity { entryCount },
+    _hashTable { (uint32_t*) (this + 1) },
+    _entries { [this]() {
+        constexpr uintptr_t Alignment = std::alignment_of_v<Entry>;
+        static_assert(detail::isPowerOfTwo(Alignment));
+        constexpr uintptr_t AlignMask = Alignment - 1;
+
+        uint32_t* hashTableEnd = _hashTable + _hashCount.value;
+        Entry* entryTable = (Entry*) (uintptr_t((char*) hashTableEnd + AlignMask) & ~AlignMask);
+
+        return entryTable;
+    }() }
+{
+    Require(detail::isPowerOfTwo(hashCount.value));
+    Require(hashCount.value >= 1);
+    Require(entryCount.value >= 2);
+
+    memset(_hashTable, 0, hashCount.value * sizeof(uint32_t));
+
+    for (auto entryIndex = 0; entryIndex < entryCount.value; ++entryIndex)
+    {
+        Entry* entry = _entries + entryIndex;
+        new (entry) Entry(NextWithSameHash(entryIndex + 1));
+    }
+    new (_entries + entryCount.value) Entry(NextWithSameHash(0));
+}
+
+template <typename Value>
+StrongLRUHashtable<Value>::~StrongLRUHashtable()
+{
+    std::destroy_n(_entries, 1 + _capacity.value);
+}
+
+template <typename Value>
+constexpr inline size_t StrongLRUHashtable<Value>::requiredMemorySize(StrongHashtableSize hashCount,
+                                                                      LRUCapacity entryCount)
+{
+    Require(detail::isPowerOfTwo(hashCount.value)); // Hash capacity must be power of 2.
+    Require(hashCount.value >= 1);
+    Require(entryCount.value >= 2);
+
+    auto const hashSize = hashCount.value * sizeof(uint32_t);
+    auto const entrySize = (1 + entryCount.value) * sizeof(Entry) + std::alignment_of_v<Entry>;
+    auto const totalSize = sizeof(StrongLRUHashtable) + hashSize + entrySize;
+    return totalSize;
+}
+
+template <typename Value>
+template <typename Allocator>
+auto StrongLRUHashtable<Value>::create(StrongHashtableSize hashCount, LRUCapacity entryCount) -> CachePtr
+{
+    // payload memory layout
+    // =====================
+    //
+    // [object  attribs]
+    // uint32_t[] hash table
+    // Entry[]    entries
+
+    Allocator allocator;
+    auto const size = requiredMemorySize(hashCount, entryCount);
+    StrongLRUHashtable* obj = (StrongLRUHashtable*) allocator.allocate(size);
+
+    // clang-format off
+    if (!obj)
+        return CachePtr { nullptr, [](auto) {} };
+    // clang-format on
+
+    memset(obj, 0, size);
+    new (obj) StrongLRUHashtable(hashCount, entryCount);
+
+    auto deleter = [size, allocator = std::move(allocator)](auto p) mutable {
+        std::destroy_n(p, 1);
+        allocator.deallocate(reinterpret_cast<typename Allocator::pointer>(p), size);
+    };
+
+    return CachePtr(obj, std::move(deleter));
+}
+
+template <typename Value>
+inline size_t StrongLRUHashtable<Value>::size() const noexcept
+{
+    return _size;
+}
+
+template <typename Value>
+inline size_t StrongLRUHashtable<Value>::capacity() const noexcept
+{
+    return _capacity.value;
+}
+
+template <typename Value>
+inline size_t StrongLRUHashtable<Value>::storageSize() const noexcept
+{
+    auto const hashTableSize = _hashCount.value * sizeof(uint32_t);
+
+    // +1 for sentinel entry in the front
+    // +1 for alignment
+    auto const entryTableSize = (2 + _capacity.value) * sizeof(Entry);
+
+    return sizeof(StrongLRUHashtable) + hashTableSize + entryTableSize;
+}
+
+template <typename Value>
+inline uint32_t* StrongLRUHashtable<Value>::hashTableSlot(StrongHash const& hash)
+{
+    uint32_t const index = _mm_cvtsi128_si32(hash.value);
+    uint32_t const slot = index & _hashMask;
+    return _hashTable + slot;
+}
+
+template <typename Value>
+LRUHashtableStats StrongLRUHashtable<Value>::fetchAndClearStats() noexcept
+{
+    auto st = _stats;
+    _stats = LRUHashtableStats {};
+    return st;
+}
+
+template <typename Value>
+void StrongLRUHashtable<Value>::clear()
+{
+    Entry& sentinel = sentinelEntry();
+    uint32_t entryIndex = sentinel.nextInLRU;
+    while (entryIndex)
+    {
+        Entry& entry = _entries[entryIndex];
+        entry.value.reset();
+        entryIndex = entry.nextInLRU;
+    }
+
+    memset(_hashTable, 0, _hashCount.value * sizeof(uint32_t));
+
+    while (entryIndex < _capacity.value)
+    {
+        _entries[entryIndex] = Entry(NextWithSameHash(1 + entryIndex));
+        ++entryIndex;
+    }
+    _entries[_capacity.value] = Entry(NextWithSameHash(0));
+
+    auto const oldSize = static_cast<int>(_size);
+    _size = 0;
+    validateChange(-oldSize);
+}
+
+template <typename Value>
+void StrongLRUHashtable<Value>::erase(StrongHash const& hash)
+{
+    uint32_t* slot = hashTableSlot(hash);
+    uint32_t entryIndex = *slot;
+    uint32_t prevWithSameHash = 0;
+    Entry* entry = nullptr;
+
+    while (entryIndex)
+    {
+        entry = _entries + entryIndex;
+        if (entry->hashValue == hash)
+            break;
+        prevWithSameHash = entryIndex;
+        entryIndex = entry->nextWithSameHash;
+    }
+
+    if (entryIndex == 0)
+        return;
+
+    Entry& prev = _entries[entry->prevInLRU];
+    Entry& next = _entries[entry->nextInLRU];
+
+    // unlink from LRU chain
+    prev.nextInLRU = entry->nextInLRU;
+    next.prevInLRU = entry->prevInLRU;
+    if (prevWithSameHash)
+    {
+        Require(_entries[prevWithSameHash].nextWithSameHash == entryIndex);
+        _entries[prevWithSameHash].nextWithSameHash = entry->nextWithSameHash;
+    }
+    else
+        *slot = entry->nextWithSameHash;
+
+    // relink into free-chain
+    Entry& sentinel = sentinelEntry();
+    entry->prevInLRU = 0;
+    entry->nextInLRU = sentinel.nextInLRU;
+    entry->nextWithSameHash = sentinel.nextWithSameHash;
+    sentinel.nextWithSameHash = entryIndex;
+
+    --_size;
+
+    validateChange(-1);
+}
+
+template <typename Value>
+inline void StrongLRUHashtable<Value>::touch(StrongHash const& hash) noexcept
+{
+    findEntry(hash, false);
+}
+
+template <typename Value>
+inline bool StrongLRUHashtable<Value>::contains(StrongHash const& hash) const noexcept
+{
+    return const_cast<StrongLRUHashtable*>(this)->findEntry(hash, false) != 0;
+}
+
+template <typename Value>
+inline Value* StrongLRUHashtable<Value>::try_get(StrongHash const& hash)
+{
+    uint32_t const entryIndex = findEntry(hash, false);
+    if (!entryIndex)
+        return nullptr;
+    return &_entries[entryIndex].value.value();
+}
+
+template <typename Value>
+inline Value const* StrongLRUHashtable<Value>::try_get(StrongHash const& hash) const
+{
+    return const_cast<StrongLRUHashtable*>(this)->try_get(hash);
+}
+
+template <typename Value>
+inline Value& StrongLRUHashtable<Value>::at(StrongHash const& hash)
+{
+    uint32_t const entryIndex = findEntry(hash, false);
+    if (!entryIndex)
+        throw std::out_of_range("hash not in table");
+    return *_entries[entryIndex].value;
+}
+
+template <typename Value>
+inline Value& StrongLRUHashtable<Value>::peek(StrongHash const& hash)
+{
+    uint32_t* slot = hashTableSlot(hash);
+    uint32_t entryIndex = *slot;
+    while (entryIndex)
+    {
+        Entry& entry = _entries[entryIndex];
+        if (entry.hashValue == hash)
+            return *entry.value;
+        entryIndex = entry.nextWithSameHash;
+    }
+
+    throw std::out_of_range("hash");
+}
+
+template <typename Value>
+inline Value const& StrongLRUHashtable<Value>::peek(StrongHash const& hash) const
+{
+    return const_cast<StrongLRUHashtable*>(this)->peek(hash);
+}
+
+template <typename Value>
+inline Value& StrongLRUHashtable<Value>::operator[](StrongHash const& hash) noexcept
+{
+    uint32_t const entryIndex = findEntry(hash, true);
+    return *_entries[entryIndex].value;
+}
+
+template <typename Value>
+template <typename ValueConstructFn>
+inline bool StrongLRUHashtable<Value>::try_emplace(StrongHash const& hash, ValueConstructFn constructValue)
+{
+    if (contains(hash))
+        return false;
+
+    uint32_t const entryIndex = findEntry(hash, true);
+    *_entries[entryIndex].value = constructValue(entryIndex);
+    return true;
+}
+
+template <typename Value>
+template <typename ValueConstructFn>
+inline Value& StrongLRUHashtable<Value>::get_or_emplace(StrongHash const& hash,
+                                                        ValueConstructFn constructValue)
+{
+    if (Value* p = try_get(hash))
+        return *p;
+
+    uint32_t const entryIndex = findEntry(hash, true);
+    return *_entries[entryIndex].value = constructValue(entryIndex);
+}
+
+template <typename Value>
+inline Value& StrongLRUHashtable<Value>::emplace(StrongHash const& hash, Value value) noexcept
+{
+    return (*this)[hash] = std::move(value);
+}
+
+template <typename Value>
+std::vector<StrongHash> StrongLRUHashtable<Value>::hashes() const
+{
+    auto result = std::vector<StrongHash> {};
+    Entry const& sentinel = sentinelEntry();
+    for (uint32_t entryIndex = sentinel.nextInLRU; entryIndex != 0;)
+    {
+        Entry const& entry = _entries[entryIndex];
+        result.emplace_back(entry.hashValue);
+        entryIndex = entry.nextInLRU;
+    }
+    Guarantee(result.size() == _size);
+
+    return result;
+}
+
+template <typename Value>
+void StrongLRUHashtable<Value>::inspect(std::ostream& output) const
+{
+    Entry const& sentinel = sentinelEntry();
+    uint32_t entryIndex = sentinel.prevInLRU;
+    uint32_t hashSlotCollisions = 0;
+    while (entryIndex != 0)
+    {
+        Entry const& entry = _entries[entryIndex];
+        output << fmt::format("  entry[{:03}]   : LRU: {} <- -> {}, alt: {}; := {}\n",
+                              entryIndex,
+                              entry.prevInLRU,
+                              entry.nextInLRU,
+                              entry.nextWithSameHash,
+                              entry.value.has_value() ? fmt::format("{}", entry.value.value()) : "nullopt");
+        if (entry.nextWithSameHash)
+            ++hashSlotCollisions;
+        entryIndex = entry.prevInLRU;
+    }
+
+    output << "------------------------\n";
+    output << fmt::format("hashslot collisions : {}\n", hashSlotCollisions);
+    output << fmt::format("stats               : {}\n", _stats);
+    output << fmt::format("hash table mask     : 0x{:04X}\n", _hashMask);
+    output << fmt::format("hash table capacity : {}\n", _hashCount.value);
+    output << fmt::format("entry count         : {}\n", _size);
+    output << fmt::format("entry capacity      : {}\n", _capacity.value);
+    output << "------------------------\n";
+}
+
+// {{{ helpers
+template <typename Value>
+uint32_t StrongLRUHashtable<Value>::findEntry(StrongHash const& hash, bool force)
+{
+    uint32_t* slot = hashTableSlot(hash);
+    uint32_t entryIndex = *slot;
+    Entry* result = nullptr;
+    while (entryIndex)
+    {
+        Entry& entry = _entries[entryIndex];
+        if (entry.hashValue == hash)
+        {
+            result = &entry;
+            break;
+        }
+        entryIndex = entry.nextWithSameHash;
+    }
+
+    if (result)
+    {
+        ++_stats.hits;
+
+        Entry& prev = _entries[result->prevInLRU];
+        Entry& next = _entries[result->nextInLRU];
+
+        prev.nextInLRU = result->nextInLRU;
+        next.prevInLRU = result->prevInLRU;
+
+        validateChange(-1);
+    }
+    else if (force)
+    {
+        ++_stats.misses;
+
+        entryIndex = allocateEntry();
+        result = &_entries[entryIndex];
+        result->nextWithSameHash = *slot;
+        result->hashValue = hash;
+        result->value.emplace(Value {});
+        *slot = entryIndex;
+    }
+    else
+    {
+        ++_stats.misses;
+        return 0;
+    }
+
+    Entry& sentinel = sentinelEntry();
+    Require(result != &sentinel);
+    result->nextInLRU = sentinel.nextInLRU;
+    result->prevInLRU = 0;
+
+    Entry& nextEntry = _entries[sentinel.nextInLRU];
+    nextEntry.prevInLRU = entryIndex;
+    sentinel.nextInLRU = entryIndex;
+
+#if defined(DEBUG_STRONG_LRU_HASHTABLE)
+    result->ordering = sentinel.ordering++;
+#endif
+
+    Require(validateChange(1) == _size);
+
+    return entryIndex;
+}
+
+template <typename Value>
+uint32_t StrongLRUHashtable<Value>::allocateEntry()
+{
+    Entry& sentinel = sentinelEntry();
+
+    if (sentinel.nextWithSameHash == 0)
+        recycle();
+    else
+        ++_size;
+
+    uint32_t poppedEntryIndex = sentinel.nextWithSameHash;
+    Require(poppedEntryIndex != 0);
+
+    Entry& poppedEntry = _entries[poppedEntryIndex];
+    sentinel.nextWithSameHash = poppedEntry.nextWithSameHash;
+    poppedEntry.nextWithSameHash = 0;
+
+    poppedEntry.value.reset();
+
+    return poppedEntryIndex;
+}
+
+template <typename Value>
+void StrongLRUHashtable<Value>::recycle()
+{
+    Require(_size == _capacity.value);
+
+    Entry& sentinel = sentinelEntry();
+    Require(sentinel.prevInLRU != 0);
+
+    uint32_t const entryIndex = sentinel.prevInLRU;
+    Entry& entry = _entries[entryIndex];
+    Entry& prev = _entries[entry.prevInLRU];
+
+    prev.nextInLRU = 0;
+    sentinel.prevInLRU = entry.prevInLRU;
+
+    validateChange(-1);
+
+    uint32_t* nextIndex = hashTableSlot(entry.hashValue);
+    while (*nextIndex != entryIndex)
+    {
+        Require(*nextIndex != 0);
+        nextIndex = &_entries[*nextIndex].nextWithSameHash;
+    }
+
+    Guarantee(*nextIndex == entryIndex);
+    *nextIndex = entry.nextWithSameHash;
+    entry.nextWithSameHash = sentinel.nextWithSameHash;
+    sentinel.nextWithSameHash = entryIndex;
+
+    ++_stats.recycles;
+}
+
+template <typename Value>
+inline int StrongLRUHashtable<Value>::validateChange(int adj)
+{
+#if defined(DEBUG_STRONG_LRU_HASHTABLE)
+    int count = 0;
+
+    Entry& sentinel = sentinelEntry();
+    size_t lastOrdering = sentinel.ordering;
+
+    for (uint32_t entryIndex = sentinel.nextInLRU; entryIndex != 0;)
+    {
+        Entry& entry = _entries[entryIndex];
+        Require(entry.ordering < lastOrdering);
+        lastOrdering = entry.ordering;
+        entryIndex = entry.nextInLRU;
+        ++count;
+    }
+    auto const newLRUCount = _lastLRUCount + adj;
+    Require(newLRUCount == count);
+    _lastLRUCount = count;
+    return newLRUCount;
+#else
+    return _size;
+#endif
+}
+
+// }}}
+// }}}
+
+} // namespace crispy
+
+// {{{ fmt
+namespace fmt
+{
+template <>
+struct formatter<crispy::LRUHashtableStats>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(crispy::LRUHashtableStats stats, FormatContext& ctx)
+    {
+        return format_to(
+            ctx.out(), "{} hits, {} misses, {} evictions", stats.hits, stats.misses, stats.recycles);
+    }
+};
+} // namespace fmt
+// }}}

--- a/src/crispy/StrongLRUHashtable_test.cpp
+++ b/src/crispy/StrongLRUHashtable_test.cpp
@@ -1,0 +1,320 @@
+/**
+ * This file is part of the "contour" project.
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <crispy/StrongLRUHashtable.h>
+#include <crispy/utils.h>
+
+#include <catch2/catch.hpp>
+
+#include <iostream>
+#include <string_view>
+
+using namespace crispy;
+using namespace std;
+using namespace std::string_view_literals;
+
+namespace
+{
+// simple 32-bit hash
+inline StrongHash h(uint32_t v)
+{
+    return StrongHash(0, 0, 0, v);
+}
+
+StrongHash collidingHash(uint32_t v) noexcept
+{
+    return StrongHash(0, 0, v, 0);
+}
+} // namespace
+
+TEST_CASE("StrongLRUHashtable.operator_index", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+
+    cache[h(1)] = 2;
+    REQUIRE(cache[h(1)] == 2);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "1");
+
+    cache[h(2)] = 4;
+    REQUIRE(cache[h(2)] == 4);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "2, 1");
+
+    cache[h(3)] = 6;
+    REQUIRE(cache[h(3)] == 6);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 2, 1");
+
+    cache[h(4)] = 8;
+    REQUIRE(cache[h(4)] == 8);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    cache[h(5)] = 10;
+    REQUIRE(cache[h(5)] == 10);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "5, 4, 3, 2");
+
+    cache[h(6)] = 12;
+    REQUIRE(cache[h(6)] == 12);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "6, 5, 4, 3");
+}
+
+TEST_CASE("StrongLRUHashtable.at", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    CHECK_THROWS_AS(cache.at(h(-1)), std::out_of_range);
+    CHECK_NOTHROW(cache.at(h(1)));
+}
+
+TEST_CASE("StrongLRUHashtable.clear", "[lrucache]")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    CHECK(cache.size() == 4);
+    cache.clear();
+    CHECK(cache.size() == 0);
+}
+
+TEST_CASE("StrongLRUHashtable.touch", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // no-op (not found)
+    cache.touch(h(-1));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // no-op (found)
+    cache.touch(h(4));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // middle to front
+    cache.touch(h(3));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 4, 2, 1");
+
+    // back to front
+    cache.touch(h(1));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "1, 3, 4, 2");
+}
+
+TEST_CASE("StrongLRUHashtable.contains", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // not found: no-op
+    REQUIRE(!cache.contains(h(-1)));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // found: front is no-op
+    REQUIRE(cache.contains(h(4)));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // found: middle to front
+    REQUIRE(cache.contains(h(3)));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 4, 2, 1");
+
+    // found: back to front
+    REQUIRE(cache.contains(h(1)));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "1, 3, 4, 2");
+}
+
+TEST_CASE("StrongLRUHashtable.try_emplace", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto& cache = *cachePtr;
+
+    auto rv = cache.try_emplace(h(2), [](auto) { return 4; });
+    CHECK(rv);
+    CHECK(joinHumanReadable(cache.hashes()) == "2");
+    CHECK(cache.at(h(2)) == 4);
+
+    rv = cache.try_emplace(h(3), [](auto) { return 6; });
+    CHECK(rv);
+    CHECK(joinHumanReadable(cache.hashes()) == "3, 2");
+    CHECK(cache.at(h(2)) == 4);
+    CHECK(cache.at(h(3)) == 6);
+
+    rv = cache.try_emplace(h(2), [](auto) { return -1; });
+    CHECK_FALSE(rv);
+    CHECK(joinHumanReadable(cache.hashes()) == "2, 3");
+    CHECK(cache.at(h(2)) == 4);
+    CHECK(cache.at(h(3)) == 6);
+}
+
+TEST_CASE("StrongLRUHashtable.try_get", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // no-op (not found)
+    REQUIRE(cache.try_get(h(-1)) == nullptr);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // no-op (found)
+    auto const p1 = cache.try_get(h(4));
+    REQUIRE(p1 != nullptr);
+    REQUIRE(*p1 == 8);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // middle to front
+    auto const p2 = cache.try_get(h(3));
+    REQUIRE(p2 != nullptr);
+    REQUIRE(*p2 == 6);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 4, 2, 1");
+
+    // back to front
+    auto const p3 = cache.try_get(h(1));
+    REQUIRE(p3 != nullptr);
+    REQUIRE(*p3 == 2);
+    REQUIRE(joinHumanReadable(cache.hashes()) == "1, 3, 4, 2");
+}
+
+TEST_CASE("StrongLRUHashtable.get_or_emplace", "[lrucache]")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto& cache = *cachePtr;
+
+    int& a = cache.get_or_emplace(h(2), [](auto) { return 4; });
+    CHECK(a == 4);
+    CHECK(cache.at(h(2)) == 4);
+    CHECK(cache.size() == 1);
+    CHECK(joinHumanReadable(cache.hashes()) == "2"sv);
+
+    int& a2 = cache.get_or_emplace(h(2), [](auto) { return -4; });
+    CHECK(a2 == 4);
+    CHECK(cache.at(h(2)) == 4);
+    CHECK(cache.size() == 1);
+
+    int& b = cache.get_or_emplace(h(3), [](auto) { return 6; });
+    CHECK(b == 6);
+    CHECK(cache.at(h(3)) == 6);
+    CHECK(cache.size() == 2);
+    CHECK(joinHumanReadable(cache.hashes()) == "3, 2"sv);
+
+    int& c = cache.get_or_emplace(h(4), [](auto) { return 8; });
+    CHECK(joinHumanReadable(cache.hashes()) == "4, 3"sv);
+    CHECK(c == 8);
+    CHECK(cache.at(h(4)) == 8);
+    CHECK(cache.size() == 2);
+    CHECK(cache.contains(h(3)));
+    CHECK_FALSE(cache.contains(h(2))); // thrown out
+
+    int& b2 = cache.get_or_emplace(h(3), [](auto) { return -3; });
+    CHECK(joinHumanReadable(cache.hashes()) == "3, 4"sv);
+    CHECK(b2 == 6);
+    CHECK(cache.at(h(3)) == 6);
+    CHECK(cache.size() == 2);
+}
+
+TEST_CASE("StrongLRUHashtable.erase", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+
+    // erase at head
+    cache.erase(h(4));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 2, 1");
+
+    // erase in middle
+    cache.erase(h(2));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3, 1");
+
+    // erase at tail
+    cache.erase(h(1));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3");
+
+    // erase last
+    cache.erase(h(3));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "");
+}
+
+TEST_CASE("StrongLRUHashtable.insert_with_cache_collision", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+
+    cache[collidingHash(1)] = 1;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "1.");
+
+    cache[collidingHash(2)] = 2;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "2., 1.");
+
+    cache[collidingHash(3)] = 3;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3., 2., 1.");
+
+    cache[collidingHash(4)] = 4;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4., 3., 2., 1.");
+
+    // verify that we're having 3 cache collisions
+    // cache.inspect(cout);
+}
+
+TEST_CASE("StrongLRUHashtable.erase_with_hashTable_lookup_collision", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[collidingHash(i)] = 2 * i;
+    REQUIRE(joinHumanReadable(cache.hashes()) == "4., 3., 2., 1.");
+
+    // erase at head
+    cache.erase(collidingHash(4));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3., 2., 1.");
+
+    // erase in middle
+    cache.erase(collidingHash(2));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3., 1.");
+
+    // erase at tail
+    cache.erase(collidingHash(1));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "3.");
+
+    // erase last
+    cache.erase(collidingHash(3));
+    REQUIRE(joinHumanReadable(cache.hashes()) == "");
+}
+
+TEST_CASE("StrongLRUHashtable.peek", "")
+{
+    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto& cache = *cachePtr;
+    for (int i = 1; i <= 4; ++i)
+        cache[h(i)] = 2 * i;
+
+    for (int i = 1; i <= 4; ++i)
+    {
+        INFO(fmt::format("i: {}", i))
+        REQUIRE(cache.peek(h(1)) == 2);
+        REQUIRE(joinHumanReadable(cache.hashes()) == "4, 3, 2, 1");
+    }
+}

--- a/src/crispy/assert.h
+++ b/src/crispy/assert.h
@@ -49,7 +49,7 @@ namespace detail
         else
         {
             fmt::print("[{}:{}] {} {}\n", _file, _line, _message, _text);
-            std::terminate();
+            std::abort();
         }
     }
 

--- a/src/terminal/Image.h
+++ b/src/terminal/Image.h
@@ -275,9 +275,9 @@ class ImagePool
 
     // data members
     //
-    ImageId nextImageId_;                                //!< ID for next image to be put into the pool
-    NameToImageIdCache::CachePtr imageNameToImageCache_; //!< keeps mapping from name to raw image
-    OnImageRemove const onImageRemove_; //!< Callback to be invoked when image gets removed from pool.
+    ImageId nextImageId_;                      //!< ID for next image to be put into the pool
+    NameToImageIdCache imageNameToImageCache_; //!< keeps mapping from name to raw image
+    OnImageRemove const onImageRemove_;        //!< Callback to be invoked when image gets removed from pool.
 };
 
 } // namespace terminal
@@ -320,45 +320,6 @@ struct formatter<terminal::ImageStats>
 };
 
 template <>
-struct formatter<terminal::Image>
-{
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename FormatContext>
-    auto format(terminal::Image const& _image, FormatContext& ctx)
-    {
-        return format_to(ctx.out(),
-                         "Image<#{}, {}, size={}>",
-                         _image.weak_from_this().use_count(),
-                         _image.id(),
-                         _image.size());
-    }
-};
-
-template <>
-struct formatter<std::shared_ptr<terminal::Image>>
-{
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename FormatContext>
-    auto format(std::shared_ptr<terminal::Image> const& _image, FormatContext& ctx)
-    {
-        if (_image)
-            return format_to(ctx.out(), "{}", *_image);
-        else
-            return format_to(ctx.out(), "nullptr");
-    }
-};
-
-template <>
 struct formatter<std::shared_ptr<terminal::Image const>>
 {
     template <typename ParseContext>
@@ -370,10 +331,14 @@ struct formatter<std::shared_ptr<terminal::Image const>>
     template <typename FormatContext>
     auto format(std::shared_ptr<terminal::Image const> const& _image, FormatContext& ctx)
     {
-        if (_image)
-            return format_to(ctx.out(), "{}", *_image);
-        else
+        if (!_image)
             return format_to(ctx.out(), "nullptr");
+        terminal::Image const& image = *_image;
+        return format_to(ctx.out(),
+                         "Image<#{}, {}, size={}>",
+                         image.weak_from_this().use_count(),
+                         image.id(),
+                         image.size());
     }
 };
 

--- a/src/terminal/RenderBuffer.h
+++ b/src/terminal/RenderBuffer.h
@@ -36,7 +36,7 @@ struct RenderCell
     RGBColor foregroundColor;
     RGBColor backgroundColor;
     RGBColor decorationColor;
-    std::optional<ImageFragment> image;
+    std::shared_ptr<ImageFragment> image;
 
     bool groupStart = false;
     bool groupEnd = false;

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -3223,11 +3223,11 @@ TEST_CASE("Sixel.simple", "[screen]")
             Cell const& cell = term.screen.at(line, column);
             if (line <= LineOffset(4) && column <= ColumnOffset(7))
             {
-                ImageFragmentId fragmentId = cell.imageFragment();
-                ImageFragment const& fragment = term.screen.imageFragments().at(fragmentId);
-                CHECK(fragment.offset().line == line);
-                CHECK(fragment.offset().column == column);
-                CHECK(fragment.data().size() != 0);
+                auto fragment = cell.imageFragment();
+                REQUIRE(fragment);
+                CHECK(fragment->offset().line == line);
+                CHECK(fragment->offset().column == column);
+                CHECK(fragment->data().size() != 0);
             }
             else
             {
@@ -3263,12 +3263,11 @@ TEST_CASE("Sixel.AutoScroll-1", "[screen]")
             Cell const& cell = term.screen.at(line, column);
             if (line <= LineOffset(4) && column <= ColumnOffset(7))
             {
-                ImageFragmentId fragmentId = cell.imageFragment();
-                REQUIRE(fragmentId != ImageFragmentId(0));
-                ImageFragment const& fragment = term.screen.imageFragments().at(fragmentId);
-                CHECK(fragment.offset().line == line + 1);
-                CHECK(fragment.offset().column == column);
-                CHECK(fragment.data().size() != 0);
+                auto fragment = cell.imageFragment();
+                REQUIRE(fragment);
+                CHECK(fragment->offset().line == line + 1);
+                CHECK(fragment->offset().column == column);
+                CHECK(fragment->data().size() != 0);
             }
             else
             {

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -442,6 +442,7 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                 if (!cellEmpty || customBackground)
                 {
                     state = State::Sequence;
+                    // clang-format off
                     _output.screen.emplace_back(makeRenderCell(screen_.colorPalette(),
                                                                screen_.hyperlinks(),
                                                                screen_.imageFragments(),
@@ -450,6 +451,7 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                                                                bg,
                                                                _line,
                                                                _column));
+                    // clang-format on
                     _output.screen.back().groupStart = true;
                 }
                 break;
@@ -461,6 +463,7 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                 }
                 else
                 {
+                    // clang-format off
                     _output.screen.emplace_back(makeRenderCell(screen_.colorPalette(),
                                                                screen_.hyperlinks(),
                                                                screen_.imageFragments(),
@@ -469,6 +472,7 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                                                                bg,
                                                                _line,
                                                                _column));
+                    // clang-format on
 
                     if (isNewLine)
                         _output.screen.back().groupStart = true;

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -301,7 +301,6 @@ void Terminal::refreshRenderBuffer(RenderBuffer& _output)
 
 RenderCell makeRenderCell(ColorPalette const& _colorPalette,
                           HyperlinkStorage const& _hyperlinks,
-                          ImageFragmentCache const& _imageFragments,
                           Cell const& _cell,
                           RGBColor fg,
                           RGBColor bg,
@@ -322,8 +321,7 @@ RenderCell makeRenderCell(ColorPalette const& _colorPalette,
             cell.codepoints.push_back(_cell.codepoint(i));
     }
 
-    if (ImageFragment const* fragment = _imageFragments.try_get(_cell.imageFragment()))
-        cell.image = *fragment;
+    cell.image = _cell.imageFragment();
 
     if (auto href = _hyperlinks.hyperlinkById(_cell.hyperlink()))
     {
@@ -445,7 +443,6 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                     // clang-format off
                     _output.screen.emplace_back(makeRenderCell(screen_.colorPalette(),
                                                                screen_.hyperlinks(),
-                                                               screen_.imageFragments(),
                                                                _cell,
                                                                fg,
                                                                bg,
@@ -466,7 +463,6 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                     // clang-format off
                     _output.screen.emplace_back(makeRenderCell(screen_.colorPalette(),
                                                                screen_.hyperlinks(),
-                                                               screen_.imageFragments(),
                                                                _cell,
                                                                fg,
                                                                bg,

--- a/src/terminal_renderer/ImageRenderer.cpp
+++ b/src/terminal_renderer/ImageRenderer.cpp
@@ -27,7 +27,7 @@ using std::optional;
 namespace terminal::renderer
 {
 
-ImageRenderer::ImageRenderer(ImageSize _cellSize): imagePool_ {}, cellSize_ { _cellSize }
+ImageRenderer::ImageRenderer(ImageSize _cellSize): cellSize_ { _cellSize }
 {
 }
 
@@ -103,6 +103,10 @@ void ImageRenderer::clearCache()
 {
     imageFragmentsInUse_.clear();
     atlas_ = std::make_unique<TextureAtlas>(renderTarget().coloredAtlasAllocator());
+}
+
+void ImageRenderer::debugCache(std::ostream& output) const
+{
 }
 
 } // namespace terminal::renderer

--- a/src/terminal_renderer/ImageRenderer.h
+++ b/src/terminal_renderer/ImageRenderer.h
@@ -89,20 +89,25 @@ class ImageRenderer: public Renderable
     /// GPU caches.
     void discardImage(ImageId _imageId);
 
-    struct Metadata
-    {
-    }; // TODO: do we want/need anything here?
+    // clang-format off
+    struct Metadata {};
+    // clang-format on
+
     using TextureAtlas = atlas::MetadataTextureAtlas<ImageFragmentKey, Metadata>;
     using DataRef = TextureAtlas::DataRef;
+
+    void debugCache(std::ostream& output) const;
 
   private:
     std::optional<DataRef> getTextureInfo(ImageFragment const& _fragment);
 
+    using ImageIdToFragmentKeyMap = std::unordered_map<ImageId, std::vector<ImageFragmentKey>>;
+
     // private data
     //
-    ImagePool imagePool_;
-    std::unordered_map<ImageId, std::vector<ImageFragmentKey>>
-        imageFragmentsInUse_; // remember each fragment key per image for proper GPU texture GC.
+
+    // remember each fragment key per image for proper GPU texture GC.
+    ImageIdToFragmentKeyMap imageFragmentsInUse_;
     ImageSize cellSize_;
     std::unique_ptr<TextureAtlas> atlas_;
 };

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -317,7 +317,7 @@ void Renderer::renderCells(vector<RenderCell> const& _renderableCells)
         backgroundRenderer_.renderCell(cell);
         decorationRenderer_.renderCell(cell);
         textRenderer_.renderCell(cell);
-        if (cell.image.has_value())
+        if (cell.image)
             imageRenderer_.renderImage(gridMetrics_.map(cell.position), *cell.image);
     }
 }
@@ -348,6 +348,7 @@ optional<RenderCursor> Renderer::renderCursor(Terminal const& _terminal)
 void Renderer::dumpState(std::ostream& _textOutput) const
 {
     textRenderer_.debugCache(_textOutput);
+    imageRenderer_.debugCache(_textOutput);
 }
 
 } // namespace terminal::renderer

--- a/src/terminal_renderer/TextRenderer.h
+++ b/src/terminal_renderer/TextRenderer.h
@@ -243,8 +243,9 @@ class TextRenderer: public Renderable
     // performance optimizations
     //
     bool pressure_ = false;
-
     std::unordered_map<text::glyph_key, text::bitmap_format> glyphToTextureMapping_;
+    std::list<std::u32string> cacheKeyStorage_;
+    crispy::LRUCache<TextCacheKey, text::shape_result> cache_;
 
     // target surface rendering
     //
@@ -267,11 +268,6 @@ class TextRenderer: public Renderable
     unsigned cellCount_ = 0;
     bool textStartFound_ = false;
     bool forceCellGroupSplit_ = false;
-
-    // text shaping cache
-    //
-    std::list<std::u32string> cacheKeyStorage_;
-    crispy::LRUCache<TextCacheKey, text::shape_result> cache_;
 
     // output fields
     //


### PR DESCRIPTION
### the problem

* [ ] texture atlas keeps growing - is this good?
* [ ] cache key storage items keeps growing (should be GC'd)
* [ ] glyph-to-texture mapping keeps growing (should be GC'd)
* [ ] after running `notcurses-demo u` the TE becomes slow, probably due to the above bloat

- the cleanups should happen as part of the LRU cache.
- can we maintain a free-list for the texture atlas? sounds like a hard problem wrt efficient use of re-using the space
- ...

This is a PREP-WORKS-PR, the actual renderer changes (addressing the above) I'll do in a follow-up PR.