### PR TITLE
Fixes DECRC

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Fixes VT sequence `OSC 4`'s response.
 - Fixes PTY write race condition.
 - Fixes installation from `.deb` (missing terminfo dependency)
+- Fixes `DECRC` with respect to `DECSTBM` enabled and `DECOM` being inverted interpreted.
 - Improved VT backend performance (#342).
 - Improved text selection behaviour.
 - Adds preliminary implementation of `DA3` VT sequence.

--- a/src/terminal/Grid.cpp
+++ b/src/terminal/Grid.cpp
@@ -33,7 +33,7 @@ auto inline GridLog = logstore::Category(
     "vt.grid", "Grid related", logstore::Category::State::Disabled, logstore::Category::Visibility::Hidden);
 
 namespace detail
-{ // {{{
+{
     template <typename... Args>
     void logf([[maybe_unused]] Args&&... args)
     {
@@ -427,9 +427,13 @@ LineCount Grid<Cell>::scrollUp(LineCount _n, GraphicsAttributes _defaultAttribut
             rotate(u, v, w);
         }
 
-        std::for_each(next(begin(lines_), *_margin.vertical.to - *n + 1),
-                      next(begin(lines_), *_margin.vertical.to + 1),
-                      [&](Line<Cell>& line) { line.reset(defaultLineFlags(), _defaultAttributes); });
+        auto const topEmptyLineNr = *_margin.vertical.to - *n + 1;
+        auto const bottomLineNumber = *_margin.vertical.to;
+        for (auto lineNumber = topEmptyLineNr; lineNumber <= bottomLineNumber; ++lineNumber)
+        {
+            Line<Cell>& line = lines_[lineNumber];
+            line.reset(defaultLineFlags(), _defaultAttributes);
+        }
     }
     else
     {

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -410,7 +410,7 @@ class Screen: public capabilities::StaticDatabase
     /// Clamps given coordinates, respecting DECOM (Origin Mode).
     Coordinate clampCoordinate(Coordinate coord) const noexcept
     {
-        if (!cursor_.originMode)
+        if (cursor_.originMode)
             return clampToOrigin(coord);
         else
             return clampToScreen(coord);
@@ -419,12 +419,8 @@ class Screen: public capabilities::StaticDatabase
     /// Clamps given logical coordinates to margins as used in when DECOM (origin mode) is enabled.
     Coordinate clampToOrigin(Coordinate coord) const noexcept
     {
-        return { std::clamp(coord.line,
-                            LineOffset { 0 },
-                            margin_.vertical.length().template as<LineOffset>() - LineOffset(1)),
-                 std::clamp(coord.column,
-                            ColumnOffset { 0 },
-                            margin_.horizontal.length().template as<ColumnOffset>() - ColumnOffset(1)) };
+        return { std::clamp(coord.line, LineOffset { 0 }, margin_.vertical.to),
+                 std::clamp(coord.column, ColumnOffset { 0 }, margin_.horizontal.to) };
     }
 
     LineOffset clampedLine(LineOffset _line) const noexcept


### PR DESCRIPTION
@whisperity that's the one for you and `aptitude`'s scroll-up issue :-)

It was using DECSC -> DECSTBM -> DECRC -> LF DECSTBM .... and the DECRC was not restoring to the correct position (in fact, it has been drunk).