### PR TITLE
Fixes Synchronized Updates (`SM/RM ? 2026`) sometimes lagging behind in rendering.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### 0.3.2 (unreleased)
 
+- Fixes Synchronized Updates (`SM/RM ? 2026`) sometimes lagging behind in rendering.
 - Fixes SGR and text breakage when altering charsets via `ESC ( 0` VT sequence (#661).
 - Fixes SEGV when closing the terminal via GUI close button.
 - Fixes scrolling in alt-screen.

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -1437,6 +1437,8 @@ void Terminal::synchronizedOutput(bool _enabled)
     if (_enabled)
         return;
 
+    tick(steady_clock::now());
+
     auto const diff = currentTime_ - renderBuffer_.lastUpdate;
     if (diff < refreshInterval_)
         return;


### PR DESCRIPTION
Fixes lagging output with synchronized updates using [rainbowbench](https://github.com/lhecker/rainbowbench) on Mac.