### PR TITLE
Fixing text cursor coloring along with some code cleanups.

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -38,13 +38,12 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
+#include <QtNetwork/QHostInfo>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 
 #include <algorithm>
 #include <fstream>
-
-#include <QtNetwork/QHostInfo>
 
 #if !defined(_WIN32)
     #include <pthread.h>

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -40,11 +40,10 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
+#include <QtNetwork/QHostInfo>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QStyle>
-
-#include <QtNetwork/QHostInfo>
 
 #if defined(CONTOUR_BLUR_PLATFORM_KWIN)
     #include <KWindowEffects>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -24,13 +24,12 @@
 #include <QtCore/QStringList>
 #include <QtCore/QUrl>
 #include <QtGui/QGuiApplication>
+#include <QtNetwork/QHostInfo>
 #include <QtWidgets/QMessageBox>
 
 #include <algorithm>
 #include <array>
 #include <mutex>
-
-#include <QtNetwork/QHostInfo>
 
 using std::array;
 using std::clamp;

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -75,10 +75,10 @@ class RenderBufferBuilder
     /// Constructs the final foreground/background colors to be displayed on the screen.
     ///
     /// This call takes cursor-position, hyperlink-states, selection, and reverse-video mode into account.
-    [[nodiscard]] std::tuple<RGBColor, RGBColor> makeColorsForCell(CellLocation,
-                                                                   CellFlags cellFlags,
-                                                                   Color foregroundColor,
-                                                                   Color backgroundColor) const noexcept;
+    [[nodiscard]] RGBColorPair makeColorsForCell(CellLocation,
+                                                 CellFlags cellFlags,
+                                                 Color foregroundColor,
+                                                 Color backgroundColor) const noexcept;
 
     [[nodiscard]] RenderLine createRenderLine(TrivialLineBuffer const& lineBuffer,
                                               LineOffset lineOffset) const;


### PR DESCRIPTION
When colorscheme's cursor color is set to inverted CellBackground/CellForeground, it seems that a bug has slipped in and the cursor becomes unreadable when cursor shape is block.

This PR primarily factors grid cell colorization with respect to: isCursor / cell hidden / reverse video / actual SGR / configured selection colors / configured highlight colors.

I think the bug was introduced after last release, so no changelog entry really needed.