### PR TITLE
vi-like input modes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### 0.3.1 (unreleased)
 
+- Adds Vi-like input modes for improved selection and copy'n'paste experience.
 - Fixes wrong-spacing rendering bug on some lines.
 - Fixes assertion on font resize when a (Sixel) image is currently being rendered (#642).
 - Fixes assertion on too quick shell terminations (#647).

--- a/docs/input-modes.md
+++ b/docs/input-modes.md
@@ -1,0 +1,61 @@
+# Contour Input Modes
+
+Normally, a terminal emulator only knows about one input mode, so
+there is no need of distinction.
+
+Inspired by Vi/Vim, the Termite terminal emulator started to introduce
+so called Vim-modes, where the user can use the keyboard only to
+screen text selection, amongst other things. So users can press
+Ctrl+Shift+Space to enter the vim mode. You can then move the cursor
+using vim motion keys and then start selecting.
+
+### Contour introduces multiple Vim-like input modes:
+
+- **insert mode**: This is the default input mode. Everything is forwarded to the application.
+- **normal mode**: Use motion keys to move the cursor and operators to act
+- **visual mode**: Linear selection, use motion keys to alter the selection.
+- **visual line mode**: Line based selection, use motion keys to alter the selection.
+- **visual block mode**: Block based selection, use motion keys to alter the selection.
+
+### Supported operators (Normal Mode)
+
+- Normal: `[count] p` (paste primary clipboard `count` times)
+- Normal: `yy` (yank current line to primary clipboard)
+- Normal: `y {motion}` (yank given `motion` to primary clipboard)
+- Normal: `y {TextObject}` (yank given `textObject` to primary clipboard, such as `yiw`, `yaw`, `yip`, `yap`, ...)
+- Visual: `y` (yank current selection into primary clipboard)
+- `v` enables/disables visual mode
+- `V` enables/disables visual line mode
+- `i` activates insert mode
+- `Ctrl+v` enables/disables visual block mode
+
+### Supported motions
+
+Moving the cursor outside of the current view using a motion, will cause
+the terminal to scroll the view to make that target line visible.
+
+- `[count] h`
+- `[count] j`
+- `[count] k`
+- `[count] l`
+- `[count] w`
+- `[count] b`
+- `[count] e`
+- `[count] |`
+- `0`
+- `$`
+- `gg`
+- `G`
+- `{` & `}`
+
+### Supported text objects
+
+- `i<`, `a<` - angle brackets enclosed text
+- `i{`, `a{` - curly brackets enclosed text
+- `i"`, `a"` - double quotes enclosed text
+- `ip`, `ap` - backtick enclosed string
+- `i(`, `a(` - round brackets enclosed string
+- `i'`, `a'` - single quoted string
+- `i\``, `a\`` - backtick enclosed string
+- `i[`, `a[` - square bracket encoded string
+- `iw`, `aw` - (space delimited) word

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -77,6 +77,7 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::ToggleAllKeyMaps>("ToggleAllKeyMaps"),
         mapAction<actions::ToggleFullscreen>("ToggleFullscreen"),
         mapAction<actions::ToggleTitleBar>("ToggleTitleBar"),
+        mapAction<actions::ViNormalMode>("ViNormalMode"),
         mapAction<actions::WriteScreen>("WriteScreen"),
     };
 

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -57,6 +57,7 @@ struct SendChars{ std::string chars; };
 struct ToggleAllKeyMaps{};
 struct ToggleFullscreen{};
 struct ToggleTitleBar{};
+struct ViNormalMode{};
 struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
 // CloseTab
 // FocusNextTab
@@ -98,6 +99,7 @@ using Action = std::variant<CancelSelection,
                             ToggleAllKeyMaps,
                             ToggleFullscreen,
                             ToggleTitleBar,
+                            ViNormalMode,
                             WriteScreen>;
 
 std::optional<Action> fromString(std::string const& _name);
@@ -158,6 +160,7 @@ DECLARE_ACTION_FMT(SendChars)
 DECLARE_ACTION_FMT(ToggleAllKeyMaps)
 DECLARE_ACTION_FMT(ToggleFullscreen)
 DECLARE_ACTION_FMT(ToggleTitleBar)
+DECLARE_ACTION_FMT(ViNormalMode)
 DECLARE_ACTION_FMT(WriteScreen)
 // }}}
 #undef DECLARE_ACTION_FMT
@@ -216,6 +219,7 @@ struct formatter<contour::actions::Action>
         HANDLE_ACTION(ToggleAllKeyMaps);
         HANDLE_ACTION(ToggleFullscreen);
         HANDLE_ACTION(ToggleTitleBar);
+        HANDLE_ACTION(ViNormalMode);
         HANDLE_ACTION(WriteScreen);
         // }}}
         return format_to(ctx.out(), "UNKNOWN ACTION");

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -103,7 +103,8 @@ namespace helper
         return testMatchMode(_actualModeFlags, _expected, Flag::AlternateScreen)
                && testMatchMode(_actualModeFlags, _expected, Flag::AppCursor)
                && testMatchMode(_actualModeFlags, _expected, Flag::AppKeypad)
-               && testMatchMode(_actualModeFlags, _expected, Flag::Select);
+               && testMatchMode(_actualModeFlags, _expected, Flag::Select)
+               && testMatchMode(_actualModeFlags, _expected, Flag::Insert);
     }
 } // namespace helper
 
@@ -126,6 +127,18 @@ std::vector<actions::Action> const* apply(
 }
 
 using opengl::ShaderConfig;
