### PR TITLE
[terminal] Always show indicator status line when in non-insert mode.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Adds vim-like `scrolloff` feature to normal mode cursor movements to ensure a line padding when scrolling up/down.
 - Adds support for HSL colorspace in Sixel images.
 - Always show indicator status line when ANSI mode KAM is enabled (which can be toggled via action `ToggleInputProtection`).
+- Always show indicator status line when in non-insert mode.
 - [Linux] Changes the .desktop file name and icon file name to conform to the flatpak recommendations.
 - [Linux] Provide an AppStream XML file.
 - [Linux] Drop KDE/KWin dependency on the binary by implementing enabling blur-behind background manually.

--- a/src/terminal/ViCommands.cpp
+++ b/src/terminal/ViCommands.cpp
@@ -53,7 +53,7 @@ void ViCommands::modeChanged(ViMode mode)
             terminal.state().cursor.visible = lastCursorVisible;
             terminal.setCursorShape(lastCursorShape);
             terminal.viewport().forceScrollToBottom();
-            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
+            terminal.popStatusDisplay();
             terminal.screenUpdated();
             break;
         case ViMode::Normal:
@@ -65,25 +65,24 @@ void ViCommands::modeChanged(ViMode mode)
                 cursorPosition = terminal.realCursorPosition();
             if (terminal.selectionAvailable())
                 terminal.clearSelection();
-            terminal.popStatusDisplay();
+            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
             break;
         case ViMode::Visual:
             terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
-            terminal.popStatusDisplay();
-            terminal.screenUpdated();
+            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             break;
         case ViMode::VisualLine:
             terminal.setSelector(make_unique<FullLineSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
-            terminal.popStatusDisplay();
+            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
             break;
         case ViMode::VisualBlock:
             terminal.setSelector(make_unique<RectangularSelection>(terminal.selectionHelper(), selectFrom));
             terminal.selector()->extend(cursorPosition);
-            terminal.popStatusDisplay();
+            terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
             break;
     }


### PR DESCRIPTION
it was implemented by accident in KAM-visual-statusline already, but accidentally inverted. This PR is basically fixing it plus adding a changelog, such that the indicator statusline is being shown when entering normal/visual mode and hidden when entering insert (default) mode.