### PR TITLE
Trivial line related refactors and an alternative less intrusive fix proposal.

### DIFF
--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -142,7 +142,7 @@ std::string Line<Cell>::toUtf8Trimmed() const
 }
 
 template <typename Cell>
-InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input)
+InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
 {
     static constexpr char32_t ReplacementCharacter { 0xFFFD };
 

--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -169,7 +169,8 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
         {
             columns.emplace_back(Cell {});
             columns.back().setHyperlink(input.hyperlink);
-            columns.back().write(input.attributes, nextChar, static_cast<uint8_t>(unicode::width(nextChar)));
+            columns.back().write(
+                input.textAttributes, nextChar, static_cast<uint8_t>(unicode::width(nextChar)));
         }
         else
         {
@@ -181,7 +182,7 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
                 auto const n = min(extendedWidth, cellsAvailable);
                 for (int i = 1; i < n; ++i)
                 {
-                    columns.emplace_back(Cell { input.attributes });
+                    columns.emplace_back(Cell { input.textAttributes });
                     columns.back().setHyperlink(input.hyperlink);
                 }
             }
@@ -190,7 +191,7 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
     assert(columns.size() == unbox<size_t>(input.usedColumns));
 
     while (columns.size() < unbox<size_t>(input.displayWidth))
-        columns.emplace_back(Cell { input.attributes });
+        columns.emplace_back(Cell { input.fillAttributes });
 
     return columns;
 }

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -51,7 +51,7 @@ template <typename T> struct OptionalProperty<T, true> { T value; };
 /**
  * Line storage with call columns sharing the same SGR attributes.
  */
-struct TriviallyStyledLineBuffer
+struct TrivialLineBuffer
 {
     ColumnCount displayWidth;
     GraphicsAttributes attributes;
@@ -72,12 +72,12 @@ struct TriviallyStyledLineBuffer
 template <typename Cell>
 using InflatedLineBuffer = std::vector<Cell>;
 
-/// Unpacks a TriviallyStyledLineBuffer into an InflatedLineBuffer<Cell>.
+/// Unpacks a TrivialLineBuffer into an InflatedLineBuffer<Cell>.
 template <typename Cell>
-InflatedLineBuffer<Cell> inflate(TriviallyStyledLineBuffer const& input);
+InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input);
 
 template <typename Cell>
