### PR TITLE
Inverting rendering coordinate system's Y-axis.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 ### 0.3.3 (unreleased)
 
+- Internal: Y-axis inverted to match GUI coordinate systems where (0, 0) is top left rather than bottom left.
+
 ### 0.3.2 (2022-07-07)
 
 - Fixes writing to a non-empty line sometimes destroying the contents of that line (#702).

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -204,10 +204,9 @@ OpenGLRenderer::OpenGLRenderer(ShaderConfig const& textShaderConfig,
     _now { _startTime },
     _renderTargetSize { targetSurfaceSize },
     _projectionMatrix { ortho(0.0f,
-                              unbox<float>(targetSurfaceSize.width), // left, right
-                              0.0f,
-                              unbox<float>(targetSurfaceSize.height) // bottom, top
-                              ) },
+                              unbox<float>(targetSurfaceSize.width),  // left, right
+                              unbox<float>(targetSurfaceSize.height), // bottom, top
+                              0.0f) },
     _margin { margin },
     _textShader { createShader(textShaderConfig) },
     _textProjectionLocation { _textShader->uniformLocation("vs_projection") },
@@ -248,10 +247,9 @@ void OpenGLRenderer::setRenderSize(ImageSize targetSurfaceSize)
     _renderTargetSize = targetSurfaceSize;
     DisplayLog()("Setting render target size to {}.", _renderTargetSize);
     _projectionMatrix = ortho(0.0f,
-                              unbox<float>(_renderTargetSize.width), // left, right
-                              0.0f,
-                              unbox<float>(_renderTargetSize.height) // bottom, top
-    );
+                              unbox<float>(_renderTargetSize.width),  // left, right
+                              unbox<float>(_renderTargetSize.height), // bottom, top
+                              0.0f);
 }
 
 void OpenGLRenderer::setMargin(terminal::renderer::PageMargin margin) noexcept

