### PR TITLE
improve VT text processing efficiency 

### DIFF
--- a/cmake/PedanticCompiler.cmake
+++ b/cmake/PedanticCompiler.cmake
@@ -56,7 +56,11 @@ else()
 endif()
 
 if(${PEDANTIC_COMPILER_WERROR})
-    try_add_compile_options(-Werror) # XXX Not yet, but hopefully soon.
+    try_add_compile_options(-Werror)
+
+    # Don't complain here. That's needed for bitpacking (codepoint_properties) in libunicode dependency.
+    try_add_compile_options(-Wno-error=c++20-extensions)
+    try_add_compile_options(-Wno-c++20-extensions)
 
     # Not sure how to work around these.
     try_add_compile_options(-Wno-error=class-memaccess)

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Removes `images.sixel_cursor_conformance` config option.</li>
           <li>Adds VT sequence DECSCA, DECSEL, DECSED and DECSERA to support protected grid areas during erase operations (#29, #30, #31).</li>
           <li>Improve Input Method (IME) handling, visualizing preedit-text.</li>
+          <li>Improve throughput performance of arbitrary complex Unicode.</li>
           <li>Update Unicode data to version 15.0.0 (release). See Announcing The Unicode® Standard, Version 15.0.0.</li>
           <li>Fixes cursor highlight in VI mode</li>
         </ul>

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -26,9 +26,9 @@ $ThirdParties =
         Macro   = ""
     };
     [ThirdParty]@{
-        Folder  = "libunicode-44969c6d80e44a4731b584d047ba108769926835";
-        Archive = "libunicode-44969c6d80e44a4731b584d047ba108769926835.zip";
-        URI     = "https://github.com/contour-terminal/libunicode/archive/44969c6d80e44a4731b584d047ba108769926835.zip";
+        Folder  = "libunicode-be83e5052f6e7590c244faad59be16af210db90b";
+        Archive = "libunicode-be83e5052f6e7590c244faad59be16af210db90b.zip";
+        URI     = "https://github.com/contour-terminal/libunicode/archive/be83e5052f6e7590c244faad59be16af210db90b.zip";
         Macro   = "libunicode"
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -102,12 +102,20 @@ fetch_and_unpack_embeds()
         https://github.com/contour-terminal/termbench-pro/archive/$termbench_pro_git_sha.tar.gz \
         termbench_pro
 
-    local libunicode_git_sha="44969c6d80e44a4731b584d047ba108769926835"
-    fetch_and_unpack \
-        libunicode-$libunicode_git_sha \
-        libunicode-$libunicode_git_sha.tar.gz \
-        https://github.com/contour-terminal/libunicode/archive/$libunicode_git_sha.tar.gz \
-        libunicode
+    if test x$LIBUNICODE_SRC_DIR = x; then
+        local libunicode_git_sha="44969c6d80e44a4731b584d047ba108769926835"
+        fetch_and_unpack \
+            libunicode-$libunicode_git_sha \
+            libunicode-$libunicode_git_sha.tar.gz \
+            https://github.com/contour-terminal/libunicode/archive/$libunicode_git_sha.tar.gz \
+            libunicode
+    else
+        echo "Hard linking external libunicode source directory to: $LIBUNICODE_SRC_DIR"
+        MACRO="libunicode"
+        echo "macro(ContourThirdParties_Embed_$MACRO)" >> $SYSDEPS_CMAKE_FILE
+        echo "    add_subdirectory($LIBUNICODE_SRC_DIR libunicode EXCLUDE_FROM_ALL)" >> $SYSDEPS_CMAKE_FILE
+        echo "endmacro()" >> $SYSDEPS_CMAKE_FILE
+    fi
 }
 
 fetch_and_unpack_yaml_cpp()

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -103,7 +103,7 @@ fetch_and_unpack_embeds()
         termbench_pro
 
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="44969c6d80e44a4731b584d047ba108769926835"
+        local libunicode_git_sha="be83e5052f6e7590c244faad59be16af210db90b"
         fetch_and_unpack \
             libunicode-$libunicode_git_sha \
             libunicode-$libunicode_git_sha.tar.gz \

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -66,3 +66,110 @@ TEST_CASE("Line.inflate", "[Line]")
         CHECK(char(cell.codepoint(0)) == testText[i]);
     }
 }
