### PR TITLE
[terminal] VTWriter: reliably write out RGB colors and indexed colors.

### DIFF
--- a/src/terminal/VTWriter.cpp
+++ b/src/terminal/VTWriter.cpp
@@ -85,6 +85,18 @@ string VTWriter::sgrFlush(vector<unsigned> const& sgr)
     return fmt::format("\033[{}m", params);
 }
 
+void VTWriter::sgrAddExplicit(unsigned n)
+{
+    if (n == 0)
+    {
+        currentForegroundColor_ = DefaultColor();
+        currentBackgroundColor_ = DefaultColor();
+        currentUnderlineColor_ = DefaultColor();
+    }
+
+    sgr_.push_back(n);
+}
+
 void VTWriter::sgrAdd(unsigned n)
 {
     if (n == 0)
@@ -100,7 +112,7 @@ void VTWriter::sgrAdd(unsigned n)
         if (sgr_.empty() || sgr_.back() != n)
             sgr_.push_back(n);
 
-        if (sgr_.size() == 16)
+        if (sgr_.size() == MaxParameterCount)
         {
             sgrFlush();
         }
@@ -134,22 +146,18 @@ void VTWriter::setForegroundColor(Color _color)
             if (static_cast<unsigned>(_color.index()) < 8)
                 sgrAdd(30 + static_cast<unsigned>(_color.index()));
             else
-            {
-                sgrAdd(38);
-                sgrAdd(5);
-                sgrAdd(static_cast<unsigned>(_color.index()));
-            }
+                sgrAdd(38, 5, static_cast<unsigned>(_color.index()));
             break;
         case ColorType::Bright:
             //.
             sgrAdd(90 + static_cast<unsigned>(getBrightColor(_color)));
             break;
         case ColorType::RGB:
-            sgrAdd(38);
-            sgrAdd(2);
-            sgrAdd(static_cast<unsigned>(_color.rgb().red));
-            sgrAdd(static_cast<unsigned>(_color.rgb().green));
-            sgrAdd(static_cast<unsigned>(_color.rgb().blue));
+            // clang-format off
+            sgrAdd(38, 2, static_cast<unsigned>(_color.rgb().red),
+                          static_cast<unsigned>(_color.rgb().green),
+                          static_cast<unsigned>(_color.rgb().blue));
+            // clang-format on
             break;
         case ColorType::Undefined: break;
     }

--- a/src/terminal/VTWriter.h
+++ b/src/terminal/VTWriter.h
@@ -35,6 +35,8 @@ class VTWriter
   public:
     using Writer = std::function<void(char const*, size_t)>;
 
+    static constexpr inline auto MaxParameterCount = 16;
+
     explicit VTWriter(Writer writer);
     explicit VTWriter(std::ostream& output);
     explicit VTWriter(std::vector<char>& output);
@@ -57,6 +59,18 @@ class VTWriter
     void sgrAdd(GraphicsRendition m);
     void setForegroundColor(Color color);
     void setBackgroundColor(Color color);
+
+    void sgrAddExplicit(unsigned n);
+
+    template <typename... Args>
+    void sgrAdd(unsigned n, Args... values)
+    {
+        if (sgr_.size() + sizeof...(values) > MaxParameterCount)
+            sgrFlush();
+
+        sgrAddExplicit(n);
+        (sgrAddExplicit(static_cast<unsigned>(values)), ...);
+    }
 
   private:
     Writer writer_;


### PR DESCRIPTION
Addresses an issue mentioned in #651.