+
+struct CursorConfig
+{
+    terminal::CursorShape cursorShape;
+    terminal::CursorDisplay cursorDisplay;
+    std::chrono::milliseconds cursorBlinkInterval;
+};
+
+struct InputModeConfig
+{
+    CursorConfig cursor;
+};
 
 struct TerminalProfile
 {
@@ -158,9 +171,12 @@ struct TerminalProfile
 
     terminal::ColorPalette colors {};
 
-    terminal::CursorShape cursorShape;
-    terminal::CursorDisplay cursorDisplay;
-    std::chrono::milliseconds cursorBlinkInterval;
+    struct
+    {
+        InputModeConfig insert;
+        InputModeConfig normal;
+        InputModeConfig visual;
+    } inputModes;
 
     terminal::Opacity backgroundOpacity; // value between 0 (fully transparent) and 0xFF (fully visible).
     bool backgroundBlur;                 // On Windows 10, this will enable Acrylic Backdrop.

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -98,12 +98,14 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     void inspect() override;
     void notify(std::string_view _title, std::string_view _body) override;
     void onClosed() override;
+    void pasteFromClipboard(unsigned count) override;
     void onSelectionCompleted() override;
     void resizeWindow(terminal::LineCount, terminal::ColumnCount) override;
     void resizeWindow(terminal::Width, terminal::Height) override;
     void setWindowTitle(std::string_view _title) override;
     void setTerminalProfile(std::string const& _configProfileName) override;
     void discardImage(terminal::Image const&) override;
+    void inputModeChanged(terminal::ViMode mode) override;
 
     // Input Events
     using Timestamp = std::chrono::steady_clock::time_point;
@@ -161,6 +163,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     bool operator()(actions::ToggleAllKeyMaps);
     bool operator()(actions::ToggleFullscreen);
     bool operator()(actions::ToggleTitleBar);
+    bool operator()(actions::ViNormalMode);
     bool operator()(actions::WriteScreen const& _event);
 
     void scheduleRedraw()
@@ -200,6 +203,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     void setFontSize(text::font_size _size);
     void setDefaultCursor();
     void configureTerminal();
+    void configureCursor(config::CursorConfig const& cursorConfig);
     void configureDisplay();
     uint8_t matchModeFlags() const;
     void flushInput();

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -317,11 +317,25 @@ profiles:
             # - rectangle     just the outline of a block
             # - underscore    a line under the text
             # - bar:          the well known i-Beam
-            shape: "block"
+            shape: "bar"
             # Determins whether or not the cursor will be blinking over time.
             blinking: false
             # Blinking interval (in milliseconds) to use when cursor is blinking.
             blinking_interval: 500
+        # vi-like normal-mode specific settings.
+        # Note, currently only the cursor can be customized.
+        normal_mode:
+            cursor:
+                shape: block
+                blinking: false
+                blinking_interval: 500
+        # vi-like visual/visual-line/visual-block mode specific settings.
+        # Note, currently only the cursor can be customized.
+        visual_mode:
+            cursor:
+                shape: block
+                blinking: false
+                blinking_interval: 500
         # Background configuration
         background:
             # Background opacity to use. A value of 1.0 means fully opaque whereas 0.0 means fully
@@ -432,11 +446,13 @@ color_schemes:
 # - AppCursor : The application key cursor mode is enabled (otherwise it's normal cursor mode).
 # - AppKeypad : The application keypad mode is enabled (otherwise it's the numeric keypad mode).
 # - Select    : The terminal has currently an active grid cell selection (such as selected text).
+# - Insert    : The Insert input mode is active, that is the default and one way to test
+#               that the input mode is not in normal mode or any of the visual select modes.
 #
 # You can combine these modes by concatenating them via | and negate a single one
 # by prefixing with ~.
 #
-# The `modes` option defaults to no filter at all (the input mappings always
+# The `modes` option defaults to not filter at all (the input mappings always
 # match based on modifier and key press / mouse event).
 #
 # `key` represents keys on your keyboard, and `mouse` represents buttons
@@ -497,6 +513,7 @@ color_schemes:
 # - ToggleAllKeyMaps  Disables/enables responding to all keybinds (this keybind will be preserved when disabling all others).
 # - ToggleFullScreen  Enables/disables full screen mode.
 # - ToggleTitleBar    Shows/Hides titlebar
+# - ViNormalMode      Enters Vi-like normal mode. The cursor can then be moved via h/j/k/l movements and text can be selected via v, yanked via y, and clipboard pasted via p.
 # - WriteScreen       Writes VT sequence in `chars` member to the screen (bypassing the application).
 
 input_mapping:
@@ -515,10 +532,11 @@ input_mapping:
     - { mods: [Control, Shift], key: N,             action: NewTerminal }
     - { mods: [Control, Shift], key: C,             action: CopySelection }
     - { mods: [Control, Shift], key: V,             action: PasteClipboard }
-    - { mods: [Control],        key: C,             action: CopySelection, mode: 'Select' }
-    - { mods: [Control],        key: V,             action: PasteClipboard, mode: 'Select' }
-    - { mods: [Control],        key: V,             action: CancelSelection, mode: 'Select' }
-    - { mods: [],               key: Escape,        action: CancelSelection, mode: 'Select' }
+    - { mods: [Control],        key: C,             action: CopySelection, mode: 'Select|Insert' }
+    - { mods: [Control],        key: V,             action: PasteClipboard, mode: 'Select|Insert' }
+    - { mods: [Control],        key: V,             action: CancelSelection, mode: 'Select|Insert' }
+    - { mods: [],               key: Escape,        action: CancelSelection, mode: 'Select|Insert' }
+    - { mods: [Control, Shift], key: Space,         action: ViNormalMode, mode: 'Insert' }
     - { mods: [Control, Shift], key: Comma,         action: OpenConfiguration }
     - { mods: [Control, Shift], key: Q,             action: Quit }
     - { mods: [Control],        mouse: WheelDown,   action: DecreaseFontSize }

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -467,4 +467,9 @@ inline std::string humanReadableBytes(long double bytes)
     return fmt::format("{:.03} GB", gb);
 }
 
+template <typename... Ts>
+constexpr void ignore_unused(Ts&&... /*values*/) noexcept
+{
+}
+
 } // namespace crispy

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -49,6 +49,8 @@ set(terminal_HEADERS
     VTType.h
     VTWriter.h
     Viewport.h
+    ViInputHandler.h
+    ViCommands.h
     primitives.h
     pty/ConPty.h
     pty/MockPty.h
@@ -92,6 +94,8 @@ set(terminal_SOURCES
     VTType.cpp
     VTWriter.cpp
     Viewport.cpp
+    ViInputHandler.cpp
+    ViCommands.cpp
     primitives.cpp
     pty/MockPty.cpp
     pty/MockViewPty.cpp

--- a/src/terminal/Cell.h
+++ b/src/terminal/Cell.h
@@ -124,6 +124,8 @@ class CONTOUR_PACKED Cell
     char32_t codepoint(size_t i) const noexcept;
     std::size_t codepointCount() const noexcept;
 
+    [[nodiscard]] bool compareText(char codepoint) const noexcept;
+
     bool empty() const noexcept;
 
     constexpr uint8_t width() const noexcept;
@@ -409,6 +411,14 @@ inline std::size_t Cell::codepointCount() const noexcept
         return 1 + extra_->codepoints.size();
     }
     return 0;
+}
+
+inline bool Cell::compareText(char codepoint) const noexcept
+{
+    if (codepointCount() != 1)
+        return false;
+
+    return codepoint_ == static_cast<char32_t>(codepoint);
 }
 
 inline char32_t Cell::codepoint(size_t i) const noexcept

--- a/src/terminal/ColorPalette.h
+++ b/src/terminal/ColorPalette.h
@@ -72,12 +72,12 @@ struct ColorPalette
 
         // normal colors
         colors[0] = 0x000000_rgb; // black
-        colors[1] = 0x800000_rgb; // red
-        colors[2] = 0x008000_rgb; // green
-        colors[3] = 0x808000_rgb; // yellow
-        colors[4] = 0x000080_rgb; // blue
-        colors[5] = 0x800080_rgb; // magenta
-        colors[6] = 0x008080_rgb; // cyan
+        colors[1] = 0xa00000_rgb; // red
+        colors[2] = 0x00a000_rgb; // green
+        colors[3] = 0xa0a000_rgb; // yellow
+        colors[4] = 0x0000a0_rgb; // blue
+        colors[5] = 0xa000a0_rgb; // magenta
+        colors[6] = 0x00a0a0_rgb; // cyan
         colors[7] = 0xc0c0c0_rgb; // white
 
         // bright colors

--- a/src/terminal/InputHandler.h
+++ b/src/terminal/InputHandler.h
@@ -1,0 +1,35 @@
+/**
+ * This file is part of the "contour" project
+ *   Copyright (c) 2019-2021 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <terminal/InputGenerator.h>
+
+namespace terminal
+{
+
+/**
+ * Generic input handler interface.
+ *
+ * @see ViInputHandler
+ * @see Terminal
+ */
+class InputHandler
+{
+  public:
+    virtual ~InputHandler() = default;
+    virtual bool sendKeyPressEvent(Key _key, Modifier _modifier) = 0;
+    virtual bool sendCharPressEvent(char32_t _char, Modifier _modifier) = 0;
+};
+
+} // namespace terminal

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -213,7 +213,8 @@ class Line
         {
             Require(ColumnOffset(0) <= column);
             Require(column < ColumnOffset::cast_from(size()));
-            return unbox<size_t>(column) >= trivialBuffer().text.size();
+            return unbox<size_t>(column) >= trivialBuffer().text.size()
+                   || trivialBuffer().text[column.as<size_t>()] == 0x20;
         }
         return inflatedBuffer().at(unbox<size_t>(column)).empty();
     }