+
+TEST_CASE("Line.inflate.Unicode", "[Line]")
+{
+    auto constexpr DisplayWidth = ColumnCount(10);
+    auto constexpr testTextUtf32 = U"0\u2705123456789ABCDEF"sv;
+    auto const testTextUtf8 = unicode::convert_to<char>(testTextUtf32);
+
+    auto pool = BufferObjectPool(32);
+    auto bufferObject = pool.allocateBufferObject();
+    bufferObject->writeAtEnd(testTextUtf8);
+
+    // Buffer fragment containing 9 codepoints, with one of them using display width of 2.
+    auto const bufferFragment = bufferObject->ref(0, 11);
+
+    auto sgr = GraphicsAttributes {};
+    sgr.foregroundColor = RGBColor(0x123456);
+    sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
+    sgr.underlineColor = Color::Indexed(IndexedColor::Red);
+    sgr.flags |= CellFlags::CurlyUnderlined;
+    auto const trivial =
+        TrivialLineBuffer { DisplayWidth, sgr, sgr, HyperlinkId {}, DisplayWidth, bufferFragment };
+
+    auto const inflated = inflate<Cell>(trivial);
+
+    CHECK(inflated.size() == unbox<size_t>(DisplayWidth));
+    for (size_t i = 0, k = 0; i < inflated.size();)
+    {
+        auto const& cell = inflated[i];
+        INFO(fmt::format("column {}, k {}, codepoint U+{:X}", i, k, (unsigned) cell.codepoint(0)));
+        REQUIRE(cell.codepointCount() == 1);
+        REQUIRE(cell.codepoint(0) == testTextUtf32[k]);
+        REQUIRE(cell.foregroundColor() == sgr.foregroundColor);
+        REQUIRE(cell.backgroundColor() == sgr.backgroundColor);
+        REQUIRE(cell.underlineColor() == sgr.underlineColor);
+        for (int n = 1; n < cell.width(); ++n)
+        {
+            INFO(fmt::format("column.sub: {}\n", n));
+            auto const& fillCell = inflated.at(i + static_cast<size_t>(n));
+            REQUIRE(fillCell.codepointCount() == 0);
+            REQUIRE(fillCell.foregroundColor() == sgr.foregroundColor);
+            REQUIRE(fillCell.backgroundColor() == sgr.backgroundColor);
+            REQUIRE(fillCell.underlineColor() == sgr.underlineColor);
+        }
+        i += cell.width();
+        k++;
+    }
+}
+
+TEST_CASE("Line.inflate.Unicode.FamilyEmoji", "[Line]")
+{
+    // Ensure inflate() is also working for reaaally complex Unicode grapheme clusters.
+
+    auto constexpr DisplayWidth = ColumnCount(5);
+    auto constexpr UsedColumnCount = ColumnCount(4);
+    auto constexpr testTextUtf32 = U"A\U0001F468\u200D\U0001F468\u200D\U0001F467B"sv;
+    auto const testTextUtf8 = unicode::convert_to<char>(testTextUtf32);
+    auto const familyEmojiUtf8 = unicode::convert_to<char>(U"\U0001F468\u200D\U0001F468\u200D\U0001F467"sv);
+
+    auto pool = BufferObjectPool(32);
+    auto bufferObject = pool.allocateBufferObject();
+    bufferObject->writeAtEnd(testTextUtf8);
+
+    auto const bufferFragment = bufferObject->ref(0, testTextUtf8.size());
+
+    auto sgr = GraphicsAttributes {};
+    sgr.foregroundColor = RGBColor(0x123456);
+    sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
+    sgr.underlineColor = Color::Indexed(IndexedColor::Red);
+    sgr.flags |= CellFlags::CurlyUnderlined;
+
+    auto fillSGR = GraphicsAttributes {};
+    fillSGR.foregroundColor = RGBColor(0x123456);
+    fillSGR.backgroundColor = Color::Indexed(IndexedColor::Yellow);
+    fillSGR.underlineColor = Color::Indexed(IndexedColor::Red);
+    fillSGR.flags |= CellFlags::CurlyUnderlined;
+
+    auto const trivial =
+        TrivialLineBuffer { DisplayWidth, sgr, fillSGR, HyperlinkId {}, UsedColumnCount, bufferFragment };
+
+    auto const inflated = inflate<Cell>(trivial);
+
+    CHECK(inflated.size() == unbox<size_t>(DisplayWidth));
+
+    // Check text in 0..3
+    // Check @4 is empty text.
+    // Check 0..3 has same SGR.
+    // Check @4 has fill-SGR.
+
+    REQUIRE(inflated[0].toUtf8() == "A");
+    REQUIRE(inflated[1].toUtf8() == familyEmojiUtf8);
+    REQUIRE(inflated[2].toUtf8() == "");
+    REQUIRE(inflated[3].toUtf8() == "B");
+    REQUIRE(inflated[4].toUtf8() == "");
+
+    for (auto const i: { 0u, 2u, 1u, 3u })
+    {
+        auto const& cell = inflated[i];
+        REQUIRE(cell.foregroundColor() == sgr.foregroundColor);
+        REQUIRE(cell.backgroundColor() == sgr.backgroundColor);
+        REQUIRE(cell.underlineColor() == sgr.underlineColor);
+    }
+
+    auto const& cell = inflated[4];
+    REQUIRE(cell.foregroundColor() == fillSGR.foregroundColor);
+    REQUIRE(cell.backgroundColor() == fillSGR.backgroundColor);
+    REQUIRE(cell.underlineColor() == fillSGR.underlineColor);
+}

