### PR TITLE
Adding AppImage packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
           retention-days: 7
 
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     name: FreeBSD 13
     # env:
     #   MYTOKEN: "value1"
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test in FreeBSD
         id: test
-        uses: vmactions/freebsd-vm@v0.1.6
+        uses: vmactions/freebsd-vm@v0.2.4
         with:
           envs: 'MYTOKEN MYTOKEN2'
           usesh: true
@@ -440,7 +440,7 @@ jobs:
         sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.deb"
         sudo dpkg --install "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_18_04_amd64.ddeb"
 
-  ubuntu_2004_matrix:
+  ubuntu_2204_matrix:
     strategy:
       fail-fast: false
       matrix:
@@ -448,14 +448,13 @@ jobs:
         build_type: ["RelWithDebInfo"]
         compiler:
           [
-            "GCC 8",
             "GCC 10",
-            "Clang 9",
+            "GCC 11",
             "Clang 12",
             "Clang 14",
           ]
-    name: "Ubuntu Linux 20.04 (${{ matrix.compiler }}, C++${{ matrix.cxx }})"
-    runs-on: ubuntu-20.04
+    name: "Ubuntu Linux 22.04 (${{ matrix.compiler }}, C++${{ matrix.cxx }})"
+    runs-on: ubuntu-22.04
     outputs:
       id: "${{ matrix.compiler }} (C++${{ matrix.cxx }}, ${{ matrix.build_type }})"
     steps:
@@ -463,7 +462,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: "ccache-ubuntu2004-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
+          key: "ccache-ubuntu2204-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
           max-size: 256M
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
@@ -488,14 +487,7 @@ jobs:
           sudo apt install -y g++-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: Set up Clang
         if: ${{ startsWith(matrix.compiler, 'Clang') }}
-        run: |
-          if [[ ${{ steps.extract_matrix.outputs.CC_VERSION }} -ge 13 ]]; then
-            wget https://apt.llvm.org/llvm.sh
-            chmod +x llvm.sh
-            sudo ./llvm.sh ${{ steps.extract_matrix.outputs.CC_VERSION}}
-          else
-            sudo apt install -y clang-${{ steps.extract_matrix.outputs.CC_VERSION }}
-          fi
+        run: sudo apt install -y clang-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: "create build directory"
         run: mkdir build
       - name: "cmake"
@@ -510,6 +502,7 @@ jobs:
             CXX="${CC_EXE}-${CC_VER}" \
             EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS \
                                -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} \
+                               -DCMAKE_INSTALL_PREFIX="/usr" \
                                -DCONTOUR_INSTALL_TOOLS=ON \
                                -DPEDANTIC_COMPILER=ON \
                                " \
@@ -524,7 +517,7 @@ jobs:
         if: ${{ matrix.compiler == 'GCC 10' && matrix.cxx == '20' }}
         uses: actions/upload-artifact@v2
         with:
-          name: contour-ubuntu2004-builddir
+          name: contour-ubuntu2204-builddir
           path: |
             build
           retention-days: 1
@@ -532,7 +525,7 @@ jobs:
         if: ${{ matrix.compiler == 'GCC 10' && matrix.cxx == '20' }}
         uses: actions/upload-artifact@v2
         with:
-          name: contour-ubuntu2004-tests
+          name: contour-ubuntu2204-tests
           path: |
             build/src/crispy/crispy_test
             build/src/terminal/terminal_test
@@ -540,16 +533,16 @@ jobs:
           retention-days: 1
 
   # Create ZIP/DEB package (and test DEB installation).
-  ubuntu_2004_packaging:
-    name: "Ubuntu 20.04: Create package"
-    needs: ubuntu_2004_matrix
-    runs-on: ubuntu-20.04
+  ubuntu_2204_AppImage:
+    name: "Ubuntu 22.04: Create AppImage"
+    needs: ubuntu_2204_matrix
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: "ccache-ubuntu2004-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
+          key: "ccache-ubuntu2204-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
           max-size: 256M
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
@@ -560,16 +553,78 @@ jobs:
           REPOSITORY: ${{ github.event.repository.name }}
       - name: "some var dumps"
         run: |
