### PR TITLE
bench-headless add raw PTY bandwidth test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,21 +2,40 @@
 Checks: >-
   -*,
   bugprone-*,
-  clang-analyzer-*,
-  clang-diagnostic-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-suspicious-include,
   cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-no-malloc,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-special-member-functions,
   modernize-*,
+  -modernize-avoid-bind,
   -modernize-avoid-c-arrays,
+  -modernize-return-braced-init-list,
+  -modernize-use-bool-literals,
+  -modernize-use-nullptr,
   -modernize-use-trailing-return-type,
-  performance-*,
-  -performance-no-int-to-ptr,
-  readability-identifier-naming,
   readability-non-const-parameter,
   readability-redundant-*
+  -readability-redundant-access-specifiers,
+WarningsAsErrors: >-
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  performance-*,
+  -performance-no-int-to-ptr,
+  readability-identifier-naming
 UseColor: true
-WarningsAsErrors: 'true'
-HeaderFilterRegex: 'src/.*\.(h|cpp)$'
+HeaderFilterRegex: '^src/(terminal.*)/.*\.(h|cpp)$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
@@ -52,17 +71,17 @@ CheckOptions:
     value:           'NULL'
   - key:             modernize-use-default-member-init.UseAssignment
     value:           '1'
-  - key:   readability-identifier-naming.EnumCase
-    value: CamelCase
-  - key:   readability-identifier-naming.ClassCase
-    value: CamelCase
-  - key:   readability-identifier-naming.ClassMemberCase
-    value: camelBack
-  - key:   readability-identifier-naming.ClassMethodCase
-    value: camelBack
-  - key:   readability-identifier-naming.ParameterCase
-    value: camelBack
-  - key:   readability-identifier-naming.ParameterPrefix
-    value: ''
-  - key:   readability-identifier-naming.ScopedEnumConstantCase
-    value: CamelCase
+  # - key:   readability-identifier-naming.EnumCase
+  #   value: CamelCase
+  # - key:   readability-identifier-naming.ClassCase
+  #   value: CamelCase
+  # - key:   readability-identifier-naming.ClassMemberCase
+  #   value: camelBack
+  # - key:   readability-identifier-naming.ClassMethodCase
+  #   value: camelBack
+  # - key:   readability-identifier-naming.ParameterCase
+  #   value: camelBack
+  # - key:   readability-identifier-naming.ParameterPrefix
+  #   value: ''
+  # - key:   readability-identifier-naming.ScopedEnumConstantCase
+  #   value: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,22 @@
 ---
-Checks: '-*,clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,-performance-no-int-to-ptr,readability-non-const-parameter,readability-redundant-*,cppcoreguidelines-slicing'
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
+Checks: >-
+  -*,
+  bugprone-*,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-magic-numbers,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  -performance-no-int-to-ptr,
+  readability-identifier-naming,
+  readability-non-const-parameter,
+  readability-redundant-*
+UseColor: true
+WarningsAsErrors: 'true'
+HeaderFilterRegex: 'src/.*\.(h|cpp)$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
@@ -35,5 +50,19 @@ CheckOptions:
     value:           llvm
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
-...
-
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '1'
+  - key:   readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ClassMemberCase
+    value: camelBack
+  - key:   readability-identifier-naming.ClassMethodCase
+    value: camelBack
+  - key:   readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key:   readability-identifier-naming.ParameterPrefix
+    value: ''
+  - key:   readability-identifier-naming.ScopedEnumConstantCase
+    value: CamelCase

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
         BUILD_DIR="build" \
           CMAKE_BUILD_TYPE="RelWithDebInfo" \
           CXX="g++-8" \
-          EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DUSE_BOOST_FILESYSTEM=ON" \
+          EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DUSE_BOOST_FILESYSTEM=ON -DCONTOUR_INSTALL_TOOLS=ON" \
           ./scripts/ci-prepare-contour.sh
     - name: "build"
       run: cmake --build build/ -- -j3
@@ -499,7 +499,7 @@ jobs:
           BUILD_DIR="build" \
             CMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
             CXX="${CC_EXE}-${CC_VER}" \
-            EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx }}" \
+            EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} -DCONTOUR_INSTALL_TOOLS=ON" \
             ./scripts/ci-prepare-contour.sh
       - name: "build"
         run: cmake --build build/ -- -j3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,7 +499,12 @@ jobs:
           BUILD_DIR="build" \
             CMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
             CXX="${CC_EXE}-${CC_VER}" \
-            EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} -DCONTOUR_INSTALL_TOOLS=ON" \
+            EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON \
+                               -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} \
+                               -DCONTOUR_INSTALL_TOOLS=ON \
+                               -DPEDANTIC_COMPILER=ON \
+                               -DPEDANTIC_COMPILER_WERROR=OFF \
+                               " \
             ./scripts/ci-prepare-contour.sh
       - name: "build"
         run: cmake --build build/ -- -j3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(CONTOUR_COVERAGE "Builds with codecov [default: OFF]" OFF)
 option(CONTOUR_SANITIZE "Builds with Address sanitizer enabled [default: OFF]" "OFF")
 option(CONTOUR_STACKTRACE_ADDR2LINE "Uses addr2line to pretty-print SEGV stacktrace." ${ADDR2LINE_DEFAULT})
 option(CONTOUR_BUILD_WITH_MIMALLOC "Builds with mimalloc [default: OFF]" OFF)
+option(CONTOUR_INSTALL_TOOLS "Installs tools, if built [default: OFF]" OFF)
 
 if(NOT WIN32 AND NOT CONTOUR_SANITIZE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CONTOUR_SANITIZE "OFF" CACHE STRING "Choose the sanitizer mode." FORCE)

--- a/autogen.sh
+++ b/autogen.sh
@@ -45,6 +45,8 @@ echo "EXTRA_CMAKE_FLAGS: ${EXTRA_CMAKE_FLAGS}"
 exec cmake "${ROOTDIR}" \
            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
            -DCMAKE_CXX_COMPILER="${CXX}" \
+           -DPEDANTIC_COMPILER=ON \
+           -DPEDANTIC_COMPILER_WERROR=ON \
            ${EXTRA_CMAKE_FLAGS} \
            -B "${BUILD_DIR}" \
            -GNinja

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -26,9 +26,9 @@ $ThirdParties =
         Macro   = ""
     };
     [ThirdParty]@{
-        Folder  = "libunicode-94e0eeadadf61a957b1184ea276e7d94e0d40cf9";
-        Archive = "libunicode-94e0eeadadf61a957b1184ea276e7d94e0d40cf9.zip";
-        URI     = "https://github.com/contour-terminal/libunicode/archive/94e0eeadadf61a957b1184ea276e7d94e0d40cf9.zip";
+        Folder  = "libunicode-bcd20f35d72bacd163fa45e985cf67fd2b6a3d64";
+        Archive = "libunicode-bcd20f35d72bacd163fa45e985cf67fd2b6a3d64.zip";
+        URI     = "https://github.com/contour-terminal/libunicode/archive/bcd20f35d72bacd163fa45e985cf67fd2b6a3d64.zip";
         Macro   = "libunicode"
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -103,7 +103,7 @@ fetch_and_unpack_embeds()
         https://github.com/contour-terminal/termbench-pro/archive/$termbench_pro_git_sha.tar.gz \
         termbench_pro
 
-    local libunicode_git_sha="94e0eeadadf61a957b1184ea276e7d94e0d40cf9"
+    local libunicode_git_sha="bcd20f35d72bacd163fa45e985cf67fd2b6a3d64"
     fetch_and_unpack \
         libunicode-$libunicode_git_sha \
         libunicode-$libunicode_git_sha.tar.gz \

--- a/src/contour/BackgroundBlur.cpp
+++ b/src/contour/BackgroundBlur.cpp
@@ -95,6 +95,8 @@ void setEnabled(QWindow* window, bool enable)
     }
 #else
     // Get me working on other platforms/compositors (such as OSX, Gnome, ...), please.
+    (void) window;
+    (void) enable;
 #endif
 }
 

--- a/src/contour/CaptureScreen.cpp
+++ b/src/contour/CaptureScreen.cpp
@@ -145,10 +145,10 @@ namespace
 
             // disable buffered input
             termios tio = savedModes;
-            tio.c_lflag &= ~ICANON;  // disable canonical input
-            tio.c_lflag &= ~ECHO;    // disable echoing
-            tio.c_iflag &= ~IMAXBEL; // disable bell on full input buffer
-            tio.c_iflag &= ~ISTRIP;  // disable stripping of 8th bit on input
+            tio.c_lflag &= (tcflag_t) ~ICANON;  // disable canonical input
+            tio.c_lflag &= (tcflag_t) ~ECHO;    // disable echoing
+            tio.c_iflag &= (tcflag_t) ~IMAXBEL; // disable bell on full input buffer
+            tio.c_iflag &= (tcflag_t) ~ISTRIP;  // disable stripping of 8th bit on input
 
             if (tcsetattr(fd, TCSANOW, &tio) < 0)
                 return;
@@ -204,7 +204,7 @@ namespace
             else
                 return -1;
 #else
-            return ::write(fd, _buf, _size);
+            return static_cast<int>(::write(fd, _buf, _size));
 #endif
         }
 
@@ -219,7 +219,7 @@ namespace
             else
                 return -1;
 #else
-            return ::read(fd, _buf, _size);
+            return static_cast<int>(::read(fd, _buf, _size));
 #endif
         }
 

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -217,6 +217,11 @@ struct Config
     // This value must be integer-devisable by 16.
     size_t ptyReadBufferSize = 16384;
 
+    // Size in bytes per PTY Buffer Object.
+    //
+    // Defaults to 1 MB, that's roughly 10k lines when column count is 100.
+    size_t ptyBufferObjectSize = 1024u * 1024u;
+
     bool reflowOnResize = true;
 
     std::unordered_map<std::string, terminal::ColorPalette> colorschemes;

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -388,8 +388,12 @@ void ContourGuiApp::showNotification(std::string_view _title, std::string_view _
     QProcess::execute(QString::fromLatin1("notify-send"), args);
 #elif defined(__APPLE__)
     // TODO: use Growl?
+    (void) _title;
+    (void) _content;
 #elif defined(_WIN32)
     // TODO: use Toast
+    (void) _title;
+    (void) _content;
 #endif
 }
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -52,7 +52,7 @@
 #endif
 
 #if !defined(_MSC_VER)
-    #include <signal.h>
+    #include <csignal>
     #include <unistd.h>
 #endif
 
@@ -104,6 +104,7 @@ TerminalSession::TerminalSession(unique_ptr<Pty> _pty,
     displayInitialized_ { move(_displayInitialized) },
     onExit_ { move(_onExit) },
     terminal_ { move(_pty),
+                config_.ptyBufferObjectSize,
                 config_.ptyReadBufferSize,
                 *this,
                 config_.profile(profileName_)->maxHistoryLineCount,
@@ -949,7 +950,6 @@ void TerminalSession::configureTerminal()
 {
     auto const _l = scoped_lock { terminal_ };
     SessionLog()("Configuring terminal.");
-    auto& screen = terminal_.primaryScreen();
 
     terminal_.setWordDelimiters(config_.wordDelimiters);
     terminal_.setMouseProtocolBypassModifier(config_.bypassMouseProtocolModifier);
@@ -996,8 +996,8 @@ void TerminalSession::configureDisplay()
 
     terminal_.setRefreshRate(display_->refreshRate());
     auto const pageSize = PageSize {
-        LineCount(*display_->pixelSize().height / *display_->cellSize().height),
-        ColumnCount(*display_->pixelSize().width / *display_->cellSize().width),
+        LineCount(unbox<int>(display_->pixelSize().height) / unbox<int>(display_->cellSize().height)),
+        ColumnCount(unbox<int>(display_->pixelSize().width) / unbox<int>(display_->cellSize().width)),
     };
     display_->setPageSize(pageSize);
     display_->setFonts(profile_.fonts);

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -61,7 +61,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
                     std::unique_ptr<TerminalDisplay> _display,
                     std::function<void()> _displayInitialized,
                     std::function<void()> _onExit);
-    ~TerminalSession();
+    ~TerminalSession() override;
 
     /// Starts the VT background thread.
     void start();

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -57,6 +57,10 @@ word_delimiters: " /\\()\"'-.,:;<>~!@#$%^&*+=[]{}~?|│"
 # Default: 16384
 read_buffer_size: 16384
 
+# Size in bytes per PTY Buffer Object.
+#
+pty_buffer_size: 1000000
+
 default_profile: main
 
 # Flag to determine whether to spawn new process or not when creating new terminal

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -413,8 +413,8 @@ terminal::renderer::PageMargin computeMargin(ImageSize _cellSize,
                                              PageSize _charCells,
                                              ImageSize _pixels) noexcept
 {
-    auto const usedHeight = static_cast<int>(*_charCells.lines * *_cellSize.height);
-    auto const freeHeight = static_cast<int>(*_pixels.height - usedHeight);
+    auto const usedHeight = unbox<int>(_charCells.lines) * unbox<int>(_cellSize.height);
+    auto const freeHeight = unbox<int>(_pixels.height) - usedHeight;
     auto const bottomMargin = freeHeight;
 
     // auto const usedWidth = _charCells.columns * regularFont_.maxAdvance();

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -59,7 +59,7 @@ namespace detail
       public:
         FunctionCallEvent(Fun&& fun): QEvent(QEvent::None), fun(std::move(fun)) {}
         FunctionCallEvent(Fun const& fun): QEvent(QEvent::None), fun(fun) {}
-        ~FunctionCallEvent() { fun(); }
+        ~FunctionCallEvent() override { fun(); }
     };
 } // namespace detail
 

--- a/src/contour/opengl/Blur.h
+++ b/src/contour/opengl/Blur.h
@@ -50,7 +50,7 @@ class Blur: protected QOpenGLFunctions_3_3_Core
 {
   public:
     Blur();
-    ~Blur();
+    ~Blur() override;
 
     QImage blurDualKawase(QImage imageToBlur, int offset, int iterations);
     QImage blurGaussian(QImage imageToBlur);
@@ -62,9 +62,13 @@ class Blur: protected QOpenGLFunctions_3_3_Core
     void renderToFBO(QOpenGLFramebufferObject* targetFBO, GLuint sourceTexture, QOpenGLShaderProgram* shader);
     void initFBOTextures();
 
+    //.
+    QOpenGLContext* m_context;
+    QOffscreenSurface* m_surface;
+    QOpenGLShaderProgram* m_gaussianBlur = nullptr;
     QOpenGLShaderProgram* m_shaderKawaseUp = nullptr;
     QOpenGLShaderProgram* m_shaderKawaseDown = nullptr;
-    QOpenGLShaderProgram* m_gaussianBlur = nullptr;
+    //.
 
     QVector<QOpenGLFramebufferObject*> m_FBO_vector;
     QOpenGLTexture* m_textureToBlur;
@@ -72,18 +76,15 @@ class Blur: protected QOpenGLFunctions_3_3_Core
     QOpenGLVertexArrayObject m_VertexArrayObject;
     QOpenGLBuffer m_vertexBuffer;
 
-    QOffscreenSurface* m_surface;
-    QOpenGLContext* m_context;
-
-    int m_iterations;
+    int m_iterations = -1;
     QImage m_imageToBlur;
 
     // GPU timer
-    GLuint64 GPUtimerElapsedTime;
+    GLuint64 GPUtimerElapsedTime {};
 
     // CPU timer
     QElapsedTimer CPUTimer;
-    quint64 CPUTimerElapsedTime;
+    quint64 CPUTimerElapsedTime {};
 };
 
 } // namespace contour::opengl