--- a/src/terminal/MatchModes.h
+++ b/src/terminal/MatchModes.h
@@ -29,7 +29,8 @@ class MatchModes
         AlternateScreen = 0x01,
         AppCursor = 0x02,
         AppKeypad = 0x04,
-        Select = 0x08,
+        Insert = 0x08, // vi-like insert mode
+        Select = 0x10,
         // future modes
         // ViSearch            = 0x10, // TODO: This mode we want.
     };
@@ -134,6 +135,7 @@ struct formatter<terminal::MatchModes>
         advance(terminal::MatchModes::AppCursor, "AppCursor");
         advance(terminal::MatchModes::AppKeypad, "AppKeypad");
         advance(terminal::MatchModes::AlternateScreen, "AltScreen");
+        advance(terminal::MatchModes::Insert, "Insert");
         advance(terminal::MatchModes::Select, "Select");
         if (s.empty())
             s = "Any";

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -76,6 +76,7 @@ class RenderBufferBuilder
 
     RenderBuffer& output;
     Terminal const& terminal;
+    CellLocation cursorPosition;
 
     bool reverseVideo = terminal.isModeEnabled(terminal::DECMode::ReverseVideo);
     int prevWidth = 0;

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -61,7 +61,10 @@ class ScreenBase: public SequenceHandler
     virtual void fail(std::string const& _message) const = 0;
     [[nodiscard]] virtual bool contains(CellLocation _coord) const noexcept = 0;
     [[nodiscard]] virtual bool isCellEmpty(CellLocation position) const noexcept = 0;
+    [[nodiscard]] virtual bool compareCellTextAt(CellLocation position, char codepoint) const noexcept = 0;
+    [[nodiscard]] virtual bool isLineEmpty(LineOffset line) const noexcept = 0;
     [[nodiscard]] virtual uint8_t cellWithAt(CellLocation position) const noexcept = 0;
+    [[nodiscard]] virtual LineCount historyLineCount() const noexcept = 0;
     [[nodiscard]] virtual HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept = 0;
     [[nodiscard]] virtual std::shared_ptr<HyperlinkInfo const> hyperlinkAt(
         CellLocation pos) const noexcept = 0;
@@ -95,8 +98,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
 
     using StaticDatabase::numericCapability;
     [[nodiscard]] unsigned numericCapability(capabilities::Code _cap) const override;
-
-    [[nodiscard]] LineCount historyLineCount() const noexcept { return grid().historyLineCount(); }
 
     // {{{ SequenceHandler overrides
     void writeText(char32_t _char) override;
@@ -429,10 +430,26 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
         return grid().lineAt(position.line).cellEmptyAt(position.column);
     }
 
+    [[nodiscard]] bool compareCellTextAt(CellLocation position, char codepoint) const noexcept override
+    {
+        return grid()
+            .lineAt(position.line)
+            .inflatedBuffer()
+            .at(position.column.as<size_t>())
+            .compareText(codepoint);
+    }
+
+    [[nodiscard]] bool isLineEmpty(LineOffset line) const noexcept override
+    {
+        return grid().lineAt(line).empty();
+    }
+
     [[nodiscard]] uint8_t cellWithAt(CellLocation position) const noexcept override
     {
         return grid().lineAt(position.line).cellWithAt(position.column);
     }
