### PR TITLE
Overall improvements and fix to #647

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.3.1 (unreleased)
 
 * Fixes assertion on font resize when a (Sixel) image is currently being rendered (#642).
+- Fixes assertion on too quick shell terminations (#647).
 
 ### 0.3.0 (2022-04-18)
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1646,7 +1646,7 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
         for (auto i = profiles.begin(); i != profiles.end(); ++i)
         {
             auto const& name = i->first.as<string>();
-            auto const& profile = i->second;
+            auto const profile = i->second;
             auto const parentPath = "profiles"s;
             usedKeys.emplace(fmt::format("{}.{}", parentPath, name));
             _config.profiles[name] =

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -59,7 +59,8 @@ read_buffer_size: 16384
 
 # Size in bytes per PTY Buffer Object.
 #
-pty_buffer_size: 1000000
+# This is an advanced option of an internal storage. Only change with care!
+pty_buffer_size: 1048576
 
 default_profile: main
 

--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -120,6 +120,12 @@ App::App(std::string _appName, std::string _appTitle, std::string _appVersion, s
     appLicense_ { std::move(_appLicense) },
     localStateDir_ { xdgStateHome() / appName_ }
 {
+    if (char const* logFilterString = getenv("LOG"))
+    {
+        logstore::configure(logFilterString);
+        customizeLogStoreOutput();
+    }
+
     instance_ = this;
 
     link(appName_ + ".help", bind(&App::helpAction, this));

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -54,13 +54,13 @@ BufferObject::BufferObject(size_t capacity) noexcept:
     new (data()) char[capacity];
 #endif
     if (BufferObjectLog)
-        BufferObjectLog()("Creating BufferObject @{}.", (void*) this);
+        BufferObjectLog()("Creating BufferObject: {}..{}.", (void*) data(), (void*) end());
 }
 
 BufferObject::~BufferObject()
 {
     if (BufferObjectLog)
-        BufferObjectLog()("Destroying BufferObject @{}.", (void*) this);
+        BufferObjectLog()("Destroying BufferObject: {}..{}.", (void*) data(), (void*) end());
 #if !defined(BUFFER_OBJECT_INLINE)
     delete[] data_;
 #endif

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -17,6 +17,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "crispy/escape.h"
+
 namespace crispy
 {
 
@@ -93,6 +95,19 @@ std::string joinHumanReadable(std::vector<T> const& list, std::string_view sep =
         if (i != 0)
             result << sep;
         result << fmt::format("{}", list[i]);
+    }
+    return result.str();
+}
+
+template <typename T, typename U>
+std::string joinHumanReadableQuoted(std::vector<T> const& list, U sep = ", ")
+{
+    std::stringstream result;
+    for (size_t i = 0; i < list.size(); ++i)
+    {
+        if (i != 0)
+            result << sep;
+        result << '"' << crispy::escape(fmt::format("{}", list[i])) << '"';
     }
     return result.str();
 }

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -99,7 +99,7 @@ class [[nodiscard]] Process: public Pty
     void close() override { pty().close(); }
     bool isClosed() const noexcept override { return pty().isClosed(); }
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override { return pty().read(_size, _timeout); }
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
+    [[nodiscard]] ReadResult read(crispy::BufferObject& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }
     int write(char const* buf, size_t size) override { return pty().write(buf, size); }
     PageSize pageSize() const noexcept override { return pty().pageSize(); }

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -239,8 +239,12 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TriviallyStyledLineBuffer cons
                                                   lineOffset,
                                                   columnOffset));
     }
-    output.screen[unbox<size_t>(textMargin)].groupStart = true;
-    output.screen.back().groupEnd = true;
+
+    if (textMargin != pageColumnsEnd)
+    {
+        output.screen[unbox<size_t>(textMargin)].groupStart = true;
+        output.screen.back().groupEnd = true;
+    }
 }
 
 template <typename Cell>

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -154,8 +154,8 @@ bool Terminal::processInputOnce()
                        currentPtyBuffer_->bytesAvailable());
         currentPtyBuffer_ = ptyBufferPool_.allocateBufferObject();
     }
-    optional<tuple<string_view, bool>> const readResult =
-        pty_->read(*currentPtyBuffer_, timeout, ptyReadBufferSize_);
+
+    auto const readResult = pty_->read(*currentPtyBuffer_, timeout, ptyReadBufferSize_);
     if (!readResult)
     {
         if (errno != EINTR && errno != EAGAIN)

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -175,7 +175,13 @@ bool Terminal::processInputOnce()
         return true;
     }
 
-    writeToScreen(buf);
+    {
+        auto const _l = std::lock_guard { *this };
+        state_.parser.parseFragment(buf);
+    }
+
+    if (!state_.modes.enabled(DECMode::BatchedRendering))
+        screenUpdated();
 
 #if defined(LIBTERMINAL_PASSIVE_RENDER_BUFFER_UPDATE)
     ensureFreshRenderBuffer();
