### PR TITLE
[Flatpak] Adds configuration key `profiles.*.escape_sandbox`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - [Linux] Changes context menu icon for "Run in Contour" action to be the Contour logo.
 - Adds `line#24` to terminfo file for backwards compatibility.
+- [Flatpak] Adds configuration key `profiles.*.escape_sandbox` to decide whether or not to escape the sandbox.
 
 ### 0.3.3 (2022-08-30)
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1252,13 +1252,14 @@ TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,
     // }}}
 
     string const basePath = fmt::format("{}.{}", _parentPath, _profileName);
+    tryLoadChildRelative(_usedKeys, _profile, basePath, "escape_sandbox", profile.shell.escapeSandbox);
     tryLoadChildRelative(_usedKeys, _profile, basePath, "shell", profile.shell.program);
     if (profile.shell.program.empty())
     {
         if (!profile.shell.arguments.empty())
             errorlog()("No shell defined but arguments. Ignoring arguments.");
 
-        auto loginShell = Process::loginShell();
+        auto loginShell = Process::loginShell(profile.shell.escapeSandbox);
         profile.shell.program = loginShell.front();
         loginShell.erase(loginShell.begin());
         profile.shell.arguments = loginShell;

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -141,6 +141,14 @@ profiles:
         # shell: "/bin/bash"
         # arguments: ["some", "optional", "arguments", "for", "the", "shell"]
 
+        # If this terminal is being executed from within Flatpak, enforces sandboxing
+        # then this boolean indicates whether or not that sandbox should be escaped or not.
+        #
+        # Default value is true.
+        #
+        # It only makes sense to set this value to false if you really know what you are doing.
+        escape_sandbox: true
+
         # Advanced value that is useful when CopyPreviousMarkRange is used
         # with multiline-prompts. This offset value is being added to the
         # current cursor's line number minus 1 (i.e. the line above the current cursor).

--- a/src/terminal/Process.h
+++ b/src/terminal/Process.h
@@ -50,15 +50,16 @@ class [[nodiscard]] Process: public Pty
         std::vector<std::string> arguments;
         FileSystem::path workingDirectory;
         Environment env;
+        bool escapeSandbox = false;
     };
 
     //! Returns login shell of current user.
-    static std::vector<std::string> loginShell();
+    static std::vector<std::string> loginShell(bool escapeSandbox);
 
     static FileSystem::path homeDirectory();
 
     Process(ExecInfo const& _exe, std::unique_ptr<Pty> _pty):
-        Process(_exe.program, _exe.arguments, _exe.workingDirectory, _exe.env, std::move(_pty))
+        Process(_exe.program, _exe.arguments, _exe.workingDirectory, _exe.env, _exe.escapeSandbox, std::move(_pty))
     {
     }
 
@@ -66,6 +67,7 @@ class [[nodiscard]] Process: public Pty
             std::vector<std::string> const& args,
             FileSystem::path const& _cwd,
             Environment const& env,
+            bool escapeSandbox,
             std::unique_ptr<Pty> pty);
 
     ~Process() override;

--- a/src/terminal/Process_win32.cpp
+++ b/src/terminal/Process_win32.cpp
@@ -175,9 +175,11 @@ Process::Process(string const& _path,
                  vector<string> const& _args,
                  FileSystem::path const& _cwd,
                  Environment const& _env,
+                 bool escapeSandbox,
                  std::unique_ptr<Pty> _pty):
     d(new Private { _path, _args, _cwd, _env, move(_pty) }, [](Private* p) { delete p; })
 {
+    crispy::ignore_unused(escapeSandbox);
 }
 
 bool Process::isFlatpak()
@@ -303,8 +305,10 @@ Process::ExitStatus Process::wait()
     return *d->checkStatus(true);
 }
 
-vector<string> Process::loginShell()
+vector<string> Process::loginShell(bool escapeSandbox)
 {
+    crispy::ignore_unused(escapeSandbox);
+
     return { "powershell.exe"s }; // TODO: Find out what the user's default shell is.
 }
 


### PR DESCRIPTION
Setting this option really only makes sense when running via Flatpak (or other sandboxed environments in the future).

By default, the sandbox is (and used to be) always escaped. But rarely it makes sense not to.