### PR TITLE
Fixes interpretation of DECSDM to disable Sixel auto-scrolling, if enabled.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -94,6 +94,7 @@
       <description>
         <ul>
           <li>Fixes selection magically deselecting when indicator status line was shown and the top page line was selected.</li>
+          <li>Fixes interpretation of VT sequence DECSDM to disable Sixel auto-scrolling, if enabled.</li>
           <li>[Linux] Changes context menu icon for "Run in Contour" action to be the Contour logo.</li>
           <li>Adds `line#24` to terminfo file for backwards compatibility.</li>
           <li>Adds configuration key `live_config` to determine whether or not to reload running terminal instances on every config file change.</li>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1091,7 +1091,7 @@ void TerminalSession::configureTerminal()
     terminal_.setSixelCursorConformance(config_.sixelCursorConformance);
     terminal_.setMaxImageColorRegisters(config_.maxImageColorRegisters);
     terminal_.setMaxImageSize(config_.maxImageSize);
-    terminal_.setMode(terminal::DECMode::SixelScrolling, config_.sixelScrolling);
+    terminal_.setMode(terminal::DECMode::NoSixelScrolling, !config_.sixelScrolling);
     terminal_.setStatusDisplay(profile_.initialStatusDisplayType);
     SessionLog()("maxImageSize={}, sixelScrolling={}", config_.maxImageSize, config_.sixelScrolling);
 

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1580,8 +1580,7 @@ void Screen<Cell>::sixelImage(ImageSize _pixelSize, Image::Data&& _data)
     auto const lineCount =
         LineCount::cast_from(ceilf(float(*_pixelSize.height) / float(*_state.cellPixelSize.height)));
     auto const extent = GridSize { lineCount, columnCount };
-    auto const autoScrollAtBottomMargin = _terminal.isModeEnabled(
-        DECMode::SixelScrolling); // If DECSDM is enabled, scrolling is meant to be disabled.
+    auto const autoScrollAtBottomMargin = !_terminal.isModeEnabled(DECMode::NoSixelScrolling);
     auto const topLeft = autoScrollAtBottomMargin ? logicalCursorPosition() : CellLocation {};
 
     auto const alignmentPolicy = ImageAlignment::TopStart;
@@ -2169,7 +2168,7 @@ namespace impl
                 // TODO: Ps = 6 7  -> Backarrow key sends backspace (DECBKM), VT340, VT420.  This sets the
                 // backarrowKey resource to "true".
                 case 69: return DECMode::LeftRightMargin;
-                case 80: return DECMode::SixelScrolling;
+                case 80: return DECMode::NoSixelScrolling;
                 case 1000: return DECMode::MouseProtocolNormalTracking;
                 case 1001: return DECMode::MouseProtocolHighlightTracking;
                 case 1002: return DECMode::MouseProtocolButtonTracking;

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -3404,7 +3404,7 @@ TEST_CASE("Sixel.AutoScroll-1", "[screen]")
     auto const pageSize = PageSize { LineCount(4), ColumnCount(10) };
     auto mock = MockTerm { pageSize, LineCount(5) };
     mock.terminal.setCellPixelSize(ImageSize { Width(10), Height(10) });
-    mock.terminal.setMode(DECMode::SixelScrolling, true);
+    mock.terminal.setMode(DECMode::NoSixelScrolling, false);
 
     auto const sixelData = crispy::readFileAsString("./test/images/squirrel-50.sixel");
 

--- a/src/terminal/TerminalState.cpp
+++ b/src/terminal/TerminalState.cpp
@@ -105,7 +105,7 @@ std::string to_string(DECMode _mode)
         case DECMode::UseAlternateScreen: return "UseAlternateScreen";
         case DECMode::BracketedPaste: return "BracketedPaste";
         case DECMode::FocusTracking: return "FocusTracking";
-        case DECMode::SixelScrolling: return "SixelScrolling";
+        case DECMode::NoSixelScrolling: return "NoSixelScrolling";
         case DECMode::UsePrivateColorRegisters: return "UsePrivateColorRegisters";
         case DECMode::MouseExtended: return "MouseExtended";
         case DECMode::MouseSGR: return "MouseSGR";

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -677,7 +677,7 @@ enum class DECMode
     UseAlternateScreen,
     BracketedPaste,
     FocusTracking,            // 1004
-    SixelScrolling,           // ?80
+    NoSixelScrolling,         // ?80
     UsePrivateColorRegisters, // ?1070
 
     // {{{ Mouse related flags
@@ -785,7 +785,7 @@ constexpr unsigned toDECModeNum(DECMode m)
         case DECMode::ExtendedAltScreen: return 1049;
         case DECMode::BracketedPaste: return 2004;
         case DECMode::FocusTracking: return 1004;
-        case DECMode::SixelScrolling: return 80;
+        case DECMode::NoSixelScrolling: return 80;
         case DECMode::UsePrivateColorRegisters: return 1070;
         case DECMode::MouseExtended: return 1005;
         case DECMode::MouseSGR: return 1006;
@@ -828,7 +828,7 @@ constexpr bool isValidDECMode(unsigned int _mode) noexcept
         case DECMode::UseAlternateScreen:
         case DECMode::BracketedPaste:
         case DECMode::FocusTracking:
-        case DECMode::SixelScrolling:
+        case DECMode::NoSixelScrolling:
         case DECMode::UsePrivateColorRegisters:
         case DECMode::MouseExtended:
         case DECMode::MouseSGR:


### PR DESCRIPTION
Mentioned in #809.

Implementation of DECSDM was flipped. To make it clear for the future, I've also renamed the enum value itself, so that I'm not getting confused again.