-using LineStorage = std::variant<TriviallyStyledLineBuffer, InflatedLineBuffer<Cell>>;
+using LineStorage = std::variant<TrivialLineBuffer, InflatedLineBuffer<Cell>>;
 
 /**
  * Line<Cell> API.
@@ -95,7 +95,7 @@ class Line
     Line& operator=(Line const&) = default;
     Line& operator=(Line&&) noexcept = default;
 
-    using TrivialBuffer = TriviallyStyledLineBuffer;
+    using TrivialBuffer = TrivialLineBuffer;
     using InflatedBuffer = InflatedLineBuffer<Cell>;
     using Storage = LineStorage<Cell>;
     using value_type = Cell;

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -54,7 +54,8 @@ template <typename T> struct OptionalProperty<T, true> { T value; };
 struct TrivialLineBuffer
 {
     ColumnCount displayWidth;
-    GraphicsAttributes attributes;
+    GraphicsAttributes textAttributes;
+    GraphicsAttributes fillAttributes = textAttributes;
     HyperlinkId hyperlink {};
 
     ColumnCount usedColumns {};
@@ -62,7 +63,8 @@ struct TrivialLineBuffer
 
     void reset(GraphicsAttributes _attributes) noexcept
     {
-        attributes = _attributes;
+        textAttributes = _attributes;
+        fillAttributes = _attributes;
         hyperlink = {};
         usedColumns = {};
         text.reset();
@@ -336,12 +338,14 @@ class Line
         storage_ = std::move(buffer);
     }
 
-    void reset(GraphicsAttributes attributes,
+    void reset(GraphicsAttributes textAttributes,
+               GraphicsAttributes fillAttributes,
                HyperlinkId hyperlink,
                crispy::BufferFragment text,
                ColumnCount columnsUsed)
     {
-        storage_ = TrivialBuffer { size(), attributes, hyperlink, columnsUsed, std::move(text) };
+        storage_ =
+            TrivialBuffer { size(), textAttributes, fillAttributes, hyperlink, columnsUsed, std::move(text) };
     }
 
   private:

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Line.inflate", "[Line]")
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
     sgr.styles |= CellFlags::CurlyUnderlined;
     auto const trivial =
-        TriviallyStyledLineBuffer { ColumnCount(10), sgr, HyperlinkId {}, ColumnCount(10), bufferFragment };
+        TrivialLineBuffer { ColumnCount(10), sgr, HyperlinkId {}, ColumnCount(10), bufferFragment };
 
     auto const inflated = inflate<Cell>(trivial);
 

--- a/src/terminal/Line_test.cpp
+++ b/src/terminal/Line_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Line.inflate", "[Line]")
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
     sgr.styles |= CellFlags::CurlyUnderlined;
     auto const trivial =
-        TrivialLineBuffer { ColumnCount(10), sgr, HyperlinkId {}, ColumnCount(10), bufferFragment };
+        TrivialLineBuffer { ColumnCount(10), sgr, sgr, HyperlinkId {}, ColumnCount(10), bufferFragment };
 
     auto const inflated = inflate<Cell>(trivial);
 

--- a/src/terminal/RenderBuffer.h
+++ b/src/terminal/RenderBuffer.h
@@ -25,8 +25,18 @@
 #include <optional>
 #include <vector>
 
+#include <terminal_renderer/RenderTarget.h>
+
 namespace terminal
 {
+
+struct RenderAttributes
+{
+    RGBColor foregroundColor {};
+    RGBColor backgroundColor {};
+    RGBColor decorationColor {};
+    CellFlags flags {};
+};
 
 /**
  * Renderable representation of a grid cell with color-altering pre-applied and
@@ -37,11 +47,8 @@ struct RenderCell
     std::u32string codepoints;
     std::shared_ptr<ImageFragment> image;
     CellLocation position;
-    CellFlags flags;
+    RenderAttributes attributes;
     uint8_t width = 1;
-    RGBColor foregroundColor;
-    RGBColor backgroundColor;
-    RGBColor decorationColor;
 
     bool groupStart = false;
     bool groupEnd = false;
@@ -55,10 +62,8 @@ struct RenderLine
     std::string_view text;
     LineOffset lineOffset;
     ColumnCount usedColumns;
-    RGBColor foregroundColor;
-    RGBColor backgroundColor;
-    RGBColor decorationColor;
-    CellFlags flags;
+    ColumnCount displayWidth;
+    RenderAttributes attributes;
 };
 
 struct RenderCursor

--- a/src/terminal/RenderBuffer.h
+++ b/src/terminal/RenderBuffer.h
@@ -63,7 +63,8 @@ struct RenderLine
     LineOffset lineOffset;
     ColumnCount usedColumns;
     ColumnCount displayWidth;
-    RenderAttributes attributes;
+    RenderAttributes textAttributes;
+    RenderAttributes fillAttributes;
 };
 
 struct RenderCursor

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -280,7 +280,8 @@ RenderLine RenderBufferBuilder<Cell>::createRenderLine(TrivialLineBuffer const& 
     renderLine.lineOffset = lineOffset;
     renderLine.usedColumns = lineBuffer.usedColumns;
     renderLine.text = lineBuffer.text.view();
-    renderLine.attributes = createRenderAttributes(gridPosition, lineBuffer.attributes);
+    renderLine.textAttributes = createRenderAttributes(gridPosition, lineBuffer.textAttributes);
+    renderLine.fillAttributes = createRenderAttributes(gridPosition, lineBuffer.fillAttributes);
 
     return renderLine;
 }
@@ -324,9 +325,9 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TrivialLineBuffer const& lineB
         auto const pos = CellLocation { lineOffset, columnOffset };
         auto const gridPosition = terminal.viewport().translateScreenToGridCoordinate(pos);
         auto const [fg, bg] = makeColorsForCell(gridPosition,
-                                                lineBuffer.attributes.styles,
-                                                lineBuffer.attributes.foregroundColor,
-                                                lineBuffer.attributes.backgroundColor);
+                                                lineBuffer.textAttributes.styles,
+                                                lineBuffer.textAttributes.foregroundColor,
+                                                lineBuffer.textAttributes.backgroundColor);
         auto const width = graphemeClusterWidth(graphemeCluster);
         // fmt::print(" start {}, count {}, bytes {}, grapheme cluster \"{}\"\n",
         //            columnOffset,
@@ -337,10 +338,10 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TrivialLineBuffer const& lineB
         output.cells.emplace_back(makeRenderCellExplicit(terminal.colorPalette(),
                                                          graphemeCluster,
                                                          width,
-                                                         lineBuffer.attributes.styles,
+                                                         lineBuffer.textAttributes.styles,
                                                          fg,
                                                          bg,
-                                                         lineBuffer.attributes.underlineColor,
+                                                         lineBuffer.textAttributes.underlineColor,
                                                          baseLine + lineOffset,
                                                          columnOffset));
 
@@ -356,14 +357,14 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TrivialLineBuffer const& lineB
     {
         auto const pos = CellLocation { lineOffset, columnOffset };
         auto const gridPosition = terminal.viewport().translateScreenToGridCoordinate(pos);
-        auto renderAttributes = createRenderAttributes(gridPosition, lineBuffer.attributes);
+        auto renderAttributes = createRenderAttributes(gridPosition, lineBuffer.fillAttributes);
 
         output.cells.emplace_back(makeRenderCellExplicit(terminal.colorPalette(),
                                                          char32_t { 0 },
-                                                         lineBuffer.attributes.styles,
+                                                         lineBuffer.fillAttributes.styles,
                                                          renderAttributes.foregroundColor,
                                                          renderAttributes.backgroundColor,
-                                                         lineBuffer.attributes.underlineColor,
+                                                         lineBuffer.fillAttributes.underlineColor,
                                                          baseLine + lineOffset,
                                                          columnOffset));
     }

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -271,7 +271,7 @@ RenderAttributes RenderBufferBuilder<Cell>::createRenderAttributes(
 }
 
 template <typename Cell>
-RenderLine RenderBufferBuilder<Cell>::createRenderLine(TriviallyStyledLineBuffer const& lineBuffer,
+RenderLine RenderBufferBuilder<Cell>::createRenderLine(TrivialLineBuffer const& lineBuffer,
                                                        LineOffset lineOffset) const
 {
     auto const pos = CellLocation { lineOffset, ColumnOffset(0) };
@@ -286,8 +286,7 @@ RenderLine RenderBufferBuilder<Cell>::createRenderLine(TriviallyStyledLineBuffer
 }
 
 template <typename Cell>
-void RenderBufferBuilder<Cell>::renderTrivialLine(TriviallyStyledLineBuffer const& lineBuffer,
-                                                  LineOffset lineOffset)
+void RenderBufferBuilder<Cell>::renderTrivialLine(TrivialLineBuffer const& lineBuffer, LineOffset lineOffset)
 {
     // if (lineBuffer.text.size())
     //     fmt::print("Rendering trivial line {:2} 0..{}/{} ({} bytes): \"{}\"\n",

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -83,6 +83,9 @@ class RenderBufferBuilder
     [[nodiscard]] RenderLine createRenderLine(TriviallyStyledLineBuffer const& lineBuffer,
                                               LineOffset lineOffset) const;
 
+    [[nodiscard]] RenderAttributes createRenderAttributes(
+        CellLocation gridPosition, GraphicsAttributes graphicsAttributes) const noexcept;
+
     // clang-format off
     enum class State { Gap, Sequence };
     // clang-format on

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -36,7 +36,7 @@ class RenderBufferBuilder
     /// with their grid cells are to be rendered using renderCell().
     ///
     /// @see renderCell
-    void renderTrivialLine(TriviallyStyledLineBuffer const& _lineBuffer, LineOffset _lineNo);
+    void renderTrivialLine(TrivialLineBuffer const& _lineBuffer, LineOffset _lineNo);
 
     /// This call is guaranteed to be invoked when the the full page has been rendered.
     void finish() noexcept {}
@@ -80,7 +80,7 @@ class RenderBufferBuilder
                                                                    Color foregroundColor,
                                                                    Color backgroundColor) const noexcept;
 
-    [[nodiscard]] RenderLine createRenderLine(TriviallyStyledLineBuffer const& lineBuffer,
+    [[nodiscard]] RenderLine createRenderLine(TrivialLineBuffer const& lineBuffer,
                                               LineOffset lineOffset) const;
 
     [[nodiscard]] RenderAttributes createRenderAttributes(

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -352,6 +352,7 @@ size_t Screen<Cell>::emplaceCharsIntoCurrentLine(string_view _chars, size_t cell
         // Only use fastpath if the currently line hasn't been inflated already.
         // Because we might lose prior-written textual/SGR information otherwise.
         line.reset(_state.cursor.graphicsRendition,
+                   line.trivialBuffer().fillAttributes,
                    _state.cursor.hyperlink,
                    crispy::BufferFragment {
                        _terminal.currentPtyBuffer(),
@@ -402,7 +403,7 @@ bool Screen<Cell>::canResumeEmplace(std::string_view continuationChars) const no
         return false;
     TrivialLineBuffer const& buffer = line.trivialBuffer();
     return buffer.text.view().end() == continuationChars.begin()
-           && buffer.attributes == _state.cursor.graphicsRendition
+           && buffer.textAttributes == _state.cursor.graphicsRendition
            && buffer.hyperlink == _state.cursor.hyperlink
            && buffer.text.owner() == _terminal.currentPtyBuffer();
 }

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -283,7 +283,7 @@ string_view Screen<Cell>::tryEmplaceChars(string_view _chars, size_t cellCount) 
 
     // In case the charset has been altered, no
     // optimization can be applied.
-    // Unless we're storing the charset in the TriviallyStyledLineBuffer, too.
+    // Unless we're storing the charset in the TrivialLineBuffer, too.
     // But for now that's too rare to be beneficial.
     if (!_state.cursor.charsets.isSelected(CharsetId::USASCII))
         return _chars;
@@ -400,7 +400,7 @@ bool Screen<Cell>::canResumeEmplace(std::string_view continuationChars) const no
     auto& line = currentLine();
     if (!line.isTrivialBuffer())
         return false;
-    TriviallyStyledLineBuffer const& buffer = line.trivialBuffer();
+    TrivialLineBuffer const& buffer = line.trivialBuffer();
     return buffer.text.view().end() == continuationChars.begin()
            && buffer.attributes == _state.cursor.graphicsRendition
            && buffer.hyperlink == _state.cursor.hyperlink

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -519,7 +519,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
         auto const& line = grid().lineAt(position.line);
         if (line.isTrivialBuffer())
         {
-            TriviallyStyledLineBuffer const& lineBuffer = line.trivialBuffer();
+            TrivialLineBuffer const& lineBuffer = line.trivialBuffer();
             return lineBuffer.hyperlink;
         }
         return at(position).hyperlink();

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -105,7 +105,7 @@ struct TextRenderBuilder
     void startLine(LineOffset lineOffset);
     void renderCell(Cell const& cell, LineOffset lineOffset, ColumnOffset columnOffset);
     void endLine();
-    void renderTrivialLine(TriviallyStyledLineBuffer const& lineBuffer, LineOffset lineOffset);
+    void renderTrivialLine(TrivialLineBuffer const& lineBuffer, LineOffset lineOffset);
     void finish();
 };
 
@@ -125,7 +125,7 @@ void TextRenderBuilder::endLine()
     text += '\n';
 }
 
-void TextRenderBuilder::renderTrivialLine(TriviallyStyledLineBuffer const& lineBuffer, LineOffset lineOffset)
+void TextRenderBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer, LineOffset lineOffset)
 {
     if (!*lineOffset)
         text.clear();

--- a/src/terminal/VTWriter.cpp
+++ b/src/terminal/VTWriter.cpp
@@ -205,8 +205,8 @@ void VTWriter::write(Line<Cell> const& line)
     if (line.isTrivialBuffer())
     {
         TrivialLineBuffer const& lineBuffer = line.trivialBuffer();
-        setForegroundColor(lineBuffer.attributes.foregroundColor);
-        setBackgroundColor(lineBuffer.attributes.backgroundColor);
+        setForegroundColor(lineBuffer.textAttributes.foregroundColor);
+        setBackgroundColor(lineBuffer.textAttributes.backgroundColor);
         // TODO: hyperlinks, underlineColor and other styles (curly underline etc.)
         write(line.toUtf8());
         // TODO: Write fill columns.

--- a/src/terminal/VTWriter.cpp
+++ b/src/terminal/VTWriter.cpp
@@ -209,6 +209,7 @@ void VTWriter::write(Line<Cell> const& line)
         setBackgroundColor(lineBuffer.attributes.backgroundColor);
         // TODO: hyperlinks, underlineColor and other styles (curly underline etc.)
         write(line.toUtf8());
+        // TODO: Write fill columns.
     }
     else
     {

--- a/src/terminal/VTWriter.cpp
+++ b/src/terminal/VTWriter.cpp
@@ -204,7 +204,7 @@ void VTWriter::write(Line<Cell> const& line)
 {
     if (line.isTrivialBuffer())
     {
-        TriviallyStyledLineBuffer const& lineBuffer = line.trivialBuffer();
+        TrivialLineBuffer const& lineBuffer = line.trivialBuffer();
         setForegroundColor(lineBuffer.attributes.foregroundColor);
         setBackgroundColor(lineBuffer.attributes.backgroundColor);
         // TODO: hyperlinks, underlineColor and other styles (curly underline etc.)

--- a/src/terminal_renderer/BackgroundRenderer.cpp
+++ b/src/terminal_renderer/BackgroundRenderer.cpp
@@ -36,20 +36,23 @@ void BackgroundRenderer::setRenderTarget(RenderTarget& renderTarget,
 
 void BackgroundRenderer::renderLine(RenderLine const& line)
 {
-    if (line.backgroundColor == defaultColor_)
-        return;
+    if (line.attributes.backgroundColor != defaultColor_)
+    {
+        auto const position = CellLocation { line.lineOffset, ColumnOffset(0) };
+        auto const pos = _gridMetrics.map(position);
+        auto const width = _gridMetrics.cellSize.width * Width::cast_from(line.usedColumns);
 
-    auto const position = CellLocation { line.lineOffset, ColumnOffset(0) };
-    auto const pos = _gridMetrics.map(position);
-    auto const width = _gridMetrics.cellSize.width * Width::cast_from(line.usedColumns);
-
-    renderTarget().renderRectangle(
-        pos.x, pos.y, width, _gridMetrics.cellSize.height, RGBAColor(line.backgroundColor, opacity_));
+        renderTarget().renderRectangle(pos.x,
+                                       pos.y,
+                                       width,
+                                       _gridMetrics.cellSize.height,
+                                       RGBAColor(line.attributes.backgroundColor, opacity_));
+    }
 }
 
 void BackgroundRenderer::renderCell(RenderCell const& _cell)
 {
-    if (_cell.backgroundColor == defaultColor_)
+    if (_cell.attributes.backgroundColor == defaultColor_)
         return;
 
     auto const pos = _gridMetrics.map(_cell.position);
@@ -58,7 +61,7 @@ void BackgroundRenderer::renderCell(RenderCell const& _cell)
                                    pos.y,
                                    _gridMetrics.cellSize.width,
                                    _gridMetrics.cellSize.height,
-                                   RGBAColor(_cell.backgroundColor, opacity_));
+                                   RGBAColor(_cell.attributes.backgroundColor, opacity_));
 }
 
 void BackgroundRenderer::inspect(std::ostream& /*output*/) const