-          echo "ID: ${{ needs.ubuntu_2004_matrix.outputs.id }}"
+          echo "ID: ${{ needs.ubuntu_2204_matrix.outputs.id }}"
+      - name: "install linuxdeploy"
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /usr/local/bin/linuxdeploy
+          chmod 0755 /usr/local/bin/linuxdeploy
+      - name: "install libfuse2 (Dependency of AppImage programs)"
+        run: sudo apt -qy install libfuse2
       - name: "install dependencies"
         run: |
           set -ex
           sudo apt -q update
           sudo ./scripts/install-deps.sh
-      - name: "Download artifact: contour-ubuntu2004-builddir"
+      - name: "Download artifact: contour-ubuntu2204-builddir"
         uses: actions/download-artifact@v2
         with:
-          name: contour-ubuntu2004-builddir
+          name: contour-ubuntu2204-builddir
+          path: build/
+      - name: "linuxdeploy: Creating AppImage"
+        run: |
+          set -ex
+          cd build
+          make install DESTDIR=AppDir
+          linuxdeploy --appdir AppDir --output appimage
+          mv -v *.AppImage ../contour-${{ steps.set_vars.outputs.VERSION_STRING }}.AppImage
+      - name: "Uploading AppImage"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}.AppImage"
+          path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}.AppImage"
+          if-no-files-found: error
+          retention-days: 7
+
+  ubuntu_2204_packaging_cleanup:
+    name: "Ubuntu 22.04: Cleaning up intermedary artifacts"
+    needs: [ubuntu_2204_AppImage, ubuntu_2204_packaging]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Delete artifact: contour-ubuntu2204-builddir"
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: contour-ubuntu2204-builddir
+
+  ubuntu_2204_packaging:
+    name: "Ubuntu 22.04: Create package"
+    needs: ubuntu_2204_matrix
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-ubuntu2204-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
+          max-size: 256M
+      - name: Installing xmllint for ci-set-vars
+        run: sudo apt -qy install libxml2-utils
+      - name: "set environment variables"
+        id: set_vars
+        run: ./scripts/ci-set-vars.sh
+        env:
+          REPOSITORY: ${{ github.event.repository.name }}
+      - name: "some var dumps"
+        run: |
+          echo "ID: ${{ needs.ubuntu_2204_matrix.outputs.id }}"
+      - name: "install dependencies"
+        run: |
+          set -ex
+          sudo apt -q update
+          sudo ./scripts/install-deps.sh
+      - name: "Download artifact: contour-ubuntu2204-builddir"
+        uses: actions/download-artifact@v2
+        with:
+          name: contour-ubuntu2204-builddir
           path: build/
       - name: "CPack: Creating DEB package"
         run: |
@@ -577,9 +632,9 @@ jobs:
           cd build
           cpack -G DEB -V
           mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour.deb" \
-                "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+                "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
           mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour-dbgsym.ddeb" \
-                "../contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
+                "../contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.ddeb"
       - name: "CPack: Creating TGZ package"
         run: |
           set -ex
@@ -587,46 +642,42 @@ jobs:
           cpack -G TGZ -V
           tar xzpf "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux.tar.gz"
           mv -v "Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux" \
-                "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
+                "../contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64"
       - name: "Uploading artifact .deb package"
         uses: actions/upload-artifact@v2
         with:
-          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
-          path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
+          path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
           if-no-files-found: error
           retention-days: 7
       - name: "Uploading artifact .ddeb package (debugging symbols)"
         uses: actions/upload-artifact@v2
         with:
-          name: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
-          path: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
+          name: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.ddeb"
+          path: "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.ddeb"
           if-no-files-found: error
           retention-days: 7
       - name: "Uploading artifact ZIP package"
         uses: actions/upload-artifact@v2
         with:
-          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
-          path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64"
+          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64"
+          path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64"
           if-no-files-found: error
           retention-days: 7
       - name: "Attempt installing the created .deb"
         run: |
-          sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
-          sudo dpkg --install "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.ddeb"
-      - name: "Delete artifact: contour-ubuntu2004-builddir"
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: contour-ubuntu2004-builddir
+          sudo dpkg --install "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
+          sudo dpkg --install "contour-dbgsym-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.ddeb"
 
-  test_ubuntu2004_valgrind:
+  test_ubuntu2204_valgrind:
     name: "Run tests via valgrind"
-    runs-on: ubuntu-20.04
-    needs: [ubuntu_2004_matrix]
+    runs-on: ubuntu-22.04
+    needs: [ubuntu_2204_matrix]
     steps:
       - name: "download artifact"
         uses: actions/download-artifact@v2
         with:
-          name: contour-ubuntu2004-tests
+          name: contour-ubuntu2204-tests
       - name: "fix unit test permissions"
         run: find . -name '*_test' -exec chmod 0755 {} \;
       - name: "install dependencies"
@@ -640,32 +691,32 @@ jobs:
                           libharfbuzz0b \
                           libqt5gui5 \
                           libqt5opengl5 \
-                          libyaml-cpp0.6 \
+                          libyaml-cpp0.7 \
                           ncurses-bin \
                           valgrind
       - name: "test: crispy (via valgrind)"
         run: valgrind --error-exitcode=64 ./build/src/crispy/crispy_test
       - name: "test: libterminal (via valgrind)"
         run: valgrind --error-exitcode=64 ./build/src/terminal/terminal_test
-      - name: "Delete artifact: contour-ubuntu2004-tests"
+      - name: "Delete artifact: contour-ubuntu2204-tests"
         uses: geekyeggo/delete-artifact@v1
         with:
-          name: contour-ubuntu2004-tests
+          name: contour-ubuntu2204-tests
 
-  check_ubuntu2004_matrix_test_matrix:
+  check_ubuntu2204_matrix_test_matrix:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: "Ubuntu Linux 20.04 post-check"
+    name: "Ubuntu Linux 22.04 post-check"
     needs:
-      - ubuntu_2004_matrix
-      - ubuntu_2004_packaging
-      - test_ubuntu2004_valgrind
+      - ubuntu_2204_matrix
+      - ubuntu_2204_packaging
+      - test_ubuntu2204_valgrind
     steps:
       - name: Print matrix status
         run: |
-          echo "Result: ${{ needs.ubuntu_2004_matrix.result }}"
+          echo "Result: ${{ needs.ubuntu_2204_matrix.result }}"
       - name: Check build matrix status
-        if: ${{ needs.ubuntu_2004_matrix.result != 'success' && needs.ubuntu_2004_matrix.result != 'skipped' }}
+        if: ${{ needs.ubuntu_2204_matrix.result != 'success' && needs.ubuntu_2204_matrix.result != 'skipped' }}
         run: exit 1
 
   # }}}

--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -28,7 +28,7 @@ jobs:
   # {{{ build fontconfig
   build_fontconfig:
     name: "Build patched fontconfig"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: "get source"
@@ -71,14 +71,14 @@ jobs:
 
   # {{{ Build Contour
   build_contour:
-    name: "Build Contour @ Ubuntu Linux 20.04"
-    runs-on: ubuntu-20.04
+    name: "Build Contour @ Ubuntu Linux 22.04"
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ccache-ubuntu_2004-external-tests
+        key: ccache-ubuntu_2204-external-tests
         max-size: 256M
     - uses: actions/cache@v2
       with:
@@ -116,13 +116,13 @@ jobs:
         cpack -G DEB
         cd ..
         mv -v "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Linux-contour.deb" \
-              "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+              "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
         ls -hl
     - name: "Uploading artifact .deb package"
       uses: actions/upload-artifact@v2
       with:
-        name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
-        path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+        name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
+        path: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
         if-no-files-found: error
         retention-days: 7
   # }}}
@@ -130,7 +130,7 @@ jobs:
   # {{{ Build notcurses
   build_notcurses:
     name: "Build notcurses"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: "install dependencies"
       run: |
@@ -155,7 +155,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ccache-ubuntu_2004-notcurses
+        key: ccache-ubuntu_2204-notcurses
         max-size: 256M
     - name: "configure cmake"
       run: |
@@ -185,7 +185,7 @@ jobs:
   # {{{ external test: notcurses
   test_notcurses:
     name: "notcurses-demo ${{ matrix.name }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_contour, build_notcurses, build_fontconfig]
     strategy:
       fail-fast: false
@@ -261,7 +261,7 @@ jobs:
         REPOSITORY: ${{ github.event.repository.name }}
     - uses: actions/download-artifact@v2
       with:
-        name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+        name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
     - uses: actions/download-artifact@v2
       with:
         name: "notcurses-install"
@@ -283,7 +283,7 @@ jobs:
       timeout-minutes: 1
       run: ~/opt/notcurses/bin/notcurses-demo -p ~/opt/notcurses/share/notcurses -h
     - name: "install contour"