--- a/src/contour/opengl/OpenGLRenderer.h
+++ b/src/contour/opengl/OpenGLRenderer.h
@@ -98,7 +98,6 @@ class OpenGLRenderer final:
     float uptime() noexcept
     {
         using namespace std::chrono;
-        auto const now = _now.time_since_epoch();
         auto const uptimeMsecs = duration_cast<milliseconds>(_now - _startTime).count();
         auto const uptimeSecs = static_cast<float>(uptimeMsecs) / 1000.0f;
         return uptimeSecs;
@@ -218,8 +217,8 @@ class OpenGLRenderer final:
     std::unique_ptr<QOpenGLShaderProgram> _rectShader;
     int _rectProjectionLocation;
     int _rectTimeLocation;
-    GLuint _rectVAO;
-    GLuint _rectVBO;
+    GLuint _rectVAO {};
+    GLuint _rectVBO {};
 
     std::optional<ScreenshotCallback> _pendingScreenshotCallback;
 

--- a/src/contour/opengl/TerminalWidget.cpp
+++ b/src/contour/opengl/TerminalWidget.cpp
@@ -867,7 +867,7 @@ void TerminalWidget::doDumpState()
     {
         auto const screenStateDump = [&]() {
             auto os = std::stringstream {};
-            terminal().primaryScreen().inspect("Screen state dump.", os);
+            terminal().currentScreen().inspect("Screen state dump.", os);
             renderer_.inspect(os);
             return os.str();
         }();

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include <cassert>
+
 using std::destroy_n;
 using std::move;
 using std::size_t;
@@ -32,13 +34,13 @@ auto const inline BufferObjectLog = logstore::Category("BufferObject",
 BufferFragment::BufferFragment(BufferObjectPtr buffer, size_t offset, size_t size) noexcept:
     buffer_ { move(buffer) }, region_ { buffer_->data() + offset, size }
 {
-    assert(buffer_->begin() <= region_.begin() && region_.end() <= buffer_->end());
+    assert(buffer_->begin() <= &*region_.begin() && &*region_.end() <= buffer_->end());
 }
 
 BufferFragment::BufferFragment(BufferObjectPtr buffer, string_view region) noexcept:
     buffer_ { move(buffer) }, region_ { region }
 {
-    assert(buffer_->begin() <= region_.begin() && region_.end() <= buffer_->end());
+    assert(buffer_->begin() <= &*region_.begin() && &*region_.end() <= buffer_->end());
 }
 
 BufferObject::BufferObject(size_t capacity) noexcept:

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -1,0 +1,144 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <crispy/BufferObject.h>
+#include <crispy/logstore.h>
+
+#include <fmt/format.h>
+
+using std::destroy_n;
+using std::move;
+using std::size_t;
+using std::string_view;
+
+namespace crispy
+{
+
+auto const inline BufferObjectLog = logstore::Category("BufferObject",
+                                                       "Logs buffer object pool activity.",
+                                                       logstore::Category::State::Disabled,
+                                                       logstore::Category::Visibility::Hidden);
+
+BufferFragment::BufferFragment(BufferObjectPtr buffer, size_t offset, size_t size) noexcept:
+    buffer_ { move(buffer) }, region_ { buffer_->data() + offset, size }
+{
+    assert(buffer_->begin() <= region_.begin() && region_.end() <= buffer_->end());
+}
+
+BufferFragment::BufferFragment(BufferObjectPtr buffer, string_view region) noexcept:
+    buffer_ { move(buffer) }, region_ { region }
+{
+    assert(buffer_->begin() <= region_.begin() && region_.end() <= buffer_->end());
+}
+
+BufferObject::BufferObject(size_t capacity) noexcept:
+#if !defined(BUFFER_OBJECT_INLINE)
+    data_ { new char[capacity] },
+#endif
+    hotEnd_ { data() },
+    end_ { data() + capacity }
+{
+    if (BufferObjectLog)
+        BufferObjectLog()("Creating BufferObject @{}.", (void*) this);
+}
+
+BufferObject::~BufferObject()
+{
+    if (BufferObjectLog)
+        BufferObjectLog()("Destroying BufferObject @{}.", (void*) this);
+#if !defined(BUFFER_OBJECT_INLINE)
+    delete[] data_;
+#endif
+}
+
+BufferObjectPtr BufferObject::create(size_t capacity, BufferObjectRelease release)
+{
+#if defined(BUFFER_OBJECT_INLINE)
+    auto const totalCapacity = nextPowerOfTwo(sizeof(BufferObject) + capacity);
+    auto const nettoCapacity = totalCapacity - sizeof(BufferObject);
+    auto ptr = (BufferObject*) malloc(totalCapacity);
+    new (ptr) BufferObject(nettoCapacity);
+    return BufferObjectPtr(ptr, move(release));
+#else
+    return BufferObjectPtr(new BufferObject(nextPowerOfTwo(capacity)), move(release));
+#endif
+}
+
+string_view BufferObject::writeAtEnd(string_view data) noexcept
+{
+    assert(hotEnd_ + data.size() <= end_);
+    memcpy(hotEnd_, data.data(), data.size());
+    return string_view { hotEnd_, data.size() };
+}
+
+BufferObjectPool::BufferObjectPool(size_t bufferSize): bufferSize_ { bufferSize }
+{
+    BufferObjectLog()("Creating BufferObject pool with chunk size {}",
+                      crispy::humanReadableBytes(bufferSize));
+}
+
+BufferObjectPool::~BufferObjectPool()
+{
+    reuseBuffers_ = false;
+}
+
+size_t BufferObjectPool::unusedBuffers() const noexcept
+{
+    return unusedBuffers_.size();
+}
+
+void BufferObjectPool::releaseUnusedBuffers()
+{
+    reuseBuffers_ = false;
+    unusedBuffers_.clear();
+    reuseBuffers_ = true;
+}
+
+BufferObjectPtr BufferObjectPool::allocateBufferObject()
+{
+    if (unusedBuffers_.empty())
+        return BufferObject::create(bufferSize_, [this](auto p) { release(p); });
+
+    BufferObjectPtr buffer = move(unusedBuffers_.front());
+    if (BufferObjectLog)
+        BufferObjectLog()("Recycling BufferObject from pool: @{}.", (void*) buffer.get());
+    unusedBuffers_.pop_front();
+    return buffer;
+}
+
+void BufferObject::reset() noexcept
+{
+    hotEnd_ = data();
+}
+
+void BufferObjectPool::release(BufferObject* ptr)
+{
+    if (reuseBuffers_)
+    {
+        if (BufferObjectLog)
+            BufferObjectLog()("Releasing BufferObject from pool: @{}", (void*) ptr);
+        ptr->reset();
+        unusedBuffers_.emplace_back(ptr, [this](auto p) { release(p); });
+    }
+    else
+    {
+#if defined(BUFFER_OBJECT_INLINE)
+        destroy_n(ptr, 1);
+        free(ptr);
+#else
+        delete ptr;
+#endif
+    }
+}
+
+} // namespace crispy

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -50,6 +50,9 @@ BufferObject::BufferObject(size_t capacity) noexcept:
     hotEnd_ { data() },
     end_ { data() + capacity }
 {
+#if defined(BUFFER_OBJECT_INLINE)
+    new (data()) char[capacity];
+#endif
     if (BufferObjectLog)
         BufferObjectLog()("Creating BufferObject @{}.", (void*) this);
 }
@@ -66,7 +69,7 @@ BufferObject::~BufferObject()
 BufferObjectPtr BufferObject::create(size_t capacity, BufferObjectRelease release)
 {
 #if defined(BUFFER_OBJECT_INLINE)
-    auto const totalCapacity = nextPowerOfTwo(sizeof(BufferObject) + capacity);
+    auto const totalCapacity = nextPowerOfTwo(static_cast<uint32_t>(sizeof(BufferObject) + capacity));
     auto const nettoCapacity = totalCapacity - sizeof(BufferObject);
     auto ptr = (BufferObject*) malloc(totalCapacity);
     new (ptr) BufferObject(nettoCapacity);

--- a/src/crispy/BufferObject.h
+++ b/src/crispy/BufferObject.h
@@ -1,0 +1,227 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <string_view>
+
+#define BUFFER_OBJECT_INLINE 1
+
+namespace crispy
+{
+
+class BufferObject;
+class BufferFragment;
+
+using BufferObjectRelease = std::function<void(BufferObject*)>;
+using BufferObjectPtr = std::shared_ptr<BufferObject>;
+
+/**
+ * BufferObject is the buffer object a Pty's read-call will use to store
+ * the read data.
+ * This buffer is suitable for efficient reuse.
+ *
+ * Properties:
+ *
+ * - Suitable for incrementally filling grid lines sharing the same SGR attributes.
+ * - Keeps reference count of how many Line instances are still using this object.
+ * - if a call to `Pty.read(BufferObject&)` does not cause any new references
+ *   to this buffer for optimized access, then the next call to `Pty.read()`
+ *   can start filling at the same offset again.
+ *   The offset gets incremented only if new references have been added.
+ * - This buffer does not grow or shrink.
+ */
+class BufferObject: public std::enable_shared_from_this<BufferObject>
+{
+  public:
+    explicit BufferObject(size_t capacity) noexcept;
+    ~BufferObject();
+
+    static BufferObjectPtr create(size_t capacity, BufferObjectRelease release = {});
+
+    void reset() noexcept;
+
+    std::size_t capacity() const noexcept { return std::distance(data(), end()); }
+    std::size_t bytesUsed() const noexcept { return std::distance(data(), hotEnd()); }
+    std::size_t bytesAvailable() const noexcept { return std::distance(hotEnd(), end()); }
+    float loadFactor() const noexcept { return float(bytesUsed()) / float(capacity()); }
+
+    char* data() noexcept;
+    char const* data() const noexcept;
+
+    BufferFragment ref(std::size_t offset, std::size_t size) noexcept;
+
+    /// Returns a pointer to the first byte in the internal data storage.
+    char* begin() noexcept { return data(); }
+    char const* begin() const noexcept { return data(); }
+
+    /// Returns a pointer one byte past the last used byte.
+    char* hotEnd() noexcept { return hotEnd_; }
+    char const* hotEnd() const noexcept { return hotEnd_; }
+
+    /// Returns a pointer one byte past the underlying storage's last byte.
+    char* end() noexcept { return end_; }
+    char const* end() const noexcept { return end_; }
+
+    /// Advances the end of the used area by the given amount of bytes.
+    void advance(size_t n) noexcept;
+
+    void advanceHotEndUntil(char const* ptr) noexcept;
+
+    /// Appends the given amount of data to the buffer object
+    /// without advancing the end pointer.
+    std::string_view writeAtEnd(std::string_view data) noexcept;
+
+    void clear() noexcept;
+
+  private:
+#if !defined(BUFFER_OBJECT_INLINE)
+    char* data_;
+#endif
+    char* hotEnd_;
+    char* end_;
+
+    friend class BufferFragment;
+};
+
+/**
+ * BufferObjectPool manages reusable BufferObject objects.
+ *
+ * BufferObject objects that are about to be disposed
+ * are not gettings its resources deleted but ownership moved
+ * back to BufferObjectPool.
+ */
+class BufferObjectPool
+{
+  public:
+    explicit BufferObjectPool(size_t bufferSize = 4096);
+    ~BufferObjectPool();
+
+    void releaseUnusedBuffers();
+    size_t unusedBuffers() const noexcept;
+    BufferObjectPtr allocateBufferObject();
+
+  private:
+    void release(BufferObject* ptr);
+
+    bool reuseBuffers_ = true;
+    size_t bufferSize_;
+    std::list<BufferObjectPtr> unusedBuffers_;
+};
+
+/**
+ * BufferFragment safely holds a reference to a region of BufferObject.
+ */
+class BufferFragment
+{
+  public:
+    BufferFragment(BufferObjectPtr buffer, std::size_t offset, std::size_t size) noexcept;
+    BufferFragment(BufferObjectPtr buffer, std::string_view region) noexcept;
+
+    BufferFragment() noexcept = default;
+    BufferFragment(BufferFragment&&) noexcept = default;
+    BufferFragment(BufferFragment const&) noexcept = default;
+    BufferFragment& operator=(BufferFragment&&) noexcept = default;
+    BufferFragment& operator=(BufferFragment const&) noexcept = default;
+
+    void reset() noexcept { region_ = {}; }
+
+    void growBy(std::size_t byteCount) noexcept
+    {
+        region_ = std::string_view(region_.data(), region_.size() + byteCount);
+    }
+
+    std::string_view view() const noexcept { return region_; }
+    BufferObjectPtr const& owner() noexcept { return buffer_; }
+
+    bool empty() const noexcept { return region_.empty(); }
+    std::size_t size() const noexcept { return region_.size(); }
+    char const* data() const noexcept { return region_.data(); }
+    char operator[](size_t i) const noexcept { return region_[i]; }
+
+    decltype(auto) begin() noexcept { return region_.begin(); }
+    decltype(auto) end() noexcept { return region_.end(); }
+
+    std::size_t startOffset() const noexcept;
+    std::size_t endOffset() const noexcept;
+
+  private:
+    BufferObjectPtr buffer_;
+    std::string_view region_;
+};
+
+// {{{ BufferObject inlines
+inline char* BufferObject::data() noexcept
+{
+#if defined(BUFFER_OBJECT_INLINE)
+    return (char*) (this + 1);
+#else
+    return data_;
+#endif
+}
+
+inline char const* BufferObject::data() const noexcept
+{
+#if defined(BUFFER_OBJECT_INLINE)
+    return (char*) (this + 1);
+#else
+    return data_;
+#endif
+}
+
+inline void BufferObject::advance(size_t n) noexcept
+{
+    assert(hotEnd_ + n <= end_);
+    hotEnd_ += n;
+}
+
+inline void BufferObject::advanceHotEndUntil(char const* ptr) noexcept
+{
+    assert(hotEnd_ <= ptr && ptr <= end_);
+    hotEnd_ = const_cast<char*>(ptr);
+}
+
+inline void BufferObject::clear() noexcept
+{
+    hotEnd_ = data();
+}
+
+inline BufferFragment BufferObject::ref(std::size_t offset, std::size_t size) noexcept
+{
+    return BufferFragment(shared_from_this(), offset, size);
+}
+// }}}
+
+// {{{ BufferFragment inlines
+inline std::size_t BufferFragment::startOffset() const noexcept
+{
+    return std::distance((char*) buffer_->data(), (char*) data());
+}
+
+inline std::size_t BufferFragment::endOffset() const noexcept
+{
+    return startOffset() + size();
+}
+// }}}
+
+} // namespace crispy

--- a/src/crispy/BufferObject.h
+++ b/src/crispy/BufferObject.h
@@ -152,7 +152,7 @@ class BufferFragment
     }
 
     std::string_view view() const noexcept { return region_; }
-    BufferObjectPtr const& owner() noexcept { return buffer_; }
+    BufferObjectPtr const& owner() const noexcept { return buffer_; }
 
     bool empty() const noexcept { return region_.empty(); }
     std::size_t size() const noexcept { return region_.size(); }

--- a/src/crispy/BufferObject.h
+++ b/src/crispy/BufferObject.h
@@ -61,9 +61,15 @@ class BufferObject: public std::enable_shared_from_this<BufferObject>
 
     void reset() noexcept;
 
-    std::size_t capacity() const noexcept { return std::distance(data(), end()); }
-    std::size_t bytesUsed() const noexcept { return std::distance(data(), hotEnd()); }
-    std::size_t bytesAvailable() const noexcept { return std::distance(hotEnd(), end()); }
+    std::size_t capacity() const noexcept { return static_cast<std::size_t>(std::distance(data(), end())); }
+    std::size_t bytesUsed() const noexcept
+    {
+        return static_cast<std::size_t>(std::distance(data(), hotEnd()));
+    }
+    std::size_t bytesAvailable() const noexcept
+    {
+        return static_cast<std::size_t>(std::distance(hotEnd(), end()));
+    }
     float loadFactor() const noexcept { return float(bytesUsed()) / float(capacity()); }
 
     char* data() noexcept;
@@ -118,8 +124,8 @@ class BufferObjectPool
     ~BufferObjectPool();
 
     void releaseUnusedBuffers();
-    size_t unusedBuffers() const noexcept;
-    BufferObjectPtr allocateBufferObject();
+    [[nodiscard]] size_t unusedBuffers() const noexcept;
+    [[nodiscard]] BufferObjectPtr allocateBufferObject();
 
   private:
     void release(BufferObject* ptr);
@@ -151,19 +157,19 @@ class BufferFragment
         region_ = std::string_view(region_.data(), region_.size() + byteCount);
     }
 
-    std::string_view view() const noexcept { return region_; }
-    BufferObjectPtr const& owner() const noexcept { return buffer_; }
+    [[nodiscard]] std::string_view view() const noexcept { return region_; }
+    [[nodiscard]] BufferObjectPtr const& owner() const noexcept { return buffer_; }
 
-    bool empty() const noexcept { return region_.empty(); }
-    std::size_t size() const noexcept { return region_.size(); }
-    char const* data() const noexcept { return region_.data(); }
-    char operator[](size_t i) const noexcept { return region_[i]; }
+    [[nodiscard]] bool empty() const noexcept { return region_.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return region_.size(); }
+    [[nodiscard]] char const* data() const noexcept { return region_.data(); }
+    [[nodiscard]] char operator[](size_t i) const noexcept { return region_[i]; }
 
-    decltype(auto) begin() noexcept { return region_.begin(); }
-    decltype(auto) end() noexcept { return region_.end(); }
+    [[nodiscard]] decltype(auto) begin() noexcept { return region_.begin(); }
+    [[nodiscard]] decltype(auto) end() noexcept { return region_.end(); }
 
-    std::size_t startOffset() const noexcept;
-    std::size_t endOffset() const noexcept;
+    [[nodiscard]] std::size_t startOffset() const noexcept;
+    [[nodiscard]] std::size_t endOffset() const noexcept;
 
   private:
     BufferObjectPtr buffer_;
@@ -215,7 +221,7 @@ inline BufferFragment BufferObject::ref(std::size_t offset, std::size_t size) no
 // {{{ BufferFragment inlines
 inline std::size_t BufferFragment::startOffset() const noexcept
 {
-    return std::distance((char*) buffer_->data(), (char*) data());
+    return static_cast<std::size_t>(std::distance((char*) buffer_->data(), (char*) data()));
 }
 
 inline std::size_t BufferFragment::endOffset() const noexcept

--- a/src/crispy/BufferObject_test.cpp
+++ b/src/crispy/BufferObject_test.cpp
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <crispy/BufferObject.h>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("BufferObject", "[BufferObject]")
+{
+    // TODO(pr)
+}

--- a/src/crispy/BufferObject_test.cpp
+++ b/src/crispy/BufferObject_test.cpp
@@ -18,5 +18,5 @@
 
 TEST_CASE("BufferObject", "[BufferObject]")
 {
-    // TODO(pr)
+    // TODO
 }

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 set(crispy_SOURCES
     App.cpp App.h
+    BufferObject.cpp BufferObject.h
     CLI.cpp CLI.h
     Comparison.h
     LRUCache.h
@@ -106,6 +107,7 @@ option(CRISPY_TESTING "Enables building of unittests for crispy library [default
 if(CRISPY_TESTING)
     enable_testing()
     add_executable(crispy_test
+        BufferObject_test.cpp
         CLI_test.cpp
         LRUCache_test.cpp
         StrongLRUCache_test.cpp

--- a/src/crispy/StackTrace.cpp
+++ b/src/crispy/StackTrace.cpp
@@ -95,7 +95,7 @@ vector<void*> StackTrace::getFrames(size_t _skip, size_t _max)
     return frames;
 }
 
-optional<DebugInfo> StackTrace::getDebugInfoForFrame(void* p)
+optional<DebugInfo> StackTrace::getDebugInfoForFrame(void const* p)
 {
     if (!p)
         return nullopt;
@@ -215,16 +215,16 @@ vector<string> StackTrace::symbols() const
 
     auto const frames = getFrames(SKIP_FRAMES, MAX_FRAMES);
     vector<string> output;
-    for (size_t i = 0; i < frames.size(); ++i)
+    for (auto const* frame: frames)
     {
 #if defined(CONTOUR_STACKTRACE_ADDR2LINE)
-        auto debugInfo = getDebugInfoForFrame(frames[i]);
+        auto debugInfo = getDebugInfoForFrame(frame);
         if (!debugInfo)
-            output.emplace_back(fmt::format("{}", frames[i]));
+            output.emplace_back(fmt::format("{}", frame));
         else
             output.emplace_back(debugInfo->text);
 #else
-        output.emplace_back(fmt::format("{}", frames[i]));
+        output.emplace_back(fmt::format("{}", frame));
 #endif
     }
     return output;

--- a/src/crispy/StackTrace.h
+++ b/src/crispy/StackTrace.h
@@ -28,7 +28,7 @@ class StackTrace
 
     static std::string demangleSymbol(const char* symbol);
     static std::vector<void*> getFrames(size_t _skip = 2, size_t _max = 64);
-    static std::optional<DebugInfo> getDebugInfoForFrame(void* _frameAddress);
+    static std::optional<DebugInfo> getDebugInfoForFrame(void const* _frameAddress);
 
   private:
     std::vector<void*> frames_;

--- a/src/crispy/StrongHash.h
+++ b/src/crispy/StrongHash.h
@@ -117,7 +117,7 @@ StrongHash StrongHash::compute(std::basic_string<T, Alloc> const& text) noexcept
     // return compute(value.data(), value.size());
     StrongHash hash;
     hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
-    for (char32_t const codepoint: text)
+    for (T const codepoint: text)
         hash = hash * static_cast<uint32_t>(codepoint);
     return hash;
 }

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -15,6 +15,7 @@
 
 #include <crispy/StrongHash.h>
 #include <crispy/assert.h>
+#include <crispy/utils.h>
 
 #include <immintrin.h>
 #include <optional>
@@ -38,21 +39,6 @@ namespace detail
     {
         //.
         return (value & (value - 1)) == 0;
-    }
-
-    // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-    // 1U << (lg(v - 1) + 1)
-    constexpr uint32_t nextPowerOfTwo(uint32_t v) noexcept
-    {
-        // return 1U << (std::log(v - 1) + 1);
-        v--;
-        v |= v >> 1;
-        v |= v >> 2;
-        v |= v >> 4;
-        v |= v >> 8;
-        v |= v >> 16;
-        v++;
-        return v;
     }
 } // namespace detail
 // }}}
@@ -368,7 +354,7 @@ auto StrongLRUHashtable<Value>::create(StrongHashtableSize hashCount,
     // Entry[]    entries
 
     if (!detail::isPowerOfTwo(hashCount.value))
-        hashCount.value = detail::nextPowerOfTwo(hashCount.value);
+        hashCount.value = nextPowerOfTwo(hashCount.value);
 
     Allocator allocator;
     auto const size = requiredMemorySize(hashCount, entryCount);

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -260,7 +260,22 @@ constexpr std::optional<T> to_integer(std::basic_string<C> _text) noexcept
 struct finally
 {
     std::function<void()> hook {};
-    ~finally() { hook(); }
+
+    void perform()
+    {
+        if (hook)
+        {
+            auto hooked = std::move(hook);
+            hook = {};
+            hooked();
+        }
+    }
+
+    ~finally()
+    {
+        if (hook)
+            hook();
+    }
 };
 
 inline std::optional<unsigned> fromHexDigit(char _value)

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -412,4 +412,19 @@ inline std::string replace(std::string_view text, std::string_view pattern, T&& 
     return os.str();
 }
 
+// https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+// 1U << (lg(v - 1) + 1)
+constexpr uint32_t nextPowerOfTwo(uint32_t v) noexcept
+{
+    // return 1U << (std::log(v - 1) + 1);
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+
 } // namespace crispy

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -427,4 +427,21 @@ constexpr uint32_t nextPowerOfTwo(uint32_t v) noexcept
     return v;
 }
 
+inline std::string humanReadableBytes(long double bytes)
+{
+    if (bytes <= 1024.0)
+        return fmt::format("{} bytes", unsigned(bytes));
+
+    auto const kb = bytes / 1024.0;
+    if (kb <= 1024.0)
+        return fmt::format("{:.03} KB", kb);
+
+    auto const mb = kb / 1024.0;
+    if (mb <= 1024.0)
+        return fmt::format("{:.03} MB", mb);
+
+    auto const gb = mb / 1024.0;
+    return fmt::format("{:.03} GB", gb);
+}
+
 } // namespace crispy

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -414,15 +414,23 @@ inline std::string replace(std::string_view text, std::string_view pattern, T&& 
 
 // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
 // 1U << (lg(v - 1) + 1)
-constexpr uint32_t nextPowerOfTwo(uint32_t v) noexcept
+template <typename T>
+constexpr T nextPowerOfTwo(T v) noexcept
 {
+    static_assert(std::is_integral_v<T>);
+    static_assert(std::is_unsigned_v<T>);
+
     // return 1U << (std::log(v - 1) + 1);
     v--;
     v |= v >> 1;
     v |= v >> 2;
     v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
+    if constexpr (sizeof(T) >= 16)
+        v |= v >> 8;
+    if constexpr (sizeof(T) >= 32)
+        v |= v >> 16;
+    if constexpr (sizeof(T) >= 64)
+        v |= v >> 32;
     v++;
     return v;
 }

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -12,6 +12,10 @@ option(LIBTERMINAL_LOG_TRACE "Enables VT sequence tracing. [default: ON]" ON)
 # But it's currently disabled by default as I am not fully satisfied with it yet.
 option(LIBTERMINAL_PASSIVE_RENDER_BUFFER_UPDATE "Updates the render buffer within the terminal thread if set to ON (otherwise the render buffer is actively refreshed in the render thread)." OFF)
 
+# Tries to avoid unnecessary copies by reusing BufferObject fragments
+# in terminal grid lines buffer.
+option(LIBTERMINAL_PTY_BUFFER_OBJECTS "PTY Buffer Objects storage [default: ON]" ON)
+
 if(MSVC)
     add_definitions(-DNOMINMAX)
 endif()
@@ -109,6 +113,11 @@ target_compile_definitions(terminal PRIVATE
     LIBTERMINAL_VERSION_STRING="${CONTOUR_VERSION_STRING}"
     LIBTERMINAL_NAME="${PROJECT_NAME}"
 )
+
+if(LIBTERMINAL_PTY_BUFFER_OBJECTS)
+    target_compile_definitions(terminal PUBLIC LIBTERMINAL_PTY_BUFFER_OBJECTS=1)
+endif()
+
 target_include_directories(terminal PUBLIC ${PROJECT_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(terminal PUBLIC ${LIBTERMINAL_LIBRARIES})
 if(LIBTERMINAL_LOG_TRACE)
@@ -133,6 +142,7 @@ if(LIBTERMINAL_TESTING)
 		Selector_test.cpp
         Functions_test.cpp
         Grid_test.cpp
+        Line_test.cpp
         Parser_test.cpp
         Screen_test.cpp
         Sequence_test.cpp

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -151,6 +151,20 @@ if(LIBTERMINAL_TESTING)
         CONTOUR_PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
     )
     target_link_libraries(bench-headless fmt::fmt-header-only terminal termbench)
+
+    if(CONTOUR_INSTALL_TOOLS)
+        if(WIN32)
+            install(TARGETS bench-headless DESTINATION bin)
+        elseif(APPLE)
+            set(INSTALL_RUNTIME_DIR "${App_Contents}/MacOS")
+            install(TARGETS bench-headless
+                BUNDLE DESTINATION . COMPONENT Runtime
+                RUNTIME DESTINATION "${INSTALL_RUNTIME_DIR}" COMPONENT Runtime
+            )
+        else()
+            install(TARGETS bench-headless DESTINATION bin)
+        endif()
+    endif()
 endif()
 
 message(STATUS "[libterminal] Compile unit tests: ${LIBTERMINAL_TESTING}")

--- a/src/terminal/Cell.h
+++ b/src/terminal/Cell.h
@@ -194,7 +194,7 @@ inline void Cell::createExtra(Args... args) noexcept
     {
         extra_.reset(new CellExtra(std::forward<Args>(args)...));
     }
-    catch (std::bad_alloc)
+    catch (std::bad_alloc const&)
     {
         Require(extra_.ptr_ != nullptr);
     }

--- a/src/terminal/Cell.h
+++ b/src/terminal/Cell.h
@@ -104,7 +104,7 @@ class CONTOUR_PACKED Cell
     Cell() noexcept;
     Cell(Cell const& v) noexcept;
     Cell& operator=(Cell const& v) noexcept;
-    explicit Cell(GraphicsAttributes const& _attributes) noexcept;
+    explicit Cell(GraphicsAttributes const& _attributes, HyperlinkId hyperlink = {}) noexcept;
 
     Cell(Cell&&) noexcept = default;
     Cell& operator=(Cell&&) noexcept = default;
@@ -205,9 +205,10 @@ inline Cell::Cell() noexcept
     setWidth(1);
 }
 
-inline Cell::Cell(GraphicsAttributes const& _attributes) noexcept
+inline Cell::Cell(GraphicsAttributes const& _attributes, HyperlinkId hyperlink) noexcept
 {
     setWidth(1);
+    setHyperlink(hyperlink);
 
     foregroundColor_ = _attributes.foregroundColor;
     backgroundColor_ = _attributes.backgroundColor;

--- a/src/terminal/Cell.h
+++ b/src/terminal/Cell.h
@@ -370,7 +370,7 @@ inline void Cell::setCharacter(char32_t _codepoint) noexcept
 
 inline int Cell::appendCharacter(char32_t _codepoint) noexcept
 {
-    assert(codepoint_ != 0);
+    assert(_codepoint != 0);
 
     CellExtra& ext = extra();
     if (ext.codepoints.size() < MaxCodepoints - 1)

--- a/src/terminal/Color.cpp
+++ b/src/terminal/Color.cpp
@@ -107,14 +107,14 @@ RGBColor& RGBColor::operator=(string const& _hexCode)
     if (_hexCode.size() == 7 && _hexCode[0] == '#')
     {
         char* eptr = nullptr;
-        uint32_t const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 1, &eptr, 16));
+        auto const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 1, &eptr, 16));
         if (eptr && *eptr == '\0')
             *this = RGBColor { value };
     }
     if (_hexCode.size() >= 3 && _hexCode[0] == '0' && _hexCode[1] == 'x')
     {
         char* eptr = nullptr;
-        uint32_t const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 2, &eptr, 16));
+        auto const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 2, &eptr, 16));
         if (eptr && *eptr == '\0')
             *this = RGBColor { value };
     }
@@ -126,7 +126,7 @@ RGBAColor& RGBAColor::operator=(string const& _hexCode)
     if (_hexCode.size() == 9 && _hexCode[0] == '#')
     {
         char* eptr = nullptr;
-        uint32_t const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 1, &eptr, 16));
+        auto const value = static_cast<uint32_t>(strtoul(_hexCode.c_str() + 1, &eptr, 16));
         if (eptr && *eptr == '\0')
             *this = RGBAColor { value };
     }

--- a/src/terminal/Color.h
+++ b/src/terminal/Color.h
@@ -61,11 +61,11 @@ enum class BrightColor
 // {{{ RGBColor
 struct RGBColor
 {
-    uint8_t red;
-    uint8_t green;
-    uint8_t blue;
+    uint8_t red { 0 };
+    uint8_t green { 0 };
+    uint8_t blue { 0 };
 
-    constexpr RGBColor(): red { 0 }, green { 0 }, blue { 0 } {}
+    constexpr RGBColor() = default;
     constexpr RGBColor(uint8_t r, uint8_t g, uint8_t b): red { r }, green { g }, blue { b } {}
     constexpr RGBColor(uint32_t rgb):
         red { static_cast<uint8_t>((rgb >> 16) & 0xFF) },
@@ -74,7 +74,7 @@ struct RGBColor
     {
     }
 
-    constexpr uint32_t value() const noexcept
+    [[nodiscard]] constexpr uint32_t value() const noexcept
     {
         return static_cast<uint32_t>((red << 16) | (green << 8) | blue);
     }
@@ -110,14 +110,23 @@ constexpr bool operator!=(RGBColor a, RGBColor b) noexcept
 // {{{ RGBAColor
 struct RGBAColor
 {
-    uint32_t value;
+    uint32_t value { 0 };
 
-    constexpr uint8_t red() const noexcept { return static_cast<uint8_t>((value >> 24) & 0xFF); }
-    constexpr uint8_t green() const noexcept { return static_cast<uint8_t>((value >> 16) & 0xFF); }
-    constexpr uint8_t blue() const noexcept { return static_cast<uint8_t>((value >> 8) & 0xFF); }
-    constexpr uint8_t alpha() const noexcept { return static_cast<uint8_t>(value & 0xFF); }
+    [[nodiscard]] constexpr uint8_t red() const noexcept
+    {
+        return static_cast<uint8_t>((value >> 24) & 0xFF);
+    }
+    [[nodiscard]] constexpr uint8_t green() const noexcept
+    {
+        return static_cast<uint8_t>((value >> 16) & 0xFF);
+    }
+    [[nodiscard]] constexpr uint8_t blue() const noexcept
+    {
+        return static_cast<uint8_t>((value >> 8) & 0xFF);
+    }
+    [[nodiscard]] constexpr uint8_t alpha() const noexcept { return static_cast<uint8_t>(value & 0xFF); }
 
-    constexpr RGBAColor() noexcept: value { 0 } {}
+    constexpr RGBAColor() noexcept = default;
     constexpr RGBAColor(uint32_t _value) noexcept: value { _value } {}
 
     constexpr RGBAColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept:
@@ -135,9 +144,9 @@ struct RGBAColor
     {
     }
 
-    constexpr RGBColor rgb() const noexcept { return RGBColor(value >> 8); }
+    [[nodiscard]] constexpr RGBColor rgb() const noexcept { return RGBColor(value >> 8); }
 
-    RGBAColor& operator=(std::string const& _hexCode);
+    [[nodiscard]] RGBAColor& operator=(std::string const& _hexCode);
 
     constexpr static inline auto White = uint32_t(0xFF'FF'FF'FF);
 };
@@ -193,15 +202,24 @@ struct CONTOUR_PACKED Color
     }
     constexpr Color(RGBColor _rgb) noexcept: content { _rgb.value() | (unsigned(ColorType::RGB) << 24) } {}
 
-    constexpr ColorType type() const noexcept { return static_cast<ColorType>((content >> 24) & 0xFF); }
-    constexpr uint8_t index() const noexcept { return content & 0xFF; }
-    constexpr RGBColor rgb() const noexcept { return RGBColor(content & 0xFFFFFF); }
+    [[nodiscard]] constexpr ColorType type() const noexcept
+    {
+        return static_cast<ColorType>((content >> 24) & 0xFF);
+    }
+    [[nodiscard]] constexpr uint8_t index() const noexcept { return content & 0xFF; }
+    [[nodiscard]] constexpr RGBColor rgb() const noexcept { return RGBColor(content & 0xFFFFFF); }
 
-    constexpr static Color Undefined() noexcept { return Color { ColorType::Undefined, 0 }; }
-    constexpr static Color Default() noexcept { return Color { ColorType::Default, 0 }; }
-    constexpr static Color Bright(uint8_t _index) noexcept { return Color { ColorType::Bright, _index }; }
-    constexpr static Color Indexed(uint8_t _index) noexcept { return Color { ColorType::Indexed, _index }; }
-    constexpr static Color Indexed(IndexedColor _index) noexcept
+    [[nodiscard]] constexpr static Color Undefined() noexcept { return Color { ColorType::Undefined, 0 }; }
+    [[nodiscard]] constexpr static Color Default() noexcept { return Color { ColorType::Default, 0 }; }
+    [[nodiscard]] constexpr static Color Bright(uint8_t _index) noexcept
+    {
+        return Color { ColorType::Bright, _index };
+    }
+    [[nodiscard]] constexpr static Color Indexed(uint8_t _index) noexcept
+    {
+        return Color { ColorType::Indexed, _index };
+    }
+    [[nodiscard]] constexpr static Color Indexed(IndexedColor _index) noexcept
     {
         return Color { ColorType::Indexed, (uint8_t) _index };
     }

--- a/src/terminal/ColorPalette.h
+++ b/src/terminal/ColorPalette.h
@@ -108,25 +108,25 @@ struct ColorPalette
     }
     ();
 
-    RGBColor normalColor(size_t _index) const noexcept
+    [[nodiscard]] RGBColor normalColor(size_t _index) const noexcept
     {
         assert(_index < 8);
         return palette.at(_index);
     }
 
-    RGBColor brightColor(size_t _index) const noexcept
+    [[nodiscard]] RGBColor brightColor(size_t _index) const noexcept
     {
         assert(_index < 8);
         return palette.at(_index + 8);
     }
 
-    RGBColor dimColor(size_t _index) const
+    [[nodiscard]] RGBColor dimColor(size_t _index) const
     {
         assert(_index < 8);
         return palette.at(_index); // TODO
     }
 
-    RGBColor indexedColor(size_t _index) const noexcept
+    [[nodiscard]] RGBColor indexedColor(size_t _index) const noexcept
     {
         assert(_index < 256);
         return palette.at(_index);

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -52,7 +52,7 @@ struct FunctionDefinition // TODO: rename Function
 
     using id_type = uint32_t;
 
-    constexpr id_type id() const noexcept
+    [[nodiscard]] constexpr id_type id() const noexcept
     {
         // clang-format off
         unsigned constexpr CategoryShift     = 0;

--- a/src/terminal/GraphicsAttributes.h
+++ b/src/terminal/GraphicsAttributes.h
@@ -15,6 +15,7 @@
 
 #include <terminal/CellFlags.h>
 #include <terminal/Color.h>
+#include <type_traits>
 
 #include <utility>
 
@@ -29,6 +30,8 @@ struct GraphicsAttributes
     Color underlineColor { DefaultColor() };
     CellFlags styles {};
 };
+
+static_assert(std::is_trivially_copy_assignable_v<GraphicsAttributes>);
 
 constexpr bool operator==(GraphicsAttributes const& a, GraphicsAttributes const& b) noexcept
 {

--- a/src/terminal/GraphicsAttributes.h
+++ b/src/terminal/GraphicsAttributes.h
@@ -15,8 +15,8 @@
 
 #include <terminal/CellFlags.h>
 #include <terminal/Color.h>
-#include <type_traits>
 
+#include <type_traits>
 #include <utility>
 
 namespace terminal

--- a/src/terminal/Grid.cpp
+++ b/src/terminal/Grid.cpp
@@ -65,7 +65,7 @@ namespace detail
         lines.reserve(totalLineCount);
 
         for ([[maybe_unused]] auto const _: ranges::views::iota(0u, totalLineCount))
-            lines.emplace_back(_pageSize.columns, defaultLineFlags, _initialSGR);
+            lines.emplace_back(defaultLineFlags, _pageSize.columns, _initialSGR);
 
         return lines;
     }
@@ -100,7 +100,7 @@ namespace detail
             auto from = _logicalLineBuffer.begin();
             auto to = from + _newColumnCount.as<std::ptrdiff_t>();
             auto const wrappedFlag = i == 0 && _initialNoWrap ? LineFlags::None : LineFlags::Wrapped;
-            _targetLines.emplace_back(LineBuffer(from, to), _baseFlags | wrappedFlag);
+            _targetLines.emplace_back(_baseFlags | wrappedFlag, LineBuffer(from, to));
             _logicalLineBuffer.erase(from, to);
             ++i;
         }
@@ -109,7 +109,8 @@ namespace detail
         {
             auto const wrappedFlag = i == 0 && _initialNoWrap ? LineFlags::None : LineFlags::Wrapped;
             ++i;
-            _targetLines.emplace_back(_newColumnCount, move(_logicalLineBuffer), _baseFlags | wrappedFlag);
+            _logicalLineBuffer.resize(unbox<size_t>(_newColumnCount));
+            _targetLines.emplace_back(_baseFlags | wrappedFlag, move(_logicalLineBuffer));
         }
         return LineCount::cast_from(i);
     }
@@ -386,7 +387,7 @@ LineCount Grid<Cell>::scrollUp(LineCount linesCountToScrollUp, GraphicsAttribute
             Require(unbox<size_t>(linesUsed_) <= lines_.size());
             fill_n(next(lines_.begin(), *pageSize_.lines),
                    unbox<size_t>(linesAppendCount),
-                   Line<Cell> { pageSize_.columns, defaultLineFlags(), _defaultAttributes });
+                   Line<Cell> { defaultLineFlags(), pageSize_.columns, _defaultAttributes });
             rotateBuffersLeft(linesAppendCount);
         }
         if (linesAppendCount < linesCountToScrollUp)
@@ -610,7 +611,7 @@ CellLocation Grid<Cell>::growLines(LineCount _newHeight, CellLocation _cursor)
     auto const linesToFill = max(0, *newTotalLineCount - *currentTotalLineCount);
 
     for ([[maybe_unused]] auto const _: ranges::views::iota(0, linesToFill))
