### PR TITLE
[terminal] Fixes VT sequence `OSC 4` to also support setting color via `#RRGGBB` and `#RGB`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Fixes VT sequence `DECFI`.
 - Fixes VT sequence `ICH` (#559).
 - Fixes VT sequence `OSC 4`'s response.
+- Fixes VT sequence `OESC 4` to also support setting color via `#RRGGBB`.
 - Fixes `DECRC` with respect to `DECSTBM` enabled and `DECOM` being inverted interpreted.
 - Fixes `XTGETTCAP` (#582).
 - Fixes `SU` in combination with `DECLRM` (#593).

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -2978,11 +2978,34 @@ TEST_CASE("OSC.4")
 
     SECTION("query")
     {
-        screen.write("\033]4;1;?");
+        screen.write("\033]4;7;?\033\\");
         INFO(term.replyData);
+        REQUIRE(e(term.replyData) == e("\033]4;7;rgb:c0c0/c0c0/c0c0\033\\"));
     }
 
-    SECTION("set") { screen.write("\033]4;1;rgb:ab/cd/ef"); }
+    SECTION("set color via format rgb:RR/GG/BB")
+    {
+        screen.write("\033]4;7;rgb:ab/cd/ef\033\\");
+        screen.write("\033]4;7;?\033\\");
+        INFO(term.replyData);
+        REQUIRE(e(term.replyData) == e("\033]4;7;rgb:abab/cdcd/efef\033\\"));
+    }
+
+    SECTION("set color via format #RRGGBB")
+    {
+        screen.write("\033]4;7;#abcdef\033\\");
+        screen.write("\033]4;7;?\033\\");
+        INFO(e(term.replyData));
+        REQUIRE(e(term.replyData) == e("\033]4;7;rgb:abab/cdcd/efef\033\\"));
+    }
+
+    SECTION("set color via format #RGB")
+    {
+        screen.write("\033]4;7;#abc\033\\");
+        screen.write("\033]4;7;?\033\\");
+        INFO(term.replyData);
+        REQUIRE(e(term.replyData) == e("\033]4;7;rgb:a0a0/b0b0/c0c0\033\\"));
+    }
 }
 
 TEST_CASE("XTGETTCAP")

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -223,8 +223,30 @@ namespace impl // {{{ some command generator helpers
                 auto const r = crispy::to_integer<16, uint8_t>(_value.substr(4, 2));
                 auto const g = crispy::to_integer<16, uint8_t>(_value.substr(7, 2));
                 auto const b = crispy::to_integer<16, uint8_t>(_value.substr(10, 2));
-                return RGBColor { *r, *g, *b };
+                return RGBColor { r.value(), g.value(), b.value() };
             }
+
+            // "#RRGGBB"
+            if (_value.size() == 7 && _value[0] == '#')
+            {
+                auto const r = crispy::to_integer<16, uint8_t>(_value.substr(1, 2));
+                auto const g = crispy::to_integer<16, uint8_t>(_value.substr(3, 2));
+                auto const b = crispy::to_integer<16, uint8_t>(_value.substr(5, 2));
+                return RGBColor { r.value(), g.value(), b.value() };
+            }
+
+            // "#RGB"
+            if (_value.size() == 4 && _value[0] == '#')
+            {
+                auto const r = crispy::to_integer<16, uint8_t>(_value.substr(1, 1));
+                auto const g = crispy::to_integer<16, uint8_t>(_value.substr(2, 1));
+                auto const b = crispy::to_integer<16, uint8_t>(_value.substr(3, 1));
+                auto const rr = static_cast<uint8_t>(r.value() << 4);
+                auto const gg = static_cast<uint8_t>(g.value() << 4);
+                auto const bb = static_cast<uint8_t>(b.value() << 4);
+                return RGBColor { rr, gg, bb };
+            }
+
             return std::nullopt;
         }
         catch (...)


### PR DESCRIPTION
Adds support for setting color via `OSC 4 ; INDEX ; #RRGGBB ST`. This format is also supported by `XParseColor` and at least one application is making use of it ([kfc](https://github.com/mcpcpc/kfc)).

Thanks @subnut for the hint.

Reference: https://github.com/contour-terminal/contour/issues/221#issuecomment-1025982122