### PR TITLE
[terminal] `inflate` uses `Grid::defaultColors` for filling empty cells

### DIFF
--- a/src/crispy/ring.h
+++ b/src/crispy/ring.h
@@ -172,6 +172,11 @@ class ring: public basic_ring<T, Container<T, Allocator>>
         this->rezero();
         this->_storage.resize(newSize);
     }
+    void resize(size_t newSize, const T& value)
+    {
+        this->rezero();
+        this->_storage.resize(newSize, value);
+    }
     void clear()
     {
         this->_storage.clear();

--- a/src/terminal/Grid.h
+++ b/src/terminal/Grid.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 
+#include <terminal/Color.h>
 #include <terminal/GraphicsAttributes.h>
 #include <terminal/Line.h>
 #include <terminal/primitives.h>
@@ -506,6 +507,12 @@ class Grid
     [[nodiscard]] constexpr LineCount linesUsed() const noexcept;
 
     void verifyState() const;
+    void setDefaultColor(Color foreground, Color background) noexcept
+    {
+        defaultColors.first = foreground;
+        defaultColors.second = background;
+    }
+    auto defaultColor() const noexcept { return defaultColors; }
 
   private:
     CellLocation growLines(LineCount _newHeight, CellLocation _cursor);
@@ -516,7 +523,7 @@ class Grid
     void resizeBuffers(PageSize _newSize)
     {
         auto const newTotalLineCount = historyLineCount() + _newSize.lines;
-        lines_.resize(unbox<size_t>(newTotalLineCount));
+        lines_.resize(unbox<size_t>(newTotalLineCount), Line(*this));
         pageSize_ = _newSize;
     }
 
@@ -542,6 +549,7 @@ class Grid
 
     // Number of lines used in the Lines buffer.
     LineCount linesUsed_;
+    std::pair<Color, Color> defaultColors { DefaultColor(), DefaultColor() };
 };
 
 template <typename Cell>

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include <terminal/GraphicsAttributes.h>
+#include <terminal/Grid.h>
 #include <terminal/Line.h>
 
 #include <unicode/grapheme_segmenter.h>
@@ -142,7 +143,7 @@ std::string Line<Cell>::toUtf8Trimmed() const
 }
 
 template <typename Cell>
-InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
+InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input, Grid<Cell> const& grid)
 {
     static constexpr char32_t ReplacementCharacter { 0xFFFD };
 
@@ -189,20 +190,12 @@ InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
     }
     assert(columns.size() == unbox<size_t>(input.usedColumns));
 
+    auto [fg, bg] = grid.defaultColor();
+    GraphicsAttributes sgr { fg, bg };
     while (columns.size() < unbox<size_t>(input.displayWidth))
-        columns.emplace_back(Cell { input.attributes });
+        columns.emplace_back(Cell { sgr });
 
     return columns;
-}
-
-template <typename Cell>
-void Line<Cell>::fillRemainingCells(GraphicsAttributes const& _sgr, HyperlinkId hyperlink)
-{
-    auto& buffer = inflatedBuffer();
-    for (auto start = buffer.rbegin();
-         start != buffer.rend() && (start->empty() && (start->codepoint(0) != 0x20));
-         ++start)
-        start->reset(_sgr, hyperlink);
 }
 
 } // end namespace terminal

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -865,6 +865,8 @@ void Screen<Cell>::clearScreen()
     // Instead of *just* clearing the screen, and thus, losing potential important content,
     // we scroll up by RowCount number of lines, so move it all into history, so the user can scroll
     // up in case the content is still needed.
+    grid().setDefaultColor(_state.cursor.graphicsRendition.foregroundColor,
+                           _state.cursor.graphicsRendition.backgroundColor);
     scrollUp(_state.pageSize.lines);
 }
 

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -1383,11 +1383,7 @@ void Terminal::setGraphicsRendition(GraphicsRendition _rendition)
     // 3.) clear some bits &= ~
     switch (_rendition)
     {
-        case GraphicsRendition::Reset:
-            state_.cursor.graphicsRendition = {};
-            primaryScreen_.currentLine().fillRemainingCells(state_.cursor.graphicsRendition,
-                                                            state_.cursor.hyperlink);
-            break;
+        case GraphicsRendition::Reset: state_.cursor.graphicsRendition = {}; break;
         case GraphicsRendition::Bold: state_.cursor.graphicsRendition.styles |= CellFlags::Bold; break;
         case GraphicsRendition::Faint: state_.cursor.graphicsRendition.styles |= CellFlags::Faint; break;
         case GraphicsRendition::Italic: state_.cursor.graphicsRendition.styles |= CellFlags::Italic; break;


### PR DESCRIPTION
This PR adds a new data member `defaultColors` (open to suggestions for name) to `terminal::Grid`. This data member stores the last foreground and background colors with which grid got painted (for example by calling `\e[48;5;196m\e[2J` or with clear command). This data member is used in `inflate` function, to fill correct colors in empty cells. Currently we fill those empty cells with what the `TriviallyStyledLineBuffer` holds in it's `attributes` member, but this may not have same foreground and background color, with which last time whole grid got painted. Also this data member must only be updated whenever whole screen is painted.

Currently I just added a const reference in `Line`, but I am open to suggestions  for other ways to share that data member of `Grid` with `inflate` function.  

closes #738 