-        lines_.emplace_back(pageSize_.columns, wrappableFlag, GraphicsAttributes {});
+        lines_.emplace_back(wrappableFlag, pageSize_.columns, GraphicsAttributes {});
 
     pageSize_.lines += totalLinesToExtend;
     linesUsed_ = min(linesUsed_ + totalLinesToExtend, LineCount::cast_from(lines_.size()));
@@ -729,11 +730,11 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
                     }
                 };
 
-            [[maybe_unused]] auto const logLogicalLine = [&logicalLineBuffer](
-                                                             [[maybe_unused]] LineFlags lineFlags,
-                                                             [[maybe_unused]] std::string_view msg) {
-                GridLog()("{} |> \"{}\"", msg, Line<Cell>(LineBuffer(logicalLineBuffer), lineFlags).toUtf8());
-            };
+            [[maybe_unused]] auto const logLogicalLine =
+                [&logicalLineBuffer]([[maybe_unused]] LineFlags lineFlags,
+                                     [[maybe_unused]] std::string_view msg) {
+                    GridLog()("{} |> \"{}\"", msg, Line<Cell>(lineFlags, logicalLineBuffer).toUtf8());
+                };
 
             for (int i = -*historyLineCount(); i < *pageSize_.lines; ++i)
             {
@@ -767,7 +768,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
                 // so fill the gap until we have a full page.
                 cy = pageSize_.lines - LineCount::cast_from(grownLines.size());
                 while (LineCount::cast_from(grownLines.size()) < pageSize_.lines)
-                    grownLines.emplace_back(_newColumnCount, defaultLineFlags(), GraphicsAttributes {});
+                    grownLines.emplace_back(defaultLineFlags(), _newColumnCount, GraphicsAttributes {});
 
                 Ensures(LineCount::cast_from(grownLines.size()) == pageSize_.lines);
             }
@@ -777,7 +778,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
             // Fill scrollback lines.
             auto const totalLineCount = unbox<size_t>(pageSize_.lines + maxHistoryLineCount_);
             while (grownLines.size() < totalLineCount)
-                grownLines.emplace_back(_newColumnCount, defaultLineFlags(), GraphicsAttributes {});
+                grownLines.emplace_back(defaultLineFlags(), _newColumnCount, GraphicsAttributes {});
 
             lines_ = move(grownLines);
             pageSize_.columns = _newColumnCount;
@@ -880,7 +881,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
             Require(numLinesWritten >= pageSize_.lines);
 
             while (shrinkedLines.size() < totalLineCount)
-                shrinkedLines.emplace_back(_newColumnCount, LineFlags::None, GraphicsAttributes {});
+                shrinkedLines.emplace_back(LineFlags::None, _newColumnCount, GraphicsAttributes {});
 
             shrinkedLines.rotate_left(
                 unbox<size_t>(numLinesWritten - pageSize_.lines)); // maybe to be done outisde?
@@ -956,7 +957,7 @@ void Grid<Cell>::appendNewLines(LineCount _count, GraphicsAttributes _attr)
     if (auto const n = std::min(_count, pageSize_.lines); *n > 0)
     {
         generate_n(
-            back_inserter(lines_), *n, [&]() { return Line<Cell>(pageSize_.columns, wrappableFlag, _attr); });
+            back_inserter(lines_), *n, [&]() { return Line<Cell>(wrappableFlag, pageSize_.columns, _attr); });
         clampHistory();
     }
 }

