### PR TITLE
[terminal] Fixes SGR and text breakage when altering charsets via `ESC ( 0` VT sequence (#661).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### 0.3.2 (unreleased)
 
+- Fixes SGR and text breakage when altering charsets via `ESC ( 0` VT sequence (#661).
 - Fixes SEGV when closing the terminal via GUI close button.
 - Fixes scrolling in alt-screen.
 - Fixes VT sequence for setting indexed color from palette.

--- a/src/terminal/Charset.h
+++ b/src/terminal/Charset.h
@@ -98,6 +98,13 @@ class CharsetMapping
         shift_ = _table;
     }
 
+    [[nodiscard]] bool isSelected(CharsetTable _table, CharsetId _id) const noexcept
+    {
+        return tables_[static_cast<size_t>(_table)] == charsetMap(_id);
+    }
+
+    [[nodiscard]] bool isSelected(CharsetId _id) const noexcept { return isSelected(currentTable(), _id); }
+
     void select(CharsetTable _table, CharsetId _id) noexcept
     {
         tables_[static_cast<size_t>(_table)] = charsetMap(_id);

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -276,6 +276,13 @@ string_view Screen<Cell, TheScreenType>::tryEmplaceChars(string_view _chars) noe
     if (!_terminal.isFullHorizontalMargins())
         return _chars;
 
+    // In case the charset has been altered, no
+    // optimization can be applied.
+    // Unless we're storing the charset in the TriviallyStyledLineBuffer, too.
+    // But for now that's too rare to be beneficial.
+    if (!_state.cursor.charsets.isSelected(CharsetId::USASCII))
+        return _chars;
+
     crlfIfWrapPending();
 
     auto const columnsAvailable = pageSize().columns.value - _state.cursor.position.column.value;


### PR DESCRIPTION
Should be fixing #661.