### PR TITLE
Further reduce host-memory usage.

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -951,6 +951,7 @@ void TerminalSession::configureDisplay()
 
     LOGSTORE(SessionLog)("Configuring display.");
     display_->setBlurBehind(profile_.backgroundBlur);
+
     display_->setBackgroundImage(profile_.colors.backgroundImage);
 
     if (profile_.maximized)

--- a/src/contour/opengl/OpenGLRenderer.cpp
+++ b/src/contour/opengl/OpenGLRenderer.cpp
@@ -23,13 +23,19 @@
 
 #include <range/v3/all.hpp>
 
+#include <QtGui/QImage>
+
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <memory>
 #include <utility>
 #include <vector>
 
 using std::array;
+using std::get;
+using std::holds_alternative;
+using std::make_shared;
 using std::min;
 using std::move;
 using std::nullopt;
@@ -763,10 +769,8 @@ void OpenGLRenderer::initializeBackgroundRendering()
 
 void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage const> const& backgroundImageOpt)
 {
-    if (!backgroundImageOpt || backgroundImageOpt->hash.value() != _renderStateCache.backgroundImageHash)
+    if (!backgroundImageOpt || backgroundImageOpt->hash != _renderStateCache.backgroundImageHash)
     {
-        _scheduledExecutions.backgroundImage = nullptr;
-        _renderStateCache.backgroundImage = nullptr;
         _renderStateCache.backgroundImageOpacity = 1.0f;
         if (_backgroundImageTexture)
         {
@@ -778,14 +782,48 @@ void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage con
     if (!backgroundImageOpt)
         return;
 
-    auto const& backgroundImage = *backgroundImageOpt;
-    _scheduledExecutions.backgroundImage = &backgroundImage;
-    _renderStateCache.backgroundImage = &backgroundImage;
+    auto& backgroundImage = *backgroundImageOpt;
     _renderStateCache.backgroundImageOpacity = backgroundImage.opacity;
-    _renderStateCache.backgroundImageHash = backgroundImage.hash.value();
+    _renderStateCache.backgroundImageBlur = backgroundImage.blur;
 
-    CHECKED_GL(glGenTextures(1, &_backgroundImageTexture));
-    CHECKED_GL(bindTexture(_backgroundImageTexture));
+    if (holds_alternative<FileSystem::path>(backgroundImage.location))
+    {
+        auto const filePath = get<FileSystem::path>(backgroundImage.location);
+        auto const qFilePath = QString::fromStdString(filePath.string());
+        auto qImage = QImage(qFilePath).convertToFormat(QImage::Format_RGBA8888);
+        if (qImage.format() != QImage::Format_RGBA8888)
+        {
+            errorlog()("Unsupported image format {} for background image at {}.",
+                       qImage.format(),
+                       filePath.string());
+            return;
+        }
+        auto const imageSize = ImageSize { Width(qImage.size().width()), Height(qImage.size().height()) };
+        auto const imageFormat = terminal::ImageFormat::RGBA;
+        auto const rowAlignment = 4; // This is default. Can it be any different?
+        DisplayLog()("Background image from disk: {} {}", imageSize, imageFormat);
+        _renderStateCache.backgroundImageHash = crispy::StrongHash::compute(filePath.string());
+        _backgroundImageTexture =
+            createAndUploadImage(imageSize, imageFormat, rowAlignment, qImage.constBits());
+    }
+    else if (holds_alternative<terminal::ImageDataPtr>(backgroundImage.location))
+    {
+        auto const& imageData = *get<terminal::ImageDataPtr>(backgroundImage.location);
+        DisplayLog()("Background inline image: {} {}", imageData.size, imageData.format);
+        _renderStateCache.backgroundImageHash = imageData.hash;
+        _backgroundImageTexture = createAndUploadImage(
+            imageData.size, imageData.format, imageData.rowAlignment, imageData.pixels.data());
+    }
+}
+
+GLuint OpenGLRenderer::createAndUploadImage(ImageSize imageSize,
+                                            terminal::ImageFormat format,
+                                            int rowAlignment,
+                                            uint8_t const* pixels)
+{
+    auto textureId = GLuint {};
+    CHECKED_GL(glGenTextures(1, &textureId));
+    CHECKED_GL(bindTexture(textureId));
 
     CHECKED_GL(glTexParameteri(GL_TEXTURE_2D,
                                GL_TEXTURE_MAG_FILTER,
@@ -794,7 +832,7 @@ void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage con
     CHECKED_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE));
     CHECKED_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     CHECKED_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    CHECKED_GL(glPixelStorei(GL_UNPACK_ALIGNMENT, backgroundImage.rowAlignment));
+    CHECKED_GL(glPixelStorei(GL_UNPACK_ALIGNMENT, rowAlignment));
 
     auto constexpr target = GL_TEXTURE_2D;
     auto constexpr levelOfDetail = 0;
@@ -803,8 +841,8 @@ void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage con
     auto constexpr UnusedParam = 0;
     auto constexpr internalFormat = GL_RGBA;
 
-    auto const textureWidth = unbox<uint32_t>(backgroundImage.size.width);
-    auto const textureHeight = unbox<uint32_t>(backgroundImage.size.height);
+    auto const textureWidth = unbox<uint32_t>(imageSize.width);
+    auto const textureHeight = unbox<uint32_t>(imageSize.height);
 
     CHECKED_GL(glTexImage2D(target,
                             levelOfDetail,
@@ -814,16 +852,8 @@ void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage con
                             UnusedParam,
                             imageFormat,
                             type,
-                            backgroundImage.pixels.data()));
-    // }}}
-
-    LOGSTORE(DisplayLog)
-    ("Uploading background image {} {} ({}x{}) {}",
-     _backgroundImageTexture,
-     backgroundImage.size,
-     textureWidth,
-     textureHeight,
-     backgroundImage.format);
+                            pixels));
+    return textureId;
 }
 
 void OpenGLRenderer::executeRenderBackground()