--- a/src/terminal/Grid.cpp
+++ b/src/terminal/Grid.cpp
@@ -290,7 +290,7 @@ template <typename Cell>
 std::string Grid<Cell>::lineText(Line<Cell> const& _line) const
 {
     std::stringstream sstr;
-    for (Cell const& cell: lineBuffer(_line))
+    for (Cell const& cell: _line.editable())
     {
         if (cell.codepointCount() == 0)
             sstr << ' ';
@@ -555,13 +555,13 @@ void Grid<Cell>::scrollLeft(GraphicsAttributes _defaultAttributes, Margin _margi
     for (LineOffset lineNo = _margin.vertical.from; lineNo <= _margin.vertical.to; ++lineNo)
     {
         auto& line = lineAt(lineNo);
-        auto column0 = line.begin() + *_margin.horizontal.from;
-        auto column1 = line.begin() + *_margin.horizontal.from + 1;
-        auto column2 = line.begin() + *_margin.horizontal.to + 1;
+        auto column0 = line.editable().begin() + *_margin.horizontal.from;
+        auto column1 = line.editable().begin() + *_margin.horizontal.from + 1;
+        auto column2 = line.editable().begin() + *_margin.horizontal.to + 1;
         std::rotate(column0, column1, column2);
 
         auto const emptyCell = Cell { _defaultAttributes };
-        auto const emptyCellsBegin = line.begin() + *_margin.horizontal.to;
+        auto const emptyCellsBegin = line.editable().begin() + *_margin.horizontal.to;
         std::fill_n(emptyCellsBegin, 1, emptyCell);
     }
 }

--- a/src/terminal/Grid.cpp
+++ b/src/terminal/Grid.cpp
@@ -29,7 +29,7 @@ using std::vector;
 namespace terminal
 {
 
-auto inline GridLog = logstore::Category(
+auto const inline GridLog = logstore::Category(
     "vt.grid", "Grid related", logstore::Category::State::Disabled, logstore::Category::Visibility::Hidden);
 
 namespace detail
@@ -151,7 +151,6 @@ template <typename Cell>
 void Grid<Cell>::verifyState() const
 {
 #if !defined(NDEBUG)
-    auto const ringBufferLinesCount = lines_.size();
     // maxHistoryLineCount_ + pageSize_.lines
     Require(LineCount::cast_from(lines_.size()) >= totalLineCount());
     Require(LineCount::cast_from(lines_.size()) >= linesUsed_);
@@ -607,7 +606,7 @@ CellLocation Grid<Cell>::growLines(LineCount _newHeight, CellLocation _cursor)
     // ? Require(linesToTakeFromSavedLines == LineCount(0));
 
     auto const newTotalLineCount = maxHistoryLineCount_ + _newHeight;
-    auto const currentTotalLineCount = LineCount(lines_.size());
+    auto const currentTotalLineCount = LineCount::cast_from(lines_.size());
     auto const linesToFill = max(0, *newTotalLineCount - *currentTotalLineCount);
 
     for ([[maybe_unused]] auto const _: ranges::views::iota(0, linesToFill))
@@ -621,7 +620,7 @@ CellLocation Grid<Cell>::growLines(LineCount _newHeight, CellLocation _cursor)
     verifyState();
 
     return cursorMove;
-};
+}
 
 template <typename Cell>
 CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPos, bool _wrapPending)
@@ -841,7 +840,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
             shrinkedLines.reserve(totalLineCount);
             Require(totalLineCount == unbox<size_t>(this->totalLineCount()));
 
-            LineCount numLinesWritten = LineCount(0);
+            auto numLinesWritten = LineCount(0);
             for (auto i = -*historyLineCount(); i < *pageSize_.lines; ++i)
             {
                 auto& line = lines_[i];

--- a/src/terminal/Grid.cpp
+++ b/src/terminal/Grid.cpp
@@ -291,7 +291,7 @@ template <typename Cell>
 std::string Grid<Cell>::lineText(Line<Cell> const& _line) const
 {
     std::stringstream sstr;
-    for (Cell const& cell: _line.editable())
+    for (Cell const& cell: _line.inflatedBuffer())
     {
         if (cell.codepointCount() == 0)
             sstr << ' ';
@@ -556,13 +556,13 @@ void Grid<Cell>::scrollLeft(GraphicsAttributes _defaultAttributes, Margin _margi
     for (LineOffset lineNo = _margin.vertical.from; lineNo <= _margin.vertical.to; ++lineNo)
     {
         auto& line = lineAt(lineNo);
-        auto column0 = line.editable().begin() + *_margin.horizontal.from;
-        auto column1 = line.editable().begin() + *_margin.horizontal.from + 1;
-        auto column2 = line.editable().begin() + *_margin.horizontal.to + 1;
+        auto column0 = line.inflatedBuffer().begin() + *_margin.horizontal.from;
+        auto column1 = line.inflatedBuffer().begin() + *_margin.horizontal.from + 1;
+        auto column2 = line.inflatedBuffer().begin() + *_margin.horizontal.to + 1;
         std::rotate(column0, column1, column2);
 
         auto const emptyCell = Cell { _defaultAttributes };
-        auto const emptyCellsBegin = line.editable().begin() + *_margin.horizontal.to;
+        auto const emptyCellsBegin = line.inflatedBuffer().begin() + *_margin.horizontal.to;
         std::fill_n(emptyCellsBegin, 1, emptyCell);
     }
 }
@@ -852,7 +852,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
                     if (line.wrapped() && line.inheritableFlags() == previousFlags)
                     {
                         // Prepend previously wrapped columns into current line.
-                        auto& editable = line.editable();
+                        auto& editable = line.inflatedBuffer();
                         editable.insert(editable.begin(), wrappedColumns.begin(), wrappedColumns.end());
                     }
                     else

--- a/src/terminal/Grid.h
+++ b/src/terminal/Grid.h
@@ -49,28 +49,43 @@ struct Margin
         ColumnOffset
             to; // TODO: call it begin and end and have end point to to+1 to avoid unnecessary +1's later
 
-        constexpr ColumnCount length() const noexcept
+        [[nodiscard]] constexpr ColumnCount length() const noexcept
         {
             return unbox<ColumnCount>(to - from) + ColumnCount(1);
         }
-        constexpr bool contains(ColumnOffset _value) const noexcept { return from <= _value && _value <= to; }
-        constexpr bool operator==(Horizontal rhs) const noexcept { return from == rhs.from && to == rhs.to; }
-        constexpr bool operator!=(Horizontal rhs) const noexcept { return !(*this == rhs); }
+        [[nodiscard]] constexpr bool contains(ColumnOffset _value) const noexcept
+        {
+            return from <= _value && _value <= to;
+        }
+        [[nodiscard]] constexpr bool operator==(Horizontal rhs) const noexcept
+        {
+            return from == rhs.from && to == rhs.to;
+        }
+        [[nodiscard]] constexpr bool operator!=(Horizontal rhs) const noexcept { return !(*this == rhs); }
     };
 
     struct Vertical
     {
         LineOffset from;
-        LineOffset
-            to; // TODO: call it begin and end and have end point to to+1 to avoid unnecessary +1's later
+        // TODO: call it begin and end and have end point to to+1 to avoid unnecessary +1's later
+        LineOffset to;
 
-        constexpr LineCount length() const noexcept { return unbox<LineCount>(to - from) + LineCount(1); }
-        constexpr bool contains(LineOffset _value) const noexcept { return from <= _value && _value <= to; }
-        constexpr bool operator==(Vertical const& rhs) const noexcept
+        [[nodiscard]] constexpr LineCount length() const noexcept
+        {
+            return unbox<LineCount>(to - from) + LineCount(1);
+        }
+        [[nodiscard]] constexpr bool contains(LineOffset _value) const noexcept
+        {
+            return from <= _value && _value <= to;
+        }
+        [[nodiscard]] constexpr bool operator==(Vertical const& rhs) const noexcept
         {
             return from == rhs.from && to == rhs.to;
         }
-        constexpr bool operator!=(Vertical const& rhs) const noexcept { return !(*this == rhs); }
+        [[nodiscard]] constexpr bool operator!=(Vertical const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
     };
 
     Vertical vertical {};     // top-bottom
@@ -103,11 +118,10 @@ struct LogicalLine
     LineOffset bottom {};
     std::vector<std::reference_wrapper<Line<Cell>>> lines {};
 
-    Line<Cell> joinWithRightTrimmed() const
+    [[nodiscard]] Line<Cell> joinWithRightTrimmed() const
     {
         // TODO: determine final line's column count and pass it to ctor.
         typename Line<Cell>::Buffer output;
-        int i = 0;
         auto lineFlags = lines.front().get().flags();
         for (Line<Cell> const& line: lines)
             for (Cell const& cell: line.cells())
@@ -119,7 +133,7 @@ struct LogicalLine
         return Line<Cell>(output, lineFlags);
     }
 
-    std::string text() const
+    [[nodiscard]] std::string text() const
     {
         std::string output;
         for (auto const& line: lines)
@@ -371,17 +385,17 @@ class Grid
     void reset();
 
     // {{{ grid global properties
-    LineCount maxHistoryLineCount() const noexcept { return maxHistoryLineCount_; }
+    [[nodiscard]] LineCount maxHistoryLineCount() const noexcept { return maxHistoryLineCount_; }
     void setMaxHistoryLineCount(LineCount _maxHistoryLineCount);
 
-    LineCount totalLineCount() const noexcept { return maxHistoryLineCount_ + pageSize_.lines; }
+    [[nodiscard]] LineCount totalLineCount() const noexcept { return maxHistoryLineCount_ + pageSize_.lines; }
 
-    LineCount historyLineCount() const noexcept { return linesUsed_ - pageSize_.lines; }
+    [[nodiscard]] LineCount historyLineCount() const noexcept { return linesUsed_ - pageSize_.lines; }
 
-    bool reflowOnResize() const noexcept { return reflowOnResize_; }
+    [[nodiscard]] bool reflowOnResize() const noexcept { return reflowOnResize_; }
     void setReflowOnResize(bool _enabled) { reflowOnResize_ = _enabled; }
 
-    PageSize pageSize() const noexcept { return pageSize_; }
+    [[nodiscard]] PageSize pageSize() const noexcept { return pageSize_; }
 
     /// Resizes the main page area of the grid and adapts the scrollback area's width accordingly.
     ///
@@ -390,7 +404,7 @@ class Grid
     /// @param _wrapPending       AutoWrap is on and a wrap is pending
     ///
     /// @returns updated cursor position.
-    CellLocation resize(PageSize _pageSize, CellLocation _currentCursorPos, bool _wrapPending);
+    [[nodiscard]] CellLocation resize(PageSize _pageSize, CellLocation _currentCursorPos, bool _wrapPending);
     // }}}
 
     // {{{ Line API
@@ -401,28 +415,28 @@ class Grid
     gsl::span<Cell const> lineBuffer(LineOffset _line) const noexcept { return lineAt(_line).cells(); }
     gsl::span<Cell const> lineBufferRightTrimmed(LineOffset _line) const noexcept;
 
-    std::string lineText(LineOffset _line) const;
-    std::string lineTextTrimmed(LineOffset _line) const;
-    std::string lineText(Line<Cell> const& _line) const;
+    [[nodiscard]] std::string lineText(LineOffset _line) const;
+    [[nodiscard]] std::string lineTextTrimmed(LineOffset _line) const;
+    [[nodiscard]] std::string lineText(Line<Cell> const& _line) const;
 
     void setLineText(LineOffset _line, std::string_view _text);
 
     // void resetLine(LineOffset _line, GraphicsAttributes _attribs) noexcept
     // { lineAt(_line).reset(_attribs); }
 
-    ColumnCount lineLength(LineOffset _line) const noexcept { return lineAt(_line).size(); }
-    bool isLineBlank(LineOffset _line) const noexcept;
-    bool isLineWrapped(LineOffset _line) const noexcept;
+    [[nodiscard]] ColumnCount lineLength(LineOffset _line) const noexcept { return lineAt(_line).size(); }
+    [[nodiscard]] bool isLineBlank(LineOffset _line) const noexcept;
+    [[nodiscard]] bool isLineWrapped(LineOffset _line) const noexcept;
 
-    int computeLogicalLineNumberFromBottom(LineCount _n) const noexcept;
+    [[nodiscard]] int computeLogicalLineNumberFromBottom(LineCount _n) const noexcept;
 
-    size_t zero_index() const noexcept { return lines_.zero_index(); }
+    [[nodiscard]] size_t zero_index() const noexcept { return lines_.zero_index(); }
     // }}}
 
     /// Gets a reference to the cell relative to screen origin (top left, 0:0).
-    Cell& useCellAt(LineOffset _line, ColumnOffset _column) noexcept;
-    Cell& at(LineOffset _line, ColumnOffset _column) noexcept;
-    Cell const& at(LineOffset _line, ColumnOffset _column) const noexcept;
+    [[nodiscard]] Cell& useCellAt(LineOffset _line, ColumnOffset _column) noexcept;
+    [[nodiscard]] Cell& at(LineOffset _line, ColumnOffset _column) noexcept;
+    [[nodiscard]] Cell const& at(LineOffset _line, ColumnOffset _column) const noexcept;
 
     // page view API
     gsl::span<Line<Cell>> pageAtScrollOffset(ScrollOffset _scrollOffset);
@@ -476,17 +490,17 @@ class Grid
     void render(RendererT&& _render, ScrollOffset _scrollOffset = {}) const;
 
     /// Takes text-screenshot of the main page.
-    std::string renderMainPageText() const;
+    [[nodiscard]] std::string renderMainPageText() const;
 
     /// Renders the full grid's text characters.
     ///
     /// Empty cells are represented as strings and lines split by LF.
-    std::string renderAllText() const;
+    [[nodiscard]] std::string renderAllText() const;
     // }}}
 
-    constexpr LineFlags defaultLineFlags() const noexcept;
+    [[nodiscard]] constexpr LineFlags defaultLineFlags() const noexcept;
 
-    constexpr LineCount linesUsed() const noexcept;
+    [[nodiscard]] constexpr LineCount linesUsed() const noexcept;
 
     void verifyState() const;
 
@@ -515,7 +529,7 @@ class Grid
     // private fields
     //
     PageSize pageSize_;
-    bool reflowOnResize_;
+    bool reflowOnResize_ = false;
     LineCount maxHistoryLineCount_;
 
     // Number of lines is at least the sum of maxHistoryLineCount_ + pageSize_.lines,

--- a/src/terminal/Image.cpp
+++ b/src/terminal/Image.cpp
@@ -116,7 +116,7 @@ Image::Data RasterizedImage::fragment(CellLocation _pos) const
                                  + *pixelOffset.column)
                                 * 4);
         auto const source = &image_->data()[startOffset];
-        target = copy(source, source + availableWidth * 4, target);
+        target = copy(source, source + static_cast<ptrdiff_t>(availableWidth) * 4, target);
 
         // fill vertical gap on right
         for (int x = availableWidth; x < unbox<int>(cellSize_.width); ++x)

--- a/src/terminal/Image.h
+++ b/src/terminal/Image.h
@@ -199,13 +199,13 @@ class ImageFragment
 
     ~ImageFragment();
 
-    RasterizedImage const& rasterizedImage() const noexcept { return *rasterizedImage_; }
+    [[nodiscard]] RasterizedImage const& rasterizedImage() const noexcept { return *rasterizedImage_; }
 
     /// @returns offset of this image fragment in pixels into the underlying image.
     CellLocation offset() const noexcept { return offset_; }
 
     /// Extracts the data from the image that is to be rendered.
-    Image::Data data() const { return rasterizedImage_->fragment(offset_); }
+    [[nodiscard]] Image::Data data() const { return rasterizedImage_->fragment(offset_); }
 
   private:
     std::shared_ptr<RasterizedImage const> rasterizedImage_;
@@ -260,7 +260,7 @@ class ImagePool
     // named image access
     //
     void link(std::string const& _name, std::shared_ptr<Image const> _imageRef);
-    std::shared_ptr<Image const> findImageByName(std::string const& _name) const noexcept;
+    [[nodiscard]] std::shared_ptr<Image const> findImageByName(std::string const& _name) const noexcept;
     void unlink(std::string const& _name);
 
     void inspect(std::ostream& os) const;

--- a/src/terminal/InputGenerator.cpp
+++ b/src/terminal/InputGenerator.cpp
@@ -52,7 +52,8 @@ namespace mappings
 #define SS3 "\x1BO"
 
     // the modifier parameter is going to be replaced via fmt::format()
-    array<KeyMapping, 30> functionKeysWithModifiers {
+    array<KeyMapping, 30> const functionKeysWithModifiers {
+        // clang-format off
         // Note, that F1..F4 is using CSI too instead of ESC when used with modifier keys.
         // XXX: Maybe I am blind when reading ctlseqs.txt, but F1..F4 with "1;{}P".. seems not to
         // match what other terminal emulators send out with modifiers and I don't see how to match
@@ -91,9 +92,11 @@ namespace mappings
         KeyMapping { Key::End, CSI "1;{}F" },
         KeyMapping { Key::PageUp, CSI "5;{}~" },
         KeyMapping { Key::PageDown, CSI "6;{}~" },
+        // clang-format on
     };
 
-    array<KeyMapping, 22> standard {
+    array<KeyMapping, 22> const standard {
+        // clang-format off
         // cursor keys
         KeyMapping { Key::UpArrow, CSI "A" },
         KeyMapping { Key::DownArrow, CSI "B" },
@@ -121,33 +124,51 @@ namespace mappings
         KeyMapping { Key::F10, CSI "21~" },
         KeyMapping { Key::F11, CSI "23~" },
         KeyMapping { Key::F12, CSI "24~" },
+        // clang-format on
     };
 
     /// (DECCKM) Cursor key mode: mappings in when cursor key application mode is set.
-    array<KeyMapping, 6> applicationCursorKeys {
-        KeyMapping { Key::UpArrow, SS3 "A" },    KeyMapping { Key::DownArrow, SS3 "B" },
-        KeyMapping { Key::RightArrow, SS3 "C" }, KeyMapping { Key::LeftArrow, SS3 "D" },
-        KeyMapping { Key::Home, SS3 "H" },       KeyMapping { Key::End, SS3 "F" },
+    array<KeyMapping, 6> const applicationCursorKeys {
+        // clang-format off
+        KeyMapping { Key::UpArrow, SS3 "A" },
+        KeyMapping { Key::DownArrow, SS3 "B" },
+        KeyMapping { Key::RightArrow, SS3 "C" },
+        KeyMapping { Key::LeftArrow, SS3 "D" },
+        KeyMapping { Key::Home, SS3 "H" },
+        KeyMapping { Key::End, SS3 "F" },
+        // clang-format on
     };
 
-    array<KeyMapping, 21> applicationKeypad
+    array<KeyMapping, 21> const applicationKeypad
     {
-        KeyMapping { Key::Numpad_NumLock, SS3 "P" }, KeyMapping { Key::Numpad_Divide, SS3 "Q" },
-            KeyMapping { Key::Numpad_Multiply, SS3 "Q" }, KeyMapping { Key::Numpad_Subtract, SS3 "Q" },
-            KeyMapping { Key::Numpad_CapsLock, SS3 "m" }, KeyMapping { Key::Numpad_Add, SS3 "l" },
-            KeyMapping { Key::Numpad_Decimal, SS3 "n" }, KeyMapping { Key::Numpad_Enter, SS3 "M" },
-            KeyMapping { Key::Numpad_Equal, SS3 "X" }, KeyMapping { Key::Numpad_0, SS3 "p" },
-            KeyMapping { Key::Numpad_1, SS3 "q" }, KeyMapping { Key::Numpad_2, SS3 "r" },
-            KeyMapping { Key::Numpad_3, SS3 "s" }, KeyMapping { Key::Numpad_4, SS3 "t" },
-            KeyMapping { Key::Numpad_5, SS3 "u" }, KeyMapping { Key::Numpad_6, SS3 "v" },
-            KeyMapping { Key::Numpad_7, SS3 "w" }, KeyMapping { Key::Numpad_8, SS3 "x" },
-            KeyMapping { Key::Numpad_9, SS3 "y" }, KeyMapping { Key::PageUp, CSI "5~" },
-            KeyMapping { Key::PageDown, CSI "6~" },
+        // clang-format off
+        KeyMapping { Key::Numpad_NumLock, SS3 "P" },
+        KeyMapping { Key::Numpad_Divide, SS3 "Q" },
+        KeyMapping { Key::Numpad_Multiply, SS3 "Q" },
+        KeyMapping { Key::Numpad_Subtract, SS3 "Q" },
+        KeyMapping { Key::Numpad_CapsLock, SS3 "m" },
+        KeyMapping { Key::Numpad_Add, SS3 "l" },
+        KeyMapping { Key::Numpad_Decimal, SS3 "n" },
+        KeyMapping { Key::Numpad_Enter, SS3 "M" },
+        KeyMapping { Key::Numpad_Equal, SS3 "X" },
+        KeyMapping { Key::Numpad_0, SS3 "p" },
+        KeyMapping { Key::Numpad_1, SS3 "q" },
+        KeyMapping { Key::Numpad_2, SS3 "r" },
+        KeyMapping { Key::Numpad_3, SS3 "s" },
+        KeyMapping { Key::Numpad_4, SS3 "t" },
+        KeyMapping { Key::Numpad_5, SS3 "u" },
+        KeyMapping { Key::Numpad_6, SS3 "v" },
+        KeyMapping { Key::Numpad_7, SS3 "w" },
+        KeyMapping { Key::Numpad_8, SS3 "x" },
+        KeyMapping { Key::Numpad_9, SS3 "y" },
+        KeyMapping { Key::PageUp, CSI "5~" },
+        KeyMapping { Key::PageDown, CSI "6~" },
 #if 0 // TODO
         KeyMapping{Key::Space,    SS3 " "}, // TODO
         KeyMapping{Key::Tab,      SS3 "I"},
         KeyMapping{Key::Enter,    SS3 "M"},
 #endif
+        // clang-format on
     };
 
 #undef ESC
@@ -509,12 +530,6 @@ namespace
     {
         return _eventType == InputGenerator::MouseEventType::Release ? 3 : buttonX10(_button);
     }
-
-    constexpr uint8_t buttonButton(MouseButton _button, InputGenerator::MouseEventType _eventType) noexcept
-    {
-        auto const normal = buttonNormal(_button, _eventType);
-        return static_cast<uint8_t>(normal + (_eventType == InputGenerator::MouseEventType::Drag ? 0x20 : 0));
-    }
 } // namespace
 
 bool InputGenerator::generateMouse(MouseEventType _eventType,
@@ -611,8 +626,8 @@ bool InputGenerator::mouseTransportX10(uint8_t _button, uint8_t _modifier, CellL
     if (*_pos.line < MaxCoordValue && *_pos.column < MaxCoordValue)
     {
         uint8_t const button = SkipCount + static_cast<uint8_t>(_button | _modifier);
-        uint8_t const line = static_cast<uint8_t>(SkipCount + *_pos.line + 1);
-        uint8_t const column = static_cast<uint8_t>(SkipCount + *_pos.column + 1);
+        auto const line = static_cast<uint8_t>(SkipCount + *_pos.line + 1);
+        auto const column = static_cast<uint8_t>(SkipCount + *_pos.column + 1);
         append("\033[M");
         append(button);
         append(column);

--- a/src/terminal/InputGenerator.h
+++ b/src/terminal/InputGenerator.h
@@ -67,18 +67,18 @@ class Modifier
     constexpr Modifier& operator=(Modifier&&) = default;
     constexpr Modifier& operator=(Modifier const&) = default;
 
-    constexpr unsigned value() const noexcept { return mask_; }
+    [[nodiscard]] constexpr unsigned value() const noexcept { return mask_; }
 
-    constexpr bool none() const noexcept { return value() == 0; }
-    constexpr bool some() const noexcept { return value() != 0; }
-    constexpr bool shift() const noexcept { return value() & Shift; }
-    constexpr bool alt() const noexcept { return value() & Alt; }
-    constexpr bool control() const noexcept { return value() & Control; }
-    constexpr bool meta() const noexcept { return value() & Meta; }
+    [[nodiscard]] constexpr bool none() const noexcept { return value() == 0; }
+    [[nodiscard]] constexpr bool some() const noexcept { return value() != 0; }
+    [[nodiscard]] constexpr bool shift() const noexcept { return value() & Shift; }
+    [[nodiscard]] constexpr bool alt() const noexcept { return value() & Alt; }
+    [[nodiscard]] constexpr bool control() const noexcept { return value() & Control; }
+    [[nodiscard]] constexpr bool meta() const noexcept { return value() & Meta; }
 
     constexpr operator unsigned() const noexcept { return mask_; }
 
-    constexpr bool any() const noexcept { return mask_ != 0; }
+    [[nodiscard]] constexpr bool any() const noexcept { return mask_ != 0; }
 
     constexpr Modifier& operator|=(Modifier const& _other) noexcept
     {
@@ -86,17 +86,20 @@ class Modifier
         return *this;
     }
 
-    constexpr Modifier with(Modifier const& _other) const noexcept
+    [[nodiscard]] constexpr Modifier with(Modifier const& _other) const noexcept
     {
         return Modifier(static_cast<Key>(mask_ | _other.mask_));
     }
 
-    constexpr Modifier without(Modifier const& _other) const noexcept
+    [[nodiscard]] constexpr Modifier without(Modifier const& _other) const noexcept
     {
         return Modifier(static_cast<Key>(mask_ & ~_other.mask_));
     }
 
-    bool contains(Modifier const& _other) const noexcept { return (mask_ & _other.mask_) == _other.mask_; }
+    [[nodiscard]] bool contains(Modifier const& _other) const noexcept
+    {
+        return (mask_ & _other.mask_) == _other.mask_;
+    }
 
     constexpr void enable(Key _key) noexcept { mask_ |= _key; }
 
@@ -253,21 +256,21 @@ class InputGenerator
 
     void setApplicationKeypadMode(bool _enable);
 
-    bool normalCursorKeys() const noexcept { return cursorKeysMode_ == KeyMode::Normal; }
-    bool applicationCursorKeys() const noexcept { return !normalCursorKeys(); }
+    [[nodiscard]] bool normalCursorKeys() const noexcept { return cursorKeysMode_ == KeyMode::Normal; }
+    [[nodiscard]] bool applicationCursorKeys() const noexcept { return !normalCursorKeys(); }
 
-    bool numericKeypad() const noexcept { return numpadKeysMode_ == KeyMode::Normal; }
-    bool applicationKeypad() const noexcept { return !numericKeypad(); }
+    [[nodiscard]] bool numericKeypad() const noexcept { return numpadKeysMode_ == KeyMode::Normal; }
+    [[nodiscard]] bool applicationKeypad() const noexcept { return !numericKeypad(); }
 
-    bool bracketedPaste() const noexcept { return bracketedPaste_; }
+    [[nodiscard]] bool bracketedPaste() const noexcept { return bracketedPaste_; }
     void setBracketedPaste(bool _enable) { bracketedPaste_ = _enable; }
 
     void setMouseProtocol(MouseProtocol _mouseProtocol, bool _enabled);
-    std::optional<MouseProtocol> mouseProtocol() const noexcept { return mouseProtocol_; }
+    [[nodiscard]] std::optional<MouseProtocol> mouseProtocol() const noexcept { return mouseProtocol_; }
 
     // Sets mouse event transport protocol (default, extended, xgr, urxvt)
     void setMouseTransport(MouseTransport _mouseTransport);
-    MouseTransport mouseTransport() const noexcept { return mouseTransport_; }
+    [[nodiscard]] MouseTransport mouseTransport() const noexcept { return mouseTransport_; }
 
     enum class MouseWheelMode
     {
@@ -280,10 +283,10 @@ class InputGenerator
     };
 
     void setMouseWheelMode(MouseWheelMode _mode) noexcept;
-    MouseWheelMode mouseWheelMode() const noexcept { return mouseWheelMode_; }
+    [[nodiscard]] MouseWheelMode mouseWheelMode() const noexcept { return mouseWheelMode_; }
 
     void setGenerateFocusEvents(bool _enable) noexcept { generateFocusEvents_ = _enable; }
-    bool generateFocusEvents() const noexcept { return generateFocusEvents_; }
+    [[nodiscard]] bool generateFocusEvents() const noexcept { return generateFocusEvents_; }
 
     bool generate(char32_t _characterEvent, Modifier _modifier);
     bool generate(std::u32string const& _characterEvent, Modifier _modifier);
@@ -308,7 +311,7 @@ class InputGenerator
     /// Peeks into the generated output, returning it as string view.
     ///
     /// @return a view into the generated buffer sequence.
-    std::string_view peek() const noexcept
+    [[nodiscard]] std::string_view peek() const noexcept
     {
         return std::string_view(pendingSequence_.data() + consumedBytes_,
                                 pendingSequence_.size() - (size_t) consumedBytes_);

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -29,7 +29,7 @@ typename Line<Cell>::InflatedBuffer Line<Cell>::reflow(ColumnCount _newColumnCou
 {
     using crispy::Comparison;
     auto& buffer = inflatedBuffer();
-    // TODO(pr): Efficiently handle TrivialBuffer-case.
+    // TODO: Efficiently handle TrivialBuffer-case.
     switch (crispy::strongCompare(_newColumnCount, size()))
     {
         case Comparison::Equal: break;
@@ -41,7 +41,7 @@ typename Line<Cell>::InflatedBuffer Line<Cell>::reflow(ColumnCount _newColumnCou
 
             if (wrappable())
             {
-                auto const [reflowStart, reflowEnd] = [this, _newColumnCount, &buffer]() {
+                auto const [reflowStart, reflowEnd] = [_newColumnCount, &buffer]() {
                     auto const reflowStart =
                         next(buffer.begin(), *_newColumnCount /* - buffer[_newColumnCount].width()*/);
 
@@ -154,7 +154,7 @@ InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
 
     for (char const ch: input.text.view())
     {
-        unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState, ch);
+        unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState, static_cast<uint8_t>(ch));
         if (holds_alternative<unicode::Incomplete>(r))
             continue;
 

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -133,9 +133,8 @@ InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
     auto lastChar = char32_t { 0 };
     auto utf8DecoderState = unicode::utf8_decoder_state {};
 
-    for (size_t i = 0; i < input.text.size(); ++i)
+    for (char const ch: input.text.view())
     {
-        char ch = input.text[i];
         unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState, ch);
         if (holds_alternative<unicode::Incomplete>(r))
             continue;

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -28,7 +28,7 @@ template <typename Cell>
 typename Line<Cell>::InflatedBuffer Line<Cell>::reflow(ColumnCount _newColumnCount)
 {
     using crispy::Comparison;
-    auto& buffer = editable();
+    auto& buffer = inflatedBuffer();
     // TODO(pr): Efficiently handle TrivialBuffer-case.
     switch (crispy::strongCompare(_newColumnCount, size()))
     {
@@ -93,14 +93,14 @@ inline void Line<Cell>::resize(ColumnCount _count)
             return;
         }
     }
-    editable().resize(unbox<size_t>(_count));
+    inflatedBuffer().resize(unbox<size_t>(_count));
 }
 
 template <typename Cell>
 gsl::span<Cell const> Line<Cell>::trim_blank_right() const noexcept
 {
-    auto i = editable().data();
-    auto e = editable().data() + editable().size();
+    auto i = inflatedBuffer().data();
+    auto e = inflatedBuffer().data() + inflatedBuffer().size();
 
     while (i != e && (e - 1)->empty())
         --e;

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -1,8 +1,21 @@
-#include <terminal/Cell.h>
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include <terminal/Line.h>
 
 #include <unicode/grapheme_segmenter.h>
 #include <unicode/utf8.h>
+#include <unicode/width.h>
 
 using std::get;
 using std::holds_alternative;
@@ -11,8 +24,8 @@ using std::min;
 namespace terminal
 {
 
-template <typename Cell, bool Optimize>
-typename Line<Cell, Optimize>::InflatedBuffer Line<Cell, Optimize>::reflow(ColumnCount _newColumnCount)
+template <typename Cell>
+typename Line<Cell>::InflatedBuffer Line<Cell>::reflow(ColumnCount _newColumnCount)
 {
     using crispy::Comparison;
     auto& buffer = editable();
@@ -67,8 +80,8 @@ typename Line<Cell, Optimize>::InflatedBuffer Line<Cell, Optimize>::reflow(Colum
     return {};
 }
 
-template <typename Cell, bool Optimize>
-inline void Line<Cell, Optimize>::resize(ColumnCount _count)
+template <typename Cell>
+inline void Line<Cell>::resize(ColumnCount _count)
 {
     assert(*_count >= 0);
     if (1) // constexpr (Optimized)
@@ -83,8 +96,8 @@ inline void Line<Cell, Optimize>::resize(ColumnCount _count)
     editable().resize(unbox<size_t>(_count));
 }
 
-template <typename Cell, bool Optimize>
-gsl::span<Cell const> Line<Cell, Optimize>::trim_blank_right() const noexcept
+template <typename Cell>
+gsl::span<Cell const> Line<Cell>::trim_blank_right() const noexcept
 {
     auto i = editable().data();
     auto e = editable().data() + editable().size();
@@ -95,8 +108,8 @@ gsl::span<Cell const> Line<Cell, Optimize>::trim_blank_right() const noexcept
     return gsl::make_span(i, e);
 }
 
-template <typename Cell, bool Optimize>
-std::string Line<Cell, Optimize>::toUtf8() const
+template <typename Cell>
+std::string Line<Cell>::toUtf8() const
 {
     if (isTrivialBuffer())
     {
@@ -118,8 +131,8 @@ std::string Line<Cell, Optimize>::toUtf8() const
     return str;
 }
 
-template <typename Cell, bool Optimize>
-std::string Line<Cell, Optimize>::toUtf8Trimmed() const
+template <typename Cell>
+std::string Line<Cell>::toUtf8Trimmed() const
 {
     std::string output = toUtf8();
     while (!output.empty() && isspace(output.back()))
@@ -180,7 +193,8 @@ InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
     return columns;
 }
 
-template class Line<Cell, true>;
-template class Line<Cell, false>;
-
 } // end namespace terminal
+
+#include <terminal/Cell.h>
+
+template class terminal::Line<terminal::Cell>;

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -57,6 +57,12 @@ struct TriviallyStyledLineBuffer
     GraphicsAttributes attributes;
     crispy::BufferFragment text {};
     HyperlinkId hyperlink {};
+
+    void reset(GraphicsAttributes _attributes) noexcept
+    {
+        attributes = _attributes;
+        text.reset();
+    }
 };
 
 template <typename Cell>
@@ -115,7 +121,10 @@ class Line
     void reset(LineFlags _flags, GraphicsAttributes _attributes) noexcept
     {
         flags_ = static_cast<unsigned>(_flags);
-        setBuffer(TrivialBuffer { size(), _attributes });
+        if (isTrivialBuffer())
+            trivialBuffer().reset(_attributes);
+        else
+            setBuffer(TrivialBuffer { size(), _attributes });
     }
 
     void fill(LineFlags _flags,
@@ -282,7 +291,7 @@ class Line
     bool isTrivialBuffer() const noexcept { return std::holds_alternative<TrivialBuffer>(storage_); }
     bool isInflatedBuffer() const noexcept { return std::holds_alternative<TrivialBuffer>(storage_); }
 
-    void setBuffer(TrivialBuffer const& buffer) { storage_ = buffer; }
+    void setBuffer(TrivialBuffer const& buffer) noexcept { storage_ = buffer; }
     void setBuffer(InflatedBuffer buffer) { storage_ = std::move(buffer); }
 
     void reset(GraphicsAttributes attributes, HyperlinkId hyperlink, crispy::BufferFragment text)

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -55,12 +55,13 @@ struct TriviallyStyledLineBuffer
 {
     ColumnCount displayWidth;
     GraphicsAttributes attributes;
-    crispy::BufferFragment text {};
     HyperlinkId hyperlink {};
+    crispy::BufferFragment text {};
 
     void reset(GraphicsAttributes _attributes) noexcept
     {
         attributes = _attributes;
+        hyperlink = {};
         text.reset();
     }
 };
@@ -289,7 +290,7 @@ class Line
 
     void reset(GraphicsAttributes attributes, HyperlinkId hyperlink, crispy::BufferFragment text)
     {
-        storage_ = TrivialBuffer { size(), attributes, std::move(text), hyperlink };
+        storage_ = TrivialBuffer { size(), attributes, hyperlink, std::move(text) };
     }
 
   private:

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -82,7 +82,7 @@ using LineStorage = std::variant<TriviallyStyledLineBuffer, InflatedLineBuffer<C
  * TODO: Use custom allocator for ensuring cache locality of Cells to sibling lines.
  * TODO: Make the line optimization work.
  */
-template <typename Cell, bool Optimize = false>
+template <typename Cell>
 class Line
 {
   public:
@@ -91,8 +91,6 @@ class Line
     Line(Line&&) noexcept = default;
     Line& operator=(Line const&) = default;
     Line& operator=(Line&&) noexcept = default;
-
-    static constexpr inline bool Optimized = Optimize;
 
     using TrivialBuffer = TriviallyStyledLineBuffer;
     using InflatedBuffer = InflatedLineBuffer<Cell>;
@@ -313,19 +311,18 @@ constexpr LineFlags operator&(LineFlags a, LineFlags b) noexcept
     return LineFlags(unsigned(a) & unsigned(b));
 }
 
-template <typename Cell, bool Optimize>
-inline typename Line<Cell, Optimize>::InflatedBuffer& Line<Cell, Optimize>::editable()
+template <typename Cell>
+inline typename Line<Cell>::InflatedBuffer& Line<Cell>::editable()
 {
-    if (1) // constexpr (Optimized)
-        if (std::holds_alternative<TrivialBuffer>(storage_))
-            storage_ = inflate<Cell>(std::get<TrivialBuffer>(storage_));
+    if (std::holds_alternative<TrivialBuffer>(storage_))
+        storage_ = inflate<Cell>(std::get<TrivialBuffer>(storage_));
     return std::get<InflatedBuffer>(storage_);
 }
 
-template <typename Cell, bool Optimize>
-inline typename Line<Cell, Optimize>::InflatedBuffer const& Line<Cell, Optimize>::editable() const
+template <typename Cell>
+inline typename Line<Cell>::InflatedBuffer const& Line<Cell>::editable() const
 {
-    return const_cast<Line<Cell, Optimize>*>(this)->editable();
+    return const_cast<Line<Cell>*>(this)->editable();
 }
 
 } // namespace terminal

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -142,17 +142,22 @@ class Line
         //     usedColumns_.value = _n;
     }
 
-    void reset(LineFlags _flags,
-               GraphicsAttributes const& _attributes,
-               char32_t _codepoint,
-               uint8_t _width) noexcept
+    void fill(LineFlags _flags,
+              GraphicsAttributes const& _attributes,
+              char32_t _codepoint,
+              uint8_t _width) noexcept
     {
-        flags_ = static_cast<unsigned>(_flags);
-        markUsedFirst(size());
-        for (Cell& cell: buffer_)
+        if (_codepoint == 0)
+            reset(_flags, _attributes);
+        else
         {
-            cell.reset();
-            cell.write(_attributes, _codepoint, _width);
+            flags_ = static_cast<unsigned>(_flags);
+            markUsedFirst(size());
+            for (Cell& cell: editable())
+            {
+                cell.reset();
+                cell.write(_attributes, _codepoint, _width);
+            }
         }
     }
 

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -101,20 +101,13 @@ class Line
     using reverse_iterator = typename InflatedBuffer::reverse_iterator;
     using const_iterator = typename InflatedBuffer::const_iterator;
 
-    Line(ColumnCount _width, LineFlags _flags, GraphicsAttributes _templateSGR):
-        storage_ { InflatedBuffer { _width.as<size_t>(), Cell { _templateSGR } /*, _allocator*/ } },
-        flags_ { static_cast<unsigned>(_flags) }
+    Line(LineFlags _flags, ColumnCount _width, GraphicsAttributes _templateSGR):
+        storage_ { TrivialBuffer { _width, _templateSGR } }, flags_ { static_cast<unsigned>(_flags) }
     {
     }
 
-    Line(ColumnCount _width, InflatedBuffer _buffer, LineFlags _flags):
-        storage_ { InflatedBuffer { std::move(_buffer) } }, flags_ { static_cast<unsigned>(_flags) }
-    {
-        inflatedBuffer().resize(unbox<size_t>(_width));
-    }
-
-    Line(InflatedBuffer _buffer, LineFlags _flags):
-        storage_ { InflatedBuffer { std::move(_buffer) } }, flags_ { static_cast<unsigned>(_flags) }
+    Line(LineFlags _flags, InflatedBuffer _buffer):
+        storage_ { std::move(_buffer) }, flags_ { static_cast<unsigned>(_flags) }
     {
     }
 

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -138,7 +138,7 @@ class Line
     }
 
     /// Tests if all cells are empty.
-    bool empty() const noexcept
+    [[nodiscard]] bool empty() const noexcept
     {
         if (isTrivialBuffer())
             return trivialBuffer().text.empty();
@@ -175,7 +175,7 @@ class Line
             (i++)->reset();
     }
 
-    ColumnCount size() const noexcept
+    [[nodiscard]] ColumnCount size() const noexcept
     {
         if (isTrivialBuffer())
             return trivialBuffer().displayWidth;
@@ -207,7 +207,7 @@ class Line
         return inflatedBuffer()[unbox<size_t>(_column)];
     }
 
-    uint8_t cellEmptyAt(ColumnOffset column) const noexcept
+    [[nodiscard]] uint8_t cellEmptyAt(ColumnOffset column) const noexcept
     {
         if (isTrivialBuffer())
         {
@@ -218,7 +218,7 @@ class Line
         return inflatedBuffer().at(unbox<size_t>(column)).empty();
     }
 
-    uint8_t cellWithAt(ColumnOffset column) const noexcept
+    [[nodiscard]] uint8_t cellWithAt(ColumnOffset column) const noexcept
     {
         if (isTrivialBuffer())
         {
@@ -229,22 +229,31 @@ class Line
         return inflatedBuffer().at(unbox<size_t>(column)).width();
     }
 
-    LineFlags flags() const noexcept { return static_cast<LineFlags>(flags_); }
+    [[nodiscard]] LineFlags flags() const noexcept { return static_cast<LineFlags>(flags_); }
 
-    bool marked() const noexcept { return isFlagEnabled(LineFlags::Marked); }
+    [[nodiscard]] bool marked() const noexcept { return isFlagEnabled(LineFlags::Marked); }
     void setMarked(bool _enable) { setFlag(LineFlags::Marked, _enable); }
 
-    bool wrapped() const noexcept { return isFlagEnabled(LineFlags::Wrapped); }
+    [[nodiscard]] bool wrapped() const noexcept { return isFlagEnabled(LineFlags::Wrapped); }
     void setWrapped(bool _enable) { setFlag(LineFlags::Wrapped, _enable); }
 
-    bool wrappable() const noexcept { return isFlagEnabled(LineFlags::Wrappable); }
+    [[nodiscard]] bool wrappable() const noexcept { return isFlagEnabled(LineFlags::Wrappable); }
     void setWrappable(bool _enable) { setFlag(LineFlags::Wrappable, _enable); }
 
-    LineFlags wrappableFlag() const noexcept { return wrappable() ? LineFlags::Wrappable : LineFlags::None; }
-    LineFlags wrappedFlag() const noexcept { return marked() ? LineFlags::Wrapped : LineFlags::None; }
-    LineFlags markedFlag() const noexcept { return marked() ? LineFlags::Marked : LineFlags::None; }
+    [[nodiscard]] LineFlags wrappableFlag() const noexcept
+    {
+        return wrappable() ? LineFlags::Wrappable : LineFlags::None;
+    }
+    [[nodiscard]] LineFlags wrappedFlag() const noexcept
+    {
+        return marked() ? LineFlags::Wrapped : LineFlags::None;
+    }
+    [[nodiscard]] LineFlags markedFlag() const noexcept
+    {
+        return marked() ? LineFlags::Marked : LineFlags::None;
+    }
 
-    LineFlags inheritableFlags() const noexcept
+    [[nodiscard]] LineFlags inheritableFlags() const noexcept
     {
         auto constexpr Inheritables = unsigned(LineFlags::Wrappable) | unsigned(LineFlags::Marked);
         return static_cast<LineFlags>(flags_ & Inheritables);
@@ -258,14 +267,14 @@ class Line
             flags_ &= ~static_cast<unsigned>(_flag);
     }
 
-    bool isFlagEnabled(LineFlags _flag) const noexcept
+    [[nodiscard]] bool isFlagEnabled(LineFlags _flag) const noexcept
     {
         return (flags_ & static_cast<unsigned>(_flag)) != 0;
     }
 
-    InflatedBuffer reflow(ColumnCount _newColumnCount);
-    std::string toUtf8() const;
-    std::string toUtf8Trimmed() const;
+    [[nodiscard]] InflatedBuffer reflow(ColumnCount _newColumnCount);
+    [[nodiscard]] std::string toUtf8() const;
+    [[nodiscard]] std::string toUtf8Trimmed() const;
 
     // Returns a reference to this mutable grid-line buffer.
     //
@@ -274,11 +283,20 @@ class Line
     InflatedBuffer& inflatedBuffer();
     InflatedBuffer const& inflatedBuffer() const;
 
-    TrivialBuffer& trivialBuffer() noexcept { return std::get<TrivialBuffer>(storage_); }
-    TrivialBuffer const& trivialBuffer() const noexcept { return std::get<TrivialBuffer>(storage_); }
+    [[nodiscard]] TrivialBuffer& trivialBuffer() noexcept { return std::get<TrivialBuffer>(storage_); }
+    [[nodiscard]] TrivialBuffer const& trivialBuffer() const noexcept
+    {
+        return std::get<TrivialBuffer>(storage_);
+    }
 
-    bool isTrivialBuffer() const noexcept { return std::holds_alternative<TrivialBuffer>(storage_); }
-    bool isInflatedBuffer() const noexcept { return std::holds_alternative<TrivialBuffer>(storage_); }
+    [[nodiscard]] bool isTrivialBuffer() const noexcept
+    {
+        return std::holds_alternative<TrivialBuffer>(storage_);
+    }
+    [[nodiscard]] bool isInflatedBuffer() const noexcept
+    {
+        return std::holds_alternative<TrivialBuffer>(storage_);
+    }
 
     void setBuffer(TrivialBuffer const& buffer) noexcept { storage_ = buffer; }
     void setBuffer(InflatedBuffer buffer) { storage_ = std::move(buffer); }

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2021 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <terminal/Cell.h>
+#include <terminal/Line.h>
+
+#include <crispy/escape.h>
+
+#include <catch2/catch.hpp>
+
+using namespace std;
+
+using namespace terminal;
+using namespace crispy;
+
+TEST_CASE("Line.BufferFragment", "[Line]")
+{
+    auto constexpr testText = "0123456789ABCDEF"sv;
+    auto pool = BufferObjectPool(16);
+    auto bufferObject = pool.allocateBufferObject();
+    bufferObject->writeAtEnd(testText);
+    auto const bufferFragment = bufferObject->ref(0, 10);
+
+    auto const externalView = string_view(bufferObject->data(), 10);
+    auto const fragment = BufferFragment(bufferObject, externalView);
+    CHECK(fragment.view() == externalView);
+}
+
+TEST_CASE("Line.inflate", "[Line]")
+{
+    auto constexpr testText = "0123456789ABCDEF"sv;
+    auto pool = BufferObjectPool(16);
+    auto bufferObject = pool.allocateBufferObject();
+    bufferObject->writeAtEnd(testText);
+    auto const bufferFragment = bufferObject->ref(0, 10);
+
+    auto const externalView = string_view(bufferObject->data(), 10);
+
+    auto sgr = GraphicsAttributes {};
+    sgr.foregroundColor = RGBColor(0x123456);
+    sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
+    sgr.underlineColor = Color::Indexed(IndexedColor::Red);
+    sgr.styles |= CellFlags::CurlyUnderlined;
+    auto const trivial = TriviallyStyledLineBuffer { ColumnCount(10), sgr, bufferFragment };
+
+    auto const inflated = inflate<Cell>(trivial);
+
+    CHECK(inflated.size() == 10);
+    for (size_t i = 0; i < inflated.size(); ++i)
+    {
+        auto const& cell = inflated[i];
+        INFO(fmt::format("column {} codepoint {}", i, (char) cell.codepoint(0)));
+        CHECK(cell.foregroundColor() == sgr.foregroundColor);
+        CHECK(cell.backgroundColor() == sgr.backgroundColor);
+        CHECK(cell.underlineColor() == sgr.underlineColor);
+        CHECK(cell.codepointCount() == 1);
+        CHECK(char(cell.codepoint(0)) == testText[i]);
+    }
+}

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Line.inflate", "[Line]")
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
     sgr.styles |= CellFlags::CurlyUnderlined;
-    auto const trivial = TriviallyStyledLineBuffer { ColumnCount(10), sgr, HyperlinkId{}, bufferFragment };
+    auto const trivial = TriviallyStyledLineBuffer { ColumnCount(10), sgr, HyperlinkId {}, bufferFragment };
 
     auto const inflated = inflate<Cell>(trivial);
 

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -44,8 +44,6 @@ TEST_CASE("Line.inflate", "[Line]")
     bufferObject->writeAtEnd(testText);
     auto const bufferFragment = bufferObject->ref(0, 10);
 
-    auto const externalView = string_view(bufferObject->data(), 10);
-
     auto sgr = GraphicsAttributes {};
     sgr.foregroundColor = RGBColor(0x123456);
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Line.inflate", "[Line]")
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
     sgr.styles |= CellFlags::CurlyUnderlined;
-    auto const trivial = TriviallyStyledLineBuffer { ColumnCount(10), sgr, bufferFragment };
+    auto const trivial = TriviallyStyledLineBuffer { ColumnCount(10), sgr, HyperlinkId{}, bufferFragment };
 
     auto const inflated = inflate<Cell>(trivial);
 

--- a/src/terminal/MockTerm.cpp
+++ b/src/terminal/MockTerm.cpp
@@ -23,18 +23,4 @@
 namespace terminal
 {
 
-MockTerm::MockTerm(PageSize pageSize, LineCount maxHistoryLineCount):
-    terminal { std::make_unique<MockPty>(pageSize),
-               1024, // pty read buffer size
-               *this,
-               maxHistoryLineCount }
-{
-    char const* logFilterString = getenv("LOG");
-    if (logFilterString)
-    {
-        logstore::configure(logFilterString);
-        crispy::App::customizeLogStoreOutput();
-    }
-}
-
 } // namespace terminal

--- a/src/terminal/MockTerm.h
+++ b/src/terminal/MockTerm.h
@@ -29,8 +29,8 @@ class MockTerm: public Terminal::Events
 
     template <typename Init>
     MockTerm(
-        PageSize _size, LineCount _hist = {}, size_t ptyReadBufferSize = 1024, Init init = [](MockTerm&) {}):
-        MockTerm { _size, _hist }
+        PageSize size, LineCount hist, size_t ptyReadBufferSize, Init init = [](MockTerm&) {}):
+        MockTerm { size, hist, ptyReadBufferSize }
     {
         init(*this);
     }
@@ -61,7 +61,9 @@ template <typename PtyDevice>
 inline MockTerm<PtyDevice>::MockTerm(PageSize pageSize,
                                      LineCount maxHistoryLineCount,
                                      size_t ptyReadBufferSize):
-    terminal { std::make_unique<PtyDevice>(pageSize), ptyReadBufferSize, *this, maxHistoryLineCount }
+    terminal {
+        std::make_unique<PtyDevice>(pageSize), 1024 * 1024, ptyReadBufferSize, *this, maxHistoryLineCount
+    }
 {
 }
 

--- a/src/terminal/Parser-impl.h
+++ b/src/terminal/Parser-impl.h
@@ -63,14 +63,14 @@ namespace detail
                 input += advance;
                 break;
             }
-            input += 16;
+            input += sizeof(__m128i);
         }
 
         // NOTE: It seems like it is natural to have the following two lines
         // in order to improve speed, but it's in fact slower.
         //
-        // while (input != _end && *input >= 0x20 && (*input & 0x80) == 0)
-        //     ++input;
+        while (input != _end && *input >= 0x20 && (*input & 0x80) == 0)
+            ++input;
 
         return static_cast<size_t>(std::distance(_begin, input));
 #else

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -99,6 +99,7 @@ class [[nodiscard]] Process: public Pty
     void close() override { pty().close(); }
     bool isClosed() const noexcept override { return pty().isClosed(); }
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override { return pty().read(_size, _timeout); }
+    std::optional<std::string_view> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout) override { return pty().read(storage, timeout); }
     void wakeupReader() override { return pty().wakeupReader(); }
     int write(char const* buf, size_t size) override { return pty().write(buf, size); }
     PageSize pageSize() const noexcept override { return pty().pageSize(); }

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -68,7 +68,7 @@ class [[nodiscard]] Process: public Pty
             Environment const& env,
             std::unique_ptr<Pty> pty);
 
-    ~Process();
+    ~Process() override;
 
     [[nodiscard]] bool alive() const noexcept
     {
@@ -99,7 +99,7 @@ class [[nodiscard]] Process: public Pty
     void close() override { pty().close(); }
     bool isClosed() const noexcept override { return pty().isClosed(); }
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override { return pty().read(_size, _timeout); }
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout) override { return pty().read(storage, timeout); }
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }
     int write(char const* buf, size_t size) override { return pty().write(buf, size); }
     PageSize pageSize() const noexcept override { return pty().pageSize(); }

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -99,7 +99,7 @@ class [[nodiscard]] Process: public Pty
     void close() override { pty().close(); }
     bool isClosed() const noexcept override { return pty().isClosed(); }
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override { return pty().read(_size, _timeout); }
-    std::optional<std::string_view> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout) override { return pty().read(storage, timeout); }
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout) override { return pty().read(storage, timeout); }
     void wakeupReader() override { return pty().wakeupReader(); }
     int write(char const* buf, size_t size) override { return pty().write(buf, size); }
     PageSize pageSize() const noexcept override { return pty().pageSize(); }

--- a/src/terminal/Process_unix.cpp
+++ b/src/terminal/Process_unix.cpp
@@ -46,8 +46,8 @@
     #include <pty.h>
 #endif
 
+#include <csignal>
 #include <pwd.h>
-#include <signal.h>
 #include <unistd.h>
 
 #include <sys/types.h>
@@ -113,7 +113,7 @@ Process::Process(string const& _path,
     d->pty = move(_pty);
 
     UnixPipe* stdoutFastPipe = [this]() -> UnixPipe* {
-        if (UnixPty* p = dynamic_cast<UnixPty*>(d->pty.get()))
+        if (auto* p = dynamic_cast<UnixPty*>(d->pty.get()))
             return &p->stdoutFastPipe();
         return nullptr;
     }();
@@ -129,7 +129,7 @@ Process::Process(string const& _path,
             throw runtime_error { getLastErrorAsString() };
         case 0: // in child
         {
-            d->pty->slave().login();
+            (void) d->pty->slave().login();
 
             auto const& cwd = _cwd.generic_string();
             if (!isFlatpak())

--- a/src/terminal/RenderBuffer.h
+++ b/src/terminal/RenderBuffer.h
@@ -71,7 +71,7 @@ struct RenderBufferRef
     RenderBuffer const& buffer;
     std::mutex& guard;
 
-    RenderBuffer const& get() const noexcept { return buffer; }
+    [[nodiscard]] RenderBuffer const& get() const noexcept { return buffer; }
 
     RenderBufferRef(RenderBuffer const& _buf, std::mutex& _lock): buffer { _buf }, guard { _lock }
     {

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1080,6 +1080,12 @@ void Screen<Cell>::clearToBeginOfLine()
         i->reset(_state.cursor.graphicsRendition);
         ++i;
     }
+
+    auto const line = _state.cursor.position.line;
+    auto const left = ColumnOffset(0);
+    auto const right = _state.cursor.position.column;
+    auto const area = Rect { Top(*line), Left(*left), Bottom(*line), Right(*right) };
+    _terminal.markRegionDirty(area);
 }
 
 template <typename Cell>

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -521,7 +521,7 @@ string_view Screen<Cell>::tryEmplaceChars(string_view _chars) noexcept
             advanceCursorAfterWrite(ColumnCount(charsToWrite));
             _chars.remove_prefix(charsToWrite);
             _chars = tryEmplaceContinuousChars(_chars);
-            _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.begin());
+            _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.data());
             return _chars;
         }
         return _chars;
@@ -538,7 +538,7 @@ string_view Screen<Cell>::tryEmplaceChars(string_view _chars) noexcept
         advanceCursorAfterWrite(ColumnCount(charsToWrite));
         _chars.remove_prefix(charsToWrite);
         _chars = tryEmplaceContinuousChars(_chars);
-        _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.begin());
+        _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.data());
         return _chars;
     }
 

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -523,14 +523,15 @@ string_view Screen<Cell, TheScreenType>::tryEmplaceChars(string_view _chars) noe
     {
         if (currentLine().empty())
         {
-            auto const charsToWrite = min(columnsAvailable, static_cast<int>(_chars.size()));
+            auto const charsToWrite =
+                static_cast<size_t>(min(columnsAvailable, static_cast<int>(_chars.size())));
             currentLine().reset(_state.cursor.graphicsRendition,
                                 _state.cursor.hyperlink,
                                 crispy::BufferFragment {
                                     _terminal.currentPtyBuffer(),
                                     _chars.substr(0, charsToWrite),
                                 });
-            advanceCursorAfterWrite(ColumnCount(charsToWrite));
+            advanceCursorAfterWrite(ColumnCount::cast_from(charsToWrite));
             _chars.remove_prefix(charsToWrite);
             _chars = tryEmplaceContinuousChars(_chars);
             _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.data());
@@ -541,9 +542,9 @@ string_view Screen<Cell, TheScreenType>::tryEmplaceChars(string_view _chars) noe
 
     if (canResumeEmplace(_chars))
     {
-        auto const charsToWrite = min(columnsAvailable, static_cast<int>(_chars.size()));
+        auto const charsToWrite = static_cast<size_t>(min(columnsAvailable, static_cast<int>(_chars.size())));
         currentLine().trivialBuffer().text.growBy(charsToWrite);
-        advanceCursorAfterWrite(ColumnCount(charsToWrite));
+        advanceCursorAfterWrite(ColumnCount::cast_from(charsToWrite));
         _chars.remove_prefix(charsToWrite);
         _chars = tryEmplaceContinuousChars(_chars);
         _terminal.currentPtyBuffer()->advanceHotEndUntil(_chars.data());

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1711,7 +1711,7 @@ void Screen<Cell>::screenAlignmentPattern()
     // fills the complete screen area with a test pattern
     for (auto& line: grid().mainPage())
     {
-        line.reset(grid().defaultLineFlags(), GraphicsAttributes {}, U'E', 1);
+        line.fill(grid().defaultLineFlags(), GraphicsAttributes {}, U'E', 1);
     }
 }
 

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1124,9 +1124,9 @@ void Screen<Cell, TheScreenType>::insertChars(LineOffset _lineNo, ColumnCount _n
 {
     auto const n = min(*_n, *_state.margin.horizontal.to - *logicalCursorPosition().column + 1);
 
-    auto column0 = grid().lineAt(_lineNo).editable().begin() + *realCursorPosition().column;
-    auto column1 = grid().lineAt(_lineNo).editable().begin() + *_state.margin.horizontal.to - n + 1;
-    auto column2 = grid().lineAt(_lineNo).editable().begin() + *_state.margin.horizontal.to + 1;
+    auto column0 = grid().lineAt(_lineNo).inflatedBuffer().begin() + *realCursorPosition().column;
+    auto column1 = grid().lineAt(_lineNo).inflatedBuffer().begin() + *_state.margin.horizontal.to - n + 1;
+    auto column2 = grid().lineAt(_lineNo).inflatedBuffer().begin() + *_state.margin.horizontal.to + 1;
 
     rotate(column0, column1, column2);
 

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -122,7 +122,8 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     ///          including initial clear screen, and initial cursor hide.
     std::string screenshot(std::function<std::string(LineOffset)> const& _postLine = {}) const;
 
-    void linefeedIfWrapPending();
+    void crlf() { linefeed(_state.margin.horizontal.from); }
+    void crlfIfWrapPending();
 
     // {{{ VT API
     void linefeed(); // LF

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -77,10 +77,13 @@ class ScreenBase: public SequenceHandler
  * allowing the object owner to control which part of the screen (or history)
  * to be viewn.
  */
-template <typename Cell>
+template <typename Cell, ScreenType TheScreenType = ScreenType::Primary>
 class Screen: public ScreenBase, public capabilities::StaticDatabase
 {
   public:
+    constexpr static bool IsPrimaryScreen = TheScreenType == ScreenType::Primary;
+    constexpr static bool IsAlternateScreen = TheScreenType == ScreenType::Alternate;
+
     Screen(TerminalState& terminalState, ScreenType screenType, Grid<Cell>& grid);
 
     Screen(Screen const&) = delete;
@@ -425,14 +428,11 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
 
     HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept override
     {
-        if (1) // constexpr (Line<Cell>::Optimized)
+        auto const& line = grid().lineAt(position.line);
+        if (line.isTrivialBuffer())
         {
-            auto const& line = grid().lineAt(position.line);
-            if (line.isTrivialBuffer())
-            {
-                TriviallyStyledLineBuffer const& lineBuffer = line.trivialBuffer();
-                return lineBuffer.hyperlink;
-            }
+            TriviallyStyledLineBuffer const& lineBuffer = line.trivialBuffer();
+            return lineBuffer.hyperlink;
         }
         return at(position).hyperlink();
     }

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -136,8 +136,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void clearToEndOfScreen();
     void clearScreen();
 
-    void clearScrollbackBuffer();
-
     void eraseCharacters(ColumnCount _n);  // ECH
     void insertCharacters(ColumnCount _n); // ICH
     void deleteCharacters(ColumnCount _n); // DCH
@@ -248,9 +246,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void inspect(std::string const& _message, std::ostream& _os) const override;
 
     // for DECSC and DECRC
-    void saveCursor();
-    void restoreCursor();
-    void restoreCursor(Cursor const& _savedCursor);
     void saveModes(std::vector<DECMode> const& _modes);
     void restoreModes(std::vector<DECMode> const& _modes);
     void requestAnsiMode(unsigned int _mode);

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -101,10 +101,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void processSequence(Sequence const& seq) override;
     // }}}
 
-    std::string_view tryEmplaceChars(std::string_view chars) noexcept;
-    std::string_view tryEmplaceContinuousChars(std::string_view chars) noexcept;
-    void advanceCursorAfterWrite(ColumnCount n) noexcept;
-
     /// Renders the full screen by passing every grid cell to the callback.
     template <typename Renderer>
     void render(Renderer&& _render, ScrollOffset _scrollOffset = {}) const
@@ -458,6 +454,11 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void fail(std::string const& _message) const override;
 
   private:
+    std::string_view tryEmplaceChars(std::string_view chars) noexcept;
+    std::string_view tryEmplaceContinuousChars(std::string_view chars) noexcept;
+    bool canResumeEmplace(std::string_view continuationChars) const noexcept;
+    void advanceCursorAfterWrite(ColumnCount n) noexcept;
+
     void clearAllTabs();
     void clearTabUnderCursor();
     void setTabUnderCursor();

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -59,11 +59,12 @@ class ScreenBase: public SequenceHandler
   public:
     virtual void verifyState() const = 0;
     virtual void fail(std::string const& _message) const = 0;
-    virtual bool contains(CellLocation _coord) const noexcept = 0;
-    virtual bool isCellEmpty(CellLocation position) const noexcept = 0;
-    virtual uint8_t cellWithAt(CellLocation position) const noexcept = 0;
-    virtual HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept = 0;
-    virtual std::shared_ptr<HyperlinkInfo const> hyperlinkAt(CellLocation pos) const noexcept = 0;
+    [[nodiscard]] virtual bool contains(CellLocation _coord) const noexcept = 0;
+    [[nodiscard]] virtual bool isCellEmpty(CellLocation position) const noexcept = 0;
+    [[nodiscard]] virtual uint8_t cellWithAt(CellLocation position) const noexcept = 0;
+    [[nodiscard]] virtual HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept = 0;
+    [[nodiscard]] virtual std::shared_ptr<HyperlinkInfo const> hyperlinkAt(
+        CellLocation pos) const noexcept = 0;
     virtual void inspect(std::string const& _message, std::ostream& _os) const = 0;
 };
 
@@ -90,12 +91,12 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     Screen& operator=(Screen const&) = delete;
     Screen(Screen&&) noexcept = default;
     Screen& operator=(Screen&&) noexcept = default;
-    ~Screen() = default;
+    ~Screen() override = default;
 
     using StaticDatabase::numericCapability;
-    unsigned numericCapability(capabilities::Code _cap) const override;
+    [[nodiscard]] unsigned numericCapability(capabilities::Code _cap) const override;
 
-    LineCount historyLineCount() const noexcept { return grid().historyLineCount(); }
+    [[nodiscard]] LineCount historyLineCount() const noexcept { return grid().historyLineCount(); }
 
     // {{{ SequenceHandler overrides
     void writeText(char32_t _char) override;
@@ -112,7 +113,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     }
 
     /// Renders the full screen as text into the given string. Each line will be terminated by LF.
-    std::string renderMainPageText() const;
+    [[nodiscard]] std::string renderMainPageText() const;
 
     /// Takes a screenshot by outputting VT sequences needed to render the current state of the screen.
     ///
@@ -214,8 +215,8 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void smGraphics(XtSmGraphics::Item _item, XtSmGraphics::Action _action, XtSmGraphics::Value _value);
     // }}}
 
-    ImageSize maxImageSize() const noexcept { return _state.maxImageSize; }
-    ImageSize maxImageSizeLimit() const noexcept { return _state.maxImageSizeLimit; }
+    [[nodiscard]] ImageSize maxImageSize() const noexcept { return _state.maxImageSize; }
+    [[nodiscard]] ImageSize maxImageSizeLimit() const noexcept { return _state.maxImageSizeLimit; }
 
     std::shared_ptr<Image const> uploadImage(ImageFormat _format,
                                              ImageSize _imageSize,
@@ -251,7 +252,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void requestAnsiMode(unsigned int _mode);
     void requestDECMode(unsigned int _mode);
 
-    PageSize pageSize() const noexcept { return _state.pageSize; }
+    [[nodiscard]] PageSize pageSize() const noexcept { return _state.pageSize; }
 
     constexpr CellLocation realCursorPosition() const noexcept { return _state.cursor.position; }
 
@@ -272,7 +273,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
         return { _state.margin.vertical.from, _state.margin.horizontal.from };
     }
 
-    Cursor const& cursor() const noexcept { return _state.cursor; }
+    [[nodiscard]] Cursor const& cursor() const noexcept { return _state.cursor; }
 
     /// Returns identity if DECOM is disabled (default), but returns translated coordinates if DECOM is
     /// enabled.
@@ -300,12 +301,12 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
                  std::clamp(coord.column, ColumnOffset { 0 }, _state.margin.horizontal.to) };
     }
 
-    LineOffset clampedLine(LineOffset _line) const noexcept
+    [[nodiscard]] LineOffset clampedLine(LineOffset _line) const noexcept
     {
         return std::clamp(_line, LineOffset(0), boxed_cast<LineOffset>(_state.pageSize.lines) - 1);
     }
 
-    ColumnOffset clampedColumn(ColumnOffset _column) const noexcept
+    [[nodiscard]] ColumnOffset clampedColumn(ColumnOffset _column) const noexcept
     {
         return std::clamp(_column, ColumnOffset(0), boxed_cast<ColumnOffset>(_state.pageSize.columns) - 1);
     }
@@ -316,7 +317,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     }
 
     // Tests if given coordinate is within the visible screen area.
-    bool contains(CellLocation _coord) const noexcept override
+    [[nodiscard]] bool contains(CellLocation _coord) const noexcept override
     {
         return LineOffset(0) <= _coord.line && _coord.line < boxed_cast<LineOffset>(_state.pageSize.lines)
                && ColumnOffset(0) <= _coord.column
@@ -372,9 +373,9 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     Cell& useCellAt(CellLocation p) noexcept { return useCellAt(p.line, p.column); }
     Cell const& at(CellLocation p) const noexcept { return grid().at(p.line, p.column); }
 
-    Margin margin() const noexcept { return _state.margin; }
+    [[nodiscard]] Margin margin() const noexcept { return _state.margin; }
 
-    std::string const& windowTitle() const noexcept { return _state.windowTitle; }
+    [[nodiscard]] std::string const& windowTitle() const noexcept { return _state.windowTitle; }
 
     /// Finds the next marker right after the given line position.
     ///
@@ -382,7 +383,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     ///                            (0..-N) for savedLines area
     /// @return cursor position relative to screen origin (1, 1), that is, if line Number os >= 1, it's
     ///         in the screen area, and in the savedLines area otherwise.
-    std::optional<LineOffset> findMarkerDownwards(LineOffset _currentCursorLine) const;
+    [[nodiscard]] std::optional<LineOffset> findMarkerDownwards(LineOffset _currentCursorLine) const;
 
     /// Finds the previous marker right next to the given line position.
     ///
@@ -390,12 +391,12 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     ///                            (0..-N) for savedLines area
     /// @return cursor position relative to screen origin (1, 1), that is, if line Number os >= 1, it's
     ///         in the screen area, and in the savedLines area otherwise.
-    std::optional<LineOffset> findMarkerUpwards(LineOffset _currentCursorLine) const;
+    [[nodiscard]] std::optional<LineOffset> findMarkerUpwards(LineOffset _currentCursorLine) const;
 
     /// ScreenBuffer's type, such as main screen or alternate screen.
-    ScreenType bufferType() const noexcept { return _state.screenType; }
+    [[nodiscard]] ScreenType bufferType() const noexcept { return _state.screenType; }
 
-    bool synchronizeOutput() const noexcept { return false; } // TODO
+    [[nodiscard]] bool synchronizeOutput() const noexcept { return false; } // TODO
 
     void scrollUp(LineCount n) { scrollUp(n, _state.margin); }
     void scrollDown(LineCount n) { scrollDown(n, _state.margin); }
@@ -403,31 +404,37 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void verifyState() const override;
 
     /// @returns the primary screen's grid.
-    Grid<Cell>& primaryGrid() noexcept { return _state.primaryBuffer; }
+    [[nodiscard]] Grid<Cell>& primaryGrid() noexcept { return _state.primaryBuffer; }
 
-    Grid<Cell> const& grid() const noexcept { return _grid; }
-    Grid<Cell>& grid() noexcept { return _grid; }
+    [[nodiscard]] Grid<Cell> const& grid() const noexcept { return _grid; }
+    [[nodiscard]] Grid<Cell>& grid() noexcept { return _grid; }
 
     /// @returns true iff given absolute line number is wrapped, false otherwise.
-    bool isLineWrapped(LineOffset _lineNumber) const noexcept { return _grid.isLineWrapped(_lineNumber); }
+    [[nodiscard]] bool isLineWrapped(LineOffset _lineNumber) const noexcept
+    {
+        return _grid.isLineWrapped(_lineNumber);
+    }
 
-    ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
-    ColorPalette const& colorPalette() const noexcept { return _state.colorPalette; }
+    [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
+    [[nodiscard]] ColorPalette const& colorPalette() const noexcept { return _state.colorPalette; }
 
-    ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
-    ColorPalette const& defaultColorPalette() const noexcept { return _state.defaultColorPalette; }
+    [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
+    [[nodiscard]] ColorPalette const& defaultColorPalette() const noexcept
+    {
+        return _state.defaultColorPalette;
+    }
 
-    bool isCellEmpty(CellLocation position) const noexcept override
+    [[nodiscard]] bool isCellEmpty(CellLocation position) const noexcept override
     {
         return grid().lineAt(position.line).cellEmptyAt(position.column);
     }
 
-    uint8_t cellWithAt(CellLocation position) const noexcept override
+    [[nodiscard]] uint8_t cellWithAt(CellLocation position) const noexcept override
     {
         return grid().lineAt(position.line).cellWithAt(position.column);
     }
 
-    HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept override
+    [[nodiscard]] HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept override
     {
         auto const& line = grid().lineAt(position.line);
         if (line.isTrivialBuffer())
@@ -438,26 +445,29 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
         return at(position).hyperlink();
     }
 
-    std::shared_ptr<HyperlinkInfo const> hyperlinkAt(CellLocation pos) const noexcept override
+    [[nodiscard]] std::shared_ptr<HyperlinkInfo const> hyperlinkAt(CellLocation pos) const noexcept override
     {
         return _state.hyperlinks.hyperlinkById(hyperlinkIdAt(pos));
     }
 
-    HyperlinkStorage const& hyperlinks() const noexcept { return _state.hyperlinks; }
+    [[nodiscard]] HyperlinkStorage const& hyperlinks() const noexcept { return _state.hyperlinks; }
 
-    uint64_t instructionCounter() const noexcept { return _state.instructionCounter; }
     void resetInstructionCounter() noexcept { _state.instructionCounter = 0; }
-    char32_t precedingGraphicCharacter() const noexcept { return _state.precedingGraphicCharacter; }
+    [[nodiscard]] uint64_t instructionCounter() const noexcept { return _state.instructionCounter; }
+    [[nodiscard]] char32_t precedingGraphicCharacter() const noexcept
+    {
+        return _state.precedingGraphicCharacter;
+    }
 
     void applyAndLog(FunctionDefinition const& function, Sequence const& seq);
-    ApplyResult apply(FunctionDefinition const& function, Sequence const& seq);
+    [[nodiscard]] ApplyResult apply(FunctionDefinition const& function, Sequence const& seq);
 
     void fail(std::string const& _message) const override;
 
   private:
     std::string_view tryEmplaceChars(std::string_view chars) noexcept;
     std::string_view tryEmplaceContinuousChars(std::string_view chars) noexcept;
-    bool canResumeEmplace(std::string_view continuationChars) const noexcept;
+    [[nodiscard]] bool canResumeEmplace(std::string_view continuationChars) const noexcept;
     void advanceCursorAfterWrite(ColumnCount n) noexcept;
 
     void clearAllTabs();

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -67,7 +67,7 @@ class ScreenBase: public SequenceHandler
     virtual void inspect(std::string const& _message, std::ostream& _os) const = 0;
 };
 
-#define LIBTERMINAL_CURRENT_LINE_CACHE 1
+//#define LIBTERMINAL_CURRENT_LINE_CACHE 1
 
 /**
  * Terminal Screen.
@@ -492,5 +492,11 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
 #endif
     std::unique_ptr<SixelImageBuilder> sixelImageBuilder_;
 };
+
+template <typename Cell, ScreenType TheScreenType>
+inline void Screen<Cell, TheScreenType>::scrollUp(LineCount _n, Margin _margin)
+{
+    scrollUp(_n, cursor().graphicsRendition, _margin);
+}
 
 } // namespace terminal

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -154,16 +154,17 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void backIndex();    // DECBI
     void forwardIndex(); // DECFI
 
-    void moveCursorBackward(ColumnCount _n);  // CUB
-    void moveCursorDown(LineCount _n);        // CUD
-    void moveCursorForward(ColumnCount _n);   // CUF
-    void moveCursorToBeginOfLine();           // CR
-    void moveCursorToColumn(ColumnOffset _n); // CHA
-    void moveCursorToLine(LineOffset _n);     // VPA
-    void moveCursorToNextLine(LineCount _n);  // CNL
-    void moveCursorToNextTab();               // HT
-    void moveCursorToPrevLine(LineCount _n);  // CPL
-    void moveCursorUp(LineCount _n);          // CUU
+    void moveCursorTo(LineOffset line, ColumnOffset column); // CUP
+    void moveCursorBackward(ColumnCount _n);                 // CUB
+    void moveCursorDown(LineCount _n);                       // CUD
+    void moveCursorForward(ColumnCount _n);                  // CUF
+    void moveCursorToBeginOfLine();                          // CR
+    void moveCursorToColumn(ColumnOffset _n);                // CHA
+    void moveCursorToLine(LineOffset _n);                    // VPA
+    void moveCursorToNextLine(LineCount _n);                 // CNL
+    void moveCursorToNextTab();                              // HT
+    void moveCursorToPrevLine(LineCount _n);                 // CPL
+    void moveCursorUp(LineCount _n);                         // CUU
 
     void cursorBackwardTab(TabStopCount _n);            // CBT
     void cursorForwardTab(TabStopCount _n);             // CHT
@@ -335,8 +336,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
 
     Cell& useCurrentCell() noexcept { return useCellAt(_state.cursor.position); }
     Cell const& currentCell() const noexcept { return at(_state.cursor.position); }
-
-    void moveCursorTo(LineOffset line, ColumnOffset column);
 
     /// Gets a reference to the cell relative to screen origin (top left, 1:1).
     Cell& at(LineOffset _line, ColumnOffset _column) noexcept { return grid().useCellAt(_line, _column); }

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -2384,7 +2384,7 @@ TEST_CASE("RequestMode", "[screen]")
 
     SECTION("ANSI modes: unknown")
     {
-        AnsiMode m = static_cast<AnsiMode>(1234);
+        auto const m = static_cast<AnsiMode>(1234);
         mock.terminal.setMode(m, true); // DECOM
         screen.requestAnsiMode((unsigned) m);
         REQUIRE(e(mock.terminal.peekInput()) == e(fmt::format("\033[{};0$y", toAnsiModeNum(m))));
@@ -2408,7 +2408,7 @@ TEST_CASE("RequestMode", "[screen]")
 
     SECTION("DEC modes: unknown")
     {
-        DECMode m = static_cast<DECMode>(1234);
+        auto const m = static_cast<DECMode>(1234);
         mock.terminal.setMode(m, true); // DECOM
         screen.requestDECMode(static_cast<unsigned>(m));
         REQUIRE(e(mock.terminal.peekInput()) == e(fmt::format("\033[?{};0$y", toDECModeNum(m))));
@@ -2984,7 +2984,6 @@ TEST_CASE("save_restore_DEC_modes", "[screen]")
 TEST_CASE("OSC.2.Unicode")
 {
     auto mock = MockTerm { PageSize { LineCount(2), ColumnCount(2) } };
-    auto& screen = mock.terminal.primaryScreen();
 
     auto const u32title = u32string_view(U"\U0001F600");
     auto const title = unicode::convert_to<char>(u32title);
@@ -2997,7 +2996,6 @@ TEST_CASE("OSC.2.Unicode")
 TEST_CASE("OSC.4")
 {
     auto mock = MockTerm { PageSize { LineCount(2), ColumnCount(2) } };
-    auto& screen = mock.terminal.primaryScreen();
 
     SECTION("query")
     {
@@ -3034,7 +3032,6 @@ TEST_CASE("OSC.4")
 TEST_CASE("XTGETTCAP")
 {
     auto mock = MockTerm { PageSize { LineCount(2), ColumnCount(2) } };
-    auto& screen = mock.terminal.primaryScreen();
     auto const queryStr = fmt::format("\033P+q{:02X}{:02X}{:02X}\033\\", 'R', 'G', 'B');
     mock.writeToScreen(queryStr);
     INFO(fmt::format("Reply data: {}", mock.terminal.peekInput()));
@@ -3317,7 +3314,6 @@ TEST_CASE("Screen.tcap.string", "[screen, tcap]")
 {
     using namespace terminal;
     auto mock = MockTerm(PageSize { LineCount(3), ColumnCount(5) }, LineCount(2));
-    auto& screen = mock.terminal.primaryScreen();
     mock.writeToScreen("\033P+q687061\033\\"); // HPA
     REQUIRE(e(mock.terminal.peekInput()) == e("\033P1+r687061=1B5B2569257031256447\033\\"));
 }

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -2220,7 +2220,7 @@ TEST_CASE("CursorNextLine", "[screen]")
         mock.terminal.setTopBottomMargin(LineOffset { 1 }, LineOffset { 3 });
         mock.terminal.setMode(DECMode::Origin, true);
         screen.moveCursorTo(LineOffset { 0 }, ColumnOffset { 1 });
-        REQUIRE(screen.currentCell().toUtf8() == "8");
+        REQUIRE(screen.useCurrentCell().toUtf8() == "8");
 
         SECTION("normal-1")
         {

--- a/src/terminal/Selector.h
+++ b/src/terminal/Selector.h
@@ -31,11 +31,11 @@ namespace terminal
 struct SelectionHelper
 {
     virtual ~SelectionHelper() = default;
-    virtual PageSize pageSize() const noexcept = 0;
-    virtual bool wordDelimited(CellLocation _pos) const noexcept = 0;
-    virtual bool wrappedLine(LineOffset _line) const noexcept = 0;
-    virtual bool cellEmpty(CellLocation _pos) const noexcept = 0;
-    virtual int cellWidth(CellLocation _pos) const noexcept = 0;
+    [[nodiscard]] virtual PageSize pageSize() const noexcept = 0;
+    [[nodiscard]] virtual bool wordDelimited(CellLocation _pos) const noexcept = 0;
+    [[nodiscard]] virtual bool wrappedLine(LineOffset _line) const noexcept = 0;
+    [[nodiscard]] virtual bool cellEmpty(CellLocation _pos) const noexcept = 0;
+    [[nodiscard]] virtual int cellWidth(CellLocation _pos) const noexcept = 0;
 };
 
 /**
@@ -81,7 +81,7 @@ class Selection
         ColumnOffset fromColumn;
         ColumnOffset toColumn;
 
-        constexpr ColumnCount length() const noexcept
+        [[nodiscard]] constexpr ColumnCount length() const noexcept
         {
             return boxed_cast<ColumnCount>(toColumn - fromColumn + 1);
         }
@@ -99,17 +99,17 @@ class Selection
 
     /// @returns boolean indicating whether or not given absolute coordinate is within the range of the
     /// selection.
-    virtual bool contains(CellLocation _coord) const noexcept;
-    virtual bool intersects(Rect _area) const noexcept;
+    [[nodiscard]] virtual bool contains(CellLocation _coord) const noexcept;
+    [[nodiscard]] virtual bool intersects(Rect _area) const noexcept;
 
     /// Tests whether the a selection is currently in progress.
-    constexpr State state() const noexcept { return state_; }
+    [[nodiscard]] constexpr State state() const noexcept { return state_; }
 
     /// Extends the selection to the given coordinate.
     virtual void extend(CellLocation _to);
 
     /// Constructs a vector of ranges for this selection.
-    virtual std::vector<Range> ranges() const;
+    [[nodiscard]] virtual std::vector<Range> ranges() const;
 
     /// Marks the selection as completed.
     void complete();

--- a/src/terminal/Sequence.h
+++ b/src/terminal/Sequence.h
@@ -44,15 +44,15 @@ class SequenceParameters
   public:
     using Storage = std::array<uint16_t, 16>;
 
-    constexpr uint16_t at(size_t index) const noexcept { return _values[index]; }
+    [[nodiscard]] constexpr uint16_t at(size_t index) const noexcept { return _values[index]; }
 
-    constexpr bool isSubParameter(size_t index) const noexcept
+    [[nodiscard]] constexpr bool isSubParameter(size_t index) const noexcept
     {
         return (_subParameterTest & (1 << index)) != 0;
     }
 
     /// Returns the number of sub-params for a given non-sub param.
-    constexpr size_t subParameterCount(size_t index) const noexcept
+    [[nodiscard]] constexpr size_t subParameterCount(size_t index) const noexcept
     {
         if (!isSubParameter(index))
         {
@@ -72,12 +72,15 @@ class SequenceParameters
         _count = 0;
     }
 
-    constexpr bool empty() const noexcept { return _count == 0; }
-    constexpr size_t count() const noexcept { return _count; }
+    [[nodiscard]] constexpr bool empty() const noexcept { return _count == 0; }
+    [[nodiscard]] constexpr size_t count() const noexcept { return _count; }
 
-    std::string subParameterBitString() const { return fmt::format("{:016b}: ", _subParameterTest); }
+    [[nodiscard]] std::string subParameterBitString() const
+    {
+        return fmt::format("{:016b}: ", _subParameterTest);
+    }
 
-    std::string str() const
+    [[nodiscard]] std::string str() const
     {
         std::string s;
 
@@ -154,25 +157,25 @@ class SequenceParameterBuilder
     constexpr void apply(uint16_t value) noexcept
     {
         if (value >= 10)
-            multiplyBy10AndAdd(value / 10);
+            multiplyBy10AndAdd(static_cast<uint8_t>(value / 10));
         multiplyBy10AndAdd(value % 10);
     }
 
     constexpr void set(uint16_t value) noexcept { *_currentParameter = value; }
 
-    constexpr bool isSubParameter(size_t index) const noexcept
+    [[nodiscard]] constexpr bool isSubParameter(size_t index) const noexcept
     {
         return (_parameters._subParameterTest & (1 << (count() - 1 - index))) != 0;
     }
 
-    constexpr size_t count() const noexcept
+    [[nodiscard]] constexpr size_t count() const noexcept
     {
         auto const result =
             std::distance(const_cast<SequenceParameterBuilder*>(this)->_parameters._values.begin(),
                           _currentParameter)
             + 1;
         if (!(result == 1 && _parameters._values[0] == 0))
-            return result;
+            return static_cast<size_t>(result);
         else
             return 0;
     }
@@ -213,11 +216,14 @@ class Sequence
     // parameter accessors
     //
 
-    Parameters& parameters() noexcept { return parameters_; }
-    Parameters const& parameters() const noexcept { return parameters_; }
+    [[nodiscard]] Parameters& parameters() noexcept { return parameters_; }
+    [[nodiscard]] Parameters const& parameters() const noexcept { return parameters_; }
 
-    size_t parameterCount() const noexcept { return parameters_.count(); }
-    size_t subParameterCount(size_t i) const noexcept { return parameters_.subParameterCount(i); }
+    [[nodiscard]] size_t parameterCount() const noexcept { return parameters_.count(); }
+    [[nodiscard]] size_t subParameterCount(size_t i) const noexcept
+    {
+        return parameters_.subParameterCount(i);
+    }
 
     // mutators
     //
@@ -238,23 +244,23 @@ class Sequence
 
     void setCategory(FunctionCategory _cat) noexcept { category_ = _cat; }
     void setLeader(char _ch) noexcept { leaderSymbol_ = _ch; }
-    Intermediaries& intermediateCharacters() noexcept { return intermediateCharacters_; }
+    [[nodiscard]] Intermediaries& intermediateCharacters() noexcept { return intermediateCharacters_; }
     void setFinalChar(char _ch) noexcept { finalChar_ = _ch; }
 
-    DataString const& dataString() const noexcept { return dataString_; }
-    DataString& dataString() noexcept { return dataString_; }
+    [[nodiscard]] DataString const& dataString() const noexcept { return dataString_; }
+    [[nodiscard]] DataString& dataString() noexcept { return dataString_; }
 
     /// @returns this VT-sequence into a human readable string form.
-    std::string text() const;
+    [[nodiscard]] std::string text() const;
 
     /// @returns the raw VT-sequence string.
-    std::string raw() const;
+    [[nodiscard]] std::string raw() const;
 
-    FunctionDefinition const* functionDefinition() const noexcept { return select(selector()); }
+    [[nodiscard]] FunctionDefinition const* functionDefinition() const noexcept { return select(selector()); }
 
     /// Converts a FunctionSpinto a FunctionSelector, applicable for finding the corresponding
     /// FunctionDefinition.
-    FunctionSelector selector() const noexcept
+    [[nodiscard]] FunctionSelector selector() const noexcept
     {
         switch (category_)
         {
@@ -277,12 +283,15 @@ class Sequence
 
     // accessors
     //
-    FunctionCategory category() const noexcept { return category_; }
-    Intermediaries const& intermediateCharacters() const noexcept { return intermediateCharacters_; }
-    char finalChar() const noexcept { return finalChar_; }
+    [[nodiscard]] FunctionCategory category() const noexcept { return category_; }
+    [[nodiscard]] Intermediaries const& intermediateCharacters() const noexcept
+    {
+        return intermediateCharacters_;
+    }
+    [[nodiscard]] char finalChar() const noexcept { return finalChar_; }
 
     template <typename T = unsigned>
-    std::optional<T> param_opt(size_t parameterIndex) const noexcept
+    [[nodiscard]] std::optional<T> param_opt(size_t parameterIndex) const noexcept
     {
         if (parameterIndex < parameters_.count())
         {
@@ -296,13 +305,13 @@ class Sequence
     }
 
     template <typename T = unsigned>
-    T param_or(size_t parameterIndex, T _defaultValue) const noexcept
+    [[nodiscard]] T param_or(size_t parameterIndex, T _defaultValue) const noexcept
     {
         return param_opt<T>(parameterIndex).value_or(_defaultValue);
     }
 
     template <typename T = unsigned>
-    T param(size_t parameterIndex) const noexcept
+    [[nodiscard]] T param(size_t parameterIndex) const noexcept
     {
         assert(parameterIndex < parameters_.count());
         if constexpr (crispy::is_boxed<T>)
@@ -312,18 +321,18 @@ class Sequence
     }
 
     template <typename T = unsigned>
-    T subparam(size_t parameterIndex, size_t subIndex) const noexcept
+    [[nodiscard]] T subparam(size_t parameterIndex, size_t subIndex) const noexcept
     {
         return param<T>(parameterIndex + subIndex);
     }
 
-    bool isSubParameter(size_t parameterIndex) const noexcept
+    [[nodiscard]] bool isSubParameter(size_t parameterIndex) const noexcept
     {
         return parameters_.isSubParameter(parameterIndex);
     }
 
     template <typename T = unsigned>
-    bool containsParameter(T _value) const noexcept
+    [[nodiscard]] bool containsParameter(T _value) const noexcept
     {
         for (size_t i = 0; i < parameterCount(); ++i)
             if constexpr (crispy::is_boxed<T>)
@@ -345,10 +354,10 @@ class SequenceHandler
   public:
     virtual ~SequenceHandler() = default;
 
-    virtual void executeControlCode(char controlCode) {}      // = 0;
-    virtual void processSequence(Sequence const& sequence) {} // = 0;
-    virtual void writeText(char32_t codepoint) {}             // = 0;
-    virtual void writeText(std::string_view codepoints) {}    // = 0;
+    virtual void executeControlCode(char controlCode) = 0;
+    virtual void processSequence(Sequence const& sequence) = 0;
+    virtual void writeText(char32_t codepoint) = 0;
+    virtual void writeText(std::string_view codepoints) = 0;
 };
 
 } // namespace terminal

--- a/src/terminal/Sequencer.h
+++ b/src/terminal/Sequencer.h
@@ -196,7 +196,7 @@ inline void Sequencer::clear() noexcept
 
 inline void Sequencer::paramDigit(char _char) noexcept
 {
-    parameterBuilder_.multiplyBy10AndAdd(static_cast<Sequence::Parameter>(_char - '0'));
+    parameterBuilder_.multiplyBy10AndAdd(static_cast<uint8_t>(_char - '0'));
 }
 
 inline void Sequencer::paramSeparator() noexcept

--- a/src/terminal/SixelParser.h
+++ b/src/terminal/SixelParser.h
@@ -129,14 +129,14 @@ class SixelColorPalette
 
     void reset();
 
-    unsigned int size() const noexcept { return static_cast<unsigned int>(palette_.size()); }
+    [[nodiscard]] unsigned int size() const noexcept { return static_cast<unsigned int>(palette_.size()); }
     void setSize(unsigned int _newSize);
 
-    unsigned int maxSize() const noexcept { return maxSize_; }
+    [[nodiscard]] unsigned int maxSize() const noexcept { return maxSize_; }
     void setMaxSize(unsigned int _newSize);
 
     void setColor(unsigned int _index, RGBColor const& _color);
-    RGBColor at(unsigned int _index) const noexcept;
+    [[nodiscard]] RGBColor at(unsigned int _index) const noexcept;
 
   private:
     std::vector<RGBColor> palette_;
@@ -157,16 +157,16 @@ class SixelImageBuilder: public SixelParser::Events
                       RGBAColor _backgroundColor,
                       std::shared_ptr<SixelColorPalette> _colorPalette);
 
-    ImageSize maxSize() const noexcept { return maxSize_; }
-    ImageSize size() const noexcept { return size_; }
-    int aspectRatioNominator() const noexcept { return aspectRatio_.nominator; }
-    int aspectRatioDenominator() const noexcept { return aspectRatio_.denominator; }
-    RGBColor currentColor() const noexcept { return colors_->at(currentColor_); }
+    [[nodiscard]] ImageSize maxSize() const noexcept { return maxSize_; }
+    [[nodiscard]] ImageSize size() const noexcept { return size_; }
+    [[nodiscard]] int aspectRatioNominator() const noexcept { return aspectRatio_.nominator; }
+    [[nodiscard]] int aspectRatioDenominator() const noexcept { return aspectRatio_.denominator; }
+    [[nodiscard]] RGBColor currentColor() const noexcept { return colors_->at(currentColor_); }
 
-    RGBAColor at(CellLocation _coord) const noexcept;
+    [[nodiscard]] RGBAColor at(CellLocation _coord) const noexcept;
 
-    Buffer const& data() const noexcept { return buffer_; }
-    Buffer& data() noexcept { return buffer_; }
+    [[nodiscard]] Buffer const& data() const noexcept { return buffer_; }
+    [[nodiscard]] Buffer& data() noexcept { return buffer_; }
 
     void clear(RGBAColor _fillColor);
 
@@ -177,7 +177,7 @@ class SixelImageBuilder: public SixelParser::Events
     void setRaster(int _pan, int _pad, ImageSize _imageSize) override;
     void render(int8_t _sixel) override;
 
-    CellLocation const& sixelCursor() const noexcept { return sixelCursor_; }
+    [[nodiscard]] CellLocation const& sixelCursor() const noexcept { return sixelCursor_; }
 
   private:
     void write(CellLocation const& _coord, RGBColor const& _value) noexcept;

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -156,8 +156,8 @@ bool Terminal::processInputOnce()
                        currentPtyBuffer_->bytesAvailable());
         currentPtyBuffer_ = ptyBufferPool_.allocateBufferObject();
     }
-    optional<string_view> const bufOpt = pty_->read(*currentPtyBuffer_, timeout);
-    if (!bufOpt)
+    optional<tuple<string_view, bool>> const readResult = pty_->read(*currentPtyBuffer_, timeout);
+    if (!readResult)
     {
         if (errno != EINTR && errno != EAGAIN)
         {
@@ -166,7 +166,8 @@ bool Terminal::processInputOnce()
         }
         return errno == EINTR || errno == EAGAIN;
     }
-    string_view const buf = *bufOpt;
+    string_view const buf = get<0>(*readResult);
+    state_.usingStdoutFastPipe = get<1>(*readResult);
 
     if (buf.empty())
     {

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -151,8 +151,9 @@ bool Terminal::processInputOnce()
     // store a single text line.
     if (currentPtyBuffer_->bytesAvailable() < unbox<size_t>(state_.pageSize.columns))
     {
-        PtyInLog()("Only {} bytes left in TBO. Allocating new buffer from pool.",
-                   currentPtyBuffer_->bytesAvailable());
+        if (PtyInLog)
+            PtyInLog()("Only {} bytes left in TBO. Allocating new buffer from pool.",
+                       currentPtyBuffer_->bytesAvailable());
         currentPtyBuffer_ = ptyBufferPool_.allocateBufferObject();
     }
     optional<string_view> const bufOpt = pty_->read(*currentPtyBuffer_, timeout);

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -37,7 +37,7 @@
 namespace terminal
 {
 
-template <typename Cell>
+template <typename Cell, ScreenType TheScreenType>
 class Screen;
 
 /// Terminal API to manage input and output devices of a pseudo terminal, such as keyboard, mouse, and screen.
@@ -344,11 +344,11 @@ class Terminal
     ScreenType screenType() const noexcept { return state_.screenType; }
     void setScreen(ScreenType screenType);
 
-    Screen<Cell> const& primaryScreen() const noexcept { return primaryScreen_; }
-    Screen<Cell>& primaryScreen() noexcept { return primaryScreen_; }
+    Screen<Cell, ScreenType::Primary> const& primaryScreen() const noexcept { return primaryScreen_; }
+    Screen<Cell, ScreenType::Primary>& primaryScreen() noexcept { return primaryScreen_; }
 
-    Screen<Cell> const& alternateScreen() const noexcept { return alternateScreen_; }
-    Screen<Cell>& alternateScreen() noexcept { return alternateScreen_; }
+    Screen<Cell, ScreenType::Alternate> const& alternateScreen() const noexcept { return alternateScreen_; }
+    Screen<Cell, ScreenType::Alternate>& alternateScreen() noexcept { return alternateScreen_; }
 
     bool isLineWrapped(LineOffset _lineNumber) const noexcept
     {
@@ -566,8 +566,8 @@ class Terminal
     TerminalState state_;
     crispy::BufferObjectPool ptyBufferPool_;
     crispy::BufferObjectPtr currentPtyBuffer_;
-    Screen<Cell> primaryScreen_;
-    Screen<Cell> alternateScreen_;
+    Screen<Cell, ScreenType::Primary> primaryScreen_;
+    Screen<Cell, ScreenType::Alternate> alternateScreen_;
     std::reference_wrapper<ScreenBase> currentScreen_;
 
     std::mutex mutable outerLock_;

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -117,6 +117,11 @@ class Terminal
     void setTopBottomMargin(std::optional<LineOffset> _top, std::optional<LineOffset> _bottom);
     void setLeftRightMargin(std::optional<ColumnOffset> _left, std::optional<ColumnOffset> _right);
 
+    bool isFullHorizontalMargins() const noexcept
+    {
+        return state_.margin.horizontal.to.value + 1 == state_.pageSize.columns.value;
+    }
+
     void moveCursorTo(LineOffset _line, ColumnOffset _column);
     void saveCursor();
     void restoreCursor();

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -54,7 +54,7 @@ class Terminal
       public:
         virtual ~Events() = default;
 
-        virtual void requestCaptureBuffer(LineCount lines, bool logical) {}
+        virtual void requestCaptureBuffer(LineCount /*lines*/, bool /*logical*/) {}
         virtual void bell() {}
         virtual void bufferChanged(ScreenType) {}
         virtual void renderBufferUpdated() {}
@@ -74,6 +74,7 @@ class Terminal
     };
 
     Terminal(std::unique_ptr<Pty> _pty,
+             size_t ptyBufferObjectSize,
              size_t _ptyReadBufferSize,
              Events& _eventListener,
              LineCount _maxHistoryLineCount = LineCount(0),
@@ -88,7 +89,7 @@ class Terminal
              ColorPalette _colorPalette = {},
              double _refreshRate = 30.0,
              bool _allowReflowOnResize = true);
-    ~Terminal();
+    ~Terminal() = default;
 
     void start();
 
@@ -566,6 +567,7 @@ class Terminal
     TerminalState state_;
     crispy::BufferObjectPool ptyBufferPool_;
     crispy::BufferObjectPtr currentPtyBuffer_;
+    size_t ptyReadBufferSize_;
     Screen<Cell, ScreenType::Primary> primaryScreen_;
     Screen<Cell, ScreenType::Alternate> alternateScreen_;
     std::reference_wrapper<ScreenBase> currentScreen_;
@@ -583,11 +585,11 @@ class Terminal
     {
         Terminal* terminal;
         explicit SelectionHelper(Terminal* self): terminal { self } {}
-        PageSize pageSize() const noexcept override;
-        bool wordDelimited(CellLocation _pos) const noexcept override;
-        bool wrappedLine(LineOffset _line) const noexcept override;
-        bool cellEmpty(CellLocation _pos) const noexcept override;
-        int cellWidth(CellLocation _pos) const noexcept override;
+        [[nodiscard]] PageSize pageSize() const noexcept override;
+        [[nodiscard]] bool wordDelimited(CellLocation _pos) const noexcept override;
+        [[nodiscard]] bool wrappedLine(LineOffset _line) const noexcept override;
+        [[nodiscard]] bool cellEmpty(CellLocation _pos) const noexcept override;
+        [[nodiscard]] int cellWidth(CellLocation _pos) const noexcept override;
     };
     SelectionHelper selectionHelper_;
 };

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -512,6 +512,8 @@ class Terminal
 
     void applyPageSizeToCurrentBuffer();
 
+    crispy::BufferObjectPtr currentPtyBuffer() const noexcept { return currentPtyBuffer_; }
+
   private:
     void mainLoop();
     void refreshRenderBuffer(RenderBuffer& _output); // <- acquires the lock
@@ -525,7 +527,6 @@ class Terminal
     /// Boolean, indicating whether the terminal's screen buffer contains updates to be rendered.
     mutable std::atomic<uint64_t> changes_;
 
-    size_t ptyReadBufferSize_;
     Events& eventListener_;
 
     std::chrono::milliseconds refreshInterval_;
@@ -558,6 +559,8 @@ class Terminal
     LineOffset copyLastMarkRangeOffset_;
 
     TerminalState state_;
+    crispy::BufferObjectPool ptyBufferPool_;
+    crispy::BufferObjectPtr currentPtyBuffer_;
     Screen<Cell> primaryScreen_;
     Screen<Cell> alternateScreen_;
     std::reference_wrapper<ScreenBase> currentScreen_;

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -171,6 +171,8 @@ struct TerminalState
     unsigned maxImageRegisterCount = 256;
     bool usePrivateColorRegisters = false;
 
+    bool usingStdoutFastPipe = false;
+
     // Hyperlink related
     //
     HyperlinkStorage hyperlinks {};

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -51,9 +51,12 @@ class Modes
 
     void set(DECMode _mode, bool _enabled) { dec_.set(static_cast<size_t>(_mode), _enabled); }
 
-    bool enabled(AnsiMode _mode) const noexcept { return ansi_.test(static_cast<size_t>(_mode)); }
+    [[nodiscard]] bool enabled(AnsiMode _mode) const noexcept
+    {
+        return ansi_.test(static_cast<size_t>(_mode));
+    }
 
-    bool enabled(DECMode _mode) const noexcept { return dec_.test(static_cast<size_t>(_mode)); }
+    [[nodiscard]] bool enabled(DECMode _mode) const noexcept { return dec_.test(static_cast<size_t>(_mode)); }
 
     void save(std::vector<DECMode> const& _modes)
     {

--- a/src/terminal/Terminal_test.cpp
+++ b/src/terminal/Terminal_test.cpp
@@ -96,6 +96,7 @@ class MockTerm: public terminal::Terminal::Events
     explicit MockTerm(PageSize _size):
         terminal_ {
             make_unique<terminal::MockPty>(_size),
+            1024 * 1024,
             1024,
             *this,
             LineCount(1024), // max history line count

--- a/src/terminal/Viewport.h
+++ b/src/terminal/Viewport.h
@@ -41,15 +41,15 @@ class Viewport
     {
     }
 
-    ScrollOffset scrollOffset() const noexcept { return scrollOffset_; }
+    [[nodiscard]] ScrollOffset scrollOffset() const noexcept { return scrollOffset_; }
 
     /// Tests if the viewport has been moved(/scrolled) off its main view position.
     ///
     /// @retval true viewport has been moved/scrolled off its main view position.
     /// @retval false viewport has NOT been moved/scrolled and is still located at its main view position.
-    bool scrolled() const noexcept { return scrollOffset_.value != 0; }
+    [[nodiscard]] bool scrolled() const noexcept { return scrollOffset_.value != 0; }
 
-    bool isLineVisible(LineOffset _line) const noexcept
+    [[nodiscard]] bool isLineVisible(LineOffset _line) const noexcept
     {
         auto const a = -scrollOffset_.as<int>();
         auto const b = _line.as<int>();
@@ -77,9 +77,9 @@ class Viewport
     }
 
   private:
-    LineCount historyLineCount() const noexcept;
-    LineCount screenLineCount() const noexcept;
-    bool scrollingDisabled() const noexcept;
+    [[nodiscard]] LineCount historyLineCount() const noexcept;
+    [[nodiscard]] LineCount screenLineCount() const noexcept;
+    [[nodiscard]] bool scrollingDisabled() const noexcept;
 
     // private fields
     //

--- a/src/terminal/bench-headless.cpp
+++ b/src/terminal/bench-headless.cpp
@@ -168,7 +168,7 @@ class ContourHeadlessBench: public crispy::App
         }
     }
 
-    crispy::cli::Command parameterDefinition() const override
+    [[nodiscard]] crispy::cli::Command parameterDefinition() const override
     {
         auto const perfOptions = CLI::OptionList {
             CLI::Option { "size", CLI::Value { 32u }, "Number of megabyte to process per test.", "MB" },
@@ -229,7 +229,7 @@ class ContourHeadlessBench: public crispy::App
         size_t const ptyReadBufferSize = 1'000'000;
         auto maxHistoryLineCount = terminal::LineCount(4000);
         auto vt = terminal::MockTerm<terminal::MockViewPty>(pageSize, maxHistoryLineCount, ptyReadBufferSize);
-        auto* pty = static_cast<terminal::MockViewPty*>(&vt.terminal.device());
+        auto* pty = dynamic_cast<terminal::MockViewPty*>(&vt.terminal.device());
         vt.terminal.setMode(terminal::DECMode::AutoWrap, true);
 
         auto const rv = baseBenchmark(
@@ -261,7 +261,7 @@ class ContourHeadlessBench: public crispy::App
         using terminal::Pty;
 
         // Benchmark configuration
-        // TODO(pr) make these values CLI configurable.
+        // TODO make these values CLI configurable.
         auto constexpr WritesPerLoop = 1;
         auto constexpr PtyWriteSize = 4096;
         auto constexpr PtyReadSize = 4096;
@@ -272,7 +272,7 @@ class ContourHeadlessBench: public crispy::App
         unique_ptr<Pty> ptyObject = createPty(PageSize { LineCount(25), ColumnCount(80) }, std::nullopt);
         auto& pty = *ptyObject;
         auto& ptySlave = pty.slave();
-        ptySlave.configure();
+        (void) ptySlave.configure();
 
         auto bytesTransferred = uint64_t { 0 };
         auto loopIterations = uint64_t { 0 };
@@ -298,7 +298,7 @@ class ContourHeadlessBench: public crispy::App
         while (stopTime - startTime < BenchTime)
         {
             for (int i = 0; i < WritesPerLoop; ++i)
-                ptySlave.write(text);
+                (void) ptySlave.write(text);
             stopTime = steady_clock::now();
         }
 
@@ -344,7 +344,7 @@ class ContourHeadlessBench: public crispy::App
 
 int main(int argc, char const* argv[])
 {
-    srand(time(nullptr)); // initialize rand(). No strong seed required.
+    srand(static_cast<unsigned int>(time(nullptr))); // initialize rand(). No strong seed required.
 
     ContourHeadlessBench app;
     return app.run(argc, argv);

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -242,8 +242,8 @@ struct Range
     {
     };
     using iterator = crispy::boxed<int, ValueTag>;
-    iterator begin() const { return iterator { from.value }; }
-    auto end() const { return iterator { to.value + 1 }; }
+    [[nodiscard]] iterator begin() const { return iterator { from.value }; }
+    [[nodiscard]] auto end() const { return iterator { to.value + 1 }; }
     // iterator end() const { return crispy::boxed_cast<iterator>(to) + iterator{1}; }
 };
 
@@ -298,7 +298,7 @@ struct PageSize
 {
     LineCount lines;
     ColumnCount columns;
-    int area() const noexcept { return *lines * *columns; }
+    [[nodiscard]] int area() const noexcept { return *lines * *columns; }
 };
 constexpr bool operator==(PageSize a, PageSize b) noexcept
 {
@@ -369,11 +369,11 @@ struct GridSize
         }
     };
 
-    constexpr iterator begin() const noexcept { return iterator { columns, 0 }; }
-    constexpr iterator end() const noexcept { return iterator { columns, *columns * *lines }; }
+    [[nodiscard]] constexpr iterator begin() const noexcept { return iterator { columns, 0 }; }
+    [[nodiscard]] constexpr iterator end() const noexcept { return iterator { columns, *columns * *lines }; }
 
-    constexpr iterator begin() noexcept { return iterator { columns, 0 }; }
-    constexpr iterator end() noexcept { return iterator { columns, *columns * *lines }; }
+    [[nodiscard]] constexpr iterator begin() noexcept { return iterator { columns, 0 }; }
+    [[nodiscard]] constexpr iterator end() noexcept { return iterator { columns, *columns * *lines }; }
 };
 
 constexpr CellLocation operator+(CellLocation a, GridSize::Offset b) noexcept

--- a/src/terminal/pty/ConPty.cpp
+++ b/src/terminal/pty/ConPty.cpp
@@ -137,12 +137,14 @@ void ConPty::close()
     }
 }
 
-optional<tuple<string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout)
+optional<tuple<string_view, bool>> ConPty::read(crispy::BufferObject& buffer,
+                                                std::chrono::milliseconds timeout,
+                                                size_t size)
 {
     // TODO: wait for timeout time at most AND got woken up upon wakeupReader() invokcation.
     (void) timeout;
 
-    auto const n = static_cast<DWORD>(buffer.bytesAvailable());
+    auto const n = static_cast<DWORD>(min(size, buffer.bytesAvailable()));
 
     DWORD nread {};
     if (!ReadFile(input_, buffer.hotEnd(), n, &nread, nullptr))

--- a/src/terminal/pty/ConPty.cpp
+++ b/src/terminal/pty/ConPty.cpp
@@ -137,6 +137,20 @@ void ConPty::close()
     }
 }
 