+
+    [[nodiscard]] LineCount historyLineCount() const noexcept override { return grid().historyLineCount(); }
 
     [[nodiscard]] HyperlinkId hyperlinkIdAt(CellLocation position) const noexcept override
     {

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -368,6 +368,9 @@ bool Terminal::sendCharPressEvent(char32_t _value, Modifier _modifier, Timestamp
     cursorBlinkState_ = 1;
     lastCursorBlink_ = _now;
 
+    if (state_.inputHandler.sendCharPressEvent(_value, _modifier))
+        return true;
+
     // Early exit if KAM is enabled.
     if (isModeEnabled(AnsiMode::KeyboardAction))
         return true;
@@ -441,6 +444,7 @@ bool Terminal::handleMouseSelection(Modifier _modifier, Timestamp _now)
 
 void Terminal::clearSelection()
 {
+    InputLog()("Clearing selection.");
     selection_.reset();
     speedClicks_ = 0;
     breakLoopAndRefreshRenderBuffer();
@@ -479,7 +483,8 @@ bool Terminal::sendMouseMoveEvent(Modifier _modifier,
         setSelector(make_unique<LinearSelection>(selectionHelper_, relativePos));
     }
 
-    if (selectionAvailable() && selector()->state() != Selection::State::Complete)
+    if (selectionAvailable() && selector()->state() != Selection::State::Complete
+        && inputHandler().mode() == ViMode::Insert)
     {
         changed = true;
         selector()->extend(relativePos);

--- a/src/terminal/TerminalState.cpp
+++ b/src/terminal/TerminalState.cpp
@@ -50,7 +50,9 @@ TerminalState::TerminalState(Terminal& _terminal,
     lastCursorPosition {},
     hyperlinks { HyperlinkCache { 1024 } },
     sequencer { _terminal },
-    parser { std::ref(sequencer) }
+    parser { std::ref(sequencer) },
+    viCommands { terminal },
+    inputHandler { viCommands, ViMode::Insert }
 {
 }
 

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -20,9 +20,12 @@
 #include <terminal/Grid.h>
 #include <terminal/Hyperlink.h>
 #include <terminal/InputGenerator.h>
+#include <terminal/InputHandler.h>
 #include <terminal/Parser.h>
 #include <terminal/ScreenEvents.h> // ScreenType
 #include <terminal/Sequencer.h>
+#include <terminal/ViCommands.h>
+#include <terminal/ViInputHandler.h>
 #include <terminal/primitives.h>
 
 #include <unicode/utf8.h>
@@ -188,6 +191,9 @@ struct TerminalState
     uint64_t instructionCounter = 0;
 
     InputGenerator inputGenerator {};
+
+    ViCommands viCommands;
+    ViInputHandler inputHandler;
 
     char32_t precedingGraphicCharacter = {};
     bool terminating = false;

--- a/src/terminal/ViCommands.cpp
+++ b/src/terminal/ViCommands.cpp
@@ -1,0 +1,392 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <terminal/Terminal.h>
+#include <terminal/ViCommands.h>
+#include <terminal/logging.h>
+
+#include <fmt/format.h>
+
+#include <memory>
+
+namespace terminal
+{
+
+using namespace std;
+
+ViCommands::ViCommands(Terminal& theTerminal): terminal { theTerminal }
+{
+}
+
+void ViCommands::modeChanged(ViMode mode)
+{
+    auto _ = crispy::finally { [this, mode]() {
+        lastMode = mode;
+    } };
+
+    InputLog()("mode changed to {}\n", mode);
+
+    auto const selectFrom = terminal.selector() ? terminal.selector()->from() : cursorPosition;
+    auto const selectTo = terminal.selector() ? terminal.selector()->to() : cursorPosition;
+
+    switch (mode)
+    {
+        case ViMode::Insert:
+            // Force re-render as viewport & cursor might have changed.
+            terminal.screenUpdated();
+            terminal.viewport().forceScrollToBottom();
+            break;
+        case ViMode::NormalMotionVisual:
+            //.
+            break;
+        case ViMode::Normal:
+            if (lastMode == ViMode::Insert)
+                cursorPosition = terminal.realCursorPosition();
+            if (terminal.selectionAvailable())
+                terminal.clearSelection();
+            terminal.screenUpdated();
+            break;
+        case ViMode::Visual:
+            terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.selector()->extend(selectTo);
+            terminal.screenUpdated();
+            break;
+        case ViMode::VisualLine:
+            terminal.setSelector(make_unique<FullLineSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.selector()->extend(selectTo);
+            terminal.screenUpdated();
+            break;
+        case ViMode::VisualBlock:
+            terminal.setSelector(make_unique<RectangularSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.selector()->extend(selectTo);
+            terminal.screenUpdated();
+            break;
+    }
+
+    terminal.inputModeChanged(mode);
+}
+
+void ViCommands::reverseSearchCurrentWord()
+{
+    // TODO
+}
+
+void ViCommands::executeYank(ViMotion motion, unsigned count)
+{
+    switch (motion)
+    {
+        case ViMotion::Selection: {
+            assert(terminal.selector());
+            terminal.copyToClipboard(terminal.extractSelectionText());
+            terminal.inputHandler().setMode(ViMode::Normal);
+            break;
+        }
+        default: {
+            auto const [from, to] = translateToCellRange(motion, count);
+            executeYank(from, to);
+        }
+        break;
+    }
+}
+
+void ViCommands::executeYank(CellLocation from, CellLocation to)
+{
+    assert(terminal.inputHandler().mode() == ViMode::Normal);
+    assert(!terminal.selector());
+
+    // TODO: ideally keep that selection for about N msecs,
+    // such that it'll be visually rendered and the user has a feedback of what's
+    // being clipboarded.
+    // Maybe via a event API to inform that a non-visual selection
+    // has happened and that it can now either be instantly destroyed
+    // or delayed (N msecs, configurable),
+    terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), from));
+    terminal.selector()->extend(to);
+    auto const text = terminal.extractSelectionText();
+    terminal.copyToClipboard(text);
+    terminal.inputHandler().setMode(ViMode::NormalMotionVisual);
+    terminal.screenUpdated();
+}
+
+void ViCommands::execute(ViOperator op, ViMotion motion, unsigned count)
+{
+    InputLog()("{}: Executing: {} {} {}\n", terminal.inputHandler().mode(), count, op, motion);
+    switch (op)
+    {
+        case ViOperator::MoveCursor:
+            //.
+            moveCursor(motion, count);
+            break;
+        case ViOperator::Yank:
+            //.
+            executeYank(motion, count);
+            break;
+        case ViOperator::Paste:
+            //.
+            terminal.sendPasteFromClipboard(count);
+            break;
+        case ViOperator::ReverseSearchCurrentWord:
+            // TODO
+            break;
+    }
+    terminal.screenUpdated();
+}
+
+void ViCommands::select(TextObjectScope scope, TextObject textObject)
+{
+    auto const [from, to] = translateToCellRange(scope, textObject);
+    cursorPosition = to;
+    InputLog()("{}: Executing: select {} {} [{} .. {}]\n",
+               terminal.inputHandler().mode(),
+               scope,
+               textObject,
+               from,
+               to);
+    terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), from));
+    terminal.selector()->extend(to);
+    terminal.screenUpdated();
+}
+
+void ViCommands::yank(TextObjectScope scope, TextObject textObject)
+{
+    auto const [from, to] = translateToCellRange(scope, textObject);
+    cursorPosition = from;
+    InputLog()("{}: Executing: yank {} {}\n", terminal.inputHandler().mode(), scope, textObject);
+    executeYank(from, to);
+    terminal.screenUpdated();
+}
+
+CellLocationRange ViCommands::expandMatchingPair(TextObjectScope scope, char left, char right) const noexcept
+{
+    auto a = cursorPosition;
+    auto b = cursorPosition;
+
+    auto const rightMargin = terminal.pageSize().columns.as<ColumnOffset>() - 1;
+    bool const inner = scope == TextObjectScope::Inner;
+
+    while (a.column.value > 0 && !terminal.currentScreen().compareCellTextAt(a, left))
+        --a.column;
+    if (inner && terminal.currentScreen().compareCellTextAt(a, left))
+        ++a.column;
+
+    while (b.column < rightMargin && !terminal.currentScreen().compareCellTextAt(b, right))
+        ++b.column;
+    if (inner && terminal.currentScreen().compareCellTextAt(b, right))
+        --b.column;
+
+    return { a, b };
+}
+
+CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
+                                                   TextObject textObject) const noexcept
+{
+    auto const gridTop = -terminal.currentScreen().historyLineCount().as<LineOffset>();
+    auto const gridBottom = terminal.pageSize().lines.as<LineOffset>() - 1;
+    auto const rightMargin = terminal.pageSize().columns.as<ColumnOffset>() - 1;
+    auto a = cursorPosition;
+    auto b = cursorPosition;
+    switch (textObject)
+    {
+        case TextObject::AngleBrackets: return expandMatchingPair(scope, '<', '>');
+        case TextObject::BackQuotes: return expandMatchingPair(scope, '`', '`');
+        case TextObject::CurlyBrackets: return expandMatchingPair(scope, '{', '}');
+        case TextObject::DoubleQuotes: return expandMatchingPair(scope, '"', '"');
+        case TextObject::Paragraph:
+            while (a.line > gridTop && !terminal.currentScreen().isLineEmpty(a.line - 1))
+                --a.line;
+            while (b.line < gridBottom && !terminal.currentScreen().isLineEmpty(b.line))
+                ++b.line;
+            break;
+        case TextObject::RoundBrackets: return expandMatchingPair(scope, '(', ')');
+        case TextObject::SingleQuotes: return expandMatchingPair(scope, '\'', '\'');
+        case TextObject::SquareBrackets: return expandMatchingPair(scope, '[', ']');
+        case TextObject::Word:
+            while (a.column.value > 0 && !terminal.currentScreen().isCellEmpty({ a.line, a.column - 1 }))
+                --a.column;
+            while (b.column < rightMargin && !terminal.currentScreen().isCellEmpty({ b.line, b.column }))
+                ++b.column;
+            break;
+    }
+    return { a, b };
+}
+
+CellLocationRange ViCommands::translateToCellRange(ViMotion motion, unsigned count) const noexcept
+{
+    switch (motion)
+    {
+        case ViMotion::FullLine:
+            return { cursorPosition - cursorPosition.column,
+                     { cursorPosition.line, terminal.pageSize().columns.as<ColumnOffset>() - 1 } };
+        default:
+            //.
+            return { cursorPosition, translateToCellLocation(motion, count) };
+    }
+}
+
+CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count) const noexcept
+{
+    switch (motion)
+    {
+        case ViMotion::CharLeft: // h
+            return cursorPosition - min(cursorPosition.column, ColumnOffset::cast_from(count));
+        case ViMotion::CharRight: // l
+        {
+            auto const columnsAvailable =
+                terminal.pageSize().columns.as<ColumnOffset>() - cursorPosition.column.as<ColumnOffset>() - 1;
+            return cursorPosition + min(ColumnOffset::cast_from(count), columnsAvailable);
+        }
+        case ViMotion::ScreenColumn: // |
+            return { cursorPosition.line,
+                     min(ColumnOffset::cast_from(count),
+                         terminal.pageSize().columns.as<ColumnOffset>() - 1) };
+        case ViMotion::FileBegin: // gg
+            return { LineOffset::cast_from(-terminal.currentScreen().historyLineCount().as<int>()),
+                     ColumnOffset(0) };
+        case ViMotion::FileEnd: // G
+            return { terminal.pageSize().lines.as<LineOffset>() - 1, cursorPosition.column };
+        case ViMotion::LineBegin: // 0
+            return { cursorPosition.line, ColumnOffset(0) };
+        case ViMotion::LineDown: // j
+            return { min(cursorPosition.line + LineOffset::cast_from(count),
+                         terminal.pageSize().lines.as<LineOffset>() - 1),
+                     cursorPosition.column };
+        case ViMotion::LineEnd: // $
+            return { cursorPosition.line, terminal.pageSize().columns.as<ColumnOffset>() - 1 };
+        case ViMotion::LineUp: // k
+            return { max(cursorPosition.line - LineOffset::cast_from(count),
+                         -terminal.currentScreen().historyLineCount().as<LineOffset>()),
+                     cursorPosition.column };
+        case ViMotion::PageDown:
+            return { min(cursorPosition.line + LineOffset::cast_from(terminal.pageSize().lines / 2),
+                         terminal.pageSize().lines.as<LineOffset>() - 1),
+                     cursorPosition.column };
+        case ViMotion::PageUp:
+            return { max(cursorPosition.line - LineOffset::cast_from(terminal.pageSize().lines / 2),
+                         -terminal.currentScreen().historyLineCount().as<LineOffset>()),
+                     cursorPosition.column };
+            return cursorPosition
+                   - min(cursorPosition.line, LineOffset::cast_from(terminal.pageSize().lines) / 2);
+        case ViMotion::ParagraphBackward: // {
+        {
+            auto const pageTop = -terminal.currentScreen().historyLineCount().as<LineOffset>();
+            auto prev = CellLocation { cursorPosition.line, ColumnOffset(0) };
+            if (prev.line.value > 0)
+                prev.line--;
+            auto current = prev;
+            while (current.line > pageTop
+                   && (!terminal.currentScreen().isLineEmpty(current.line)
+                       || terminal.currentScreen().isLineEmpty(prev.line)))
+            {
+                prev.line = current.line;
+                current.line--;
+            }
+            return current;
+        }
+        case ViMotion::ParagraphForward: // }
+        {
+            auto const pageBottom = terminal.pageSize().lines.as<LineOffset>() - 1;
+            auto prev = CellLocation { cursorPosition.line, ColumnOffset(0) };
+            if (prev.line < pageBottom)
+                prev.line++;
+            auto current = prev;
+            while (current.line < pageBottom
+                   && (!terminal.currentScreen().isLineEmpty(current.line)
+                       || terminal.currentScreen().isLineEmpty(prev.line)))
+            {
+                prev.line = current.line;
+                current.line++;
+            }
+            return current;
+        }
+        case ViMotion::ParenthesisMatching:  // % TODO
+        case ViMotion::SearchResultBackward: // N TODO
+        case ViMotion::SearchResultForward:  // n TODO
+        case ViMotion::WordBackward: {       // b
+            auto prev = cursorPosition;
+            if (prev.column.value > 0)
+                prev.column--;
+            auto current = prev;
+
+            while (current.column.value > 0
+                   && (!terminal.currentScreen().isCellEmpty(current)
+                       || terminal.currentScreen().isCellEmpty(prev)))
+            {
+                prev.column = current.column;
+                current.column--;
+            }
+            if (current.column.value == 0)
+                return current;
+            else
+                return prev;
+        }
+        case ViMotion::WordEndForward: { // e
+            auto const rightMargin = terminal.pageSize().columns.as<ColumnOffset>();
+            auto prev = cursorPosition;
+            if (prev.column + 1 < rightMargin)
+                prev.column++;
+            auto current = prev;
+            while (current.column + 1 < rightMargin
+                   && (!terminal.currentScreen().isCellEmpty(current)
+                       || terminal.currentScreen().isCellEmpty(prev)))
+            {
+                prev.column = current.column;
+                current.column++;
+            }
+            return prev;
+        }
+        case ViMotion::WordForward: { // w
+            auto const rightMargin = terminal.pageSize().columns.as<ColumnOffset>();
+            auto prev = cursorPosition;
+            if (prev.column + 1 < rightMargin)
+                prev.column++;
+            auto current = prev;
+            while (current.column + 1 < rightMargin
+                   && (terminal.currentScreen().isCellEmpty(current)
+                       || !terminal.currentScreen().isCellEmpty(prev)))
+            {
+                prev = current;
+                current.column++;
+            }
+            return current;
+        }
+        case ViMotion::Explicit:  // <special for explicit operations>
+        case ViMotion::Selection: // <special for visual modes>
+        case ViMotion::FullLine:  // <special for full-line operations>
+            return cursorPosition;
+    }
+    crispy::unreachable();
+}
+
+void ViCommands::moveCursor(ViMotion motion, unsigned count)
+{
+    Require(terminal.inputHandler().mode() != ViMode::Insert);
+
+    cursorPosition = translateToCellLocation(motion, count);
+    terminal.viewport().makeVisible(cursorPosition.line);
+    InputLog()("Move cursor: {} to {}\n", motion, cursorPosition);
+
+    switch (terminal.inputHandler().mode())
+    {
+        case ViMode::NormalMotionVisual:
+        case ViMode::Normal:
+        case ViMode::Insert: break;
+        case ViMode::Visual:
+        case ViMode::VisualLine:
+        case ViMode::VisualBlock:
+            if (terminal.selector())
+                terminal.selector()->extend(cursorPosition);
+            break;
+    }
+}
+
+} // namespace terminal

