### PR TITLE
Implements DECSASD, DECSSDT (VT status line)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
         uses: lukka/run-vcpkg@v5
         id: runvcpkg
         with:
-          vcpkgArguments: angle fmt freetype fontconfig harfbuzz yaml-cpp range-v3
+          vcpkgArguments: fmt freetype fontconfig harfbuzz yaml-cpp range-v3
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
           vcpkgGitCommitId: faed44dfa013088fe1910908a8a65887622f412f
           vcpkgTriplet: x64-windows

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@
   - `<S-K>` and `<S-J>` don't just move the cursor up/down but also move the terminal's viewport respectively.
   - and more...
 - Adds specialized PTY implementation for Linux operating system utilizing OS-specific kernel APIs.
+- Adds basic support for Indicator status line and their VT sequences `DECSASD` and `DECSSDT`, and `DECRQSS` has been adapted (#687).
+- Adds configuration option `profiles.*.status_line.display` to be either `none` or `indicator` to reflect the initial state of the status line (more customizability of the Indicator status-line will come in future releases).
 - Changes CLI syntax for `contour parser-table` to `contour generate parser-table`.
 
 ### 0.3.1 (2022-05-01)

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -76,6 +76,7 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::SendChars>("SendChars"),
         mapAction<actions::ToggleAllKeyMaps>("ToggleAllKeyMaps"),
         mapAction<actions::ToggleFullscreen>("ToggleFullscreen"),
+        mapAction<actions::ToggleStatusLine>("ToggleStatusLine"),
         mapAction<actions::ToggleTitleBar>("ToggleTitleBar"),
         mapAction<actions::ViNormalMode>("ViNormalMode"),
         mapAction<actions::WriteScreen>("WriteScreen"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -56,6 +56,7 @@ struct ScrollUp{};
 struct SendChars{ std::string chars; };
 struct ToggleAllKeyMaps{};
 struct ToggleFullscreen{};
+struct ToggleStatusLine{};
 struct ToggleTitleBar{};
 struct ViNormalMode{};
 struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
@@ -98,6 +99,7 @@ using Action = std::variant<CancelSelection,
                             SendChars,
                             ToggleAllKeyMaps,
                             ToggleFullscreen,
+                            ToggleStatusLine,
                             ToggleTitleBar,
                             ViNormalMode,
                             WriteScreen>;
@@ -159,6 +161,7 @@ DECLARE_ACTION_FMT(ScrollUp)
 DECLARE_ACTION_FMT(SendChars)
 DECLARE_ACTION_FMT(ToggleAllKeyMaps)
 DECLARE_ACTION_FMT(ToggleFullscreen)
+DECLARE_ACTION_FMT(ToggleStatusLine)
 DECLARE_ACTION_FMT(ToggleTitleBar)
 DECLARE_ACTION_FMT(ViNormalMode)
 DECLARE_ACTION_FMT(WriteScreen)

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1544,6 +1544,14 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
         }
     }
 
+    tryLoadChildRelative(_usedKeys, _profile, basePath, "status_line.display", strValue);
+    if (strValue == "indicator")
+        profile.initialStatusDisplayType = terminal::StatusDisplayType::Indicator;
+    else if (strValue == "none")
+        profile.initialStatusDisplayType = terminal::StatusDisplayType::None;
+    else
+        errorlog()("Invalid value for config entry {}: {}", "status_line.display", strValue);
+
     return profile;
 }
 

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -179,6 +179,8 @@ struct TerminalProfile
         InputModeConfig visual;
     } inputModes;
 
+    terminal::StatusDisplayType initialStatusDisplayType = terminal::StatusDisplayType::None;
+
     terminal::Opacity backgroundOpacity; // value between 0 (fully transparent) and 0xFF (fully visible).
     bool backgroundBlur;                 // On Windows 10, this will enable Acrylic Backdrop.
 

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -100,8 +100,8 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     void onClosed() override;
     void pasteFromClipboard(unsigned count) override;
     void onSelectionCompleted() override;
-    void resizeWindow(terminal::LineCount, terminal::ColumnCount) override;
-    void resizeWindow(terminal::Width, terminal::Height) override;
+    void requestWindowResize(terminal::LineCount, terminal::ColumnCount) override;
+    void requestWindowResize(terminal::Width, terminal::Height) override;
     void setWindowTitle(std::string_view _title) override;
     void setTerminalProfile(std::string const& _configProfileName) override;
     void discardImage(terminal::Image const&) override;