+optional<string_view> ConPty::read(crispy::BufferObject& buffer, std::chrono::milliseconds timeout)
+{
+    // TODO: wait for timeout time at most AND got woken up upon wakeupReader() invokcation.
+    (void) timeout;
+
+    auto const n = static_cast<DWORD>(buffer.bytesAvailable());
+
+    DWORD nread {};
+    if (!ReadFile(input_, buffer.hotEnd(), n, &nread, nullptr))
+        return nullopt;
+
+    return string_view { buffer.hotEnd(), nread };
+}
+
 optional<string_view> ConPty::read(size_t _size, std::chrono::milliseconds _timeout)
 {
     // TODO: wait for _timeout time at most AND got woken up upon wakeupReader() invokcation.

--- a/src/terminal/pty/ConPty.cpp
+++ b/src/terminal/pty/ConPty.cpp
@@ -137,7 +137,7 @@ void ConPty::close()
     }
 }
 
-optional<string_view> ConPty::read(crispy::BufferObject& buffer, std::chrono::milliseconds timeout)
+optional<tuple<string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout)
 {
     // TODO: wait for timeout time at most AND got woken up upon wakeupReader() invokcation.
     (void) timeout;
@@ -148,7 +148,7 @@ optional<string_view> ConPty::read(crispy::BufferObject& buffer, std::chrono::mi
     if (!ReadFile(input_, buffer.hotEnd(), n, &nread, nullptr))
         return nullopt;
 
-    return string_view { buffer.hotEnd(), nread };
+    return { tuple { string_view { buffer.hotEnd(), nread }, false } };
 }
 
 optional<string_view> ConPty::read(size_t _size, std::chrono::milliseconds _timeout)

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -34,7 +34,8 @@ class ConPty: public Pty
     bool isClosed() const noexcept override;
 
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    std::optional<std::string_view> read(crispy::BufferObject& buffer, std::chrono::milliseconds timeout) override;
+    std::optional<std::string_view> read(crispy::BufferObject& buffer,
+                                         std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -34,8 +34,8 @@ class ConPty: public Pty
     bool isClosed() const noexcept override;
 
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    std::optional<std::string_view> read(crispy::BufferObject& buffer,
-                                         std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -34,8 +34,9 @@ class ConPty: public Pty
     bool isClosed() const noexcept override;
 
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
+                                                                         std::chrono::milliseconds timeout,
+                                                                         size_t size) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -16,6 +16,7 @@
 #include <terminal/pty/Pty.h>
 
 #include <Windows.h>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -48,6 +49,7 @@ class ConPty: public Pty
     HANDLE input_;
     HANDLE output_;
     std::vector<char> buffer_;
+    std::unique_ptr<PtySlave> slave_;
 };
 
 } // namespace terminal

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -34,6 +34,7 @@ class ConPty: public Pty
     bool isClosed() const noexcept override;
 
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
+    std::optional<std::string_view> read(crispy::BufferObject& buffer, std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/MockPty.cpp
+++ b/src/terminal/pty/MockPty.cpp
@@ -4,6 +4,7 @@ using namespace std::chrono;
 using std::nullopt;
 using std::optional;
 using std::string_view;
+using std::tuple;
 
 namespace terminal
 {
@@ -29,12 +30,13 @@ optional<string_view> MockPty::read(size_t _size, std::chrono::milliseconds)
     return result;
 }
 
-optional<string_view> MockPty::read(crispy::BufferObject& storage, std::chrono::milliseconds _timeout)
+optional<tuple<string_view, bool>> MockPty::read(crispy::BufferObject& storage,
+                                                 std::chrono::milliseconds /*timeout*/)
 {
     auto const n = std::min(outputBuffer_.size() - outputReadOffset_, storage.bytesAvailable());
     auto const chunk = string_view { outputBuffer_.data() + outputReadOffset_, n };
     outputReadOffset_ += n;
-    return storage.writeAtEnd(chunk);
+    return { tuple { storage.writeAtEnd(chunk), false } };
 }
 
 void MockPty::wakeupReader()

--- a/src/terminal/pty/MockPty.cpp
+++ b/src/terminal/pty/MockPty.cpp
@@ -1,6 +1,7 @@
 #include <terminal/pty/MockPty.h>
 
 using namespace std::chrono;
+using std::min;
 using std::nullopt;
 using std::optional;
 using std::string_view;
@@ -31,9 +32,10 @@ optional<string_view> MockPty::read(size_t _size, std::chrono::milliseconds)
 }
 
 optional<tuple<string_view, bool>> MockPty::read(crispy::BufferObject& storage,
-                                                 std::chrono::milliseconds /*timeout*/)
+                                                 std::chrono::milliseconds /*timeout*/,
+                                                 size_t size)
 {
-    auto const n = std::min(outputBuffer_.size() - outputReadOffset_, storage.bytesAvailable());
+    auto const n = min(size, min(outputBuffer_.size() - outputReadOffset_, storage.bytesAvailable()));
     auto const chunk = string_view { outputBuffer_.data() + outputReadOffset_, n };
     outputReadOffset_ += n;
     return { tuple { storage.writeAtEnd(chunk), false } };

--- a/src/terminal/pty/MockPty.cpp
+++ b/src/terminal/pty/MockPty.cpp
@@ -1,6 +1,7 @@
 #include <terminal/pty/MockPty.h>
 
 using namespace std::chrono;
+using std::nullopt;
 using std::optional;
 using std::string_view;
 
@@ -26,6 +27,14 @@ optional<string_view> MockPty::read(size_t _size, std::chrono::milliseconds)
     auto const result = string_view { outputBuffer_.data() + outputReadOffset_, n };
     outputReadOffset_ += n;
     return result;
+}
+
+optional<string_view> MockPty::read(crispy::BufferObject& storage, std::chrono::milliseconds _timeout)
+{
+    auto const n = std::min(outputBuffer_.size() - outputReadOffset_, storage.bytesAvailable());
+    auto const chunk = string_view { outputBuffer_.data() + outputReadOffset_, n };
+    outputReadOffset_ += n;
+    return storage.writeAtEnd(chunk);
 }
 
 void MockPty::wakeupReader()