--- a/src/terminal_renderer/BackgroundRenderer.cpp
+++ b/src/terminal_renderer/BackgroundRenderer.cpp
@@ -39,7 +39,7 @@ void BackgroundRenderer::renderLine(RenderLine const& line)
     if (line.textAttributes.backgroundColor != defaultColor_)
     {
         auto const position = CellLocation { line.lineOffset, ColumnOffset(0) };
-        auto const pos = _gridMetrics.map(position);
+        auto const pos = _gridMetrics.mapTopLeft(position);
         auto const width = _gridMetrics.cellSize.width * Width::cast_from(line.usedColumns);
 
         renderTarget().renderRectangle(pos.x,
@@ -52,7 +52,7 @@ void BackgroundRenderer::renderLine(RenderLine const& line)
     if (line.fillAttributes.backgroundColor != defaultColor_)
     {
         auto const position = CellLocation { line.lineOffset, boxed_cast<ColumnOffset>(line.usedColumns) };
-        auto const pos = _gridMetrics.map(position);
+        auto const pos = _gridMetrics.mapTopLeft(position);
         auto const width =
             _gridMetrics.cellSize.width * Width::cast_from(line.displayWidth - line.usedColumns);
 
@@ -69,7 +69,7 @@ void BackgroundRenderer::renderCell(RenderCell const& _cell)
     if (_cell.attributes.backgroundColor == defaultColor_)
         return;
 
-    auto const pos = _gridMetrics.map(_cell.position);
+    auto const pos = _gridMetrics.mapTopLeft(_cell.position);
 
     renderTarget().renderRectangle(pos.x,
                                    pos.y,

--- a/src/terminal_renderer/DecorationRenderer.cpp
+++ b/src/terminal_renderer/DecorationRenderer.cpp
@@ -108,7 +108,7 @@ void DecorationRenderer::renderLine(RenderLine const& line)
     for (auto const& mapping: CellFlagDecorationMappings)
         if (line.textAttributes.flags & mapping.first)
             renderDecoration(mapping.second,
-                             _gridMetrics.map(CellLocation { line.lineOffset }),
+                             _gridMetrics.mapBottomLeft(CellLocation { line.lineOffset }),
                              line.usedColumns,
                              line.textAttributes.decorationColor);
 }
@@ -118,7 +118,7 @@ void DecorationRenderer::renderCell(RenderCell const& _cell)
     for (auto const& mapping: CellFlagDecorationMappings)
         if (_cell.attributes.flags & mapping.first)
             renderDecoration(mapping.second,
-                             _gridMetrics.map(_cell.position),
+                             _gridMetrics.mapBottomLeft(_cell.position),
                              ColumnCount(1),
                              _cell.attributes.decorationColor);
 }
@@ -312,7 +312,7 @@ void DecorationRenderer::renderDecoration(Decorator decoration,
         TextureAtlas::TileCreateData tileData = createTileData(decoration, tileLocation);
         AtlasTileAttributes const& tileAttributes = _textureAtlas->directMapped(tileIndex);
         renderTile({ pos.x + unbox<int>(i) * unbox<int>(_gridMetrics.cellSize.width) },
-                   { pos.y },
+                   { pos.y - unbox<int>(tileAttributes.bitmapSize.height) },
                    color,
                    tileAttributes);
     }

--- a/src/terminal_renderer/GridMetrics.h
+++ b/src/terminal_renderer/GridMetrics.h
@@ -64,19 +64,38 @@ struct GridMetrics
 
     /// Maps screen coordinates to target surface coordinates.
     ///
-    /// @param col screen coordinate's column (between 1 and number of screen columns)
-    /// @param line screen coordinate's line (between 1 and number of screen lines)
+    /// @param col screen coordinate's column (between 0 and number of screen columns minus 1)
+    /// @param line screen coordinate's line (between 0 and number of screen lines minus 1)
     ///
-    /// @return 2D point into drawing coordinate system
+    /// @return 2D point into the grid cell's top left in drawing system coordinates.
     constexpr crispy::Point map(LineOffset _line, ColumnOffset _column) const noexcept
     {
+        return mapTopLeft(_line, _column);
+    }
+
+    constexpr crispy::Point map(CellLocation _pos) const noexcept { return map(_pos.line, _pos.column); }
+
+    constexpr crispy::Point mapTopLeft(CellLocation _pos) const noexcept
+    {
+        return mapTopLeft(_pos.line, _pos.column);
+    }
+
+    constexpr crispy::Point mapTopLeft(LineOffset _line, ColumnOffset _column) const noexcept
+    {
         auto const x = pageMargin.left + *_column * cellSize.width.as<int>();
-        auto const y = pageMargin.bottom + (*pageSize.lines - *_line - 1) * cellSize.height.as<int>();
+        auto const y = pageMargin.bottom + *_line * cellSize.height.as<int>();
 
         return { x, y };
     }
 
-    constexpr crispy::Point map(CellLocation _pos) const noexcept { return map(_pos.line, _pos.column); }
+    constexpr crispy::Point mapBottomLeft(CellLocation _pos) const noexcept
+    {
+        return mapBottomLeft(_pos.line, _pos.column);
+    }
+    constexpr crispy::Point mapBottomLeft(LineOffset _line, ColumnOffset _column) const noexcept
+    {
+        return mapTopLeft(_line + 1, _column);
+    }
 };
 
 } // namespace terminal::renderer

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -423,7 +423,7 @@ void TextRenderer::renderLine(RenderLine const& renderLine)
     auto columnOffset = ColumnOffset(0);
 
     textClusterGroup_.initialPenPosition =
