### PR TITLE
defer PTY (and Process) creation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - [Linux] Provide an AppStream XML file.
 - [Linux] Drop KDE/KWin dependency on the binary by implementing enabling blur-behind background manually.
 - [Linux] Adds support for blur-behind window on GNOME shell (Please read https://github.com/aunetx/blur-my-shell/issues/300 for further details if in trouble).
+- Changes behavior of PTY (and shell process) creation until only when a PTY is required by the terminal emulator during instanciation, possibly avoiding problems with xdotool running too early.
 - Internal: Y-axis inverted to match GUI coordinate systems where (0, 0) is top left rather than bottom left.
 - Fixes logging file toggle.
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -167,6 +167,7 @@ void TerminalSession::scheduleRedraw()
 
 void TerminalSession::start()
 {
+    terminal_.device().start();
     screenUpdateThread_ = make_unique<std::thread>(bind(&TerminalSession::mainLoop, this));
 }
 

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -95,6 +95,7 @@ class [[nodiscard]] Process: public Pty
 
     // Pty overrides
     // clang-format off
+    void start() override;
     PtySlave& slave() noexcept override { return pty().slave(); }
     void close() override { pty().close(); }
     bool isClosed() const noexcept override { return pty().isClosed(); }

--- a/src/terminal/pty/ConPty.h
+++ b/src/terminal/pty/ConPty.h
@@ -31,6 +31,7 @@ class ConPty: public Pty
     explicit ConPty(PageSize const& windowSize);
     ~ConPty() override;
 
+    void start() override;
     void close() override;
     bool isClosed() const noexcept override;
 

--- a/src/terminal/pty/LinuxPty.h
+++ b/src/terminal/pty/LinuxPty.h
@@ -17,6 +17,7 @@
 #include <terminal/pty/UnixPty.h> // UnixPipe (TODO: move somewhere else)
 
 #include <array>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -49,13 +50,13 @@ class LinuxPty: public Pty
         PtySlaveHandle slave;
     };
 
-    LinuxPty(PageSize const& _windowSize, std::optional<ImageSize> _pixels);
-    LinuxPty(PtyHandles handles, PageSize size);
+    LinuxPty(PageSize _windowSize, std::optional<ImageSize> _pixels);
     ~LinuxPty() override;
 
     PtySlave& slave() noexcept override;
 
     [[nodiscard]] PtyMasterHandle handle() const noexcept;
+    void start() override;
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
@@ -72,12 +73,13 @@ class LinuxPty: public Pty
     std::optional<std::string_view> readSome(int fd, char* target, size_t n) noexcept;
     int waitForReadable(std::chrono::milliseconds timeout) noexcept;
 
-    int _masterFd;
-    int _epollFd;
-    int _eventFd;
+    int _masterFd = -1;
+    int _epollFd = -1;
+    int _eventFd = -1;
     UnixPipe _stdoutFastPipe;
     PageSize _pageSize;
-    Slave _slave;
+    std::optional<ImageSize> _pixels;
+    std::unique_ptr<Slave> _slave;
 };
 
 } // namespace terminal

--- a/src/terminal/pty/MockPty.cpp
+++ b/src/terminal/pty/MockPty.cpp
@@ -56,6 +56,11 @@ void MockPty::resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels)
     pixelSize_ = _pixels;
 }
 
+void MockPty::start()
+{
+    closed_ = false;
+}
+
 void MockPty::close()
 {
     closed_ = true;

--- a/src/terminal/pty/MockPty.h
+++ b/src/terminal/pty/MockPty.h
@@ -36,6 +36,7 @@ class MockPty: public Pty
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
+    void start() override;
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 

--- a/src/terminal/pty/MockViewPty.cpp
+++ b/src/terminal/pty/MockViewPty.cpp
@@ -66,6 +66,11 @@ void MockViewPty::resizeScreen(terminal::PageSize _cells, std::optional<terminal
     pixelSize_ = _pixels;
 }
 
+void MockViewPty::start()
+{
+    closed_ = false;
+}
+
 void MockViewPty::close()
 {
     closed_ = true;

--- a/src/terminal/pty/MockViewPty.h
+++ b/src/terminal/pty/MockViewPty.h
@@ -35,6 +35,7 @@ class MockViewPty: public Pty
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize _cells, std::optional<ImageSize> _pixels = std::nullopt) override;
 
+    void start() override;
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 

--- a/src/terminal/pty/Pty.h
+++ b/src/terminal/pty/Pty.h
@@ -66,6 +66,9 @@ class Pty
 
     virtual ~Pty() = default;
 
+    /// Starts the PTY instance.
+    virtual void start() = 0;
+
     virtual PtySlave& slave() noexcept = 0;
 
     /// Releases this PTY early.

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -16,6 +16,7 @@
 #include <terminal/pty/Pty.h>
 
 #include <array>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -74,13 +75,13 @@ class UnixPty: public Pty
         PtySlaveHandle slave;
     };
 
-    UnixPty(PageSize const& _windowSize, std::optional<ImageSize> _pixels);
-    UnixPty(PtyHandles handles, PageSize size);
+    UnixPty(PageSize _windowSize, std::optional<ImageSize> _pixels);
     ~UnixPty() override;
 
     PtySlave& slave() noexcept override;
 
     PtyMasterHandle handle() const noexcept;
+    void start() override;
     void close() override;
     bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
@@ -96,11 +97,14 @@ class UnixPty: public Pty
   private:
     std::optional<std::string_view> readSome(int fd, char* target, size_t n) noexcept;
 
+    [[nodiscard]] bool started() const noexcept { return _masterFd != -1; }
+
     int _masterFd;
     std::array<int, 2> _pipe;
     UnixPipe _stdoutFastPipe;
     PageSize _pageSize;
-    Slave _slave;
+    std::optional<ImageSize> _pixels;
+    std::unique_ptr<Slave> _slave;
 };
 
 } // namespace terminal


### PR DESCRIPTION
While I do need this change for my QML port of the frontend (as a work-around on a Qt5 bug!), this might still be helpful for the behavior mentioned in #773, where `xdotool` is run during shell initialization but the window may not be visible just yet.

This PR will defer the PTY & shell process creation until it cannot be deferred anymore.