--- a/src/terminal/pty/MockPty.h
+++ b/src/terminal/pty/MockPty.h
@@ -29,6 +29,8 @@ class MockPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
+    std::optional<std::string_view> read(crispy::BufferObject& storage,
+                                         std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;
@@ -38,6 +40,8 @@ class MockPty: public Pty
     bool isClosed() const noexcept override;
 
     std::string& stdinBuffer() noexcept { return inputBuffer_; }
+
+    bool isStdoutDataAvailable() const noexcept { return outputReadOffset_ < outputBuffer_.size(); }
 
     void appendStdOutBuffer(std::string_view _that)
     {

--- a/src/terminal/pty/MockPty.h
+++ b/src/terminal/pty/MockPty.h
@@ -29,8 +29,8 @@ class MockPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    std::optional<std::string_view> read(crispy::BufferObject& storage,
-                                         std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/MockPty.h
+++ b/src/terminal/pty/MockPty.h
@@ -29,19 +29,23 @@ class MockPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
+                                                                         std::chrono::milliseconds timeout,
+                                                                         size_t size) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
-    PageSize pageSize() const noexcept override;
+    [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
     void close() override;
-    bool isClosed() const noexcept override;
+    [[nodiscard]] bool isClosed() const noexcept override;
 
     std::string& stdinBuffer() noexcept { return inputBuffer_; }
 
-    bool isStdoutDataAvailable() const noexcept { return outputReadOffset_ < outputBuffer_.size(); }
+    [[nodiscard]] bool isStdoutDataAvailable() const noexcept
+    {
+        return outputReadOffset_ < outputBuffer_.size();
+    }
 
     void appendStdOutBuffer(std::string_view _that)
     {

--- a/src/terminal/pty/MockViewPty.cpp
+++ b/src/terminal/pty/MockViewPty.cpp
@@ -39,6 +39,15 @@ optional<string_view> MockViewPty::read(size_t _maxSize, std::chrono::millisecon
     return result;
 }
 
+optional<string_view> MockViewPty::read(crispy::BufferObject& storage, std::chrono::milliseconds timeout)
+{
+    auto const n = storage.bytesAvailable();
+    auto const result = outputBuffer_.substr(0, n);
+    outputBuffer_.remove_prefix(n);
+    storage.writeAtEnd(result);
+    return result;
+}
+
 void MockViewPty::wakeupReader()
 {
     // No-op. as we're a mock-pty.

--- a/src/terminal/pty/MockViewPty.cpp
+++ b/src/terminal/pty/MockViewPty.cpp
@@ -14,6 +14,7 @@
 
 #include <terminal/pty/MockViewPty.h>
 
+using std::min;
 using std::optional;
 using std::string_view;
 using std::tuple;
@@ -34,16 +35,17 @@ PtySlave& MockViewPty::slave() noexcept
 
 optional<string_view> MockViewPty::read(size_t _maxSize, std::chrono::milliseconds /*_timeout*/)
 {
-    auto const n = std::min(outputBuffer_.size(), _maxSize);
+    auto const n = min(outputBuffer_.size(), _maxSize);
     auto const result = outputBuffer_.substr(0, n);
     outputBuffer_.remove_prefix(n);
     return result;
 }
 
 optional<tuple<string_view, bool>> MockViewPty::read(crispy::BufferObject& storage,
-                                                     std::chrono::milliseconds /*timeout*/)
+                                                     std::chrono::milliseconds /*timeout*/,
+                                                     size_t size)
 {
-    auto const n = std::min(std::min(outputBuffer_.size(), storage.bytesAvailable()), size_t { 4096 });
+    auto const n = min(min(outputBuffer_.size(), storage.bytesAvailable()), size);
     auto result = storage.writeAtEnd(outputBuffer_.substr(0, n));
     outputBuffer_.remove_prefix(n);
     return { tuple { result, false } };

--- a/src/terminal/pty/MockViewPty.cpp
+++ b/src/terminal/pty/MockViewPty.cpp
@@ -16,6 +16,7 @@
 
 using std::optional;
 using std::string_view;
+using std::tuple;
 
 namespace terminal
 {
@@ -39,12 +40,13 @@ optional<string_view> MockViewPty::read(size_t _maxSize, std::chrono::millisecon
     return result;
 }
 
-optional<string_view> MockViewPty::read(crispy::BufferObject& storage, std::chrono::milliseconds timeout)
+optional<tuple<string_view, bool>> MockViewPty::read(crispy::BufferObject& storage,
+                                                     std::chrono::milliseconds /*timeout*/)
 {
     auto const n = std::min(std::min(outputBuffer_.size(), storage.bytesAvailable()), size_t { 4096 });
     auto result = storage.writeAtEnd(outputBuffer_.substr(0, n));
     outputBuffer_.remove_prefix(n);
-    return result;
+    return { tuple { result, false } };
 }
 
 void MockViewPty::wakeupReader()

--- a/src/terminal/pty/MockViewPty.cpp
+++ b/src/terminal/pty/MockViewPty.cpp
@@ -41,10 +41,9 @@ optional<string_view> MockViewPty::read(size_t _maxSize, std::chrono::millisecon
 
 optional<string_view> MockViewPty::read(crispy::BufferObject& storage, std::chrono::milliseconds timeout)
 {
-    auto const n = storage.bytesAvailable();
-    auto const result = outputBuffer_.substr(0, n);
+    auto const n = std::min(std::min(outputBuffer_.size(), storage.bytesAvailable()), size_t { 4096 });
+    auto result = storage.writeAtEnd(outputBuffer_.substr(0, n));
     outputBuffer_.remove_prefix(n);
-    storage.writeAtEnd(result);
     return result;
 }
 

--- a/src/terminal/pty/MockViewPty.h
+++ b/src/terminal/pty/MockViewPty.h
@@ -30,6 +30,8 @@ class MockViewPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
+    std::optional<std::string_view> read(crispy::BufferObject& storage,
+                                         std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/MockViewPty.h
+++ b/src/terminal/pty/MockViewPty.h
@@ -24,24 +24,23 @@ class MockViewPty: public Pty
   public:
     explicit MockViewPty(PageSize _windowSize): pageSize_ { _windowSize } {}
 
-    ~MockViewPty() {}
-
     void setReadData(std::string_view _data);
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
+                                                                         std::chrono::milliseconds timeout,
+                                                                         size_t size) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
-    PageSize pageSize() const noexcept override;
+    [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
     void close() override;
-    bool isClosed() const noexcept override;
+    [[nodiscard]] bool isClosed() const noexcept override;
 
-    std::string& stdinBuffer() noexcept { return inputBuffer_; }
-    std::string_view& stdoutBuffer() noexcept { return outputBuffer_; }
+    [[nodiscard]] std::string& stdinBuffer() noexcept { return inputBuffer_; }
+    [[nodiscard]] std::string_view& stdoutBuffer() noexcept { return outputBuffer_; }
 
   private:
     PageSize pageSize_;

--- a/src/terminal/pty/MockViewPty.h
+++ b/src/terminal/pty/MockViewPty.h
@@ -30,8 +30,8 @@ class MockViewPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    std::optional<std::string_view> read(crispy::BufferObject& storage,
-                                         std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -43,20 +43,20 @@ class PtySlave
   public:
     virtual ~PtySlave() = default;
     virtual void close() = 0;
-    virtual bool isClosed() const noexcept = 0;
-    virtual bool configure() noexcept = 0;
-    virtual bool login() = 0;
-    virtual int write(std::string_view text) noexcept = 0;
+    [[nodiscard]] virtual bool isClosed() const noexcept = 0;
+    [[nodiscard]] virtual bool configure() noexcept = 0;
+    [[nodiscard]] virtual bool login() = 0;
+    [[nodiscard]] virtual int write(std::string_view text) noexcept = 0;
 };
 
 class PtySlaveDummy: public PtySlave
 {
   public:
     void close() override {}
-    bool isClosed() const noexcept override { return false; }
+    [[nodiscard]] bool isClosed() const noexcept override { return false; }
     bool configure() noexcept override { return true; }
     bool login() override { return true; }
-    virtual int write(std::string_view) noexcept override { return 0; }
+    int write(std::string_view) noexcept override { return 0; }
 };
 
 class Pty
@@ -72,17 +72,18 @@ class Pty
     virtual void close() = 0;
 
     /// Returns true if the underlying PTY is closed, otherwise false.
-    virtual bool isClosed() const noexcept = 0;
+    [[nodiscard]] virtual bool isClosed() const noexcept = 0;
 
     /// Reads from the terminal whatever has been written to from the other side of the terminal.
     ///
     /// @param _size   Capacity of parameter @p buf. At most @p size bytes will be stored into it.
     ///
     /// @returns view to the consumed buffer.
-    virtual std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) = 0;
+    [[nodiscard]] virtual std::optional<std::string_view> read(size_t _size,
+                                                               std::chrono::milliseconds _timeout) = 0;
 
     [[nodiscard]] virtual std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout) = 0;
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout, size_t size) = 0;
 
     /// Inerrupts the read() operation on this PTY if a read() is currently in progress.
     ///
@@ -98,16 +99,16 @@ class Pty
     /// @param size   Number of bytes in @p buf to write.
     ///
     /// @returns Number of bytes written or -1 on error.
-    virtual int write(char const* buf, size_t size) = 0;
+    [[nodiscard]] virtual int write(char const* buf, size_t size) = 0;
 
     /// @returns current underlying window size in characters width and height.
-    virtual PageSize pageSize() const noexcept = 0;
+    [[nodiscard]] virtual PageSize pageSize() const noexcept = 0;
 
     /// Resizes underlying window buffer by given character width and height.
     virtual void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) = 0;
 };
 
-std::unique_ptr<Pty> createPty(PageSize pageSize, std::optional<ImageSize> viewSize);
+[[nodiscard]] std::unique_ptr<Pty> createPty(PageSize pageSize, std::optional<ImageSize> viewSize);
 
 auto const inline PtyLog = logstore::Category("pty", "Logs general PTY informations.");
 auto const inline PtyInLog = logstore::Category("pty.input", "Logs PTY raw input.");

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -43,7 +43,9 @@ class PtySlave
     virtual ~PtySlave() = default;
     virtual void close() = 0;
     virtual bool isClosed() const noexcept = 0;
+    virtual bool configure() noexcept = 0;
     virtual bool login() = 0;
+    virtual int write(std::string_view text) noexcept = 0;
 };
 
 class PtySlaveDummy: public PtySlave
@@ -51,7 +53,9 @@ class PtySlaveDummy: public PtySlave
   public:
     void close() override {}
     bool isClosed() const noexcept override { return false; }
-    bool login() override { return false; }
+    bool configure() noexcept override { return true; }
+    bool login() override { return true; }
+    virtual int write(std::string_view) noexcept override { return 0; }
 };
 
 class Pty

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -15,6 +15,7 @@
 
 #include <terminal/primitives.h>
 
+#include <crispy/BufferObject.h>
 #include <crispy/boxed.h>
 #include <crispy/logstore.h>
 
@@ -79,6 +80,9 @@ class Pty
     ///
     /// @returns view to the consumed buffer.
     virtual std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) = 0;
