### PR TITLE
[terminal] Always show indicator status line when ANSI mode KAM is enabled (which can be toggled via action `ToggleInputProtection`).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - Adds vim-like `scrolloff` feature to normal mode cursor movements to ensure a line padding when scrolling up/down.
 - Adds support for HSL colorspace in Sixel images.
+- Always show indicator status line when ANSI mode KAM is enabled (which can be toggled via action `ToggleInputProtection`).
 - [Linux] Changes the .desktop file name and icon file name to conform to the flatpak recommendations.
 - [Linux] Provide an AppStream XML file.
 - [Linux] Drop KDE/KWin dependency on the binary by implementing enabling blur-behind background manually.

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -904,6 +904,13 @@ bool TerminalSession::operator()(actions::ToggleStatusLine)
         terminal().setStatusDisplay(StatusDisplayType::Indicator);
     else
         terminal().setStatusDisplay(StatusDisplayType::None);
+
+    // `savedStatusDisplayType` holds only a value if the application has been overriding
+    // the status display type. But the user now actively requests a given type,
+    // so make sure restoring will not destroy the user's desire.
+    if (terminal().state().savedStatusDisplayType)
+        terminal().state().savedStatusDisplayType = terminal().state().statusDisplayType;
+
     return true;
 }
 

--- a/src/terminal/Process_win32.cpp
+++ b/src/terminal/Process_win32.cpp
@@ -176,7 +176,7 @@ Process::Process(string const& _path,
                  FileSystem::path const& _cwd,
                  Environment const& _env,
                  std::unique_ptr<Pty> _pty):
-    d(new Private {_path, _args, _cwd, _env, move(_pty)}, [](Private* p) { delete p; })
+    d(new Private { _path, _args, _cwd, _env, move(_pty) }, [](Private* p) { delete p; })
 {
 }
 

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -1144,6 +1144,14 @@ void Terminal::setMode(AnsiMode _mode, bool _enable)
     if (!isValidAnsiMode(static_cast<unsigned int>(_mode)))
         return;
 
+    if (_mode == AnsiMode::KeyboardAction)
+    {
+        if (_enable)
+            pushStatusDisplay(StatusDisplayType::Indicator);
+        else
+            popStatusDisplay();
+    }
+
     state_.modes.set(_mode, _enable);
 }
 
@@ -1697,6 +1705,29 @@ void Terminal::setActiveStatusDisplay(ActiveStatusDisplay activeDisplay)
             break;
         }
     }
+}
+
+void Terminal::pushStatusDisplay(StatusDisplayType type)
+{
+    // Only remember the outermost saved status display type.
+    if (!state_.savedStatusDisplayType)
+        state_.savedStatusDisplayType = state_.statusDisplayType;
+
+    setStatusDisplay(type);
+}
+
+void Terminal::popStatusDisplay()
+{
+    if (!state_.savedStatusDisplayType)
+        return;
+
+    setStatusDisplay(state_.savedStatusDisplayType.value());
+    state_.savedStatusDisplayType.reset();
+}
+
+void Terminal::setAllowInput(bool enabled)
+{
+    setMode(AnsiMode::KeyboardAction, !enabled);
 }
 
 bool Terminal::isHighlighted(CellLocation _cell) const noexcept

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -583,8 +583,12 @@ class Terminal
     void setStatusDisplay(StatusDisplayType statusDisplayType);
     void setActiveStatusDisplay(ActiveStatusDisplay activeDisplay);
 
+    void pushStatusDisplay(StatusDisplayType statusDisplayType);
+    void popStatusDisplay();
+
     bool allowInput() const noexcept { return !isModeEnabled(AnsiMode::KeyboardAction); }
-    void setAllowInput(bool enabled) noexcept { setMode(AnsiMode::KeyboardAction, !enabled); }
+
+    void setAllowInput(bool enabled);
 
   private:
     void mainLoop();

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -165,6 +165,7 @@ struct TerminalState
     Grid<Cell> hostWritableStatusBuffer; // writable status-display, see DECSASD and DECSSDT.
     Grid<Cell> indicatorStatusBuffer;    // status buffer as used for indicator status line AND error lines.
     StatusDisplayType statusDisplayType;
