### PR TITLE
Work around flatpak PTY related bugs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@
 - [Linux] Provide an AppStream XML file.
 - [Linux] Drop KDE/KWin dependency on the binary by implementing enabling blur-behind background manually.
 - [Linux] Adds support for blur-behind window on GNOME shell.
+- [Flatpak] Also pass stdout-fastpipe (`3`) to shell.
+- [Flatpak] Do not set controlling terminal in order to allow TTY abilities like Ctrl+C. This seems to be a known bug in flatpak.
 - Changes behavior of PTY (and shell process) creation until only when a PTY is required by the terminal emulator during instanciation, possibly avoiding problems with xdotool running too early.
 - Internal: Y-axis inverted to match GUI coordinate systems where (0, 0) is top left rather than bottom left.
 

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -70,6 +70,9 @@ class [[nodiscard]] Process: public Pty
 
     ~Process() override;
 
+    // Tests if the current process is running inside flatpak.
+    static bool isFlatpak();
+
     [[nodiscard]] bool alive() const noexcept
     {
         auto const status = checkStatus();

--- a/src/terminal/Process_unix.cpp
+++ b/src/terminal/Process_unix.cpp
@@ -77,12 +77,6 @@ namespace
     constexpr auto StdoutFastPipeFdStr = "3"sv;
     constexpr auto StdoutFastPipeEnvironmentName = "STDOUT_FASTPIPE"sv;
 
-    bool isFlatpak()
-    {
-        static bool check = FileSystem::exists("/.flatpak-info");
-        return check;
-    }
-
     string getLastErrorAsString()
     {
         return strerror(errno);
@@ -135,6 +129,12 @@ Process::Process(string const& _path,
 {
 }
 
+bool Process::isFlatpak()
+{
+    static bool check = FileSystem::exists("/.flatpak-info");
+    return check;
+}
+
 void Process::start()
 {
     d->pty->start();
@@ -185,6 +185,8 @@ void Process::start()
                 auto realArgs = std::vector<string> {};
                 realArgs.emplace_back("--host");
                 realArgs.emplace_back("--watch-bus");
+                if (stdoutFastPipe)
+                    realArgs.emplace_back(fmt::format("--forward-fd={}", StdoutFastPipeFdStr));
                 if (!d->cwd.empty())
                     realArgs.emplace_back(fmt::format("--directory={}", d->cwd.generic_string()));
                 if (auto const value = getenv("TERM"))

--- a/src/terminal/Process_win32.cpp
+++ b/src/terminal/Process_win32.cpp
@@ -180,6 +180,11 @@ Process::Process(string const& _path,
 {
 }
 
+bool Process::isFlatpak()
+{
+    return false;
+}
+
 void Process::start()
 {
     Require(static_cast<ConPty const*>(d->pty.get()));


### PR DESCRIPTION
Apparrently one shall not enable controlling terminal for the child process, which happens to be flatpak-spawn when running within flatpak sandboxed environment. This is just a workaround for something that is hopefully(!) fixed soon-ish.

Apart from that, flatpak-spawn is now also properly forwarding file descriptor `3` (stdout-fastpipe).

### References

- https://github.com/flatpak/flatpak/issues/3697
- https://github.com/flatpak/flatpak/issues/3285