+
+    virtual std::optional<std::string_view> read(crispy::BufferObject& storage,
+                                                 std::chrono::milliseconds _timeout) = 0;
 
     /// Inerrupts the read() operation on this PTY if a read() is currently in progress.
     ///

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -81,8 +81,8 @@ class Pty
     /// @returns view to the consumed buffer.
     virtual std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) = 0;
 
-    virtual std::optional<std::string_view> read(crispy::BufferObject& storage,
-                                                 std::chrono::milliseconds _timeout) = 0;
+    [[nodiscard]] virtual std::optional<std::tuple<std::string_view, bool>> read(
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout) = 0;
 
     /// Inerrupts the read() operation on this PTY if a read() is currently in progress.
     ///

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -428,11 +428,12 @@ int waitForReadable(int ptyMaster,
 }
 
 optional<tuple<string_view, bool>> UnixPty::read(crispy::BufferObject& sink,
-                                                 std::chrono::milliseconds timeout)
+                                                 std::chrono::milliseconds timeout,
+                                                 size_t size)
 {
     // TODO: We might want to make the read size limit configurable. Especially for the stdout-fastpipe.
     if (int fd = waitForReadable(_masterFd, _stdoutFastPipe.reader(), _pipe[0], timeout); fd != -1)
-        if (auto x = readSome(fd, sink.hotEnd(), min(size_t { 4096 }, sink.bytesAvailable())))
+        if (auto x = readSome(fd, sink.hotEnd(), min(size, sink.bytesAvailable())))
             return { tuple { x.value(), fd == _stdoutFastPipe.reader() } };
 
     return nullopt;

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -47,6 +47,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+using crispy::BufferObject;
 using std::max;
 using std::min;
 using std::nullopt;
@@ -338,6 +339,14 @@ bool waitForReadable(int _masterFd, int* _pipe, std::chrono::milliseconds timeou
             return false;
         }
     }
+}
+
+optional<std::string_view> UnixPty::read(BufferObject& sink, std::chrono::milliseconds timeout)
+{
+    if (waitForReadable(_masterFd, _pipe.data(), timeout))
+        return readSome(sink.hotEnd(), sink.bytesAvailable());
+
+    return nullopt;
 }
 
 optional<std::string_view> UnixPty::read(size_t size, std::chrono::milliseconds timeout)

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -82,6 +82,11 @@ namespace
         // special characters
         tio.c_cc[VMIN] = 1;  // Report as soon as 1 character is available.
         tio.c_cc[VTIME] = 0; // Disable timeout (no need).
+        tio.c_iflag &= ~ISTRIP; // Disable stripping 8th bit off the bytes.
+        // tio.c_iflag &= ~INLCR;  // Disable NL-to-CR mapping
+        // tio.c_iflag &= ~ICRNL;  // Disable CR-to-NL mapping
+        // tio.c_iflag &= ~IXON;   // Disable control flow
+        // tio.c_iflag &= ~BRKINT; // disable signal-break handling
 
         return tio;
     }

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -40,7 +40,9 @@ class UnixPty: public Pty
         PtySlaveHandle handle() const noexcept;
         void close() override;
         bool isClosed() const noexcept override;
+        bool configure() noexcept override;
         bool login() override;
+        int write(std::string_view) noexcept override;
     };
 
   public:

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -68,6 +68,8 @@ class UnixPty: public Pty
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
   private:
+    std::optional<std::string_view> readSome(char* target, size_t n) noexcept;
+
     int _masterFd;
     std::array<int, 2> _pipe;
     std::vector<char> _buffer;

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -63,6 +63,8 @@ class UnixPty: public Pty
     bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
+    std::optional<std::string_view> read(crispy::BufferObject& sink,
+                                         std::chrono::milliseconds timeout) override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -70,7 +70,7 @@ class UnixPty: public Pty
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
   private:
-    std::optional<std::string_view> readSome(char* target, size_t n) noexcept;
+    std::optional<std::string_view> readSome(int fd, char* target, size_t n) noexcept;
 
     int _masterFd;
     std::array<int, 2> _pipe;

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -39,10 +39,10 @@ struct UnixPipe
     UnixPipe& operator=(UnixPipe const&) = delete;
     ~UnixPipe();
 
-    bool good() const noexcept { return pfd[0] != -1 && pfd[1] != -1; }
+    [[nodiscard]] bool good() const noexcept { return pfd[0] != -1 && pfd[1] != -1; }
 
-    int reader() noexcept { return pfd[0]; }
-    int writer() noexcept { return pfd[1]; }
+    [[nodiscard]] int reader() noexcept { return pfd[0]; }
+    [[nodiscard]] int writer() noexcept { return pfd[1]; }
 
     void closeReader() noexcept;
     void closeWriter() noexcept;
@@ -85,8 +85,9 @@ class UnixPty: public Pty
     bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
+                                                                         std::chrono::milliseconds timeout,
+                                                                         size_t size) override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -85,8 +85,8 @@ class UnixPty: public Pty
     bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    std::optional<std::string_view> read(crispy::BufferObject& sink,
-                                         std::chrono::milliseconds timeout) override;
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
+        crispy::BufferObject& storage, std::chrono::milliseconds timeout) override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;

--- a/src/terminal_renderer/BoxDrawingRenderer.h
+++ b/src/terminal_renderer/BoxDrawingRenderer.h
@@ -43,12 +43,12 @@ class BoxDrawingRenderer: public Renderable
     void setRenderTarget(RenderTarget& renderTarget, DirectMappingAllocator& directMappingAllocator) override;
     void clearCache() override;
 
-    bool renderable(char32_t codepoint) const noexcept;
+    [[nodiscard]] bool renderable(char32_t codepoint) const noexcept;
 
     /// Renders boxdrawing character.
     ///
     /// @param _char the boxdrawing character's codepoint.
-    bool render(LineOffset _line, ColumnOffset _column, char32_t codepoint, RGBColor _color);
+    [[nodiscard]] bool render(LineOffset _line, ColumnOffset _column, char32_t codepoint, RGBColor _color);
 
     void inspect(std::ostream& output) const override;
 
@@ -56,11 +56,13 @@ class BoxDrawingRenderer: public Renderable
     AtlasTileAttributes const* getOrCreateCachedTileAttributes(char32_t codepoint);
 
     using Renderable::createTileData;
-    std::optional<TextureAtlas::TileCreateData> createTileData(char32_t codepoint,
-                                                               atlas::TileLocation tileLocation);
+    [[nodiscard]] std::optional<TextureAtlas::TileCreateData> createTileData(
+        char32_t codepoint, atlas::TileLocation tileLocation);
 
-    std::optional<atlas::Buffer> buildBoxElements(char32_t codepoint, ImageSize _size, int _lineThickness);
-    std::optional<atlas::Buffer> buildElements(char32_t codepoint);
+    [[nodiscard]] std::optional<atlas::Buffer> buildBoxElements(char32_t codepoint,
+                                                                ImageSize _size,
+                                                                int _lineThickness);
+    [[nodiscard]] std::optional<atlas::Buffer> buildElements(char32_t codepoint);
 };
 
 } // namespace terminal::renderer

--- a/src/terminal_renderer/CursorRenderer.cpp
+++ b/src/terminal_renderer/CursorRenderer.cpp
@@ -43,8 +43,8 @@ namespace
 
     constexpr uint32_t toDirectMappingIndex(CursorShape shape, int width, uint32_t sliceIndex) noexcept
     {
-        return static_cast<unsigned>(shape) + sliceIndex
-               + (width - 1)
+        return static_cast<uint32_t>(shape) + sliceIndex
+               + uint32_t(width - 1)
                      * (static_cast<uint32_t>(std::numeric_limits<CursorShape>::count())
                         + static_cast<uint32_t>(shape));
     }
@@ -106,7 +106,7 @@ auto CursorRenderer::createTileData(CursorShape cursorShape,
                                     int columnWidth,
                                     atlas::TileLocation tileLocation) -> TextureAtlas::TileCreateData
 {
-    auto const width = Width(*_gridMetrics.cellSize.width * columnWidth);
+    auto const width = Width::cast_from(unbox<int>(_gridMetrics.cellSize.width) * columnWidth);
     auto const height = _gridMetrics.cellSize.height;
     auto const defaultBitmapSize = ImageSize { width, height };
     auto const baseline = _gridMetrics.baseline;
@@ -130,25 +130,25 @@ auto CursorRenderer::createTileData(CursorShape cursorShape,
                 return atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0xFFu);
             });
         case CursorShape::Underscore:
-            return create(ImageSize { width, Height(baseline) }, [&]() {
-                auto const height = Height(baseline);
-                auto const thickness = max(LineThickness * baseline / 3, 1);
+            return create(ImageSize { width, Height::cast_from(baseline) }, [&]() {
+                auto const height = Height::cast_from(baseline);
+                auto const thickness = (unsigned) max(LineThickness * baseline / 3, 1);
                 auto const base_y = max((*height - thickness) / 2, 0u);
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0);
 
-                for (int y = 1; y <= thickness; ++y)
-                    for (int x = 0; x < width.as<int>(); ++x)
-                        image[(base_y + y) * width.as<int>() + x] = 0xFF;
+                for (size_t y = 1; y <= thickness; ++y)
+                    for (size_t x = 0; x < *width; ++x)
+                        image[(base_y + unsigned(y)) * *width + x] = 0xFF;
                 return image;
             });
         case CursorShape::Bar:
             return create(defaultBitmapSize, [&]() {
-                auto const thickness = max(LineThickness * baseline / 3, 1);
+                auto const thickness = (size_t) max(LineThickness * baseline / 3, 1);
                 // auto const base_y = max((height - thickness) / 2, 0);
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0);
 
-                for (int x = 0; x < thickness; ++x)
-                    for (int y = 0; y < unbox<int>(height); ++y)
+                for (size_t x = 0; x < thickness; ++x)
+                    for (size_t y = 0; y < unbox<size_t>(height); ++y)
                         image[y * *width + x] = 0xFF;
                 return image;
             });