@@ -587,7 +593,15 @@ void Terminal::writeToScreen(string_view _data)
 {
     {
         auto const _l = std::lock_guard { *this };
-        state_.parser.parseFragment(_data);
+        while (!_data.empty())
+        {
+            if (currentPtyBuffer_->bytesAvailable() < 64
+                && currentPtyBuffer_->bytesAvailable() < _data.size())
+                currentPtyBuffer_ = ptyBufferPool_.allocateBufferObject();
+            auto const chunk = _data.substr(0, std::min(_data.size(), currentPtyBuffer_->bytesAvailable()));
+            _data.remove_prefix(chunk.size());
+            state_.parser.parseFragment(currentPtyBuffer_->writeAtEnd(chunk));
+        }
     }
 
     if (!state_.modes.enabled(DECMode::BatchedRendering))

--- a/src/terminal/pty/ConPty.cpp
+++ b/src/terminal/pty/ConPty.cpp
@@ -137,9 +137,7 @@ void ConPty::close()
     }
 }
 
-optional<tuple<string_view, bool>> ConPty::read(crispy::BufferObject& buffer,
-                                                std::chrono::milliseconds timeout,
-                                                size_t size)
+Pty::ReadResult ConPty::read(crispy::BufferObject& buffer, std::chrono::milliseconds timeout, size_t size)
 {
     // TODO: wait for timeout time at most AND got woken up upon wakeupReader() invokcation.
     (void) timeout;

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -34,9 +34,9 @@ class ConPty: public Pty
     bool isClosed() const noexcept override;
 
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
-                                                                         std::chrono::milliseconds timeout,
-                                                                         size_t size) override;
+    [[nodiscard]] ReadResult read(crispy::BufferObject& storage,
+                                  std::chrono::milliseconds timeout,
+                                  size_t size) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/MockPty.cpp
+++ b/src/terminal/pty/MockPty.cpp
@@ -31,9 +31,9 @@ optional<string_view> MockPty::read(size_t _size, std::chrono::milliseconds)
     return result;
 }
 
-optional<tuple<string_view, bool>> MockPty::read(crispy::BufferObject& storage,
-                                                 std::chrono::milliseconds /*timeout*/,
-                                                 size_t size)
+Pty::ReadResult MockPty::read(crispy::BufferObject& storage,
+                              std::chrono::milliseconds /*timeout*/,
+                              size_t size)
 {
     auto const n = min(size, min(outputBuffer_.size() - outputReadOffset_, storage.bytesAvailable()));
     auto const chunk = string_view { outputBuffer_.data() + outputReadOffset_, n };

--- a/src/terminal/pty/MockPty.h
+++ b/src/terminal/pty/MockPty.h
@@ -29,9 +29,9 @@ class MockPty: public Pty
 
     PtySlave& slave() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
-                                                                         std::chrono::milliseconds timeout,
-                                                                         size_t size) override;
+    [[nodiscard]] ReadResult read(crispy::BufferObject& storage,
+                                  std::chrono::milliseconds timeout,
+                                  size_t size) override;
     void wakeupReader() override;
     int write(char const* buf, size_t size) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -62,6 +62,8 @@ class PtySlaveDummy: public PtySlave
 class Pty
 {
   public:
+    using ReadResult = std::optional<std::tuple<std::string_view, bool>>;
+
     virtual ~Pty() = default;
 
     virtual PtySlave& slave() noexcept = 0;
@@ -82,8 +84,9 @@ class Pty
     [[nodiscard]] virtual std::optional<std::string_view> read(size_t _size,
                                                                std::chrono::milliseconds _timeout) = 0;
 
-    [[nodiscard]] virtual std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::BufferObject& storage, std::chrono::milliseconds timeout, size_t size) = 0;
+    [[nodiscard]] virtual ReadResult read(crispy::BufferObject& storage,
+                                          std::chrono::milliseconds timeout,
+                                          size_t size) = 0;
 
     /// Inerrupts the read() operation on this PTY if a read() is currently in progress.
     ///

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -341,7 +341,7 @@ optional<string_view> UnixPty::readSome(int fd, char* target, size_t n) noexcept
         return nullopt;
 
     if (PtyInLog)
-        PtyInLog()("{} received: {}",
+        PtyInLog()("{} received: \"{}\"",
                    fd == _masterFd ? "master" : "stdout-fastpipe",
                    crispy::escape(target, target + rv));
 

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -425,9 +425,7 @@ int waitForReadable(int ptyMaster,
     }
 }
 
-optional<tuple<string_view, bool>> UnixPty::read(crispy::BufferObject& sink,
-                                                 std::chrono::milliseconds timeout,
-                                                 size_t size)
+Pty::ReadResult UnixPty::read(crispy::BufferObject& sink, std::chrono::milliseconds timeout, size_t size)
 {
     // TODO: We might want to make the read size limit configurable. Especially for the stdout-fastpipe.
     if (int fd = waitForReadable(_masterFd, _stdoutFastPipe.reader(), _pipe[0], timeout); fd != -1)

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -85,9 +85,9 @@ class UnixPty: public Pty
     bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
     std::optional<std::string_view> read(size_t _size, std::chrono::milliseconds _timeout) override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject& storage,
-                                                                         std::chrono::milliseconds timeout,
-                                                                         size_t size) override;
+    [[nodiscard]] ReadResult read(crispy::BufferObject& storage,
+                                  std::chrono::milliseconds timeout,
+                                  size_t size) override;
     int write(char const* buf, size_t size) override;
     PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;


### PR DESCRIPTION
Fixes #647.
Also contains general improvements / cleanups.

I think we could further improve the behavior...
Currently: any argument at the end of the CLI that can't be parsed is treated as shell program to spawn. This mimics KDE's konsole and the way KDE desktop is spawning apps in a terminal.
If that command however cannot be executed, an error message is being printed into the terminal.