### PR TITLE
Use pacman instead of packman

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -217,7 +217,7 @@ install_deps_arch()
 {
     [ x$PREPARE_ONLY_EMBEDS = xON ] && return
 
-    packman -S -y \
+    pacman -S -y \
         catch2 \
         cmake \
         extra-cmake-modules \


### PR DESCRIPTION
I don't know if it's a typo, but all packages are in the official
repo, so we should using pacman