@@ -834,11 +864,11 @@ void OpenGLRenderer::executeRenderBackground()
     auto const h = unbox<float>(_renderTargetSize.height);
 
     // {{{ setup uniforms
-    auto const opacity = float(_renderStateCache.backgroundColor.alpha()) / 255.0f
-                         * _renderStateCache.backgroundImage->opacity;
+    auto const opacity =
+        float(_renderStateCache.backgroundColor.alpha()) / 255.0f * _renderStateCache.backgroundImageOpacity;
     auto const now = chrono::steady_clock::now().time_since_epoch();
     auto const timestamp = chrono::duration_cast<chrono::milliseconds>(now).count();
-    auto const blur = _renderStateCache.backgroundImage->blur ? 1.0f : 0.0f;
+    auto const blur = _renderStateCache.backgroundImageBlur ? 1.0f : 0.0f;
 
     _backgroundShader->setUniformValue(_backgroundUniformLocations.projection, _projectionMatrix);
     _backgroundShader->setUniformValue(_backgroundUniformLocations.resolution, w, h);

--- a/src/contour/opengl/OpenGLRenderer.cpp
+++ b/src/contour/opengl/OpenGLRenderer.cpp
@@ -202,6 +202,11 @@ void OpenGLRenderer::setRenderSize(ImageSize targetSurfaceSize)
     );
 }
 
+void OpenGLRenderer::setContentScale(double scale)
+{
+    _contentScale = scale;
+}
+
 void OpenGLRenderer::setMargin(terminal::renderer::PageMargin margin) noexcept
 {
     _margin = margin;

--- a/src/contour/opengl/OpenGLRenderer.h
+++ b/src/contour/opengl/OpenGLRenderer.h
@@ -72,6 +72,7 @@ class OpenGLRenderer final:
 
     // RenderTarget implementation
     void setRenderSize(crispy::ImageSize _size) override;
+    void setContentScale(double scale) override;
     void setMargin(terminal::renderer::PageMargin _margin) noexcept override;
     std::optional<AtlasTextureScreenshot> readAtlas() override;
     AtlasBackend& textureScheduler() override;
@@ -151,6 +152,8 @@ class OpenGLRenderer final:
     bool _initialized = false;
     crispy::ImageSize _renderTargetSize;
     QMatrix4x4 _projectionMatrix;
+
+    double _contentScale = 1.0;
 
     terminal::renderer::PageMargin _margin {};
 

--- a/src/contour/opengl/OpenGLRenderer.h
+++ b/src/contour/opengl/OpenGLRenderer.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <terminal/Image.h>
+
 #include <terminal_renderer/RenderTarget.h>
 #include <terminal_renderer/TextureAtlas.h>
 
@@ -101,6 +103,11 @@ class OpenGLRenderer final:
     int maxTextureUnits();
     crispy::ImageSize renderBufferSize();
 
+    GLuint createAndUploadImage(ImageSize imageSize,
+                                terminal::ImageFormat format,
+                                int rowAlignment,
+                                uint8_t const* pixels);
+
     void executeRenderBackground();
     void executeRenderTextures();
     void executeConfigureAtlas(ConfigureAtlas const& _param);
@@ -135,14 +142,12 @@ class OpenGLRenderer final:
         std::optional<terminal::renderer::atlas::ConfigureAtlas> configureAtlas = std::nullopt;
         std::vector<terminal::renderer::atlas::UploadTile> uploadTiles {};
         RenderBatch renderBatch {};
-        terminal::BackgroundImage const* backgroundImage = nullptr;
 
         void clear()
         {
             configureAtlas.reset();
             uploadTiles.clear();
             renderBatch.clear();
-            backgroundImage = nullptr;
         }
     };
 
@@ -207,7 +212,7 @@ class OpenGLRenderer final:
     {
         terminal::RGBAColor backgroundColor {};
         float backgroundImageOpacity = 1.0f;
-        terminal::BackgroundImage const* backgroundImage = nullptr;
+        bool backgroundImageBlur = false;
         crispy::StrongHash backgroundImageHash;
     } _renderStateCache;
 };

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -368,8 +368,12 @@ void TerminalWidget::onScreenDpiChanged()
     fd.dpi = newScreenDPI;
     renderer_.setFonts(fd);
 