@@ -162,6 +162,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     bool operator()(actions::SendChars const& _event);
     bool operator()(actions::ToggleAllKeyMaps);
     bool operator()(actions::ToggleFullscreen);
+    bool operator()(actions::ToggleStatusLine);
     bool operator()(actions::ToggleTitleBar);
     bool operator()(actions::ViNormalMode);
     bool operator()(actions::WriteScreen const& _event);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -341,6 +341,12 @@ profiles:
                 blinking: false
                 blinking_interval: 500
 
+        status_line:
+            # Either none or indicator.
+            # This only reflects the initial state of the status line, as it can
+            # be changed at any time during runtime by the user or by an application.
+            display: none
+
         # Background configuration
         background:
             # Background opacity to use. A value of 1.0 means fully opaque whereas 0.0 means fully
@@ -533,6 +539,7 @@ color_schemes:
 # - SendChars         Writes given characters in `chars` member to the applications input.
 # - ToggleAllKeyMaps  Disables/enables responding to all keybinds (this keybind will be preserved when disabling all others).
 # - ToggleFullScreen  Enables/disables full screen mode.
+# - ToggleStatusLine  Shows/hides the VT320 compatible Indicator status line.
 # - ToggleTitleBar    Shows/Hides titlebar
 # - ViNormalMode      Enters Vi-like normal mode. The cursor can then be moved via h/j/k/l movements and text can be selected via v, yanked via y, and clipboard pasted via p.
 # - WriteScreen       Writes VT sequence in `chars` member to the screen (bypassing the application).
@@ -574,3 +581,4 @@ input_mapping:
     - { mods: [Shift],          mouse: WheelDown,   action: ScrollPageDown }
     - { mods: [Shift],          mouse: WheelUp,     action: ScrollPageUp }
     - { mods: [Control, Alt],   key: O,             action: OpenFileManager }
+    - { mods: [Control, Alt],   key: '.',           action: ToggleStatusLine }

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -68,7 +68,7 @@ namespace
         auto constexpr MarginTop = 0;
         auto constexpr MarginLeft = 0;
 
-        auto const pageSize = session.terminal().pageSize();
+        auto const pageSize = session.terminal().totalPageSize();
         auto const cellSize = session.display()->cellSize();
         auto const dpr = session.contentScale();
 

--- a/src/crispy/BufferObject.h
+++ b/src/crispy/BufferObject.h
@@ -23,6 +23,7 @@
 #include <iterator>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string_view>
 
 #define BUFFER_OBJECT_INLINE 1
@@ -100,6 +101,9 @@ class BufferObject: public std::enable_shared_from_this<BufferObject>
 
     void clear() noexcept;
 
+    void lock() { mutex_.lock(); }
+    void unlock() { mutex_.unlock(); }
+
   private:
 #if !defined(BUFFER_OBJECT_INLINE)
     char* data_;
@@ -108,6 +112,8 @@ class BufferObject: public std::enable_shared_from_this<BufferObject>
     char* end_;
 
     friend class BufferFragment;
+
+    std::mutex mutex_;
 };
 
 /**

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -347,6 +347,9 @@ constexpr inline auto XTSHIFTESCAPE=detail::CSI('>', 0, 1, std::nullopt, 's', VT
 constexpr inline auto XTVERSION   = detail::CSI('>', 0, 1, std::nullopt, 'q', VTType::VT525 /*Xterm*/, "XTVERSION", "Query terminal name and version");
 constexpr inline auto CAPTURE     = detail::CSI('>', 0, 2, std::nullopt, 't', VTType::VT525 /*Extension*/, "CAPTURE", "Report screen buffer capture.");
 
+constexpr inline auto DECSSDT     = detail::CSI(std::nullopt, 0, 1, '$', '~', VTType::VT320, "DECSSDT", "Select Status Display (Line) Type");
+constexpr inline auto DECSASD     = detail::CSI(std::nullopt, 0, 1, '$', '}', VTType::VT420, "DECSASD", "Select Active Status Display");
+
 // DCS functions
 constexpr inline auto STP         = detail::DCS(std::nullopt, 0, 0, '$', 'p', VTType::VT525, "STP", "Set Terminal Profile");
 constexpr inline auto DECRQSS     = detail::DCS(std::nullopt, 0, 0, '$', 'q', VTType::VT420, "DECRQSS", "Request Status String");