--- a/src/terminal_renderer/BackgroundRenderer.cpp
+++ b/src/terminal_renderer/BackgroundRenderer.cpp
@@ -36,7 +36,7 @@ void BackgroundRenderer::setRenderTarget(RenderTarget& renderTarget,
 
 void BackgroundRenderer::renderLine(RenderLine const& line)
 {
-    if (line.attributes.backgroundColor != defaultColor_)
+    if (line.textAttributes.backgroundColor != defaultColor_)
     {
         auto const position = CellLocation { line.lineOffset, ColumnOffset(0) };
         auto const pos = _gridMetrics.map(position);
@@ -46,7 +46,21 @@ void BackgroundRenderer::renderLine(RenderLine const& line)
                                        pos.y,
                                        width,
                                        _gridMetrics.cellSize.height,
-                                       RGBAColor(line.attributes.backgroundColor, opacity_));
+                                       RGBAColor(line.textAttributes.backgroundColor, opacity_));
+    }
+
+    if (line.fillAttributes.backgroundColor != defaultColor_)
+    {
+        auto const position = CellLocation { line.lineOffset, boxed_cast<ColumnOffset>(line.usedColumns) };
+        auto const pos = _gridMetrics.map(position);
+        auto const width =
+            _gridMetrics.cellSize.width * Width::cast_from(line.displayWidth - line.usedColumns);
+
+        renderTarget().renderRectangle(pos.x,
+                                       pos.y,
+                                       width,
+                                       _gridMetrics.cellSize.height,
+                                       RGBAColor(line.fillAttributes.backgroundColor, opacity_));
     }
 }
 