-        _gridMetrics.map(CellLocation { renderLine.lineOffset, columnOffset });
+        _gridMetrics.mapBottomLeft(CellLocation { renderLine.lineOffset, columnOffset });
 
     for (u32string const& graphemeCluster: graphemeClusterSegmenter)
     {
@@ -458,7 +458,7 @@ void TextRenderer::renderCell(CellLocation position,
     if (updateInitialPenPosition_)
     {
         updateInitialPenPosition_ = false;
-        textClusterGroup_.initialPenPosition = _gridMetrics.map(position);
+        textClusterGroup_.initialPenPosition = _gridMetrics.mapBottomLeft(position);
     }
 
     bool const isBoxDrawingCharacter = fontDescriptions_.builtinBoxDrawing && codepoints.size() == 1
@@ -494,11 +494,11 @@ Point TextRenderer::applyGlyphPositionToPen(Point pen,
     auto const x = pen.x + glyphMetrics.x.value + gpos.offset.x;
 
     // Emoji are simple square bitmap fonts that do not need special positioning.
-    auto const y = pen.y                                        // -> base pen position
-                   + _gridMetrics.baseline                      // -> baseline
-                   + glyphMetrics.y.value                       // -> bitmap top
-                   + gpos.offset.y                              // -> harfbuzz adjustment
-                   - tileAttributes.bitmapSize.height.as<int>() // -> bitmap height
+    auto const y = pen.y                   // -> base pen position
+                   - _gridMetrics.baseline // -> text baseline
+                   - glyphMetrics.y.value  // -> bitmap top
+                   - gpos.offset.y         // -> harfbuzz adjustment
+                                           //- tileAttributes.bitmapSize.height.as<int>() // -> bitmap height
         ;
 
     // fmt::print("pen! {} <- {}, gpos {}, glyph offset {}x+{}y, glyph height {} ({})\n",
@@ -577,7 +577,7 @@ void TextRenderer::flushTextClusterGroup()
     if (!textClusterGroup_.codepoints.empty())
     {
         // fmt::print("TextRenderer.flushTextClusterGroup: textPos={}, cellCount={}, width={}, count={}\n",
-        //            textClusterGroup_.initialPenPosition.x, textClusterGroup_.cellCount,
+        //            textClusterGroup_.initialPenPosition, textClusterGroup_.cellCount,
         //            _gridMetrics.cellSize.width,
         //            textClusterGroup_.codepoints.size());
 

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -56,7 +56,7 @@ namespace
         for (auto i = 0; i < height; i++)
             for (auto j = 0; j < width; j++)
             {
-                const auto base = ((height - 1 - i) * width + j) * 3;
+                const auto base = (i * width + j) * 3;
                 const auto srcR = tmp[base];
                 const auto srcG = tmp[base + 1];
                 const auto srcB = tmp[base + 2];

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -779,10 +779,8 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key _glyph, render_mode 
             auto const pitch = static_cast<size_t>(ftBitmap.pitch);
             for (auto const i: iota(size_t { 0 }, static_cast<size_t>(ftBitmap.rows)))
                 for (auto const j: iota(size_t { 0 }, static_cast<size_t>(ftBitmap.width)))
-                    output.bitmap[i * width.as<size_t>() + j] =
-                        min(static_cast<uint8_t>(
-                                uint8_t(ftBitmap.buffer[(height.as<size_t>() - 1 - i) * pitch + j]) * 255),
-                            uint8_t { 255 });
+                    output.bitmap[i * width.as<size_t>() + j] = min(
+                        static_cast<uint8_t>(uint8_t(ftBitmap.buffer[i * pitch + j]) * 255), uint8_t { 255 });
 
             FT_Bitmap_Done(d->ft_, &ftBitmap);
             break;
@@ -796,8 +794,7 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key _glyph, render_mode 
             auto const s = ftFace->glyph->bitmap.buffer;
             for (auto const i: iota(0u, *output.bitmapSize.height))
                 for (auto const j: iota(0u, *output.bitmapSize.width))
-                    output.bitmap[i * *output.bitmapSize.width + j] =
-                        s[(*output.bitmapSize.height - 1 - i) * pitch + j];
+                    output.bitmap[i * *output.bitmapSize.width + j] = s[i * pitch + j];
             break;
         }
         case FT_PIXEL_MODE_LCD: {
@@ -812,7 +809,7 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key _glyph, render_mode 
             auto const s = ftFace->glyph->bitmap.buffer;
             for (auto const i: iota(0u, ftFace->glyph->bitmap.rows))
                 for (auto const j: iota(0u, ftFace->glyph->bitmap.width))
-                    output.bitmap[i * width + j] = s[(height - 1 - i) * pitch + j];
+                    output.bitmap[i * width + j] = s[i * pitch + j];
             break;
         }
         case FT_PIXEL_MODE_BGRA: {
@@ -820,7 +817,7 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key _glyph, render_mode 
             auto const height = output.bitmapSize.height;
 
             output.format = bitmap_format::rgba;
-            output.bitmap.resize(height.as<size_t>() * width.as<size_t>() * 4);
+            output.bitmap.resize(output.bitmapSize.area() * 4);
             auto t = output.bitmap.begin();
 
             auto const pitch = static_cast<unsigned>(ftFace->glyph->bitmap.pitch);
@@ -829,8 +826,7 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key _glyph, render_mode 
                 for (auto const j: iota(0u, width.as<size_t>()))
                 {
                     auto const s = &ftFace->glyph->bitmap
-                                        .buffer[static_cast<size_t>(height.as<size_t>() - i - 1u) * pitch
-                                                + static_cast<size_t>(j) * 4u];
+                                        .buffer[static_cast<size_t>(i) * pitch + static_cast<size_t>(j) * 4u];
 
                     // BGRA -> RGBA
                     *t++ = s[2];


### PR DESCRIPTION
This is a prep-work refactor for the future move to Qt QML / QtQuick. There, the coordinate system (as in every GUI app) top left is (0, 0) and not bottom left (0, 0).

OpenGL however is the other way around. Qt internally seems to go the GUI way (just like web browsers do, too, so yeah, maintaining two coordinate systems is PITA).

This prep-work ought to make it easier in future QtQuick refactor to adhere to `QQuickitem`'s positioning and transformation API.