@@ -447,9 +450,9 @@ inline auto const& functions() noexcept
             DCH,
             DECCARA,
             DECCRA,
+            DECDC,
             DECERA,
             DECFRA,
-            DECDC,
             DECIC,
             DECMODERESTORE,
             DECMODESAVE,
@@ -457,12 +460,14 @@ inline auto const& functions() noexcept
             DECRQM,
             DECRQM_ANSI,
             DECRQPSR,
+            DECSASD,
             DECSCL,
             DECSCPP,
             DECSCUSR,
             DECSLRM,
             DECSM,
             DECSNLS,
+            DECSSDT,
             DECSTBM,
             DECSTR,
             DECXCPR,
@@ -486,8 +491,8 @@ inline auto const& functions() noexcept
             TBC,
             VPA,
             WINMANIP,
-            XTSMGRAPHICS,
             XTSHIFTESCAPE,
+            XTSMGRAPHICS,
             XTVERSION,
 
             // DCS

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -93,14 +93,18 @@ namespace
 } // namespace
 
 template <typename Cell>
-RenderBufferBuilder<Cell>::RenderBufferBuilder(Terminal const& _terminal, RenderBuffer& _output):
+RenderBufferBuilder<Cell>::RenderBufferBuilder(Terminal const& _terminal,
+                                               RenderBuffer& _output,
+                                               LineOffset base,
+                                               bool theReverseVideo):
     output { _output },
     terminal { _terminal },
     cursorPosition { _terminal.inputHandler().mode() == ViMode::Insert
                          ? _terminal.realCursorPosition()
-                         : _terminal.state().viCommands.cursorPosition }
+                         : _terminal.state().viCommands.cursorPosition },
+    baseLine { base },
+    reverseVideo { theReverseVideo }
 {
-    output.clear();
     output.frameID = _terminal.lastFrameID();
     output.cursor = renderCursor();
 }
@@ -275,7 +279,7 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TriviallyStyledLineBuffer cons
                                                          fg,
                                                          bg,
                                                          lineBuffer.attributes.underlineColor,
-                                                         lineOffset,
+                                                         baseLine + lineOffset,
                                                          columnOffset));
 
         columnOffset += ColumnOffset::cast_from(width);
@@ -301,7 +305,7 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TriviallyStyledLineBuffer cons
                                                          fg,
                                                          bg,
                                                          lineBuffer.attributes.underlineColor,
-                                                         lineOffset,
+                                                         baseLine + lineOffset,
                                                          columnOffset));
     }
     // }}}
@@ -355,7 +359,7 @@ void RenderBufferBuilder<Cell>::renderCell(Cell const& screenCell, LineOffset _l
                                                          screenCell,
                                                          fg,
                                                          bg,
-                                                         _line,
+                                                         baseLine + _line,
                                                          _column));
                 output.cells.back().groupStart = true;
             }