--- a/src/terminal/Parser.h
+++ b/src/terminal/Parser.h
@@ -19,6 +19,7 @@
 #include <crispy/range.h>
 
 #include <unicode/convert.h>
+#include <unicode/scan.h>
 #include <unicode/utf8.h>
 
 #include <fmt/format.h>
@@ -554,17 +555,18 @@ class Parser
 
     [[nodiscard]] State state() const noexcept { return state_; }
 
-    char32_t precedingGraphicCharacter = 0;
+    [[nodiscard]] char32_t precedingGraphicCharacter() const noexcept { return scanState_.lastCodepointHint; }
+
+    void printUtf8Byte(char ch);
 
   private:
     void handle(ActionClass _actionClass, Action _action, uint8_t _char);
-    void printUtf8Byte(char ch);
 
     // private properties
     //
     State state_ = State::Ground;
     EventListener& eventListener_;
-    unicode::utf8_decoder_state utf8DecoderState_ = {};
+    unicode::scan_state scanState_ {};
 };
 
 /// @returns parsed tuple with OSC code and offset to first data parameter byte.

--- a/src/terminal/ParserEvents.h
+++ b/src/terminal/ParserEvents.h
@@ -49,6 +49,14 @@ class ParserEvents
     virtual size_t print(std::string_view _chars, size_t cellCount) = 0;
 
     /**
+     * Used to indicate whether or not the print() overload may be used to process bulk text.
+     *
+     * There may be situations where it would not be efficient to process bulk text. In such situations,
+     * simply calling print() per codepoint is sufficient (potentially being more performant).
+     */
+    [[nodiscard]] virtual bool acceptsBulkText() const noexcept = 0;
+
+    /**
      * The C0 or C1 control function should be executed, which may have any one of a variety of
      * effects, including changing the cursor position, suspending or resuming communications or
      * changing the shift states in effect. There are no parameters to this action.
@@ -168,6 +176,7 @@ class NullParserEvents: public ParserEvents
     void error(std::string_view const&) override {}
     void print(char32_t) override {}
     size_t print(std::string_view, size_t) override { return 0; }
+    [[nodiscard]] bool acceptsBulkText() const noexcept override { return true; }
     void execute(char) override {}
     void clear() override {}
     void collect(char) override {}

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -430,8 +430,8 @@ TEST_CASE("AppendChar.emoji_VS15_smiley", "[screen]")
     mock.writeToScreen(U"\U0001F600");
     REQUIRE(*screen.logicalCursorPosition().column == 2);
     mock.writeToScreen(U"\uFE0E");
-    REQUIRE(*screen.logicalCursorPosition().column
-            == 2); // U+FE0E does *NOT* lower width to 1 (easier to implement)
+    REQUIRE(*screen.logicalCursorPosition().column == 2);
+    // ^^^ U+FE0E does *NOT* lower width to 1 (easier to implement)
     mock.writeToScreen("X");
     REQUIRE(*screen.logicalCursorPosition().column == 3);
     logScreenText(screen);

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -150,6 +150,11 @@ void Sequencer::unhook()
     }
 }
 
+bool Sequencer::acceptsBulkText() const noexcept
+{
+    return terminal_.isPrimaryScreen() && terminal_.primaryScreen().currentLine().isTrivialBuffer();
+}
+
 void Sequencer::handleSequence()
 {
     parameterBuilder_.fixiate();

--- a/src/terminal/Sequencer.h
+++ b/src/terminal/Sequencer.h
@@ -168,6 +168,8 @@ class Sequencer
         hookedParser_ = std::move(parserExtension);
     }
 
+    [[nodiscard]] bool acceptsBulkText() const noexcept;
+
   private:
     void handleSequence();
 


### PR DESCRIPTION
## Goals:

- [x] less resource usage on RenderBuffer array of RenderCell's, also in order to reduce locking time on TE backend.
- [x] extend trivial line optimization from US ASCII to non US-ASCII text.
- [x] ensure processing multibyte UTF-8 across multiple scan-API calls retains UTF-8 parsing state (also have a unit test for that) <-- this sometimes breaks notcurses external tests (e.g. grid test)
- [x] does it make sense to wait for https://github.com/contour-terminal/libunicode/issues/43?