### PR TITLE
Removes `fillRemainingCells`, which clears line on `CSI 0m`

### DIFF
--- a/src/terminal/Line.cpp
+++ b/src/terminal/Line.cpp
@@ -195,17 +195,6 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
 
     return columns;
 }
-
-template <typename Cell>
-void Line<Cell>::fillRemainingCells(GraphicsAttributes const& _sgr, HyperlinkId hyperlink)
-{
-    auto& buffer = inflatedBuffer();
-    for (auto start = buffer.rbegin();
-         start != buffer.rend() && (start->empty() && (start->codepoint(0) != 0x20));
-         ++start)
-        start->reset(_sgr, hyperlink);
-}
-
 } // end namespace terminal
 
 #include <terminal/Cell.h>

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -124,7 +124,6 @@ class Line
             setBuffer(TrivialBuffer { size(), _attributes });
     }
 
-    void fillRemainingCells(GraphicsAttributes const& _sgr, HyperlinkId hyperlink);
     void fill(LineFlags _flags,
               GraphicsAttributes const& _attributes,
               char32_t _codepoint,

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -1383,11 +1383,7 @@ void Terminal::setGraphicsRendition(GraphicsRendition _rendition)
     // 3.) clear some bits &= ~
     switch (_rendition)
     {
-        case GraphicsRendition::Reset:
-            state_.cursor.graphicsRendition = {};
-            primaryScreen_.currentLine().fillRemainingCells(state_.cursor.graphicsRendition,
-                                                            state_.cursor.hyperlink);
-            break;
+        case GraphicsRendition::Reset: state_.cursor.graphicsRendition = {}; break;
         case GraphicsRendition::Bold: state_.cursor.graphicsRendition.styles |= CellFlags::Bold; break;
         case GraphicsRendition::Faint: state_.cursor.graphicsRendition.styles |= CellFlags::Faint; break;
         case GraphicsRendition::Italic: state_.cursor.graphicsRendition.styles |= CellFlags::Italic; break;


### PR DESCRIPTION
closes #748 