### PR TITLE
Adds support for blur-behind window on GNOME shell.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - [Linux] Changes the .desktop file name and icon file name to conform to the flatpak recommendations.
 - [Linux] Provide an AppStream XML file.
 - [Linux] Drop KDE/KWin dependency on the binary by implementing enabling blur-behind background manually.
+- [Linux] Adds support for blur-behind window on GNOME shell (Please read https://github.com/aunetx/blur-my-shell/issues/300 for further details if in trouble).
 - Internal: Y-axis inverted to match GUI coordinate systems where (0, 0) is top left rather than bottom left.
 - Fixes logging file toggle.
 

--- a/src/contour/BlurBehind.cpp
+++ b/src/contour/BlurBehind.cpp
@@ -39,6 +39,7 @@ void setEnabled(QWindow* window, bool enable, QRegion region)
         window->setProperty("kwin_background_contrast", 1);
         window->setProperty("kwin_background_intensity", 1);
         window->setProperty("kwin_background_saturation", 1);
+        window->setProperty("_MUTTER_HINTS", "blur-provider=sigma:60,brightness:0.9");
     }
     else
     {
@@ -47,6 +48,7 @@ void setEnabled(QWindow* window, bool enable, QRegion region)
         window->setProperty("kwin_background_contrast", {});
         window->setProperty("kwin_background_intensity", {});
         window->setProperty("kwin_background_saturation", {});
+        window->setProperty("_MUTTER_HINTS", {});
     }
 #elif defined(_WIN32)
     // Awesome hack with the noteworty links:


### PR DESCRIPTION
Implement what is said in https://github.com/aunetx/blur-my-shell#application-blurring

Refs #52.

I did NOT test this yet. it should work on GNOME shell as far as I understood it. (famous last words).

EDIT: seems like blur-my-shell GNOME shell extension is needed for this to work. I couldn't get it to work yet though.

Waiting on input from https://github.com/aunetx/blur-my-shell/issues/300