### PR TITLE
Adds CLI syntax `contour info vt` to print list of supporte VT sequences

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -36,6 +36,7 @@
 - Adds new action `ToggleInputProtection` to protect terminal application against accidental input (#697).
 - Adds configuration options `logging.enabled` as well as `logging.file`.
 - Adds VT sequences `XTPUSHCOLORS`, `XTPOPCOLORS`, `XTREPORTCOLORS` (#714).
+- Adds CLI syntax `contour info vt` to print list of supported VT sequences (#730).
 
 ### 0.3.1 (2022-05-01)
 

--- a/src/contour/ContourApp.h
+++ b/src/contour/ContourApp.h
@@ -36,6 +36,7 @@ class ContourApp: public crispy::App
     int terminfoAction();
     int configAction();
     int integrationAction();
+    int infoVT();
 };
 
 } // namespace contour

--- a/src/crispy/escape.h
+++ b/src/crispy/escape.h
@@ -36,9 +36,7 @@ inline std::string escape(uint8_t ch)
         case '\n': return "\\n";
         case '"': return "\\\"";
         default:
-            if (ch < 0x20)
-                return fmt::format("\\{:03o}", static_cast<uint8_t>(ch) & 0xFF);
-            else if (ch < 0x80)
+            if (0x20 <= ch && ch < 0x80)
                 return fmt::format("{}", static_cast<char>(ch));
             else
                 return fmt::format("\\x{:02x}", static_cast<uint8_t>(ch) & 0xFF);

--- a/src/terminal/InputGenerator_test.cpp
+++ b/src/terminal/InputGenerator_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE("InputGenerator.Ctrl+Space", "[terminal,input]")
 {
     auto input = InputGenerator {};
     input.generate(L' ', Modifier::Control);
-    CHECK(escape(input.peek()) == "\\000");
+    CHECK(escape(input.peek()) == "\\x00");
 }
 
 TEST_CASE("InputGenerator.Ctrl+A", "[terminal,input]")

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -3286,8 +3286,8 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
         case TBC: return impl::TBC(seq, *this);
         case VPA: moveCursorToLine(seq.param_or<LineOffset>(0, LineOffset { 1 }) - 1); break;
         case WINMANIP: return impl::WINDOWMANIP(seq, _terminal);
-        case DECMODERESTORE: return impl::restoreDECModes(seq, *this);
-        case DECMODESAVE: return impl::saveDECModes(seq, *this);
+        case XTRESTORE: return impl::restoreDECModes(seq, *this);
+        case XTSAVE: return impl::saveDECModes(seq, *this);
         case XTPOPCOLORS:
             if (!seq.parameterCount())
                 _terminal.popColorPalette(0);
@@ -3340,7 +3340,7 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
         case RCOLPAL: return impl::RCOLPAL(seq, *this);
         case SETCWD: return impl::SETCWD(seq, *this);
         case HYPERLINK: return impl::HYPERLINK(seq, *this);
-        case CAPTURE: return impl::CAPTURE(seq, _terminal);
+        case XTCAPTURE: return impl::CAPTURE(seq, _terminal);
         case COLORFG:
             return impl::setOrRequestDynamicColor(seq, *this, DynamicColorName::DefaultForegroundColor);
         case COLORBG:

--- a/src/terminal/VTType.h
+++ b/src/terminal/VTType.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <crispy/assert.h>
+
 #include <fmt/format.h>
 
 #include <string>
@@ -39,6 +41,14 @@ enum class VTType
     VT510 = 61,
     VT520 = 64,
     VT525 = 65,
+};
+
+enum class VTExtension
+{
+    None,
+    Unknown,
+    XTerm,
+    Contour,
 };
 
 /**
@@ -106,7 +116,28 @@ struct formatter<terminal::VTType>
             case terminal::VTType::VT520: return fmt::format_to(ctx.out(), "VT520");
             case terminal::VTType::VT525: return fmt::format_to(ctx.out(), "VT525");
         }
-        return fmt::format_to(ctx.out(), "INVALID-{}", static_cast<unsigned>(_id));
+        crispy::unreachable();
+    }
+};
+template <>
+struct formatter<terminal::VTExtension>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(const terminal::VTExtension _id, FormatContext& ctx)
+    {
+        switch (_id)
+        {
+            case terminal::VTExtension::None: return fmt::format_to(ctx.out(), "none");
+            case terminal::VTExtension::Unknown: return fmt::format_to(ctx.out(), "unknown");
+            case terminal::VTExtension::XTerm: return fmt::format_to(ctx.out(), "XTerm");
+            case terminal::VTExtension::Contour: return fmt::format_to(ctx.out(), "Contour");
+        }
+        crispy::unreachable();
     }
 };
 } // namespace fmt


### PR DESCRIPTION
Implements #730

<details>
<summary>It currently looks like something like this:</summary>

```txt
C0 sequences
============

 EOT                  EOT             End of Transmission (VT100)
 BEL                  BEL             Bell (VT100)
 BS                   BS              Backspace (VT100)
 TAB                  TAB             Tab (VT100)
 LF                   LF              Line Feed (VT100)
 VT                   VT              Vertical Tab (VT100)
 FF                   FF              Form Feed (VT100)
 CR                   CR              Carriage Return (VT100)
 SO                   SO              Shift Out; Switch to an alternative character set.  (VT100)
 SI                   SI              Shift In; Return to regular character set after Shift Out. (VT100)

ESC sequences
=============

 SCS_G0_SPECIAL       ESC ( 0         Set G0 to DEC Special Character and Line Drawing Set (VT100)
 SCS_G1_SPECIAL       ESC ) 0         Set G1 to DEC Special Character and Line Drawing Set (VT100)
 DECBI                ESC   6         Back Index (VT100)
 DECSC                ESC   7         Save Cursor (VT100)
 DECRS                ESC   8         Restore Cursor (VT100)
 DECALN               ESC # 8         Screen Alignment Pattern (VT100)
 DECFI                ESC   9         Forward Index (VT100)
 DECKPAM              ESC   =         Keypad Application Mode (VT100)
 DECKPNM              ESC   >         Keypad Numeric Mode (VT100)
 SCS_G0_USASCII       ESC ( B         Set G0 to USASCII (VT100)
 SCS_G1_USASCII       ESC ) B         Set G1 to USASCII (VT100)
 IND                  ESC   D         Index (VT100)
 NEL                  ESC   E         Next Line (VT100)
 HTS                  ESC   H         Horizontal Tab Set (VT100)
 RI                   ESC   M         Reverse Index (VT100)
 SS2                  ESC   N         Single Shift Select (G2 Character Set) (VT220)
 SS3                  ESC   O         Single Shift Select (G3 Character Set) (VT220)
 RIS                  ESC   c         Reset to Initial State (Hard Reset) (VT100)

CSI sequences
=============

 DECXCPR              CSI   0      6  Request extended cursor position (VT100)
 ICH                  CSI   0..1   @  Insert character (VT420)
 CUU                  CSI   0..1   A  Move cursor up (VT100)
 CUD                  CSI   0..1   B  Move cursor down (VT100)
 CUF                  CSI   0..1   C  Move cursor forward (VT100)
 CUB                  CSI   0..1   D  Move cursor backward (VT100)
 CNL                  CSI   0..1   E  Move cursor to next line (VT100)
 CPL                  CSI   0..1   F  Move cursor to previous line (VT100)
 CHA                  CSI   0..1   G  Move cursor to column (VT100)
 CUP                  CSI   0..2   H  Move cursor to position (VT100)
 CHT                  CSI   0..1   I  Cursor Horizontal Forward Tabulation (VT100)
 ED                   CSI   0..    J  Erase in display (VT100)
 EL                   CSI   0..1   K  Erase in line (VT100)
 IL                   CSI   0..1   L  Insert lines (VT100)
 DL                   CSI   0..1   M  Delete lines (VT100)
 XTSETMARK            CSI > 0      M  Set Vertical Mark (experimental syntax) (Contour)
 DCH                  CSI   0..1   P  Delete characters (VT100)
 XTPUSHCOLORS         CSI   0..  # P  Pushes the color palette onto the palette's saved-stack. (XTerm)
 XTPOPCOLORS          CSI   0..  # Q  Pops the color palette from the palette's saved-stack. (XTerm)
 XTREPORTCOLORS       CSI   0    # R  Reports number of color palettes on the stack. (XTerm)
 SU                   CSI   0..1   S  Scroll up (pan down) (VT100)
 XTSMGRAPHICS         CSI ? 2..4   S  Setting/getting Sixel/ReGIS graphics settings. (XTerm)
 SD                   CSI   0..1   T  Scroll down (pan up) (VT100)
 ECH                  CSI   0..1   X  Erase characters (VT420)
 CBT                  CSI   0..1   Z  Cursor Backward Tabulation (VT100)
 HPA                  CSI   1      `  Horizontal position absolute (VT100)
 HPR                  CSI   1      a  Horizontal position relative (VT100)
 REP                  CSI   1      b  Repeat the preceding graphic character Ps times (VT100)
 DA1                  CSI   0..1   c  Send primary device attributes (VT100)
 DA3                  CSI = 0..1   c  Send tertiary device attributes (VT100)
 DA2                  CSI > 0..1   c  Send secondary device attributes (VT100)
 VPA                  CSI   0..1   d  Vertical Position Absolute (VT100)
 HVP                  CSI   0..2   f  Horizontal and vertical position (VT100)
 TBC                  CSI   0..1   g  Horizontal Tab Clear (VT100)
 SM                   CSI   1..    h  Set mode (VT100)
 DECSM                CSI ? 1..    h  Set DEC-mode (VT100)
 RM                   CSI   1..    l  Reset mode (VT100)
 DECRM                CSI ? 1..    l  Reset DEC-mode (VT100)
 SGR                  CSI   0..    m  Select graphics rendition (VT100)
 CPR                  CSI   1      n  Request Cursor position (VT100)
 DECSTR               CSI   0    ! p  Soft terminal reset (VT100)
 DECSCL               CSI   2    " p  Set conformance level (DECSCL), VT220 and up. (VT220)
 DECRQM_ANSI          CSI   1    $ p  Request ANSI-mode (VT100)
 DECRQM               CSI ? 1    $ p  Request DEC-mode (VT100)
 DECSCUSR             CSI   0..1   q  Set Cursor Style (VT100)
 XTVERSION            CSI > 0..1   q  Query terminal name and version (XTerm)
 DECSTBM              CSI   0..2   r  Set top/bottom margin (VT100)
 DECCARA              CSI   5..  $ r  Change Attributes in Rectangular Area (VT420)
 DECMODERESTORE       CSI ? 0..    r  Restore DEC private modes. (VT525)
 SCOSC                CSI   0      s  Save Cursor (VT100)
 DECSLRM              CSI   2      s  Set left/right margin (VT420)
 XTSHIFTESCAPE        CSI > 0..1   s  Set/reset shift-escape options. (XTerm)
 DECMODESAVE          CSI ? 0..    s  Save DEC private modes. (VT525)
 WINMANIP             CSI   1..3   t  Window Manipulation (XTerm)
 XTCAPTURE            CSI > 0..2   t  Report screen buffer capture. (Contour)
 ANSISYSSC            CSI   0      u  Save Cursor (ANSI.SYS) (VT100)
 DECCRA               CSI   0..8 $ v  Copy rectangular area (VT420)
 DECRQPSR             CSI   1    $ w  Request presentation state report (VT320)
 DECFRA               CSI   0..4 $ x  Fill rectangular area (VT420)
 DECERA               CSI   0..4 $ z  Erase rectangular area (VT420)
 DECSCPP              CSI   0..1 $ |  Select 80 or 132 Columns per Page (VT100)
 DECSNLS              CSI   0..1 * |  Select number of lines per screen. (VT420)
 DECSASD              CSI   0..1 $ }  Select Active Status Display (VT420)
 DECIC                CSI   0..1 ' }  Insert column (VT420)
 DECSSDT              CSI   0..1 $ ~  Select Status Display (Line) Type (VT320)
 DECDC                CSI   0..1 ' ~  Delete column (VT420)

OSC sequences
=============

 SETINICON            OSC 0           Change Window & Icon Title (XTerm)
 SETWINICON           OSC 1           Change Icon Title (XTerm)
 SETWINTITLE          OSC 2           Change Window Title (XTerm)
 SETXPROP             OSC 3           Set X11 property (XTerm)
 SETCOLPAL            OSC 4           Set/Query color palette (XTerm)
 SETCWD               OSC 7           Set current working directory (XTerm)
 HYPERLINK            OSC 8           Hyperlinked Text (unknown)
 COLORFG              OSC 10          Change or request text foreground color. (XTerm)
 COLORBG              OSC 11          Change or request text background color. (XTerm)
 COLORCURSOR          OSC 12          Change text cursor color to Pt. (XTerm)
 COLORMOUSEFG         OSC 13          Change mouse foreground color. (XTerm)
 COLORMOUSEBG         OSC 14          Change mouse background color. (XTerm)
 SETFONT              OSC 50          Get or set font. (XTerm)
 CLIPBOARD            OSC 52          Clipboard management. (XTerm)
 SETFONTALL           OSC 60          Get or set all font faces, styles, size. (Contour)
 RCOLPAL              OSC 104         Reset color full palette or entry (XTerm)
 COLORSPECIAL         OSC 106         Enable/disable Special Color Number c. (XTerm)
 RCOLORFG             OSC 110         Reset VT100 text foreground color. (XTerm)
 RCOLORBG             OSC 111         Reset VT100 text background color. (XTerm)
 RCOLORCURSOR         OSC 112         Reset text cursor color. (XTerm)
 RCOLORMOUSEFG        OSC 113         Reset mouse foreground color. (XTerm)
 RCOLORMOUSEBG        OSC 114         Reset mouse background color. (XTerm)
 RCOLORHIGHLIGHTBG    OSC 117         Reset highlight background color. (XTerm)
 RCOLORHIGHLIGHTFG    OSC 119         Reset highlight foreground color. (XTerm)
 NOTIFY               OSC 777         Send Notification. (XTerm)
 DUMPSTATE            OSC 888         Dumps internal state to debug stream. (Contour)

DCS sequences
=============

 XTSETPROFILE         DCS   0    $ p  Set Terminal Profile (Contour)
 DECSIXEL             DCS   0..3   q  Sixel Graphics Image (VT330)
 DECRQSS              DCS   0    $ q  Request Status String (VT420)
 XTGETTCAP            DCS   0    + q  Request Termcap/Terminfo String (XTerm)


```
</details>

### ideas for future improvements.

- more meta information
- actual output format like markdown?
- show syntax in a more human friendly way (currently the syntax string is auto-generated from the function definition)
- Maybe add `filter` CLI option to allow filtering output by given string (matched against mnemonic and description)?