@@ -373,7 +377,7 @@ void RenderBufferBuilder<Cell>::renderCell(Cell const& screenCell, LineOffset _l
                                                          screenCell,
                                                          fg,
                                                          bg,
-                                                         _line,
+                                                         baseLine + _line,
                                                          _column));
 
                 if (isNewLine)

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -15,7 +15,7 @@ template <typename Cell>
 class RenderBufferBuilder
 {
   public:
-    RenderBufferBuilder(Terminal const& terminal, RenderBuffer& output);
+    RenderBufferBuilder(Terminal const& terminal, RenderBuffer& output, LineOffset base, bool reverseVideo);
 
     /// Renders a single grid cell.
     /// This call is guaranteed to be invoked sequencially, from top line
@@ -87,8 +87,9 @@ class RenderBufferBuilder
     RenderBuffer& output;
     Terminal const& terminal;
     CellLocation cursorPosition;
+    LineOffset baseLine;
+    bool reverseVideo;
 
-    bool reverseVideo = terminal.isModeEnabled(terminal::DECMode::ReverseVideo);
     int prevWidth = 0;
     bool prevHasCursor = false;
     State state = State::Gap;

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -237,8 +237,8 @@ namespace // {{{ helper
 // }}}
 
 template <typename Cell, ScreenType TheScreenType>
-Screen<Cell, TheScreenType>::Screen(TerminalState& terminalState, ScreenType screenType, Grid<Cell>& grid):
-    _terminal { terminalState.terminal }, _state { terminalState }, _screenType { screenType }, _grid { grid }
+Screen<Cell, TheScreenType>::Screen(TerminalState& terminalState, Grid<Cell>& grid):
+    _terminal { terminalState.terminal }, _state { terminalState }, _grid { grid }
 {
     updateCursorIterator();
 }

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -426,6 +426,18 @@ void Screen<Cell, TheScreenType>::writeText(string_view _chars, size_t cellCount
 }
 
 template <typename Cell, ScreenType TheScreenType>
+void Screen<Cell, TheScreenType>::writeTextFromExternal(std::string_view _chars)
+{
+#if defined(LIBTERMINAL_LOG_TRACE)
+    if (VTTraceSequenceLog)
+        VTTraceSequenceLog()("external text: \"{}\"", _chars);
+#endif
+
+    for (char const ch: _chars)
+        writeTextInternal(static_cast<char32_t>(ch));
+}
+
+template <typename Cell, ScreenType TheScreenType>
 void Screen<Cell, TheScreenType>::crlfIfWrapPending()
 {
     if (_state.wrapPending && _state.cursor.autoWrap) // && !_terminal.isModeEnabled(DECMode::TextReflow))
@@ -1800,6 +1812,21 @@ void Screen<Cell, TheScreenType>::requestStatusString(RequestStatusString _value
             case RequestStatusString::DECSCA: // TODO
                 errorlog()(fmt::format("Requesting device status for {} not implemented yet.", _value));
                 break;
+            case RequestStatusString::DECSASD:
+                switch (_state.activeStatusDisplay)
+                {
+                    case ActiveStatusDisplay::Main: return "0$}";
+                    case ActiveStatusDisplay::StatusLine: return "1$}";
+                }
+                break;
+            case RequestStatusString::DECSSDT:
+                switch (_state.statusDisplayType)
+                {
+                    case StatusDisplayType::None: return "0$~";
+                    case StatusDisplayType::Indicator: return "1$~";
+                    case StatusDisplayType::HostWritable: return "2$~";
+                }
+                break;
         }
         return nullopt;
     }(_value);
@@ -2799,11 +2826,11 @@ namespace impl
             switch (_seq.param(0))
             {
                 case 4: // resize in pixel units
-                    terminal.resizeWindow(ImageSize { Width(_seq.param(2)), Height(_seq.param(1)) });
+                    terminal.requestWindowResize(ImageSize { Width(_seq.param(2)), Height(_seq.param(1)) });
                     break;
                 case 8: // resize in cell units
-                    terminal.resizeWindow(PageSize { LineCount::cast_from(_seq.param(1)),
-                                                     ColumnCount::cast_from(_seq.param(2)) });
+                    terminal.requestWindowResize(PageSize { LineCount::cast_from(_seq.param(1)),
+                                                            ColumnCount::cast_from(_seq.param(2)) });
                     break;
                 case 22: terminal.saveWindowTitle(); break;
                 case 23: terminal.restoreWindowTitle(); break;
@@ -2819,7 +2846,7 @@ namespace impl
                 case 8:
                     // this means, resize to full display size
                     // TODO: just create a dedicated callback for fulscreen resize!
-                    terminal.resizeWindow(ImageSize {});
+                    terminal.requestWindowResize(ImageSize {});
                     break;
                 case 14:
                     if (_seq.parameterCount() == 2 && _seq.param(1) == 2)
@@ -3261,6 +3288,26 @@ ApplyResult Screen<Cell, TheScreenType>::apply(FunctionDefinition const& functio
         case XTVERSION:
             _terminal.reply(fmt::format("\033P>|{} {}\033\\", LIBTERMINAL_NAME, LIBTERMINAL_VERSION_STRING));
             return ApplyResult::Ok;
+        case DECSSDT: {
+            // Changes the status line display type.
+            switch (seq.param_or(0, 0))
+            {
+                case 0: _terminal.setStatusDisplay(StatusDisplayType::None); break;
+                case 1: _terminal.setStatusDisplay(StatusDisplayType::Indicator); break;
+                case 2: _terminal.setStatusDisplay(StatusDisplayType::HostWritable); break;
+                default: return ApplyResult::Invalid;
+            }
+            break;
+        }
+        case DECSASD:
+            // Selects whether the terminal sends data to the main display or the status line.
+            switch (seq.param_or(0, 0))
+            {
+                case 0: _terminal.setActiveStatusDisplay(ActiveStatusDisplay::Main); break;
+                case 1: _terminal.setActiveStatusDisplay(ActiveStatusDisplay::StatusLine); break;
+                default: return ApplyResult::Invalid;
+            }
+            break;
 
         // OSC
         case SETTITLE:
@@ -3404,11 +3451,12 @@ unique_ptr<ParserExtension> Screen<Cell, TheScreenType>::hookDECRQSS(Sequence co
 {
     return make_unique<SimpleStringCollector>([this](string_view const& _data) {
         auto const s = [](string_view _dataString) -> optional<RequestStatusString> {
-            auto const mappings = array<pair<string_view, RequestStatusString>, 9> {
+            auto const mappings = array<pair<string_view, RequestStatusString>, 11> {
                 pair { "m", RequestStatusString::SGR },       pair { "\"p", RequestStatusString::DECSCL },
                 pair { " q", RequestStatusString::DECSCUSR }, pair { "\"q", RequestStatusString::DECSCA },
                 pair { "r", RequestStatusString::DECSTBM },   pair { "s", RequestStatusString::DECSLRM },
                 pair { "t", RequestStatusString::DECSLPP },   pair { "$|", RequestStatusString::DECSCPP },
+                pair { "$}", RequestStatusString::DECSASD },  pair { "$~", RequestStatusString::DECSSDT },
                 pair { "*|", RequestStatusString::DECSNLS }
             };
             for (auto const& mapping: mappings)

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -82,13 +82,10 @@ class ScreenBase: public SequenceHandler
  * to be viewn.
  */
 template <typename Cell, ScreenType TheScreenType = ScreenType::Primary>
-class Screen: public ScreenBase, public capabilities::StaticDatabase
+class Screen final: public ScreenBase, public capabilities::StaticDatabase
 {
   public:
-    constexpr static bool IsPrimaryScreen = TheScreenType == ScreenType::Primary;
-    constexpr static bool IsAlternateScreen = TheScreenType == ScreenType::Alternate;
-
-    Screen(TerminalState& terminalState, ScreenType screenType, Grid<Cell>& grid);
+    Screen(TerminalState& terminalState, Grid<Cell>& grid);
 
     Screen(Screen const&) = delete;
     Screen& operator=(Screen const&) = delete;
@@ -516,7 +513,6 @@ class Screen: public ScreenBase, public capabilities::StaticDatabase
 
     Terminal& _terminal;
     TerminalState& _state;
-    ScreenType const _screenType;
     Grid<Cell>& _grid;
 #if defined(LIBTERMINAL_CURRENT_LINE_CACHE)
     Line<Cell>* _currentLine = nullptr;

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -52,7 +52,7 @@ void Sequencer::print(char _char)
     terminal_.state().instructionCounter++;
     auto const codepoint =
         holds_alternative<unicode::Success>(r) ? get<unicode::Success>(r).value : ReplacementCharacter;
-    terminal_.currentScreen().writeText(codepoint);
+    terminal_.activeDisplay().writeText(codepoint);
     terminal_.state().precedingGraphicCharacter = codepoint;
 }
 
@@ -63,7 +63,7 @@ void Sequencer::print(string_view _chars, size_t cellCount)
     if (utf8DecoderState_.expectedLength == 0)
     {
         terminal_.state().instructionCounter += _chars.size();
-        terminal_.currentScreen().writeText(_chars, cellCount);
+        terminal_.activeDisplay().writeText(_chars, cellCount);
         terminal_.state().precedingGraphicCharacter = static_cast<char32_t>(_chars.back());
     }
     else
@@ -76,7 +76,7 @@ void Sequencer::print(string_view _chars, size_t cellCount)
 
 void Sequencer::execute(char controlCode)
 {
-    terminal_.currentScreen().executeControlCode(controlCode);
+    terminal_.activeDisplay().executeControlCode(controlCode);
     resetUtf8DecoderState();
 }
 
@@ -170,7 +170,7 @@ void Sequencer::unhook()
 void Sequencer::handleSequence()
 {
     parameterBuilder_.fixiate();
-    terminal_.currentScreen().processSequence(sequence_);
+    terminal_.activeDisplay().processSequence(sequence_);
 }
 
 } // namespace terminal

--- a/src/terminal/Sequencer.h
+++ b/src/terminal/Sequencer.h
@@ -91,7 +91,9 @@ enum class RequestStatusString
     DECSLRM,
     DECSLPP,
     DECSCPP,
-    DECSNLS
+    DECSNLS,
+    DECSASD,
+    DECSSDT,
 };
 
 /// DECSIXEL - Sixel Graphics Image.
@@ -239,6 +241,8 @@ struct formatter<terminal::RequestStatusString>
             case terminal::RequestStatusString::DECSLPP: return format_to(ctx.out(), "DECSLPP");
             case terminal::RequestStatusString::DECSCPP: return format_to(ctx.out(), "DECSCPP");
             case terminal::RequestStatusString::DECSNLS: return format_to(ctx.out(), "DECSNLS");
+            case terminal::RequestStatusString::DECSASD: return format_to(ctx.out(), "DECSASD");
+            case terminal::RequestStatusString::DECSSDT: return format_to(ctx.out(), "DECSSDT");
         }
         return format_to(ctx.out(), "{}", unsigned(value));
     }

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -69,8 +69,8 @@ class Terminal
         virtual void onClosed() {}
         virtual void pasteFromClipboard(unsigned /*count*/) {}
         virtual void onSelectionCompleted() {}
-        virtual void resizeWindow(LineCount, ColumnCount) {}
-        virtual void resizeWindow(Width, Height) {}
+        virtual void requestWindowResize(LineCount, ColumnCount) {}
+        virtual void requestWindowResize(Width, Height) {}
         virtual void setWindowTitle(std::string_view /*_title*/) {}
         virtual void setTerminalProfile(std::string const& /*_configProfileName*/) {}
         virtual void discardImage(Image const&) {}
@@ -212,7 +212,26 @@ class Terminal
     Pty& device() noexcept { return *pty_; }
 
     PageSize pageSize() const noexcept { return pty_->pageSize(); }
+
+    PageSize totalPageSize() const noexcept
+    {
+        switch (state_.statusDisplayType)
+        {
+            case StatusDisplayType::None:
+                //.
+                return pageSize();
+            case StatusDisplayType::Indicator:
+            case StatusDisplayType::HostWritable:
+                return pageSize() + hostWritableStatusLineScreen_.pageSize().lines;
+        }
+        crispy::unreachable();
+    }
+
+    /// Resizes the terminal screen to the given amount of grid cells with their pixel dimensions.
+    /// Important! In case a status line is currently visible, the status line count is being
+    /// accumulated into the screen size, too.
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt);
+    void resizeScreenInternal(PageSize _cells, std::optional<ImageSize> _pixels);
 
     /// Implements semantics for  DECCOLM / DECSCPP.
     void resizeColumns(ColumnCount _newColumnCount, bool _clear);
@@ -261,6 +280,9 @@ class Terminal
 
     /// Writes a given VT-sequence to screen.
     void writeToScreen(std::string_view _text);
+
+    /// Writes a given VT-sequence to screen - but without acquiring the lock (must be already acquired).
+    void writeToScreenInternal(std::string_view _text);
 
     // viewport management
     Viewport& viewport() noexcept { return viewport_; }
@@ -347,6 +369,16 @@ class Terminal
 
     ScreenBase& currentScreen() noexcept { return currentScreen_.get(); }
     ScreenBase const& currentScreen() const noexcept { return currentScreen_.get(); }
+
+    ScreenBase& activeDisplay() noexcept
+    {
+        switch (state_.activeStatusDisplay)
+        {
+            case ActiveStatusDisplay::Main: return currentScreen_.get();
+            case ActiveStatusDisplay::StatusLine: return hostWritableStatusLineScreen_;
+        }
+        crispy::unreachable();
+    }
 
     bool isPrimaryScreen() const noexcept { return state_.screenType == ScreenType::Primary; }
     bool isAlternateScreen() const noexcept { return state_.screenType == ScreenType::Alternate; }
@@ -490,8 +522,8 @@ class Terminal
         reply(fmt::vformat(fmt, fmt::make_format_args(args...)));
     }
 
-    void resizeWindow(PageSize);
-    void resizeWindow(ImageSize);
+    void requestWindowResize(PageSize);
+    void requestWindowResize(ImageSize);
     void setApplicationkeypadMode(bool _enabled);
     void setBracketedPaste(bool _enabled);
     void setCursorStyle(CursorDisplay _display, CursorShape _shape);
@@ -533,12 +565,22 @@ class Terminal
     ViInputHandler& inputHandler() noexcept { return state_.inputHandler; }
     ViInputHandler const& inputHandler() const noexcept { return state_.inputHandler; }
 
+    void setStatusDisplay(StatusDisplayType statusDisplayType);
+    void setActiveStatusDisplay(ActiveStatusDisplay activeDisplay);
+
   private:
     void mainLoop();
     void refreshRenderBuffer(RenderBuffer& _output); // <- acquires the lock
     void refreshRenderBufferInternal(RenderBuffer& _output);
+    void updateIndicatorStatusLine();
     void updateCursorVisibilityState() const;
     bool updateCursorHoveringState();
+
+    // Reads from PTY.
+    Pty::ReadResult readFromPty();
+
+    // Writes partially or all input data to the PTY buffer object and returns a string view to it.
+    std::string_view lockedWriteToPtyBuffer(std::string_view data);
 
     // private data
     //
@@ -583,6 +625,8 @@ class Terminal
     size_t ptyReadBufferSize_;
     Screen<Cell, ScreenType::Primary> primaryScreen_;
     Screen<Cell, ScreenType::Alternate> alternateScreen_;
+    Screen<Cell, ScreenType::Alternate> hostWritableStatusLineScreen_;
+    Screen<Cell, ScreenType::Alternate> indicatorStatusScreen_;
     std::reference_wrapper<ScreenBase> currentScreen_;
 
     std::mutex mutable outerLock_;

--- a/src/terminal/TerminalState.cpp
+++ b/src/terminal/TerminalState.cpp
@@ -46,6 +46,12 @@ TerminalState::TerminalState(Terminal& _terminal,
     allowReflowOnResize { _allowReflowOnResize },
     primaryBuffer { Grid<Cell>(_pageSize, _allowReflowOnResize, _maxHistoryLineCount) },
     alternateBuffer { Grid<Cell>(_pageSize, false, LineCount(0)) },
+    hostWritableStatusBuffer { Grid<Cell>(
+        PageSize { LineCount(1), _pageSize.columns }, false, LineCount(0)) },
+    indicatorStatusBuffer { Grid<Cell> {
+        PageSize { LineCount(1), _pageSize.columns }, false, LineCount(0) } },
+    statusDisplayType { StatusDisplayType::None },
+    activeStatusDisplay { ActiveStatusDisplay::Main },
     cursor {},
     lastCursorPosition {},
     hyperlinks { HyperlinkCache { 1024 } },

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -160,12 +160,17 @@ struct TerminalState
     ScreenType screenType = ScreenType::Primary;
     Grid<Cell> primaryBuffer;
     Grid<Cell> alternateBuffer;
+    Grid<Cell> hostWritableStatusBuffer; // writable status-display, see DECSASD and DECSSDT.
+    Grid<Cell> indicatorStatusBuffer;    // status buffer as used for indicator status line AND error lines.
+    StatusDisplayType statusDisplayType;
+    ActiveStatusDisplay activeStatusDisplay;
 
     // cursor related
     //
     Cursor cursor;
     Cursor savedCursor;
-    Cursor savedPrimaryCursor; //!< saved cursor of primary-screen when switching to alt-screen.
+    Cursor savedPrimaryCursor;    //!< Saved cursor of primary-screen when switching to alt-screen.
+    Cursor savedCursorStatusLine; //!< Saved cursor of the status line if not active, the other way around.
     CellLocation lastCursorPosition;
     bool wrapPending = false;
 

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -284,13 +284,32 @@ struct PageSize
     ColumnCount columns;
     [[nodiscard]] int area() const noexcept { return *lines * *columns; }
 };
+
+constexpr PageSize operator+(PageSize pageSize, LineCount lines) noexcept
+{
+    return PageSize { pageSize.lines + lines, pageSize.columns };
+}
+
+constexpr PageSize operator-(PageSize pageSize, LineCount lines) noexcept
+{
+    return PageSize { pageSize.lines - lines, pageSize.columns };
+}
+
 constexpr bool operator==(PageSize a, PageSize b) noexcept
 {
     return a.lines == b.lines && a.columns == b.columns;
 }
+
 constexpr bool operator!=(PageSize a, PageSize b) noexcept
 {
     return !(a == b);
+}
+
+/// Tests whether given CellLocation is within the right hand side's PageSize.
+constexpr bool operator<(CellLocation location, PageSize pageSize) noexcept
+{
+    return location.line < boxed_cast<LineOffset>(pageSize.lines)
+           && location.column < boxed_cast<ColumnOffset>(pageSize.columns);
 }
 // }}}
 // {{{ Coordinate types
@@ -520,6 +539,23 @@ enum class GraphicsRendition
     Overline = 53,        //!< Overlined glyph
     NoFramed = 54,        //!< Reverses Framed
     NoOverline = 55,      //!< Reverses Overline.
+};
+
+enum class StatusDisplayType
+{
+    None,
+    Indicator,
+    HostWritable,
+};
+
+// Selects whether the terminal sends data to the main display or the status line.
+enum class ActiveStatusDisplay
+{
+    // Selects the main display. The terminal sends data to the main display only.
+    Main,
+
+    // Selects the host-writable status line. The terminal sends data to the status line only.
+    StatusLine,
 };
 
 enum class AnsiMode

--- a/src/terminal/pty/LinuxPty.cpp
+++ b/src/terminal/pty/LinuxPty.cpp
@@ -48,6 +48,7 @@ using std::nullopt;
 using std::numeric_limits;
 using std::optional;
 using std::runtime_error;
+using std::scoped_lock;
 using std::string_view;
 using std::tuple;
 
@@ -314,8 +315,11 @@ int LinuxPty::waitForReadable(std::chrono::milliseconds timeout) noexcept
 Pty::ReadResult LinuxPty::read(crispy::BufferObject& sink, std::chrono::milliseconds timeout, size_t size)
 {
     if (int fd = waitForReadable(timeout); fd != -1)
+    {
+        auto const _l = scoped_lock { sink };
         if (auto x = readSome(fd, sink.hotEnd(), min(size, sink.bytesAvailable())))
             return { tuple { x.value(), fd == _stdoutFastPipe.reader() } };
+    }
 
     return nullopt;
 }

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -54,6 +54,7 @@ using std::nullopt;
 using std::numeric_limits;
 using std::optional;
 using std::runtime_error;
+using std::scoped_lock;
 using std::string_view;
 using std::tuple;
 
@@ -384,8 +385,11 @@ int waitForReadable(int ptyMaster,
 Pty::ReadResult UnixPty::read(crispy::BufferObject& sink, std::chrono::milliseconds timeout, size_t size)
 {
     if (int fd = waitForReadable(_masterFd, _stdoutFastPipe.reader(), _pipe[0], timeout); fd != -1)
+    {
+        auto const _l = scoped_lock { sink };
         if (auto x = readSome(fd, sink.hotEnd(), min(size, sink.bytesAvailable())))
             return { tuple { x.value(), fd == _stdoutFastPipe.reader() } };
+    }
 
     return nullopt;
 }

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -291,7 +291,10 @@ void Renderer::updateFontMetrics()
 
 uint64_t Renderer::render(Terminal& _terminal, bool _pressure)
 {
-    gridMetrics_.pageSize = _terminal.pageSize();
+    auto const statusLineHeight = _terminal.state().statusDisplayType == StatusDisplayType::None
+                                      ? LineCount(0)
+                                      : _terminal.state().hostWritableStatusBuffer.pageSize().lines;
+    gridMetrics_.pageSize = _terminal.pageSize() + statusLineHeight;
 
     auto const changes = _terminal.tick(steady_clock::now());
 


### PR DESCRIPTION
References #687.

host writable status line and switching is already working. Indicator and configurability of Indicator is not yet.

- [x] `DECSSDT`
- [x] `DECSASD`
- [x] adapt `DECRQSS` (can be used for feature detection)
- [x] frontend input mapping action: ToggleStatusLine (Indicator status line)

### Notes

Indicator status line: when we want to write arbitrary VT sequences, it MUST have its own VT parser state.

I think having the Indicator status line configurable should be its own PR as a separate feature step, not not make this PR too complex