### PR TITLE
Flatpak: Exposes TERMINFO environment variable pointing to a valid path containing the contour terminfo file.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 - [Linux] Adds support for blur-behind window on GNOME shell.
 - [Flatpak] Also pass stdout-fastpipe (`3`) to shell.
 - [Flatpak] Do not set controlling terminal in order to allow TTY abilities like Ctrl+C. This seems to be a known bug in flatpak.
+- [Flatpak] Exposes TERMINFO environment variable pointing to a valid path containing the contour terminfo file.
 - Changes behavior of PTY (and shell process) creation until only when a PTY is required by the terminal emulator during instanciation, possibly avoiding problems with xdotool running too early.
 - Internal: Y-axis inverted to match GUI coordinate systems where (0, 0) is top left rather than bottom left.
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -136,6 +136,10 @@ namespace // {{{ helper
 #if defined(_WIN32)
         return "contour";
 #else
+
+        if (Process::isFlatpak())
+            return "contour";
+
         auto locations = getTermInfoDirs(_appTerminfoDir);
         auto const terms = vector<string> {
             "contour", "contour-latest", "xterm-256color", "xterm", "vt340", "vt220",

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -340,6 +340,8 @@ int ContourGuiApp::terminalGuiAction()
 
     QSurfaceFormat::setDefaultFormat(display::createSurfaceFormat());
 
+    ensureTermInfoFile();
+
     // auto const HTS = "\033H";
     // auto const TBC = "\033[g";
     // printf("\r%s        %s                        %s\r", TBC, HTS, HTS);
@@ -365,6 +367,21 @@ int ContourGuiApp::terminalGuiAction()
 
     // printf("\r%s", TBC);
     return rv;
+}
+
+void ContourGuiApp::ensureTermInfoFile()
+{
+    if (!terminal::Process::isFlatpak())
+        return;
+
+    auto const hostTerminfoBaseDirectory =
+        Process::homeDirectory() / ".var/app/org.contourterminal.Contour/terminfo/c";
+    if (!FileSystem::is_directory(hostTerminfoBaseDirectory))
+        FileSystem::create_directories(hostTerminfoBaseDirectory);
+
+    auto const sandboxTerminfoFile = FileSystem::path("/app/share/terminfo/c/contour");
+    if (!FileSystem::is_regular_file(hostTerminfoBaseDirectory / "contour"))
+        FileSystem::copy_file(sandboxTerminfoFile, hostTerminfoBaseDirectory / "contour");
 }
 
 TerminalWindow* ContourGuiApp::newWindow(contour::config::Config const& config)

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -77,6 +77,7 @@ class ContourGuiApp: public ContourApp
     std::string programPath() const { return _argv[0]; }
 
   private:
+    void ensureTermInfoFile();
     bool loadConfig(std::string const& target);
     int terminalGuiAction();
     int fontConfigAction();

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -793,6 +793,7 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
     }
     // }}}
 
+#if !defined(__APPLE__) // Not building on OS/X CI?
     if (RasterizerLog)
         RasterizerLog()("Inserting {} id {} render mode {} {} yOverflow {} yMin {}.",
                         glyph,
@@ -801,6 +802,7 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
                         presentation,
                         yOverflow,
                         yMin);
+#endif
 
     return { createTileData(tileLocation,
                             move(glyph.bitmap),
@@ -862,9 +864,8 @@ text::shape_result TextRenderer::shapeTextRun(unicode::run_segmenter::range cons
     if (RasterizerLog && !glyphPosition.empty())
     {
         auto msg = RasterizerLog();
-        msg.append("Shaped codepoints ({}/{}): {}",
+        msg.append("Shaped codepoints ({}): {}",
                    isEmojiPresentation ? "emoji" : "text",
-                   get<unicode::PresentationStyle>(_run.properties),
                    unicode::convert_to<char>(codepoints));
 
         msg.append(" (");


### PR DESCRIPTION

Refs #764 