+    renderTarget_->setContentScale(contentScale());
+
+    auto const newPixelSize = terminal::ImageSize { Width(width()), Height(height()) } * contentScale();
+
     // Apply resize on same window metrics propagates proper recalculations and repaint.
-    applyResize(terminal::ImageSize { Width(width()), Height(height()) }, session_, renderer_);
+    applyResize(newPixelSize, session_, renderer_);
 }
 
 void TerminalWidget::logDisplayInfo()

--- a/src/terminal/ColorPalette.cpp
+++ b/src/terminal/ColorPalette.cpp
@@ -39,7 +39,7 @@ namespace
     }
 } // namespace
 
-void BackgroundImage::updateImageHash() noexcept
+void ImageData::updateHash() noexcept
 {
     // clang-format off
     using crispy::StrongHash;

--- a/src/terminal/ColorPalette.h
+++ b/src/terminal/ColorPalette.h
@@ -18,6 +18,7 @@
 #include <terminal/defines.h>
 
 #include <crispy/StrongHash.h>
+#include <crispy/stdfs.h>
 
 #include <fmt/format.h>
 
@@ -35,17 +36,26 @@
 namespace terminal
 {
 
-struct BackgroundImage
+struct ImageData
 {
-    // image data
     terminal::ImageFormat format;
     int rowAlignment = 1;
     ImageSize size;
     std::vector<uint8_t> pixels;
 
-    std::optional<crispy::StrongHash> hash;
+    crispy::StrongHash hash;
 
-    void updateImageHash() noexcept;
+    void updateHash() noexcept;
+};
+
+using ImageDataPtr = std::shared_ptr<ImageData const>;
+
+struct BackgroundImage
+{
+    using Location = std::variant<FileSystem::path, ImageDataPtr>;
+
+    Location location;
+    crispy::StrongHash hash;
 
     // image configuration
     float opacity = 1.0; // normalized value

--- a/src/terminal_renderer/RenderTarget.h
+++ b/src/terminal_renderer/RenderTarget.h
@@ -109,6 +109,8 @@ class RenderTarget
     /// This is the size that can be rendered to.
     virtual void setRenderSize(ImageSize _size) = 0;
 
+    virtual void setContentScale(double scale) = 0;
+
     virtual void setMargin(PageMargin _margin) = 0;
 
     virtual atlas::AtlasBackend& textureScheduler() = 0;

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -172,15 +172,7 @@ void Renderer::setRenderTarget(RenderTarget& renderTarget)
     configureTextureAtlas();
 
     if (colorPalette_.backgroundImage)
-    {
-        LOGSTORE(RendererLog)
-        ("- Background image     : {} {}\n",
-         colorPalette_.backgroundImage->size,
-         colorPalette_.backgroundImage->format);
         renderTarget.setBackgroundImage(colorPalette_.backgroundImage);
-    }
-    else
-        LOGSTORE(RendererLog)("- Background image     : {}\n", "blank");
 }
 
 void Renderer::configureTextureAtlas()
@@ -199,12 +191,12 @@ void Renderer::configureTextureAtlas()
     textureAtlas_ = make_unique<Renderable::TextureAtlas>(_renderTarget->textureScheduler(), atlasProperties);
 
     // clang-format off
-    LOGSTORE(RendererLog)("Configuring texture atlas.\n", atlasProperties);
-    LOGSTORE(RendererLog)("- Atlas properties     : {}\n", atlasProperties);
-    LOGSTORE(RendererLog)("- Atlas texture size   : {} pixels\n", textureAtlas_->atlasSize());
-    LOGSTORE(RendererLog)("- Atlas hashtable      : {} slots\n", _atlasHashtableSlotCount.value);
-    LOGSTORE(RendererLog)("- Atlas tile count     : {} = {}x * {}y\n", textureAtlas_->capacity(), textureAtlas_->tilesInX(), textureAtlas_->tilesInY());
-    LOGSTORE(RendererLog)("- Atlas direct mapping : {} (for text rendering)", _atlasDirectMapping ? "enabled" : "disabled");
+    RendererLog()("Configuring texture atlas.\n", atlasProperties);
+    RendererLog()("- Atlas properties     : {}\n", atlasProperties);
+    RendererLog()("- Atlas texture size   : {} pixels\n", textureAtlas_->atlasSize());
+    RendererLog()("- Atlas hashtable      : {} slots\n", _atlasHashtableSlotCount.value);
+    RendererLog()("- Atlas tile count     : {} = {}x * {}y\n", textureAtlas_->capacity(), textureAtlas_->tilesInX(), textureAtlas_->tilesInY());
+    RendererLog()("- Atlas direct mapping : {} (for text rendering)", _atlasDirectMapping ? "enabled" : "disabled");
     // clang-format on
 
     for (reference_wrapper<Renderable>& renderable: renderables())


### PR DESCRIPTION
Have background image loaded in host memory only once and only until it's uploaded to the GPU.