### PR TITLE
[terminal] Fixes `XTSMGRAPHICS` when querying sixel image limits, to be capped at terminal viewport dimensions (#656).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - Fixes scrolling in alt-screen.
 - Fixes VT sequence for setting indexed color from palette.
+- Fixes `XTSMGRAPHICS` when querying sixel image limits, to be capped at terminal viewport dimensions (#656).
 - Implements UTF-8 encoded mouse transport (`CSI ? 1005 h`)
 - Improved vi-like input modes.
   - Fixed the text cursor not being visible during selection.

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1654,13 +1654,11 @@ void Screen<Cell, TheScreenType>::requestPixelSize(RequestPixelSize _area)
     switch (_area)
     {
         case RequestPixelSize::WindowArea: [[fallthrough]]; // TODO
-        case RequestPixelSize::TextArea:
+        case RequestPixelSize::TextArea: {
             // Result is CSI  4 ;  height ;  width t
-            _terminal.reply(
-                "\033[4;{};{}t",
-                unbox<unsigned>(_state.cellPixelSize.height) * unbox<unsigned>(_state.pageSize.lines),
-                unbox<unsigned>(_state.cellPixelSize.width) * unbox<unsigned>(_state.pageSize.columns));
+            _terminal.reply("\033[4;{};{}t", pixelSize().height, pixelSize().width);
             break;
+        }
         case RequestPixelSize::CellArea:
             // Result is CSI  6 ;  height ;  width t
             _terminal.reply("\033[6;{};{}t", _state.cellPixelSize.height, _state.cellPixelSize.width);
@@ -2002,13 +2000,15 @@ void Screen<Cell, TheScreenType>::smGraphics(XtSmGraphics::Item _item,
         case Item::SixelGraphicsGeometry:
             switch (_action)
             {
-                case Action::Read:
+                case Action::Read: {
+                    auto const viewportSize = pixelSize();
                     _terminal.reply("\033[?{};{};{};{}S",
                                     SixelItem,
                                     Success,
-                                    _state.maxImageSize.width,
-                                    _state.maxImageSize.height);
-                    break;
+                                    min(viewportSize.width, _state.maxImageSize.width),
+                                    min(viewportSize.height, _state.maxImageSize.height));
+                }
+                break;
                 case Action::ReadLimit:
                     _terminal.reply("\033[?{};{};{};{}S",
                                     SixelItem,

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -254,6 +254,7 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
     void requestDECMode(unsigned int _mode);
 
     [[nodiscard]] PageSize pageSize() const noexcept { return _state.pageSize; }
+    [[nodiscard]] ImageSize pixelSize() const noexcept { return _state.cellPixelSize * _state.pageSize; }
 
     constexpr CellLocation realCursorPosition() const noexcept { return _state.cursor.position; }
 


### PR DESCRIPTION
Addresses inconsistency with xterm's implementation of XTSMGRAPHICS `\e[?2;1;0S` as mentioned in #656.