### PR TITLE
Improve startup-time by not pre-rasterizing all printable US-ASCII codepoints at once

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -105,6 +105,7 @@
           <li>[Packaging] Adding AppImage files to Github release page and CI artifacts and bump Ubuntu packages using Ubuntu 22.04 LTS</li>
           <li>Adds `CreateDebugDump` action to dump terminal state for debugging purposes.</li>
           <li>Fixes glyph rendering for some unexpectly oversized glyphs (#423).</li>
+          <li>Improve startup-time by not pre-rasterizing all printable US-ASCII codepoints at once.</li>
         </ul>
       </description>
     </release>

--- a/src/terminal_renderer/TextRenderer.h
+++ b/src/terminal_renderer/TextRenderer.h
@@ -162,6 +162,8 @@ class TextRenderer: public Renderable
                && _directMappedGlyphKeyToTileIndex[glyph.index.value] != 0;
     }
 
+    AtlasTileAttributes const* ensureRasterizedIfDirectMapped(text::glyph_key const& glyphKey);
+
     // sub-renderer
     //
     BoxDrawingRenderer boxDrawingRenderer_;


### PR DESCRIPTION

Implements #811.