-      run: sudo dpkg -i "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_20_04_amd64.deb"
+      run: sudo dpkg -i "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu_22_04_amd64.deb"
     - name: "contour executable test"
       run: |
         contour version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,24 @@ concurrency:
 # [ ] label package files with "prerelease" if they're not a release
 
 jobs:
+  chk_release:
+    name: Release Checks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Installing xmllint for ci-set-vars
+        run: sudo apt -qy install libxml2-utils
+      - name: set variables
+        id: set_vars
+        run: ./scripts/ci-set-vars.sh
+        env:
+          REPOSITORY: ${{ github.event.repository.name }}
+      - name: Installing xmllint dependency
+        run: sudo apt -qy install libxml2-utils
+      - name: run release checks
+        run: ./scripts/check_release.sh
+
   build_windows:
     name: Build on Windows
     runs-on: windows-latest
@@ -147,27 +165,9 @@ jobs:
           sudo dpkg --install "contour_${{ steps.set_vars.outputs.version }}-ubuntu_18_04_amd64.deb"
           sudo dpkg --install "contour-dbgsym_${{ steps.set_vars.outputs.version }}-ubuntu_18_04_amd64.ddeb"
 
-  chk_release:
-    name: Release Checks
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Installing xmllint for ci-set-vars
-        run: sudo apt -qy install libxml2-utils
-      - name: set variables
-        id: set_vars
-        run: ./scripts/ci-set-vars.sh
-        env:
-          REPOSITORY: ${{ github.event.repository.name }}
-      - name: Installing xmllint dependency
-        run: sudo apt -qy install libxml2-utils
-      - name: run release checks
-        run: ./scripts/check_release.sh
-
-  build_ubuntu2004:
-    name: Build on Ubuntu 20.04
-    runs-on: ubuntu-20.04
+  build_ubuntu2204:
+    name: Build on Ubuntu 22.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -211,6 +211,67 @@ jobs:
       - name: "Attempt installing the created .deb"
         run: |
           sudo dpkg --install "contour_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.deb"
+
+  build_AppImage:
+    name: "Linux AppImage"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-ubuntu2204-AppImage"
+          max-size: 256M
+      - name: Installing xmllint for ci-set-vars
+        run: sudo apt -qy install libxml2-utils
+      - name: set environment variables
+        id: set_vars
+        run: ./scripts/ci-set-vars.sh
+        env:
+          REPOSITORY: ${{ github.event.repository.name }}
+      - name: "install linuxdeploy"
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /usr/local/bin/linuxdeploy
+          chmod 0755 /usr/local/bin/linuxdeploy
+      - name: "install dependencies"
+        run: |
+          set -ex
+          sudo apt -q update
+          sudo ./scripts/install-deps.sh
+      - name: "create build directory"
+        run: mkdir build
+      - name: "cmake"
+        run: |
+          [[ "${{ matrix.compiler }}" = "GCC 8" ]] || EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DPEDANTIC_COMPILER_WERROR=ON"
+          BUILD_DIR="build" \
+            CMAKE_BUILD_TYPE="RelWithDebInfo" \
+            EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS \
+                               -DCMAKE_CXX_STANDARD=20 \
+                               -DCMAKE_INSTALL_PREFIX="/usr" \
+                               -DCONTOUR_INSTALL_TOOLS=ON \
+                               -DPEDANTIC_COMPILER=ON \
+                               " \
+            ./scripts/ci-prepare-contour.sh
+      - name: "build"
+        run: cmake --build build/ -- -j3
+      - name: "test: crispy"
+        run: ./build/src/crispy/crispy_test
+      - name: "test: libterminal"
+        run: ./build/src/terminal/terminal_test
+      - name: "linuxdeploy: Creating AppImage"
+        run: |
+          set -ex
+          cd build
+          make install DESTDIR=AppDir
+          linuxdeploy --appdir AppDir --output appimage
+          mv -v *.AppImage ../contour-${{ steps.set_vars.outputs.version }}.AppImage
+      - name: "Uploading AppImage"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "contour-${{ steps.set_vars.outputs.version }}_x86_64.AppImage"
+          path: "contour-${{ steps.set_vars.outputs.version }}_x86_64.AppImage"
+          if-no-files-found: error
+          retention-days: 7
 
   build_osx:
     name: Build on OS/X
@@ -411,7 +472,7 @@ jobs:
   do_release:
     name: Create Github release
     runs-on: ubuntu-latest
