### PR TITLE
Now moves cursor vertically for sixel newlines even if there is no sixel

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -103,6 +103,7 @@
       <description>
         <ul>
           <li>Fixes a problem with oversized glyphs being wrongly cut off (#821).</li>
+          <li>Fixes vertical cursor movement for sixel graphics with only newlines (#822)</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -104,6 +104,7 @@
         <ul>
           <li>Fixes a problem with oversized glyphs being wrongly cut off (#821).</li>
           <li>Fixes vertical cursor movement for sixel graphics with only newlines (#822)</li>
+          <li>Fixes sixel rendering for images with aspect ratios other than 1:1</li>
 					<li>Removes `images.sixel_cursor_conformance` config option</li>
         </ul>
       </description>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -104,6 +104,7 @@
         <ul>
           <li>Fixes a problem with oversized glyphs being wrongly cut off (#821).</li>
           <li>Fixes vertical cursor movement for sixel graphics with only newlines (#822)</li>
+					<li>Removes `images.sixel_cursor_conformance` config option</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1705,7 +1705,6 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     }
 
     tryLoadValue(usedKeys, doc, "images.sixel_scrolling", _config.sixelScrolling);
-    tryLoadValue(usedKeys, doc, "images.sixel_cursor_conformance", _config.sixelCursorConformance);
     tryLoadValue(usedKeys, doc, "images.sixel_register_count", _config.maxImageColorRegisters);
     tryLoadValue(usedKeys, doc, "images.max_width", _config.maxImageSize.width);
     tryLoadValue(usedKeys, doc, "images.max_height", _config.maxImageSize.height);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -283,7 +283,6 @@ struct Config
     std::shared_ptr<logstore::Sink> loggingSink;
 
     bool sixelScrolling = true;
-    bool sixelCursorConformance = true;
     terminal::ImageSize maxImageSize = {}; // default to runtime system screen size.
     unsigned maxImageColorRegisters = 4096;
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -110,7 +110,7 @@ TerminalSession::TerminalSession(unique_ptr<Pty> _pty, ContourGuiApp& _app):
                 config_.bypassMouseProtocolModifier, // TODO: you too
                 config_.maxImageSize,
                 config_.maxImageColorRegisters,
-                config_.sixelCursorConformance,
+                true,
                 profile_.colors,
                 50.0,
                 config_.reflowOnResize,
@@ -1088,7 +1088,7 @@ void TerminalSession::configureTerminal()
 
     SessionLog()("Setting terminal ID to {}.", profile_.terminalId);
     terminal_.setTerminalId(profile_.terminalId);
-    terminal_.setSixelCursorConformance(config_.sixelCursorConformance);
+    terminal_.setSixelCursorConformance(true);
     terminal_.setMaxImageColorRegisters(config_.maxImageColorRegisters);
     terminal_.setMaxImageSize(config_.maxImageSize);
     terminal_.setMode(terminal::DECMode::NoSixelScrolling, !config_.sixelScrolling);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -125,9 +125,6 @@ images:
     sixel_scrolling: true
     # Configures the maximum number of color registers available when rendering Sixel graphics.
     sixel_register_count: 4096
-    # If enabled, the ANSI text cursor is placed at the position of the sixel graphics cursor after
-    # image rendering, otherwise (if disabled) the cursor is placed underneath the image.
-    sixel_cursor_conformance: true
     # maximum width in pixels of an image to be accepted (0 defaults to system screen pixel width)
     max_width: 0
     # maximum height in pixels of an image to be accepted (0 defaults to system screen pixel height)

--- a/src/terminal/Screen_test.cpp
+++ b/src/terminal/Screen_test.cpp
@@ -3372,8 +3372,8 @@ TEST_CASE("Sixel.simple", "[screen]")
 
     mock.writeToScreen(sixelData);
 
-    CHECK(mock.terminal.primaryScreen().cursor().position.column == ColumnOffset(8));
-    CHECK(mock.terminal.primaryScreen().cursor().position.line == LineOffset(4));
+    CHECK(mock.terminal.primaryScreen().cursor().position.column == ColumnOffset(0));
+    CHECK(mock.terminal.primaryScreen().cursor().position.line == LineOffset(5));
 
     for (auto line = LineOffset(0); line < boxed_cast<LineOffset>(pageSize.lines); ++line)
     {
@@ -3410,7 +3410,7 @@ TEST_CASE("Sixel.AutoScroll-1", "[screen]")
 
     mock.writeToScreen(sixelData);
 
-    CHECK(mock.terminal.primaryScreen().cursor().position.column == ColumnOffset(8));
+    CHECK(mock.terminal.primaryScreen().cursor().position.column == ColumnOffset(0));
     CHECK(mock.terminal.primaryScreen().cursor().position.line == LineOffset(3));
 
     for (auto line = LineOffset(-1); line < boxed_cast<LineOffset>(pageSize.lines); ++line)

--- a/src/terminal/SixelParser.cpp
+++ b/src/terminal/SixelParser.cpp
@@ -412,13 +412,19 @@ void SixelImageBuilder::write(CellLocation const& _coord, RGBColor const& _value
                 size_.width = Width::cast_from(_coord.column + 1);
         }
 
-        auto const base =
-            unbox<unsigned>(_coord.line) * unbox<unsigned>((explicitSize_ ? size_.width : maxSize_.width)) * 4
-            + unbox<unsigned>(_coord.column) * 4;
-        buffer_[base + 0] = _value.red;
-        buffer_[base + 1] = _value.green;
-        buffer_[base + 2] = _value.blue;
-        buffer_[base + 3] = 0xFF;
+        for (auto i = 0; i < aspectRatio_.nominator; ++i)
+        {
+            auto const base = unbox<unsigned>(_coord.line + i)
+                                  * unbox<unsigned>((explicitSize_ ? size_.width : maxSize_.width)) * 4
+                              + unbox<unsigned>(_coord.column) * 4;
+            for (auto j = 0; j < aspectRatio_.denominator; ++j)
+            {
+                buffer_[base + 0 + 4 * static_cast<unsigned int>(j)] = _value.red;
+                buffer_[base + 1 + 4 * static_cast<unsigned int>(j)] = _value.green;
+                buffer_[base + 2 + 4 * static_cast<unsigned int>(j)] = _value.blue;
+                buffer_[base + 3 + 4 * static_cast<unsigned int>(j)] = 0xFF;
+            }
+        }
     }
 }
 
@@ -451,7 +457,7 @@ void SixelImageBuilder::setRaster(int _pan, int _pad, ImageSize _imageSize)
     size_.width = clamp(_imageSize.width, Width(0), maxSize_.width);
     size_.height = clamp(_imageSize.height, Height(0), maxSize_.height);
 
-    buffer_.resize(size_.area() * 4);
+    buffer_.resize(size_.area() * static_cast<size_t>(_pad * _pan) * 4);
     explicitSize_ = true;
 }
 

--- a/src/terminal/SixelParser.cpp
+++ b/src/terminal/SixelParser.cpp
@@ -440,8 +440,7 @@ void SixelImageBuilder::rewind()
 void SixelImageBuilder::newline()
 {
     sixelCursor_.column = {};
-
-    if (unbox<int>(sixelCursor_.line) + 6 < unbox<int>(maxSize_.height))
+    if (unbox<int>(sixelCursor_.line) + 6 < unbox<int>(explicitSize_ ? size_.height : maxSize_.height))
         sixelCursor_.line.value += 6;
 }
 
@@ -477,6 +476,12 @@ void SixelImageBuilder::render(int8_t _sixel)
 
 void SixelImageBuilder::finalize()
 {
+    if (unbox<int>(size_.height) == 1)
+    {
+        size_.height = Height::cast_from(sixelCursor_.line * aspectRatio_.nominator);
+        buffer_.resize(size_.area() * 4);
+        return;
+    }
     if (!explicitSize_)
     {
         Buffer tempBuffer(static_cast<size_t>(size_.height.value * size_.width.value) * 4);

--- a/src/terminal/SixelParser_test.cpp
+++ b/src/terminal/SixelParser_test.cpp
@@ -338,3 +338,17 @@ TEST_CASE("SixelParser.newline", "[sixel]")
         }
     }
 }
+
+TEST_CASE("SixelParser.vertical_cursor_advance", "[sixel]")
+{
+    auto constexpr defaultColor = RGBAColor { 0, 0, 0, 255 };
+    SixelImageBuilder ib(
+        { Width(5), Height(30) }, 1, 1, defaultColor, std::make_shared<SixelColorPalette>(16, 256));
+    auto sp = SixelParser { ib };
+
+    sp.parseFragment("$-$-$-$-");
+    sp.done();
+
+    REQUIRE(ib.size() == terminal::ImageSize { Width(1), Height(24) });
+    REQUIRE(ib.sixelCursor() == CellLocation { LineOffset(24), ColumnOffset { 0 } });
+}


### PR DESCRIPTION
fixes #822

To test this use [this script](https://github.com/hackerb9/vt340test/blob/main/jerch/gcrglf.sh). Since the script requires cell height to be 20px, you can change font size to be 11 in default config with monospace font family.
![Screenshot from 2022-09-20 22-53-58](https://user-images.githubusercontent.com/29328319/191325040-ac679d6e-744a-4cea-800c-886dad4dfe54.png)