--- a/src/terminal/ViCommands.h
+++ b/src/terminal/ViCommands.h
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <terminal/ViInputHandler.h>
+
+#include <utility>
+
+namespace terminal
+{
+
+class Terminal;
+
+/**
+ * Implements the Vi commands for a Terminal as emitted by ViInputHandler.
+ */
+class ViCommands: public ViInputHandler::Executor
+{
+  public:
+    explicit ViCommands(Terminal& theTerminal);
+
+    void modeChanged(ViMode mode) override;
+    void reverseSearchCurrentWord() override;
+    void execute(ViOperator op, ViMotion motion, unsigned count) override;
+    void yank(TextObjectScope scope, TextObject textObject) override;
+    void select(TextObjectScope scope, TextObject textObject) override;
+
+    [[nodiscard]] CellLocation translateToCellLocation(ViMotion motion, unsigned count) const noexcept;
+    [[nodiscard]] CellLocationRange translateToCellRange(ViMotion motion, unsigned count) const noexcept;
+    [[nodiscard]] CellLocationRange translateToCellRange(TextObjectScope scope,
+                                                         TextObject textObject) const noexcept;
+    [[nodiscard]] CellLocationRange expandMatchingPair(TextObjectScope scope,
+                                                       char lhs,
+                                                       char rhs) const noexcept;
+    void executeYank(ViMotion motion, unsigned count);
+    void executeYank(CellLocation from, CellLocation to);
+
+    Terminal& terminal;
+
+    // Cursor offset into the grid.
+    CellLocation cursorPosition {};
+
+  private:
+    ViMode lastMode = ViMode::Insert;
+    void moveCursor(ViMotion motion, unsigned count);
+};
+
+} // namespace terminal