--- a/src/terminal_renderer/DecorationRenderer.cpp
+++ b/src/terminal_renderer/DecorationRenderer.cpp
@@ -106,19 +106,21 @@ void DecorationRenderer::inspect(std::ostream& /*output*/) const
 void DecorationRenderer::renderLine(RenderLine const& line)
 {
     for (auto const& mapping: CellFlagDecorationMappings)
-        if (line.flags & mapping.first)
+        if (line.attributes.flags & mapping.first)
             renderDecoration(mapping.second,
                              _gridMetrics.map(CellLocation { line.lineOffset }),
                              line.usedColumns,
-                             line.decorationColor);
+                             line.attributes.decorationColor);
 }
 
 void DecorationRenderer::renderCell(RenderCell const& _cell)
 {
     for (auto const& mapping: CellFlagDecorationMappings)
-        if (_cell.flags & mapping.first)
-            renderDecoration(
-                mapping.second, _gridMetrics.map(_cell.position), ColumnCount(1), _cell.decorationColor);
+        if (_cell.attributes.flags & mapping.first)
+            renderDecoration(mapping.second,
+                             _gridMetrics.map(_cell.position),
+                             ColumnCount(1),
+                             _cell.attributes.decorationColor);
 }
 
 auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocation tileLocation)

--- a/src/terminal_renderer/DecorationRenderer.cpp
+++ b/src/terminal_renderer/DecorationRenderer.cpp
@@ -106,11 +106,11 @@ void DecorationRenderer::inspect(std::ostream& /*output*/) const
 void DecorationRenderer::renderLine(RenderLine const& line)
 {
     for (auto const& mapping: CellFlagDecorationMappings)
-        if (line.attributes.flags & mapping.first)
+        if (line.textAttributes.flags & mapping.first)
             renderDecoration(mapping.second,
                              _gridMetrics.map(CellLocation { line.lineOffset }),
                              line.usedColumns,
-                             line.attributes.decorationColor);
+                             line.textAttributes.decorationColor);
 }
 
 void DecorationRenderer::renderCell(RenderCell const& _cell)

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -417,7 +417,7 @@ void TextRenderer::renderLine(RenderLine const& renderLine)
     if (renderLine.text.empty())
         return;
 
