### PR TITLE
customizable dim (faint) colors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 - Adds Vi-like input modes for improved selection and copy'n'paste experience.
 - Adds contour executable to search path for spawned shell process on OS/X and Windows.
+- Adds customizability to dim colors (#664).
+- Adds the profile configuration option: `draw_bold_text_with_bright_colors`.
 - Fixes `CSI K` accidentally removing line flags, e.g. line marks (#658).
 - Fixes wrong-spacing rendering bug on some lines.
 - Fixes assertion on font resize when a (Sixel) image is currently being rendered (#642).
@@ -10,6 +12,7 @@
 - Fixes selection being wrongly rendered when viewport is scrolled (#641).
 - Fixes full-line selection not properly injecting linefeeds between the lines.
 - Changes behaviour of full-line selection to include a trailing linefeed for the last line (#641).
+- Changes behaviour of bold text to by rendered using normal colors by default (was forced to bright before, and is now configurable via `draw_bold_text_with_bright_colors`).
 
 ### 0.3.0 (2022-04-18)
 

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -169,6 +169,7 @@ struct TerminalProfile
         Permission changeFont = Permission::Ask;
     } permissions;
 
+    bool drawBoldTextWithBrightColors = false;
     terminal::ColorPalette colors {};
 
     struct

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -309,6 +309,8 @@ profiles:
             # Defaults to "emoji".
             emoji: "emoji"
 
+        bold_is_bright: false
+
         # Terminal cursor display configuration
         cursor:
             # Supported shapes are:
@@ -322,6 +324,7 @@ profiles:
             blinking: false
             # Blinking interval (in milliseconds) to use when cursor is blinking.
             blinking_interval: 500
+
         # vi-like normal-mode specific settings.
         # Note, currently only the cursor can be customized.
         normal_mode:
@@ -329,6 +332,7 @@ profiles:
                 shape: block
                 blinking: false
                 blinking_interval: 500
+
         # vi-like visual/visual-line/visual-block mode specific settings.
         # Note, currently only the cursor can be customized.
         visual_mode:
@@ -336,6 +340,7 @@ profiles:
                 shape: block
                 blinking: false
                 blinking_interval: 500
+
         # Background configuration
         background:
             # Background opacity to use. A value of 1.0 means fully opaque whereas 0.0 means fully
@@ -343,8 +348,14 @@ profiles:
             opacity: 1.0
             # Some platforms can blur the transparent background (currently only Windows 10 is supported).
             blur: false
+
         # Specifies a colorscheme to use (alternatively the colors can be inlined).
         colors: "default"
+
+        # If true, bold text is also using bright colors as well.
+        #
+        # Default: false
+        draw_bold_text_with_bright_colors: false
 
         # Hyperlinks (via OSC-8) can be stylized and colorized on hover.
         hyperlink_decoration:
@@ -414,6 +425,16 @@ color_schemes:
 
         # Normal colors
         normal:
+            black:   '#1d1f21'
+            red:     '#cc342b'
+            green:   '#198844'
+            yellow:  '#fba922'
+            blue:    '#3971ed'
+            magenta: '#a36ac7'
+            cyan:    '#3971ed'
+            white:   '#c5c8c6'
+        # Dim (faint) colors, if not set, they're automatically computed based on normal colors.
+        dim:
             black:   '#1d1f21'
             red:     '#cc342b'
             green:   '#198844'

--- a/src/terminal/ColorPalette.cpp
+++ b/src/terminal/ColorPalette.cpp
@@ -56,26 +56,34 @@ void ImageData::updateHash() noexcept
         scanLine += pitch;
     }
     hash = hashValue;
-    // clang-format off
+    // clang-format on
 }
 
-RGBColor apply(ColorPalette const& _profile, Color _color, ColorTarget _target, bool _bright) noexcept
+RGBColor apply(ColorPalette const& _profile, Color _color, ColorTarget _target, ColorMode mode) noexcept
 {
+    // clang-format off
     switch (_color.type())
     {
-    case ColorType::RGB: return _color.rgb();
-    case ColorType::Indexed: {
-        auto const index = static_cast<size_t>(_color.index());
-        if (_bright && index < 8)
-            return _profile.brightColor(index);
-        else
-            return _profile.indexedColor(index);
-        break;
+        case ColorType::RGB:
+            return _color.rgb();
+        case ColorType::Indexed:
+        {
+            auto const index = static_cast<size_t>(_color.index());
+            if (mode == ColorMode::Bright && index < 8)
+                return _profile.brightColor(index);
+            else if (mode == ColorMode::Dimmed && index < 8)
+                return _profile.dimColor(index);
+            else
+                return _profile.indexedColor(index);
+            break;
+        }
+        case ColorType::Bright:
+            return _profile.brightColor(static_cast<size_t>(_color.index()));
+        case ColorType::Undefined:
+        case ColorType::Default:
+            break;
     }
-    case ColorType::Bright: return _profile.brightColor(static_cast<size_t>(_color.index()));
-    case ColorType::Undefined:
-    case ColorType::Default: break;
-    }
+    // clang-format on
     return _target == ColorTarget::Foreground ? _profile.defaultForeground : _profile.defaultBackground;
 }
 

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -371,7 +371,7 @@ struct formatter<terminal::LineFlags>
                 s += mapping.second;
             }
         }
-        return format_to(ctx.out(), s);
+        return format_to(ctx.out(), "{}", s);
     }
 };
 } // namespace fmt


### PR DESCRIPTION
Fixes #664

Also adds profile config option: `draw_bold_text_with_bright_colors` (default false).

Prior to this PR, bold text was always rendered with bright colors additionally to using the bold font face. Now this is configurable (defaulting to false, however).