--- a/src/terminal/ViInputHandler.cpp
+++ b/src/terminal/ViInputHandler.cpp
@@ -1,0 +1,306 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <terminal/ViInputHandler.h>
+#include <terminal/logging.h>
+
+#include <crispy/assert.h>
+#include <crispy/utils.h>
+
+using std::nullopt;
+using std::optional;
+
+namespace terminal
+{
+
+// Possible future improvements (aka. nice TODO):
+//
+// motion f{char}
+// motion t{char}
+// motion %
+// motion to jump marks up/down
+
+optional<TextObject> charToTextObject(char32_t ch) noexcept
+{
+    switch (ch)
+    {
+        case '"': return TextObject::DoubleQuotes;
+        case '(': return TextObject::RoundBrackets;
+        case '<': return TextObject::AngleBrackets;
+        case '[': return TextObject::SquareBrackets;
+        case '\'': return TextObject::SingleQuotes;
+        case '`': return TextObject::BackQuotes;
+        case 'w': return TextObject::Word;
+        case '{': return TextObject::CurlyBrackets;
+        default: return nullopt;
+    }
+}
+
+optional<ViMotion> charToMotion(char ch) noexcept
+{
+    switch (ch)
+    {
+        case 'j': return ViMotion::LineDown;
+        case 'k': return ViMotion::LineUp;
+        case 'h': return ViMotion::CharLeft;
+        case 'l': return ViMotion::CharRight;
+        case '0': return ViMotion::LineBegin;
+        case '$': return ViMotion::LineEnd;
+        case 'g': return ViMotion::FileBegin;
+        case 'G': return ViMotion::FileEnd;
+        case 'b': return ViMotion::WordBackward;
+        case 'e': return ViMotion::WordEndForward;
+        case 'w': return ViMotion::WordForward;
+        case 'N': return ViMotion::SearchResultBackward;
+        case 'n': return ViMotion::SearchResultForward;
+        case '|': return ViMotion::ScreenColumn;
+        case '{': return ViMotion::ParagraphBackward;
+        case '}': return ViMotion::ParagraphForward;
+        case '%': return ViMotion::ParenthesisMatching;
+        default: return nullopt;
+    }
+}
+
+void ViInputHandler::setMode(ViMode theMode)
+{
+    if (viMode == theMode)
+        return;
+
+    viMode = theMode;
+    count = 0;
+    pendingOperator = nullopt;
+    pendingTextObjectScope = nullopt;
+
+    executor.modeChanged(theMode);
+}
+
+bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
+{
+    crispy::ignore_unused(key, modifier);
+    return false;
+}
+
+bool ViInputHandler::sendCharPressEvent(char32_t ch, Modifier modifier)
+{
+    // clang-format off
+    switch (viMode)
+    {
+        case ViMode::Insert:
+            return false;
+        case ViMode::NormalMotionVisual:
+            setMode(ViMode::Normal);
+            [[fallthrough]];
+        case ViMode::Normal:
+            handleNormalMode(ch, modifier);
+            return true;
+        case ViMode::Visual:
+        case ViMode::VisualLine:
+        case ViMode::VisualBlock:
+            handleVisualMode(ch, modifier);
+            return true;
+    }
+    // clang-format on
+
+    crispy::unreachable();
+}
+
+bool ViInputHandler::parseCount(char32_t ch, Modifier modifier)
+{
+    if (!modifier.none())
+        return false;
+
+    switch (ch)
+    {
+        case '0':
+            if (!count)
+                break;
+            [[fallthrough]];
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            //.
+            count = count * 10 + (ch - '0');
+            return true;
+    }
+    return false;
+}
+
+void ViInputHandler::yank(TextObjectScope scope, TextObject textObject)
+{
+    executor.yank(scope, textObject);
+
+    count = 0;
+    pendingOperator.reset();
+    pendingTextObjectScope.reset();
+}
+
+void ViInputHandler::select(TextObjectScope scope, TextObject textObject)
+{
+    executor.select(scope, textObject);
+
+    count = 0;
+    pendingOperator.reset();
+    pendingTextObjectScope.reset();
+}
+
+void ViInputHandler::execute(ViOperator op, ViMotion motion)
+{
+    executor.execute(op, motion, count ? count : 1);
+
+    count = 0;
+    pendingOperator.reset();
+    pendingTextObjectScope.reset();
+}
+
+bool ViInputHandler::handleVisualMode(char32_t ch, Modifier modifier)
+{
+    Require(viMode == ViMode::Visual || viMode == ViMode::VisualLine || viMode == ViMode::VisualBlock);
+
+    if (parseCount(ch, modifier))
+        return true;
+
+    if (pendingTextObjectScope)
+    {
+        if (optional<TextObject> const textObject = charToTextObject(ch))
+        {
+            select(*pendingTextObjectScope, *textObject);
+            return true;
+        }
+    }
+
+    if (auto const motion = charToMotion(static_cast<char>(ch)))
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), motion.value());
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'D')
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), ViMotion::PageDown);
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'U')
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), ViMotion::PageUp);
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'V')
+    {
+        setMode(ViMode::VisualBlock);
+        return true;
+    }
+
+    switch (ch)
+    {
+        case 27: setMode(ViMode::Normal); return true; // Escape key.
+        case '#': executor.reverseSearchCurrentWord(); return true;
+        case 'V': setMode(viMode != ViMode::VisualLine ? ViMode::VisualLine : ViMode::Normal); return true;
+        case 'Y': execute(ViOperator::Yank, ViMotion::FullLine); return true;
+        case 'a': pendingTextObjectScope = TextObjectScope::A; return true;
+        case 'i': pendingTextObjectScope = TextObjectScope::Inner; return true;
+        case 'v': setMode(viMode != ViMode::Visual ? ViMode::Visual : ViMode::Normal); return true;
+        case 'y': execute(ViOperator::Yank, ViMotion::Selection); return true;
+        default: return true;
+    }
+}
+
+bool ViInputHandler::parseTextObject(char32_t ch, Modifier modifier)
+{
+    if (modifier.any())
+        return false;
+
+    if (!(pendingOperator && *pendingOperator == ViOperator::Yank))
+        return false;
+
+    switch (ch)
+    {
+        case 'i': pendingTextObjectScope = TextObjectScope::Inner; return true;
+        case 'a': pendingTextObjectScope = TextObjectScope::A; return true;
+        default: break;
+    }
+
+    if (!pendingTextObjectScope)
+        return false;
+
+    if (optional<TextObject> const textObject = charToTextObject(ch))
+    {
+        yank(*pendingTextObjectScope, *textObject);
+        return true;
+    }
+
+    return false;
+}
+
+bool ViInputHandler::handleNormalMode(char32_t ch, Modifier modifier)
+{
+    Require(viMode == ViMode::Normal);
+
+    if (parseCount(ch, modifier))
+        return true;
+
+    if (parseTextObject(ch, modifier))
+        return true;
+
+    if (auto const motion = charToMotion(static_cast<char>(ch)))
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), motion.value());
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'D')
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), ViMotion::PageDown);
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'U')
+    {
+        execute(pendingOperator.value_or(ViOperator::MoveCursor), ViMotion::PageUp);
+        return true;
+    }
+
+    if (modifier == Modifier::Control && ch == 'V')
+    {
+        setMode(ViMode::VisualBlock);
+        return true;
+    }
+
+    switch (ch)
+    {
+        case '#': executor.reverseSearchCurrentWord(); return true;
+        case 'V': setMode(ViMode::VisualLine); return true;
+        case 'i': setMode(ViMode::Insert); return true;
+        case 'v': setMode(ViMode::Visual); return true;
+        case 'p': execute(ViOperator::Paste, ViMotion::Explicit); return true;
+        case 'y':
+            if (!pendingOperator.has_value())
+                pendingOperator = ViOperator::Yank;
+            else if (pendingOperator == ViOperator::Yank)
+                execute(ViOperator::Yank, ViMotion::FullLine);
+            else
+                pendingOperator.reset(); // is this good?
+            return true;
+    }
+
+    return false;
+}
+
+} // namespace terminal