+    std::optional<StatusDisplayType> savedStatusDisplayType;
     ActiveStatusDisplay activeStatusDisplay;
 
     // cursor related

--- a/src/terminal/ViCommands.cpp
+++ b/src/terminal/ViCommands.cpp
@@ -53,6 +53,7 @@ void ViCommands::modeChanged(ViMode mode)
             terminal.state().cursor.visible = lastCursorVisible;
             terminal.setCursorShape(lastCursorShape);
             terminal.viewport().forceScrollToBottom();
+            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
             break;
         case ViMode::Normal:
@@ -64,21 +65,25 @@ void ViCommands::modeChanged(ViMode mode)
                 cursorPosition = terminal.realCursorPosition();
             if (terminal.selectionAvailable())
                 terminal.clearSelection();
+            terminal.popStatusDisplay();
             terminal.screenUpdated();
             break;
         case ViMode::Visual:
             terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
+            terminal.popStatusDisplay();
             terminal.screenUpdated();
             break;
         case ViMode::VisualLine:
             terminal.setSelector(make_unique<FullLineSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
+            terminal.popStatusDisplay();
             terminal.screenUpdated();
             break;
         case ViMode::VisualBlock:
             terminal.setSelector(make_unique<RectangularSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
+            terminal.popStatusDisplay();
             terminal.screenUpdated();
             break;
     }

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -115,7 +115,7 @@ struct directwrite_shaper::Private
 {
     ComPtr<IDWriteFactory7> factory;
     ComPtr<IDWriteTextAnalyzer1> textAnalyzer;
-    std::unique_ptr<font_locator> locator_;
+    font_locator* locator_;
 
     DPI dpi_;
     std::wstring userLocale;
@@ -124,7 +124,7 @@ struct directwrite_shaper::Private
 
     font_key nextFontKey;
 
-    Private(DPI dpi, std::unique_ptr<font_locator> _locator): dpi_ { dpi }, locator_ { move(_locator) }
+    Private(DPI dpi, font_locator& _locator): dpi_ { dpi }, locator_ { &_locator }
     {
         auto hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED,
                                       __uuidof(IDWriteFactory7),
@@ -271,8 +271,8 @@ struct directwrite_shaper::Private
     float pixelPerDip() { return dpi_.x / 96.0; }
 };
 
-directwrite_shaper::directwrite_shaper(DPI _dpi, std::unique_ptr<font_locator> _locator):
-    d(new Private(_dpi, move(_locator)), [](Private* p) { delete p; })
+directwrite_shaper::directwrite_shaper(DPI _dpi, font_locator& _locator):
+    d(new Private(_dpi, _locator), [](Private* p) { delete p; })
 {
 }
 
@@ -589,9 +589,9 @@ void directwrite_shaper::set_dpi(DPI dpi)
     clear_cache();
 }
 
-void directwrite_shaper::set_locator(std::unique_ptr<font_locator> _locator)
+void directwrite_shaper::set_locator(font_locator& _locator)
 {
-    // TODO: use the given font locator for subsequent font location requests.
+    d->locator_ = &_locator;
 }
 
 void directwrite_shaper::clear_cache()

--- a/src/text_shaper/directwrite_shaper.h
+++ b/src/text_shaper/directwrite_shaper.h
@@ -28,10 +28,10 @@ namespace text
 class directwrite_shaper: public shaper
 {
   public:
-    directwrite_shaper(DPI _dpi, std::unique_ptr<font_locator> _locator);
+    directwrite_shaper(DPI _dpi, font_locator& _locator);
 
     void set_dpi(DPI _dpi) override;
-    void set_locator(std::unique_ptr<font_locator> _locator) override;
+    void set_locator(font_locator& _locator) override;
     void clear_cache() override;
 
     std::optional<font_key> load_font(font_description const& _description, font_size _size) override;

--- a/src/text_shaper/font_locator_provider.h
+++ b/src/text_shaper/font_locator_provider.h
@@ -50,5 +50,4 @@ class font_locator_provider
     std::unique_ptr<font_locator> _mock {};
 };
 
-
-}
+} // namespace text


### PR DESCRIPTION
@whisperity I know you once asked for it. 

While I think this is useful already - I did it as API prep-work for incremental search (which also needs the statusline :) )