### PR TITLE
[CI] Upload Ubuntu `ddeb`s as artefacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           set -ex
           cd build
-          sudo cpack
+          sudo cpack -V
           BASENAME="contour-${{ steps.set_vars.outputs.version }}-${{ steps.set_vars.outputs.RUN_ID }}-osx"
           echo "pwd: `pwd`:" && ls -hl
           mv -vf "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Darwin.zip" "../${BASENAME}.zip"
@@ -327,7 +327,7 @@ jobs:
         shell: powershell
         run: |
           cd build
-          cpack
+          cpack -V
           type "_CPack_Packages/win64/WIX/wix.log"
       - name: inspect
         run: Get-ChildItem -Recurse
@@ -381,7 +381,7 @@ jobs:
     - name: "cmake"
       run: |
         BUILD_DIR="build" \
-          CMAKE_BUILD_TYPE="Release" \
+          CMAKE_BUILD_TYPE="RelWithDebInfo" \
           CXX="g++-8" \
           EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DUSE_BOOST_FILESYSTEM=ON" \
           ./scripts/ci-prepare-contour.sh
@@ -395,12 +395,14 @@ jobs:
       run: |
         set -ex
         cd build/
-        cpack -G DEB
-        cpack -G TGZ
+        cpack -G DEB -V
+        cpack -G TGZ -V
         cd ..
         # CPack DEB:
-        mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.deb" \
+        mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour.deb" \
               "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.deb"
+        mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour-dbgsym.ddeb" \
+              "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.ddeb"
         # CPack TGZ:
         tar xzpf "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.tar.gz"
         mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux" \
@@ -413,6 +415,13 @@ jobs:
         path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.deb"
         if-no-files-found: error
         retention-days: 7
+    - name: "Uploading artifact .ddeb package (debugging symbols)"
+      uses: actions/upload-artifact@v2
+      with:
+        name: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.ddeb"
+        path: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.ddeb"
+        if-no-files-found: error
+        retention-days: 7
     - name: "Uploading artifact ZIP package"
       uses: actions/upload-artifact@v2
       with:
@@ -423,6 +432,7 @@ jobs:
     - name: "Attempt installing the created .deb"
       run: |
         sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.deb"
+        sudo dpkg --install "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.ddeb"
 
   ubuntu_2004_matrix:
     strategy:
@@ -550,14 +560,16 @@ jobs:
         run: |
           set -ex
           cd build
-          cpack -G DEB
-          mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.deb" \
+          cpack -G DEB -V
+          mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour.deb" \
                 "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+          mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour-dbgsym.ddeb" \
+                "../contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
       - name: "CPack: Creating TGZ package"
         run: |
           set -ex
           cd build
-          cpack -G TGZ
+          cpack -G TGZ -V
           tar xzpf "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.tar.gz"
           mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux" \
                 "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
@@ -566,6 +578,13 @@ jobs:
         with:
           name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
           path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+          if-no-files-found: error
+          retention-days: 7
+      - name: "Uploading artifact .ddeb package (debugging symbols)"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
+          path: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
           if-no-files-found: error
           retention-days: 7
       - name: "Uploading artifact ZIP package"
@@ -578,6 +597,7 @@ jobs:
       - name: "Attempt installing the created .deb"
         run: |
           sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+          sudo dpkg --install "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
       - name: "Delete artifact: contour-ubuntu2004-builddir"
         uses: geekyeggo/delete-artifact@v1
         with:

--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -107,18 +107,14 @@ jobs:
       run: ./build/src/crispy/crispy_test
     - name: "test: libterminal"
       run: ./build/src/terminal/terminal_test
-    - name: "CPack: Creating DEB & TGZ package"
+    - name: "CPack: Creating DEB package"
       run: |
         set -ex
         cd build/
         cpack -G DEB
-        cpack -G TGZ
         cd ..
-        mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.deb" \
+        mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour.deb" \
               "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
-        tar xzpf "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.tar.gz"
-        mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux" \
-              "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
         ls -hl
     - name: "Uploading artifact .deb package"
       uses: actions/upload-artifact@v2

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -173,6 +173,8 @@ if(NOT(CPACK_GENERATOR))
     endif()
 endif()
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "contour")
+
 set(CPACK_PACKAGE_NAME "Contour")
 set(CPACK_PACKAGE_VENDOR "https://github.com/contour-terminal/contour/")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "`contour` is a modern terminal emulator, for everyday use.")
@@ -297,8 +299,11 @@ else()
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/contour-terminal/contour/")
     set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "xdg-open")
     set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
-    # set(CPACK_STRIP_FILES OFF)
-    # set(CPACK_DEB_COMPONENT_INSTALL ON)
+    set(CPACK_DEB_COMPONENT_INSTALL ON)
+    # Override because component-based install would create "contour-contour".
+    set(CPACK_DEBIAN_CONTOUR_PACKAGE_NAME "contour")
+
+    set(CPACK_COMPONENTS_ALL "contour")
 
     include(GNUInstallDirs)
     install(TARGETS contour DESTINATION bin)
@@ -314,3 +319,11 @@ else()
 endif()
 
 include(CPack)
+
+if(UNIX)
+    # CPackDeb is broken. If no components are used, it does not create a ddeb...
+    cpack_add_component(contour
+        DISPLAY_NAME "${CPACK_PACKAGE_NAME}"
+        REQUIRED
+        )
+endif()


### PR DESCRIPTION
> Closes #632 

CPackDeb is ridiculously broken, but I've found a workaround so now we can properly generate debuginfo.

It needs to have a component, even if the program package is a single thing binary only.