--- a/src/terminal/ViInputHandler.h
+++ b/src/terminal/ViInputHandler.h
@@ -1,0 +1,338 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <terminal/InputHandler.h>
+#include <terminal/Selector.h>
+#include <terminal/primitives.h>
+
+#include <crispy/logstore.h>
+
+namespace terminal
+{
+
+/*
+ * ViInput emulates vi very basic in order to support
+ * -------------------------
+ *
+ * - selecting ranges/lines of text
+ * - simple and composed movements
+ *
+ * FSM could look like this:
+ * -------------------------
+ *
+ * Start      := Count? (Operator | Motion)
+ * Count      := [1-9][0-9]*
+ * ModeSwitch := i      ; insert mode
+ *             | v      ; visual mode
+ *             | V      ; visual line mode
+ *             | <C-V>  ; visual block mode
+ * Operator   := y Motion?
+ * Motion     := [jkhl] ; move cursor down/up/left/right
+ *             | v      ; enter/leave select mode
+ *             | V      ; enter/leave line select mode
+ *             | Y      ; yank line
+ *             | p      ; leave select mode and paste selection/yanked to stdin
+ *             | #      ; reverse search for word below cursor
+ *             | w      ; move cursor to next word
+ *             | b      ; move cursor to prev word
+ *             | e      ; move cursor to end of current word
+ *             | \^     ; move cursor to line's first non-space character.
+ *             | 0      ; move cursor to BOL
+ *             | \$     ; move cursor to EOL
+ *             | gg     ; move cursor to BOF (begin of file)
+ *             | G      ; move cursor to EOF
+ *             | n      ; move cursor to next word that is currently being searched
+ *
+ * Requirement Examples:
+ * ---------------------
+ *
+ *   3{        move cursor 3 blocks up
+ *   5j        move cursor 5 lines down
+ *   viw       visual select in word
+ *   ya"       yank around "
+ */
+
+enum class ViMotion
+{
+    Explicit,             // <special one for explicit operators>
+    Selection,            // <special one for v_ modes>
+    FullLine,             // <special one for full-line motions>
+    CharLeft,             // h
+    CharRight,            // l
+    ScreenColumn,         // |
+    FileBegin,            // gg
+    FileEnd,              // G
+    LineBegin,            // 0
+    LineDown,             // j
+    LineEnd,              // $
+    LineUp,               // k
+    PageDown,             // <C-D>
+    PageUp,               // <C-U>
+    ParagraphBackward,    // {
+    ParagraphForward,     // }
+    ParenthesisMatching,  // %
+    SearchResultBackward, // N
+    SearchResultForward,  // n
+    WordBackward,         // b
+    WordEndForward,       // e
+    WordForward,          // w
+};
+
+enum class ViOperator
+{
+    MoveCursor,
+    Yank = 'y',
+    Paste = 'p',
+    ReverseSearchCurrentWord = '#',
+};
+
+enum class ViMode
+{
+    /// Vi-like normal-mode.
+    Normal, // <Escape>, <C-[>
+
+    /// Vi-like insert/terminal mode.
+    Insert, // i
+
+    /// Vi-like visual select mode.
+    Visual, // v
+
+    /// Vi-like visual line-select mode.
+    VisualLine, // V
+
+    /// Vi-like visual block-select mode.
+    VisualBlock, // <C-V>
+
+    /// Acts exactly like normal mode, except that visual selection active and visible.
+    NormalMotionVisual // special one for yanks in Normal mode.
+};
+
+enum class TextObject
+{
+    AngleBrackets = '<',  // i<  a<
+    CurlyBrackets = '{',  // i{  a{
+    DoubleQuotes = '"',   // i"  a"
+    Paragraph = 'p',      // ip  ap
+    RoundBrackets = '(',  // i(  a(
+    SingleQuotes = '\'',  // i'  a'
+    BackQuotes = '`',     // i`  a`
+    SquareBrackets = '[', // i[  a[
+    Word = 'w',           // iw  aw
+};
+
+enum class TextObjectScope
+{
+    Inner = 'i',
+    A = 'a'
+};
+
+using CellLocationRange = std::pair<CellLocation, CellLocation>;
+
+/**
+ * ViInputHandler provides Vi-input handling.
+ */
+class ViInputHandler: public InputHandler
+{
+  public:
+    class Executor
+    {
+      public:
+        virtual ~Executor() = default;
+
+        virtual void execute(ViOperator op, ViMotion motion, unsigned count) = 0;
+        virtual void yank(TextObjectScope scope, TextObject textObject) = 0;
+        virtual void select(TextObjectScope scope, TextObject textObject) = 0;
+
+        virtual void modeChanged(ViMode mode) = 0;
+
+        // Starts searching for the word under the cursor position in reverse order.
+        // This is like pressing # in Vi.
+        virtual void reverseSearchCurrentWord() = 0;
+    };
+
+    ViInputHandler(Executor& theExecutor, ViMode initialMode):
+        viMode { initialMode }, executor { theExecutor }
+    {
+    }
+
+    bool sendKeyPressEvent(Key key, Modifier modifier) override;
+    bool sendCharPressEvent(char32_t ch, Modifier modifier) override;
+
+    void setMode(ViMode mode);
+    [[nodiscard]] ViMode mode() const noexcept { return viMode; }
+
+    [[nodiscard]] CellLocationRange translateToCellRange(TextObjectScope scope,
+                                                         TextObject textObject) const noexcept;
+
+  private:
+    bool parseCount(char32_t ch, Modifier modifier);
+    bool parseTextObject(char32_t ch, Modifier modifier);
+    bool handleNormalMode(char32_t ch, Modifier modifier);
+    bool handleVisualMode(char32_t ch, Modifier modifier);
+    void execute(ViOperator op, ViMotion motion);
+    void yank(TextObjectScope scope, TextObject textObject);
+    void select(TextObjectScope scope, TextObject textObject);
+
+    ViMode viMode = ViMode::Normal;
+    unsigned count = 0;
+    std::optional<ViOperator> pendingOperator = std::nullopt;
+    std::optional<TextObjectScope> pendingTextObjectScope = std::nullopt;
+    Executor& executor;
+};
+
+} // namespace terminal
+
+namespace fmt // {{{
+{
+template <>
+struct formatter<terminal::ViMode>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::ViMode mode, FormatContext& ctx)
+    {
+        using terminal::ViMode;
+        switch (mode)
+        {
+            case ViMode::Normal: return format_to(ctx.out(), "Normal");
+            case ViMode::Insert: return format_to(ctx.out(), "Insert");
+            case ViMode::Visual: return format_to(ctx.out(), "Visual");
+            case ViMode::VisualLine: return format_to(ctx.out(), "VisualLine");
+            case ViMode::VisualBlock: return format_to(ctx.out(), "VisualBlock");
+            case ViMode::NormalMotionVisual: return format_to(ctx.out(), "NormalMotionVisual");
+        }
+        return format_to(ctx.out(), "({})", static_cast<unsigned>(mode));
+    }
+};
+
+template <>
+struct formatter<terminal::TextObjectScope>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::TextObjectScope scope, FormatContext& ctx)
+    {
+        using TextObjectScope = terminal::TextObjectScope;
+        switch (scope)
+        {
+            case TextObjectScope::Inner: return format_to(ctx.out(), "inner");
+            case TextObjectScope::A: return format_to(ctx.out(), "a");
+        }
+        return format_to(ctx.out(), "({})", static_cast<unsigned>(scope));
+    }
+};
+
+template <>
+struct formatter<terminal::TextObject>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::TextObject value, FormatContext& ctx)
+    {
+        using terminal::TextObject;
+        switch (value)
+        {
+            case TextObject::AngleBrackets: return format_to(ctx.out(), "AngleBrackets");
+            case TextObject::BackQuotes: return format_to(ctx.out(), "BackQuotes");
+            case TextObject::CurlyBrackets: return format_to(ctx.out(), "CurlyBrackets");
+            case TextObject::DoubleQuotes: return format_to(ctx.out(), "DoubleQuotes");
+            case TextObject::Paragraph: return format_to(ctx.out(), "Paragraph");
+            case TextObject::RoundBrackets: return format_to(ctx.out(), "RoundBrackets");
+            case TextObject::SingleQuotes: return format_to(ctx.out(), "SingleQuotes");
+            case TextObject::SquareBrackets: return format_to(ctx.out(), "SquareBrackets");
+            case TextObject::Word: return format_to(ctx.out(), "Word");
+        }
+        return format_to(ctx.out(), "({})", static_cast<unsigned>(value));
+    }
+};
+template <>
+struct formatter<terminal::ViOperator>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::ViOperator op, FormatContext& ctx)
+    {
+        using terminal::ViOperator;
+        switch (op)
+        {
+            case ViOperator::MoveCursor: return format_to(ctx.out(), "MoveCursor");
+            case ViOperator::Yank: return format_to(ctx.out(), "Yank");
+            case ViOperator::Paste: return format_to(ctx.out(), "Paste");
+            case ViOperator::ReverseSearchCurrentWord:
+                return format_to(ctx.out(), "ReverseSearchCurrentWord");
+        }
+        return format_to(ctx.out(), "({})", static_cast<unsigned>(op));
+    }
+};
+
+template <>
+struct formatter<terminal::ViMotion>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::ViMotion motion, FormatContext& ctx)
+    {
+        using terminal::ViMotion;
+        switch (motion)
+        {
+            case ViMotion::Explicit: return format_to(ctx.out(), "Explicit");
+            case ViMotion::Selection: return format_to(ctx.out(), "Selection");
+            case ViMotion::FullLine: return format_to(ctx.out(), "FullLine");
+            case ViMotion::CharLeft: return format_to(ctx.out(), "CharLeft");
+            case ViMotion::CharRight: return format_to(ctx.out(), "CharRight");
+            case ViMotion::ScreenColumn: return format_to(ctx.out(), "ScreenColumn");
+            case ViMotion::FileBegin: return format_to(ctx.out(), "FileBegin");
+            case ViMotion::FileEnd: return format_to(ctx.out(), "FileEnd");
+            case ViMotion::LineBegin: return format_to(ctx.out(), "LineBegin");
+            case ViMotion::LineDown: return format_to(ctx.out(), "LineDown");
+            case ViMotion::LineEnd: return format_to(ctx.out(), "LineEnd");
+            case ViMotion::LineUp: return format_to(ctx.out(), "LineUp");
+            case ViMotion::PageDown: return format_to(ctx.out(), "PageDown");
+            case ViMotion::PageUp: return format_to(ctx.out(), "PageUp");
+            case ViMotion::ParagraphBackward: return format_to(ctx.out(), "ParagraphBackward");
+            case ViMotion::ParagraphForward: return format_to(ctx.out(), "ParagraphForward");
+            case ViMotion::ParenthesisMatching: return format_to(ctx.out(), "ParenthesisMatching");
+            case ViMotion::SearchResultBackward: return format_to(ctx.out(), "SearchResultBackward");
+            case ViMotion::SearchResultForward: return format_to(ctx.out(), "SearchResultForward");
+            case ViMotion::WordBackward: return format_to(ctx.out(), "WordBackward");
+            case ViMotion::WordEndForward: return format_to(ctx.out(), "WordEndForward");
+            case ViMotion::WordForward: return format_to(ctx.out(), "WordForward");
+        }
+        return format_to(ctx.out(), "({})", static_cast<unsigned>(motion));
+    }
+};
+
+} // namespace fmt
+// }}}