-    needs: [chk_release, build_ubuntu1804, build_ubuntu2004, build_windows, build_osx, build_archlinux, build_fedora]
+    needs: [chk_release, build_ubuntu1804, build_ubuntu2204, build_AppImage, build_windows, build_osx, build_archlinux, build_fedora]
     steps:
       - uses: actions/checkout@v3
       - name: Installing xmllint for ci-set-vars
@@ -469,8 +530,8 @@ jobs:
           asset_content_type: application/vnd.debian.binary-package
 
       # -------------------------------------------------------------
-      - name: Upload Ubuntu 20.04 package (.deb)
-        id: upload-release-asset-deb-2004
+      - name: Upload Ubuntu 22.04 package (.deb)
+        id: upload-release-asset-deb-2204
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -480,8 +541,8 @@ jobs:
           asset_name: contour_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.deb
           asset_content_type: application/vnd.debian.binary-package
 
-      - name: Upload Ubuntu 20.04 debug package (.ddeb)
-        id: upload-release-asset-ddeb-2004
+      - name: Upload Ubuntu 22.04 debug package (.ddeb)
+        id: upload-release-asset-ddeb-2204
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -490,6 +551,18 @@ jobs:
           asset_path: ./contour-dbgsym_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.ddeb
           asset_name: contour-dbgsym_${{ steps.set_vars.outputs.version }}-ubuntu_20_04_amd64.ddeb
           asset_content_type: application/vnd.debian.binary-package
+
+      # -------------------------------------------------------------
+      - name: Upload AppImage package x86_64
+        id: upload-release-asset-archlinux-x86_64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: contour-${{ steps.set_vars.outputs.version }}_x64_64.AppImage
+          asset_name: contour-${{ steps.set_vars.outputs.version }}_x64_64.AppImage
+          asset_content_type: application/x-zstd-compressed-tar
 
       # -------------------------------------------------------------
       - name: Upload Archlinux package x86_64
@@ -597,4 +670,3 @@ jobs:
           asset_path: contour-${{ steps.set_vars.outputs.version }}-osx.dmg
           asset_name: contour-${{ steps.set_vars.outputs.version }}-osx.dmg
           asset_content_type: application/x-apple-diskimage
-

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -98,6 +98,7 @@
           <li>Adds `line#24` to terminfo file for backwards compatibility.</li>
           <li>Adds configuration key `live_config` to determine whether or not to reload running terminal instances on every config file change.</li>
           <li>[Flatpak] Adds configuration key `profiles.*.escape_sandbox` to decide whether or not to escape the sandbox.</li>
+          <li>[Packaging] Adding AppImage files to Github release page and CI artifacts and bump Ubuntu packages using Ubuntu 22.04 LTS</li>
         </ul>
       </description>
     </release>

--- a/scripts/ci/notcurses-install-deps.sh
+++ b/scripts/ci/notcurses-install-deps.sh
@@ -26,4 +26,4 @@ sudo apt install -y \
             libqt5network5 \
             libqt5multimedia5 \
             libqt5x11extras5 \
-            libyaml-cpp0.6
+            libyaml-cpp0.7

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -169,7 +169,7 @@ install_deps_ubuntu()
 
     fetch_and_unpack_gsl
     case $RELEASE in
-        "18.04" | "19.04" | "20.04" | "21.04" | "21.10")
+        "18.04" | "19.04" | "20.04" | "21.04" | "21.10" | "22.04")
             # Older Ubuntu's don't have a recent enough fmt / range-v3, so supply it.
             fetch_and_unpack \
                 range-v3-0.11.0 \

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -285,7 +285,7 @@ else()
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    set(YAML_CPP_PKG_NAME "libyaml-cpp0.6")
+    set(YAML_CPP_PKG_NAME "libyaml-cpp0.7")
     if ("${LSB_RELEASE_NUMBER}" STREQUAL "18.04")
         set(YAML_CPP_PKG_NAME "libyaml-cpp0.5v5")
     endif()


### PR DESCRIPTION
## checklist

- [x] bump CI Ubuntu images to 22.04, and ensure CI macos is set to macos-latest.
- [x] CI build.yml to create AppImage and upload it to artifact store
- [x] CI release.yml to create AppImage and also provide it to the release page
- [x] Changelog entry added

## references

- https://docs.appimage.org/packaging-guide/from-source/native-binaries.html#packaging-from-source