-    auto const textStyle = makeTextStyle(renderLine.attributes.flags);
+    auto const textStyle = makeTextStyle(renderLine.textAttributes.flags);
 
     auto graphemeClusterSegmenter = unicode::utf8_grapheme_segmenter(renderLine.text);
     auto columnOffset = ColumnOffset(0);
@@ -428,7 +428,7 @@ void TextRenderer::renderLine(RenderLine const& renderLine)
     for (u32string const& graphemeCluster: graphemeClusterSegmenter)
     {
         auto const gridPosition = CellLocation { renderLine.lineOffset, columnOffset };
-        renderCell(gridPosition, graphemeCluster, textStyle, renderLine.attributes.foregroundColor);
+        renderCell(gridPosition, graphemeCluster, textStyle, renderLine.textAttributes.foregroundColor);
 
         auto const width = graphemeClusterWidth(graphemeCluster);
         columnOffset += ColumnOffset::cast_from(width);

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -417,7 +417,7 @@ void TextRenderer::renderLine(RenderLine const& renderLine)
     if (renderLine.text.empty())
         return;
 
-    auto const textStyle = makeTextStyle(renderLine.flags);
+    auto const textStyle = makeTextStyle(renderLine.attributes.flags);
 
     auto graphemeClusterSegmenter = unicode::utf8_grapheme_segmenter(renderLine.text);
     auto columnOffset = ColumnOffset(0);
@@ -428,7 +428,7 @@ void TextRenderer::renderLine(RenderLine const& renderLine)
     for (u32string const& graphemeCluster: graphemeClusterSegmenter)
     {
         auto const gridPosition = CellLocation { renderLine.lineOffset, columnOffset };
-        renderCell(gridPosition, graphemeCluster, textStyle, renderLine.foregroundColor);
+        renderCell(gridPosition, graphemeCluster, textStyle, renderLine.attributes.foregroundColor);
 
         auto const width = graphemeClusterWidth(graphemeCluster);
         columnOffset += ColumnOffset::cast_from(width);
@@ -441,7 +441,10 @@ void TextRenderer::renderCell(RenderCell const& cell)
     if (cell.groupStart)
         updateInitialPenPosition_ = true;
 
-    renderCell(cell.position, cell.codepoints, makeTextStyle(cell.flags), cell.foregroundColor);
+    renderCell(cell.position,
+               cell.codepoints,
+               makeTextStyle(cell.attributes.flags),
+               cell.attributes.foregroundColor);
 
     if (cell.groupEnd)
         flushTextClusterGroup();


### PR DESCRIPTION
Based on the work at #742.
Should be closing #738.

@Utkarsh-khambra - please look at the diff per commit individually.

The first commit does some refactorings, reducing some code duplications by introducing `RenderAttributes`. This looks like a little bit of overkill at first, but makes sense in the third commit.

The second commit simply renames the trival-line buffer struct to `TrivialLineBuffer` to finally fix my brain damage and hopefully have a nice and yet still self-explaining type name. :)

The third commit **actually fixes** the line inflation bug by differenciating between SGR at the time of line creation/erase/reset versus current SGR at the time of actually writing the text.

@Utkarsh-khambra I by no means intended to steal that from you, but I hoped to give you a less intrusive solution with that.
What do you think?