--- a/src/terminal/Viewport.cpp
+++ b/src/terminal/Viewport.cpp
@@ -62,6 +62,22 @@ bool Viewport::forceScrollToBottom()
     return true;
 }
 
+bool Viewport::makeVisible(LineOffset lineOffset)
+{
+    auto const viewportTop = -scrollOffset_.as<LineOffset>();
+    auto const viewportBottom = boxed_cast<LineOffset>(screenLineCount() - 1) - scrollOffset_.as<int>();
+
+    // Is the line above the viewport?
+    if (!(viewportTop < lineOffset))
+        return scrollUp(LineCount::cast_from(viewportTop.as<int>() - lineOffset.as<int>()));
+
+    // Is the line below the viewport?
+    if (!(lineOffset < viewportBottom))
+        return scrollDown(LineCount::cast_from(lineOffset.as<int>() - viewportBottom.as<int>()));
+
+    return false;
+}
+
 bool Viewport::scrollTo(ScrollOffset _offset)
 {
     if (scrollingDisabled())

--- a/src/terminal/Viewport.h
+++ b/src/terminal/Viewport.h
@@ -66,6 +66,12 @@ class Viewport
     bool scrollMarkUp();
     bool scrollMarkDown();
 
+    /// Ensures given line is visible by optionally scrolling the
+    /// screen's viewport up or down in order to make that line visible.
+    ///
+    /// If the line is already visible, no scrolling is applied.
+    bool makeVisible(LineOffset line);
+
     /// Translates a screen coordinate to a Grid-coordinate by applying
     /// the scroll-offset to it.
     constexpr CellLocation translateScreenToGridCoordinate(CellLocation p) const noexcept

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -191,9 +191,19 @@ constexpr CellLocation operator+(CellLocation c, LineOffset y) noexcept
     return CellLocation { c.line + y, c.column };
 }
 
+constexpr CellLocation operator-(CellLocation c, LineOffset y) noexcept
+{
+    return CellLocation { c.line - y, c.column };
+}
+
 constexpr CellLocation operator+(CellLocation c, ColumnOffset x) noexcept
 {
     return CellLocation { c.line, c.column + x };
+}
+
+constexpr CellLocation operator-(CellLocation c, ColumnOffset x) noexcept
+{
+    return CellLocation { c.line, c.column - x };
 }
 
 // }}}


### PR DESCRIPTION
Implements #282.

I think i'll (have to) address the remaining events mentioned in #641.


### checklist

- [x] way to enter the mode
- [x] ability to move the vi-mode cursor around with <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd>, <kbd>l</kbd>
- [x] paragraph wise up/down (<kbd>{</kbd> and <kbd>}</kbd>)
- [x] also be able to support attacking commands, such as `5k`
- [x] enter visual selection mode (and then support vim motions to block/line/char select the grid cells. <kbd>v</kbd> with/without mods)
- [x] yank the selection into clipboard or have it straight pasted back into stdin (or both)
- [x] exit visual selection mode (<kbd>V</kbd>)
- [x] exit vi-search mode (usually via <kbd>Esc</kbd>`)
- [x] visual motion/yank feedback on commands like `yy`
- [x] config: cursor shape per input mode.
- [x] config: ability to filter keybinds by new Vi modes to avoid shortcut conflicts.
- [x] auto-scroll if cursor gets out of viewport.
- [x] ensure mouse-based selection doesn't interfere AND still works (see #641)
- [x] `{operator}i{motion}` and `{operator}a{motion}` where `{motion}` describes a boundary to the left and right and `{operator}` is at least either `y` for yank or `v` for switching to visual mode and directly start selecting using the given motion:
  - [x] `w` for word boundary
  - [x] `"` for double quoted string
  - [x] `'` for single quoted string
  - [x] `<` for angle bracket enclosed string
  - [x] `[` embedded between `[` and `]`
  - [x] `(` embedded between `(` and `)`
  - [x] `{` embedded between `{` and `}`
  - [x] ensure this isn't just working for y(ank) but also for v(isual).
- [x] but also page-wise up/down (<kbd>Ctrl</kbd>+<kbd>d</kbd> and <kbd>Ctrl</kbd>+<kbd>u</kbd>)
- [ ] do not auto-scroll to bottom on screen-update or keyboard if non-insert mode is active
- [ ] config: cursor backgroud/text color per input mode.
- [ ] `'{count}k` motion mark up (count defaults to 1)
- [ ] `'{count}j` motion mark down (count defaults to 1)