### PR TITLE
[contour] Adds new input action `ToggleInputProtection` to protect terminal application against accidental input (#697).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@
 - Adds specialized PTY implementation for Linux operating system utilizing OS-specific kernel APIs.
 - Adds basic support for Indicator status line and their VT sequences `DECSASD` and `DECSSDT`, and `DECRQSS` has been adapted (#687).
 - Adds configuration option `profiles.*.status_line.display` to be either `none` or `indicator` to reflect the initial state of the status line (more customizability of the Indicator status-line will come in future releases).
+- Adds new action `ToggleInputProtection` to protect terminal application against accidental input (#697).
 - Changes CLI syntax for `contour parser-table` to `contour generate parser-table`.
 
 ### 0.3.1 (2022-05-01)

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -76,6 +76,7 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::SendChars>("SendChars"),
         mapAction<actions::ToggleAllKeyMaps>("ToggleAllKeyMaps"),
         mapAction<actions::ToggleFullscreen>("ToggleFullscreen"),
+        mapAction<actions::ToggleInputProtection>("ToggleInputProtection"),
         mapAction<actions::ToggleStatusLine>("ToggleStatusLine"),
         mapAction<actions::ToggleTitleBar>("ToggleTitleBar"),
         mapAction<actions::ViNormalMode>("ViNormalMode"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -56,6 +56,7 @@ struct ScrollUp{};
 struct SendChars{ std::string chars; };
 struct ToggleAllKeyMaps{};
 struct ToggleFullscreen{};
+struct ToggleInputProtection{};
 struct ToggleStatusLine{};
 struct ToggleTitleBar{};
 struct ViNormalMode{};
@@ -99,6 +100,7 @@ using Action = std::variant<CancelSelection,
                             SendChars,
                             ToggleAllKeyMaps,
                             ToggleFullscreen,
+                            ToggleInputProtection,
                             ToggleStatusLine,
                             ToggleTitleBar,
                             ViNormalMode,
@@ -161,6 +163,7 @@ DECLARE_ACTION_FMT(ScrollUp)
 DECLARE_ACTION_FMT(SendChars)
 DECLARE_ACTION_FMT(ToggleAllKeyMaps)
 DECLARE_ACTION_FMT(ToggleFullscreen)
+DECLARE_ACTION_FMT(ToggleInputProtection)
 DECLARE_ACTION_FMT(ToggleStatusLine)
 DECLARE_ACTION_FMT(ToggleTitleBar)
 DECLARE_ACTION_FMT(ViNormalMode)

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -501,6 +501,7 @@ void TerminalSession::sendCharPressEvent(char32_t _value, Modifier _modifier, Ti
     InputLog()("Character press event received: {} {}",
                _modifier,
                crispy::escape(unicode::convert_to<char>(_value)));
+
     assert(display_ != nullptr);
 
     if (terminatedAndWaitingForKeyPress_)
@@ -867,6 +868,12 @@ bool TerminalSession::operator()(actions::ToggleFullscreen)
 {
     if (display_)
         display_->toggleFullScreen();
+    return true;
+}
+
+bool TerminalSession::operator()(actions::ToggleInputProtection)
+{
+    terminal().setAllowInput(!terminal().allowInput());
     return true;
 }
 

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -162,6 +162,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     bool operator()(actions::SendChars const& _event);
     bool operator()(actions::ToggleAllKeyMaps);
     bool operator()(actions::ToggleFullscreen);
+    bool operator()(actions::ToggleInputProtection);
     bool operator()(actions::ToggleStatusLine);
     bool operator()(actions::ToggleTitleBar);
     bool operator()(actions::ViNormalMode);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -539,6 +539,7 @@ color_schemes:
 # - SendChars         Writes given characters in `chars` member to the applications input.
 # - ToggleAllKeyMaps  Disables/enables responding to all keybinds (this keybind will be preserved when disabling all others).
 # - ToggleFullScreen  Enables/disables full screen mode.
+# - ToggleInputProtection Enables/disables terminal input protection.
 # - ToggleStatusLine  Shows/hides the VT320 compatible Indicator status line.
 # - ToggleTitleBar    Shows/Hides titlebar
 # - ViNormalMode      Enters Vi-like normal mode. The cursor can then be moved via h/j/k/l movements and text can be selected via v, yanked via y, and clipboard pasted via p.

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -568,6 +568,9 @@ class Terminal
     void setStatusDisplay(StatusDisplayType statusDisplayType);
     void setActiveStatusDisplay(ActiveStatusDisplay activeDisplay);
 
+    bool allowInput() const noexcept { return !isModeEnabled(AnsiMode::KeyboardAction); }
+    void setAllowInput(bool enabled) noexcept { setMode(AnsiMode::KeyboardAction, !enabled); }
+
   private:
     void mainLoop();
     void refreshRenderBuffer(RenderBuffer& _output); // <- acquires the lock


### PR DESCRIPTION
Closes #697.

Utilizing (already existing) DECKAM for this feature.