@@ -156,13 +156,13 @@ auto CursorRenderer::createTileData(CursorShape cursorShape,
             return create(defaultBitmapSize, [&]() {
                 auto const height = _gridMetrics.cellSize.height;
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0xFFu);
-                auto const thickness = max(unbox<int>(width) / 12, 1);
+                auto const thickness = max(unbox<size_t>(width) / 12, size_t { 1 });
 
-                auto const innerWidth = unbox<int>(width) - 2 * thickness;
-                auto const innerHeight = unbox<int>(height) - 2 * thickness;
+                auto const innerWidth = unbox<size_t>(width) - 2 * thickness;
+                auto const innerHeight = unbox<size_t>(height) - 2 * thickness;
 
-                for (int y = thickness; y <= innerHeight; ++y)
-                    for (int x = thickness; x <= innerWidth; ++x)
+                for (size_t y = thickness; y <= innerHeight; ++y)
+                    for (size_t x = thickness; x <= innerWidth; ++x)
                         image[y * *width + x] = 0;
 
                 return image;
@@ -174,13 +174,13 @@ auto CursorRenderer::createTileData(CursorShape cursorShape,
 
 void CursorRenderer::render(crispy::Point _pos, int _columnWidth, RGBColor _color)
 {
-    for (int i = 0; i < _columnWidth; ++i)
+    for (uint32_t i = 0; i < uint32_t(_columnWidth); ++i)
     {
         auto const directMappingIndex = toDirectMappingIndex(shape_, _columnWidth, i);
         auto const tileIndex = _directMapping.toTileIndex(directMappingIndex);
-        auto const x = _pos.x + i * unbox<int>(_gridMetrics.cellSize.width);
+        auto const x = _pos.x + int(i) * unbox<int>(_gridMetrics.cellSize.width);
         AtlasTileAttributes const& tileAttributes = _textureAtlas->directMapped(tileIndex);
-        renderTile({ x }, { _pos.y }, _color, tileAttributes);
+        renderTile({ int(x) }, { _pos.y }, _color, tileAttributes);
     }
 }
 

--- a/src/terminal_renderer/CursorRenderer.h
+++ b/src/terminal_renderer/CursorRenderer.h
@@ -46,7 +46,6 @@ class CursorRenderer: public Renderable
 
   private:
     void initializeDirectMapping();
-
     using Renderable::createTileData;
     TextureAtlas::TileCreateData createTileData(CursorShape shape,
                                                 int columnWidth,

--- a/src/terminal_renderer/DecorationRenderer.cpp
+++ b/src/terminal_renderer/DecorationRenderer.cpp
@@ -135,30 +135,30 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             // TODO (default to Underline for now)
             [[fallthrough]];
         case Decorator::Underline: {
-            auto const thickness_half = max(1, int(ceil(underlineThickness() / 2.0)));
+            auto const thickness_half = max(1u, unsigned(ceil(underlineThickness() / 2.0)));
             auto const thickness = thickness_half * 2;
-            auto const y0 = max(0, underlinePosition() - thickness_half);
+            auto const y0 = max(0u, unsigned(underlinePosition()) - thickness_half);
             auto const height = Height(y0 + thickness);
             auto const imageSize = ImageSize { width, height };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(imageSize.area(), 0);
-                for (int y = 1; y <= thickness; ++y)
-                    for (int x = 0; x < unbox<int>(width); ++x)
+                for (unsigned y = 1; y <= thickness; ++y)
+                    for (unsigned x = 0; x < unbox<unsigned>(width); ++x)
                         image[(*height - y0 - y) * *width + x] = 0xFF;
                 return image;
             });
         }
         case Decorator::DoubleUnderline: {
-            auto const thickness = max(1, int(ceil(double(underlineThickness()) * 2.0) / 3.0));
-            auto const y1 = max(0, underlinePosition() + thickness);
-            auto const y0 = max(0, y1 - 3 * thickness);
+            auto const thickness = max(1u, unsigned(ceil(double(underlineThickness()) * 2.0) / 3.0));
+            auto const y1 = max(0u, unsigned(underlinePosition()) + thickness);
+            auto const y0 = max(0u, y1 - 3 * thickness);
             auto const height = Height(y1 + thickness);
             auto const imageSize = ImageSize { width, height };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(imageSize.area(), 0);
-                for (int y = 1; y <= thickness; ++y)
+                for (unsigned y = 1; y <= thickness; ++y)
                 {
-                    for (int x = 0; x < unbox<int>(width); ++x)
+                    for (unsigned x = 0; x < unbox<unsigned>(width); ++x)
                     {
                         image[(*height - y1 - y) * *width + x] = 0xFF; // top line
                         image[(*height - y0 - y) * *width + x] = 0xFF; // bottom line
@@ -184,30 +184,30 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
                     auto const y = yScalar * cos(xScalar * x);
                     auto const y1 = static_cast<int>(floor(y));
                     auto const y2 = static_cast<int>(ceil(y));
-                    auto const intensity = static_cast<int>(255 * fabs(y - y1));
+                    auto const intensity = static_cast<uint8_t>(255 * fabs(y - y1));
                     // block.paintOver(x, yBase + y1, 255 - intensity);
                     // block.paintOver(x, yBase + y2, intensity);
-                    block.paintOverThick(x, yBase + y1, 255 - intensity, thickness_half, 0);
+                    block.paintOverThick(x, yBase + y1, uint8_t(255 - intensity), thickness_half, 0);
                     block.paintOverThick(x, yBase + y2, intensity, thickness_half, 0);
                 }
                 return block.take();
             });
         }
         case Decorator::DottedUnderline: {
-            auto const dotHeight = _gridMetrics.underline.thickness;
+            auto const dotHeight = (unsigned) _gridMetrics.underline.thickness;
             auto const dotWidth = dotHeight;
-            auto const height = Height(_gridMetrics.underline.position + dotHeight);
-            auto const y0 = _gridMetrics.underline.position - dotHeight;
-            auto const x0 = 0;
-            auto const x1 = unbox<int>(width) / 2;
+            auto const height = Height::cast_from((unsigned) _gridMetrics.underline.position + dotHeight);
+            auto const y0 = (unsigned) _gridMetrics.underline.position - dotHeight;
+            auto const x0 = 0u;
+            auto const x1 = unbox<unsigned>(width) / 2;
             auto block = blockElement(ImageSize { width, height });
             return create(block.downsampledSize(), [&]() -> atlas::Buffer {
-                for (int y = 0; y < dotHeight; ++y)
+                for (unsigned y = 0; y < dotHeight; ++y)
                 {
-                    for (int x = 0; x < dotWidth; ++x)
+                    for (unsigned x = 0; x < dotWidth; ++x)
                     {
-                        block.paint(x + x0, y + y0);
-                        block.paint(x + x1, y + y0);
+                        block.paint(int(x + x0), int(y + y0));
+                        block.paint(int(x + x1), int(y + y0));
                     }
                 }
                 return block.take();
@@ -216,15 +216,15 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
         case Decorator::DashedUnderline: {
             // Devides a grid cell's underline in three sub-ranges and only renders first and third one,
             // whereas the middle one is being skipped.
-            auto const thickness_half = max(1, int(ceil(underlineThickness() / 2.0)));
-            auto const thickness = max(1, thickness_half * 2);
-            auto const y0 = max(0, underlinePosition() - thickness_half);
+            auto const thickness_half = max(1u, unsigned(ceil(underlineThickness() / 2.0)));
+            auto const thickness = max(1u, thickness_half * 2);
+            auto const y0 = max(0u, unsigned(underlinePosition()) - thickness_half);
             auto const height = Height(y0 + thickness);
             auto const imageSize = ImageSize { width, height };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0);
-                for (int y = 1; y <= thickness; ++y)
-                    for (int x = 0; x < unbox<int>(width); ++x)
+                for (unsigned y = 1; y <= thickness; ++y)
+                    for (unsigned x = 0; x < unbox<unsigned>(width); ++x)
                         if (fabsf(float(x) / float(*width) - 0.5f) >= 0.25f)
                             image[(*height - y0 - y) * *width + x] = 0xFF;
                 return image;
@@ -232,22 +232,22 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
         }
         case Decorator::Framed: {
             auto const cellHeight = _gridMetrics.cellSize.height;
-            auto const thickness = max(1, underlineThickness() / 2);
+            auto const thickness = max(1u, unsigned(underlineThickness()) / 2);
             auto const imageSize = ImageSize { width, cellHeight };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(cellHeight), 0);
                 auto const gap = 0; // thickness;
                 // Draws the top and bottom horizontal lines
-                for (int y = gap; y < thickness + gap; ++y)
-                    for (int x = gap; x < unbox<int>(width) - gap; ++x)
+                for (unsigned y = gap; y < thickness + gap; ++y)
+                    for (unsigned x = gap; x < unbox<unsigned>(width) - gap; ++x)
                     {
                         image[y * *width + x] = 0xFF;
                         image[(*cellHeight - 1 - y) * *width + x] = 0xFF;
                     }
 
                 // Draws the left and right vertical lines
-                for (int y = gap; y < unbox<int>(cellHeight) - gap; y++)
-                    for (int x = gap; x < thickness + gap; ++x)
+                for (unsigned y = gap; y < unbox<unsigned>(cellHeight) - gap; y++)
+                    for (unsigned x = gap; x < thickness + gap; ++x)
                     {
                         image[y * *width + x] = 0xFF;
                         image[y * *width + (*width - 1 - x)] = 0xFF;
@@ -257,24 +257,24 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
         }
         case Decorator::Overline: {
             auto const cellHeight = _gridMetrics.cellSize.height;
-            auto const thickness = underlineThickness();
+            auto const thickness = (unsigned) underlineThickness();
             auto const imageSize = ImageSize { width, cellHeight };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(cellHeight), 0);
-                for (int y = 0; y < thickness; ++y)
-                    for (int x = 0; x < unbox<int>(width); ++x)
+                for (unsigned y = 0; y < thickness; ++y)
+                    for (unsigned x = 0; x < unbox<unsigned>(width); ++x)
                         image[(*cellHeight - y - 1) * *width + x] = 0xFF;
                 return image;
             });
         }
         case Decorator::CrossedOut: {
             auto const height = Height(*_gridMetrics.cellSize.height / 2);
-            auto const thickness = underlineThickness();
+            auto const thickness = (unsigned) underlineThickness();
             auto const imageSize = ImageSize { width, height };
             return create(imageSize, [&]() -> atlas::Buffer {
                 auto image = atlas::Buffer(unbox<size_t>(width) * unbox<size_t>(height), 0);
-                for (int y = 1; y <= thickness; ++y)
-                    for (int x = 0; x < unbox<int>(width); ++x)
+                for (unsigned y = 1; y <= thickness; ++y)
+                    for (unsigned x = 0; x < unbox<unsigned>(width); ++x)
                         image[(*height - y) * *width + x] = 0xFF;
                 return image;
             });

--- a/src/terminal_renderer/Pixmap.cpp
+++ b/src/terminal_renderer/Pixmap.cpp
@@ -145,7 +145,7 @@ Pixmap& Pixmap::segment_bar(int which)
     auto const L = 2 * Z;
     auto const R = unbox<int>(_size.width) - Z;
 
-    auto const T = static_cast<int>(ceil(unbox<double>(_size.height) * 1 / 8_th)); // Z;
+    auto const T = static_cast<int>(ceil(unbox<double>(_size.height) * (1 / 8_th))); // Z;
     auto const B = unbox<int>(_size.height) - _baseLine - Z / 2;
     auto const M = T + (B - T) / 2;
 

--- a/src/terminal_renderer/Pixmap.h
+++ b/src/terminal_renderer/Pixmap.h
@@ -130,7 +130,7 @@ constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::Point radius)
 
     while (dx < dy)
     {
-        doDraw4WaySymmetric(x, y);
+        doDraw4WaySymmetric(int(x), int(y));
 
         // Checking and updating value of decision parameter based on algorithm
         if (d1 < 0)
@@ -154,7 +154,7 @@ constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::Point radius)
 
     while (y >= 0)
     {
-        doDraw4WaySymmetric(x, y);
+        doDraw4WaySymmetric(int(x), int(y));
 
         // Checking and updating parameter value based on algorithm
         if (d2 > 0)
@@ -192,7 +192,7 @@ struct Pixmap
     int _lineThickness = 1;
     int _baseLine = 0; // baseline position relative to cell bottom.
 
-    constexpr ImageSize downsampledSize() const noexcept { return _downsampledSize; }
+    [[nodiscard]] constexpr ImageSize downsampledSize() const noexcept { return _downsampledSize; }
 
     Pixmap& halfFilledCircleLeft();
     Pixmap& halfFilledCircleRight();
@@ -265,7 +265,7 @@ inline void Pixmap::paint(int x, int y, uint8_t _value)
         return;
     if (!(0 <= x && x < w))
         return;
-    _buffer.at((h - y) * w + x) = _value;
+    _buffer.at(static_cast<unsigned>((h - y) * w + x)) = _value;
 }
 
 inline void Pixmap::paintOver(int x, int y, uint8_t intensity)
@@ -276,7 +276,7 @@ inline void Pixmap::paintOver(int x, int y, uint8_t intensity)
         return;
     if (!(0 <= x && x < w))
         return;
-    auto& target = _buffer.at((h - y) * w + x);
+    auto& target = _buffer.at(static_cast<unsigned>((h - y) * w + x));
     target = static_cast<uint8_t>(std::min(static_cast<int>(target) + static_cast<int>(intensity), 255));
 }
 
@@ -290,10 +290,9 @@ inline void Pixmap::paintOverThick(int x, int y, uint8_t intensity, int sx, int 
 template <typename F>
 Pixmap& Pixmap::fill(F const& filler)
 {
-    auto const h = unbox<int>(_size.height) - 1;
     for (auto const y: ranges::views::iota(0, unbox<int>(_size.height)))
         for (auto const x: ranges::views::iota(0, unbox<int>(_size.width)))
-            _buffer[(h - y) * *_size.width + x] = filler(x, y);
+            paint(x, y, static_cast<uint8_t>(filler(x, y)));
     return *this;
 }
 

--- a/src/terminal_renderer/RenderTarget.h
+++ b/src/terminal_renderer/RenderTarget.h
@@ -159,7 +159,6 @@ class Renderable
     virtual void clearCache() {}
 
     virtual void setRenderTarget(RenderTarget& renderTarget, DirectMappingAllocator& directMappingAllocator);
-    virtual void initializeDirectMapping(DirectMappingAllocator& /*directMappingAllocator*/) {}
     virtual void setTextureAtlas(TextureAtlas& atlas) { _textureAtlas = &atlas; }
 
     TextureAtlas::TileCreateData createTileData(atlas::TileLocation tileLocation,

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -48,8 +48,8 @@ void loadGridMetricsFromFont(text::font_key _font, GridMetrics& _gm, text::shape
 {
     auto const m = _textShaper.metrics(_font);
 
-    _gm.cellSize.width = Width(m.advance);
-    _gm.cellSize.height = Height(m.line_height);
+    _gm.cellSize.width = Width::cast_from(m.advance);
+    _gm.cellSize.height = Height::cast_from(m.line_height);
     _gm.baseline = m.line_height - m.ascender;
     _gm.underline.position = _gm.baseline + m.underline_position;
     _gm.underline.thickness = m.underline_thickness;
@@ -117,7 +117,7 @@ unique_ptr<text::shaper> createTextShaper(TextShapingEngine _engine,
 }
 
 Renderer::Renderer(PageSize pageSize,
-                   FontDescriptions const& fontDescriptions,
+                   FontDescriptions fontDescriptions,
                    terminal::ColorPalette const& colorPalette,
                    terminal::Opacity backgroundOpacity,
                    crispy::StrongHashtableSize atlasHashtableSlotCount,
@@ -130,7 +130,7 @@ Renderer::Renderer(PageSize pageSize,
     _atlasDirectMapping { atlasDirectMapping },
     _renderTarget { nullptr },
     //.
-    fontDescriptions_ { fontDescriptions },
+    fontDescriptions_ { move(fontDescriptions) },
     textShaper_ { createTextShaper(fontDescriptions_.textShapingEngine,
                                    fontDescriptions_.dpi,
                                    createFontLocator(fontDescriptions_.fontLocator)) },

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -125,7 +125,7 @@ Renderer::Renderer(PageSize pageSize,
                    bool atlasDirectMapping,
                    Decorator hyperlinkNormal,
                    Decorator hyperlinkHover):
-    _atlasHashtableSlotCount { crispy::detail::nextPowerOfTwo(atlasHashtableSlotCount.value) },
+    _atlasHashtableSlotCount { crispy::nextPowerOfTwo(atlasHashtableSlotCount.value) },
     _atlasTileCount { std::max(atlasTileCount.value, static_cast<uint32_t>(pageSize.area())) },
     _atlasDirectMapping { atlasDirectMapping },
     _renderTarget { nullptr },

--- a/src/terminal_renderer/Renderer.h
+++ b/src/terminal_renderer/Renderer.h
@@ -60,7 +60,7 @@ class Renderer
      * @p atlasTileCount     Number of tiles guaranteed to be available in LRU cache.
      */
     Renderer(PageSize screenSize,
-             FontDescriptions const& fontDescriptions,
+             FontDescriptions fontDescriptions,
              ColorPalette const& colorPalette,
              Opacity backgroundOpacity,
              crispy::StrongHashtableSize atlasHashtableSlotCount,

--- a/src/terminal_renderer/TextureAtlas.h
+++ b/src/terminal_renderer/TextureAtlas.h
@@ -449,12 +449,12 @@ inline ImageSize computeAtlasSize(AtlasProperties const& atlasProperties) noexce
     using std::sqrt;
 
     // clang-format off
-    auto const totalTileCount = crispy::detail::nextPowerOfTwo(1 + atlasProperties.tileCount.value + atlasProperties.directMappingCount);
+    auto const totalTileCount = crispy::nextPowerOfTwo(1 + atlasProperties.tileCount.value + atlasProperties.directMappingCount);
     //auto const totalTileCount = atlasProperties.tileCount.value + atlasProperties.directMappingCount;
     auto const squareEdgeCount = static_cast<uint32_t>(ceil(sqrt(totalTileCount)));
-    auto const width = Width::cast_from(crispy::detail::nextPowerOfTwo(static_cast<uint32_t>(
+    auto const width = Width::cast_from(crispy::nextPowerOfTwo(static_cast<uint32_t>(
         squareEdgeCount * unbox<uint32_t>(atlasProperties.tileSize.width))));
-    auto const height = Height::cast_from(crispy::detail::nextPowerOfTwo(static_cast<uint32_t>(
+    auto const height = Height::cast_from(crispy::nextPowerOfTwo(static_cast<uint32_t>(
         squareEdgeCount * unbox<uint32_t>(atlasProperties.tileSize.height))));
     // clang-format on
 

--- a/src/terminal_renderer/TextureAtlas.h
+++ b/src/terminal_renderer/TextureAtlas.h
@@ -198,7 +198,7 @@ class AtlasBackend
   public:
     virtual ~AtlasBackend() = default;
 
-    virtual ImageSize atlasSize() const noexcept = 0;
+    [[nodiscard]] virtual ImageSize atlasSize() const noexcept = 0;
 
     /// Creates a new texture atlas, effectively destroying any prior existing one
     /// as there  can be only one atlas.
@@ -243,17 +243,15 @@ class TextureAtlas
     /// This will create at least one atlas in the backend.
     TextureAtlas(AtlasBackend& backend, AtlasProperties atlasProperties);
 
-    ~TextureAtlas();
-
     void reset(AtlasProperties atlasProperties);
 
     AtlasBackend& backend() noexcept { return _backend; }
 
-    ImageSize atlasSize() const noexcept { return _atlasSize; }
-    ImageSize tileSize() const noexcept { return _atlasProperties.tileSize; }
+    [[nodiscard]] ImageSize atlasSize() const noexcept { return _atlasSize; }
+    [[nodiscard]] ImageSize tileSize() const noexcept { return _atlasProperties.tileSize; }
 
     // Tests in LRU-cache if the tile
-    constexpr bool contains(crispy::StrongHash const& _id) const noexcept;
+    [[nodiscard]] constexpr bool contains(crispy::StrongHash const& _id) const noexcept;
 
     // Return type for in-place tile-construction callback.
     struct TileCreateData
@@ -293,17 +291,17 @@ class TextureAtlas
     // The index must be between 0 and number of direct-mapped tiles minus 1.
     TileAttributes<Metadata> const& directMapped(uint32_t index) const;
 
-    bool isDirectMappingEnabled() const noexcept { return !_directMapping.empty(); }
+    [[nodiscard]] bool isDirectMappingEnabled() const noexcept { return !_directMapping.empty(); }
 
-    TileLocation tileLocation(uint32_t tileIndex) const { return _tileLocations[tileIndex]; }
+    [[nodiscard]] TileLocation tileLocation(uint32_t tileIndex) const { return _tileLocations[tileIndex]; }
 
     // Retrieves the number of total tiles that can be stored.
-    size_t capacity() const noexcept { return _tileLocations.size(); }
+    [[nodiscard]] size_t capacity() const noexcept { return _tileLocations.size(); }
 
     void inspect(std::ostream& output) const;
 
-    uint32_t tilesInX() const noexcept { return _tilesInX; }
-    uint32_t tilesInY() const noexcept { return _tilesInY; }
+    [[nodiscard]] uint32_t tilesInX() const noexcept { return _tilesInX; }
+    [[nodiscard]] uint32_t tilesInY() const noexcept { return _tilesInY; }
 
   private:
     using TileCache = crispy::StrongLRUHashtable<TileAttributes<Metadata>>;
@@ -345,7 +343,7 @@ struct DirectMapping
     constexpr operator bool() const noexcept { return count != 0; }
     constexpr bool operator!() const noexcept { return count == 0; }
 
-    uint32_t toTileIndex(uint32_t directMappingIndex) const noexcept
+    [[nodiscard]] uint32_t toTileIndex(uint32_t directMappingIndex) const noexcept
     {
         Require(directMappingIndex < count);
         return baseIndex + directMappingIndex;
@@ -413,7 +411,7 @@ constexpr auto sliced(Width tileWidth, uint32_t offsetX, ImageSize bitmapSize)
             }
         };
 
-        constexpr uint32_t offsetForEndX() const noexcept
+        [[nodiscard]] constexpr uint32_t offsetForEndX() const noexcept
         {
             auto const c = unbox<uint32_t>(bitmapSize.width) % unbox<uint32_t>(tileWidth);
             return unbox<uint32_t>(bitmapSize.width) + c;
@@ -530,11 +528,6 @@ TextureAtlas<Metadata>::TextureAtlas(AtlasBackend& backend, AtlasProperties atla
     }
 
     _directMapping.resize(_atlasProperties.directMappingCount);
-}
-
-template <typename Metadata>
-TextureAtlas<Metadata>::~TextureAtlas()
-{
 }
 
 template <typename Metadata>

--- a/src/terminal_renderer/utils.cpp
+++ b/src/terminal_renderer/utils.cpp
@@ -129,7 +129,7 @@ vector<uint8_t> downsample(vector<uint8_t> const& _sourceBitmap, ImageSize _targ
     vector<uint8_t> targetBitmap(*_targetSize.width * *_targetSize.height, 0);
 
     auto const sourceWidth = _factor * *_targetSize.width;
-    auto const average_intensity_in_src = [&](int destX, int destY) -> int {
+    auto const average_intensity_in_src = [&](unsigned destX, unsigned destY) -> unsigned {
         auto sourceY = destY * _factor;
         auto sourceX = destX * _factor;
         auto total = 0u;
@@ -139,14 +139,15 @@ vector<uint8_t> downsample(vector<uint8_t> const& _sourceBitmap, ImageSize _targ
             for (auto const x: ::ranges::views::iota(sourceX, sourceX + _factor))
                 total += _sourceBitmap[offset + x];
         }
-        return int(double(total) / double(_factor * _factor));
+        return unsigned(double(total) / double(_factor * _factor));
     };
 
     for (auto const y: ::ranges::views::iota(0u, *_targetSize.height))
     {
         auto const offset = *_targetSize.width * y;
         for (auto const x: ::ranges::views::iota(0u, *_targetSize.width))
-            targetBitmap[offset + x] = min(255, targetBitmap[offset + x] + average_intensity_in_src(x, y));
+            targetBitmap[offset + x] =
+                (uint8_t) min(255u, unsigned(targetBitmap[offset + x]) + average_intensity_in_src(x, y));
     }
 
     return targetBitmap;

--- a/src/text_shaper/coretext_locator.mm
+++ b/src/text_shaper/coretext_locator.mm
@@ -54,10 +54,10 @@ namespace text
 
         constexpr font_slant ctFontSlant(int _slant) noexcept
         {
-            if (_slant & NSItalicFontMask)
+            if (unsigned(_slant) & NSItalicFontMask)
                 return font_slant::italic;
 
-            if (_slant & (NSUnitalicFontMask | NSUnboldFontMask))
+            if (unsigned(_slant) & (NSUnitalicFontMask | NSUnboldFontMask))
                 return font_slant::normal;
 
             // Figure out how to get Oblique font, even though according to some docs.
@@ -109,7 +109,7 @@ namespace text
 
         for (bool const forceWeight: {true, false})
         {
-            for (bool const forceSlant: {true, false})
+            for ([[maybe_unused]] bool const forceSlant: {true, false})
             {
                 for (NSArray* object in fonts)
                 {
@@ -149,7 +149,7 @@ namespace text
         return output;
     }
 
-    font_source_list coretext_locator::resolve(gsl::span<const char32_t> codepoints)
+    font_source_list coretext_locator::resolve(gsl::span<const char32_t> /*codepoints*/)
     {
         return {};
     }

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -82,7 +82,7 @@ struct FontPathAndSize
     text::font_size size;
 };
 
-bool operator==(FontPathAndSize const& a, FontPathAndSize const& b) noexcept
+[[maybe_unused]] bool operator==(FontPathAndSize const& a, FontPathAndSize const& b) noexcept
 {
     return a.path == b.path && a.size.pt == b.size.pt;
 }
@@ -133,18 +133,6 @@ namespace
         throw invalid_argument("source");
     }
 
-    constexpr string_view fcSpacingStr(int _value) noexcept
-    {
-        switch (_value)
-        {
-            case FC_PROPORTIONAL: return "proportional"sv;
-            case FC_DUAL: return "dual"sv;
-            case FC_MONO: return "mono"sv;
-            case FC_CHARCELL: return "charcell"sv;
-            default: return "INVALID"sv;
-        }
-    }
-
     // clang-format off
     static string ftErrorStr(FT_Error _errorCode)
     {
@@ -160,42 +148,6 @@ namespace
     constexpr bool glyphMissing(text::glyph_position const& _gp) noexcept
     {
         return _gp.glyph.index.value == 0;
-    }
-
-    constexpr int fcWeight(font_weight _weight) noexcept
-    {
-        switch (_weight)
-        {
-            case font_weight::thin: return FC_WEIGHT_THIN;
-            case font_weight::extra_light: return FC_WEIGHT_EXTRALIGHT;
-            case font_weight::light: return FC_WEIGHT_LIGHT;
-            case font_weight::demilight:
-#if defined(FC_WEIGHT_DEMILIGHT)
-                return FC_WEIGHT_DEMILIGHT;
-#else
-                return FC_WEIGHT_LIGHT; // Is this a good fallback? Maybe.
-#endif
-            case font_weight::book: return FC_WEIGHT_BOOK;
-            case font_weight::normal: return FC_WEIGHT_NORMAL;
-            case font_weight::medium: return FC_WEIGHT_MEDIUM;
-            case font_weight::demibold: return FC_WEIGHT_DEMIBOLD;
-            case font_weight::bold: return FC_WEIGHT_BOLD;
-            case font_weight::extra_bold: return FC_WEIGHT_EXTRABOLD;
-            case font_weight::black: return FC_WEIGHT_BLACK;
-            case font_weight::extra_black: return FC_WEIGHT_EXTRABLACK;
-        }
-        return FC_WEIGHT_NORMAL;
-    }
-
-    constexpr int fcSlant(font_slant _slant) noexcept
-    {
-        switch (_slant)
-        {
-            case font_slant::italic: return FC_SLANT_ITALIC;
-            case font_slant::oblique: return FC_SLANT_OBLIQUE;
-            case font_slant::normal: return FC_SLANT_ROMAN;
-        }
-        return FC_SLANT_ROMAN;
     }
 
     constexpr int ftRenderFlag(render_mode _mode) noexcept
@@ -461,7 +413,7 @@ struct open_shaper::Private // {{{
         return result;
     }
 
-    bool has_color(font_key _font) const noexcept
+    [[nodiscard]] bool has_color(font_key _font) const noexcept
     {
         return FT_HAS_COLOR(fontKeyToHbFontInfoMapping.at(_font).ftFace.get());
     }


### PR DESCRIPTION
this pr started simple, but i added the following:
- PTY buffer objects
- more effecient grid line handling for trivial lines (especially in primary screen)
- compiler warning cleanup
- .clang-tidy refinements.