### PR TITLE
Sixel rendering for images that show below but should be rendered above text

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -106,6 +106,7 @@
           <li>Fixes Sixel mode, when updating the color palette with a new color, that color must also be used for subsequent paints.</li>
           <li>Fixes vertical cursor movement for Sixel graphics with only newlines (#822).</li>
           <li>Fixes Sixel rendering for images with aspect ratios other than 1:1.</li>
+          <li>Fixes Sixel rendering for images that show below but should be rendered above text (#831).</li>
 					<li>Removes `images.sixel_cursor_conformance` config option.</li>
         </ul>
       </description>

--- a/src/terminal_renderer/ImageRenderer.h
+++ b/src/terminal_renderer/ImageRenderer.h
@@ -16,6 +16,7 @@
 #include <terminal/Image.h>
 
 #include <terminal_renderer/RenderTarget.h>
+#include <terminal_renderer/TextRenderer.h>
 
 #include <crispy/FNV.h>
 #include <crispy/point.h>
@@ -51,7 +52,7 @@ struct ImageFragmentKey
 /// Image Rendering API.
 ///
 /// Can render any arbitrary RGBA image (for example Sixel Graphics images).
-class ImageRenderer: public Renderable
+class ImageRenderer: public Renderable, public TextRendererEvents
 {
   public:
     ImageRenderer(GridMetrics const& gridMetrics, ImageSize cellSize);
@@ -70,8 +71,15 @@ class ImageRenderer: public Renderable
 
     void inspect(std::ostream& output) const override;
 
+    void beginFrame();
+    void endFrame();
+
+    void onBeforeRenderingText() override;
+    void onAfterRenderingText() override;
+
   private:
     AtlasTileAttributes const* getOrCreateCachedTileAttributes(ImageFragment const& fragment);
+    std::vector<atlas::RenderTile> pendingRenderTilesAboveText_;
 
     // private data
     //

--- a/src/terminal_renderer/RenderTarget.cpp
+++ b/src/terminal_renderer/RenderTarget.cpp
@@ -91,10 +91,10 @@ auto Renderable::sliceTileData(Renderable::TextureAtlas::TileCreateData const& c
                           createData.metadata.fragmentShaderSelector);
 }
 
-void Renderable::renderTile(atlas::RenderTile::X x,
-                            atlas::RenderTile::Y y,
-                            RGBAColor color,
-                            Renderable::AtlasTileAttributes const& attributes)
+atlas::RenderTile Renderable::createRenderTile(atlas::RenderTile::X x,
+                                               atlas::RenderTile::Y y,
+                                               RGBAColor color,
+                                               Renderable::AtlasTileAttributes const& attributes)
 {
     auto renderTile = atlas::RenderTile {};
     renderTile.x = atlas::RenderTile::X { x };
@@ -105,5 +105,13 @@ void Renderable::renderTile(atlas::RenderTile::X x,
     renderTile.normalizedLocation = attributes.metadata.normalizedLocation;
     renderTile.targetSize = attributes.metadata.targetSize;
     renderTile.tileLocation = attributes.location;
-    textureScheduler().renderTile(renderTile);
+    return renderTile;
+}
+
+void Renderable::renderTile(atlas::RenderTile::X x,
+                            atlas::RenderTile::Y y,
+                            RGBAColor color,
+                            Renderable::AtlasTileAttributes const& attributes)
+{
+    textureScheduler().renderTile(createRenderTile(x, y, color, attributes));
 }

--- a/src/terminal_renderer/RenderTarget.h
+++ b/src/terminal_renderer/RenderTarget.h
@@ -185,6 +185,11 @@ class Renderable
         TileSliceIndex sliceIndex,
         atlas::TileLocation tileLocation);
 
+    atlas::RenderTile createRenderTile(atlas::RenderTile::X x,
+                                       atlas::RenderTile::Y y,
+                                       RGBAColor color,
+                                       Renderable::AtlasTileAttributes const& attributes);
+
     void renderTile(atlas::RenderTile::X x,
                     atlas::RenderTile::Y y,
                     RGBAColor color,

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -146,7 +146,7 @@ Renderer::Renderer(PageSize pageSize,
     backgroundOpacity_ { backgroundOpacity },
     backgroundRenderer_ { gridMetrics_, colorPalette.defaultBackground },
     imageRenderer_ { gridMetrics_, cellSize() },
-    textRenderer_ { gridMetrics_, *textShaper_, fontDescriptions_, fonts_ },
+    textRenderer_ { gridMetrics_, *textShaper_, fontDescriptions_, fonts_, imageRenderer_ },
     decorationRenderer_ { gridMetrics_, hyperlinkNormal, hyperlinkHover },
     cursorRenderer_ { gridMetrics_, CursorShape::Block }
 {
@@ -313,6 +313,7 @@ uint64_t Renderer::render(Terminal& _terminal, bool _pressure)
 #endif // }}}
 
     optional<terminal::RenderCursor> cursorOpt;
+    imageRenderer_.beginFrame();
     textRenderer_.beginFrame();
     textRenderer_.setPressure(_pressure && _terminal.isPrimaryScreen());
     {
@@ -322,6 +323,7 @@ uint64_t Renderer::render(Terminal& _terminal, bool _pressure)
         renderLines(renderBuffer.get().lines);
     }
     textRenderer_.endFrame();
+    imageRenderer_.endFrame();
 
     if (cursorOpt && cursorOpt.value().shape != CursorShape::Block)
     {

--- a/src/terminal_renderer/TextRenderer.cpp
+++ b/src/terminal_renderer/TextRenderer.cpp
@@ -305,8 +305,10 @@ constexpr uint32_t TextShapingCacheSize = 4000;
 TextRenderer::TextRenderer(GridMetrics const& gridMetrics,
                            text::shaper& _textShaper,
                            FontDescriptions& _fontDescriptions,
-                           FontKeys const& _fonts):
+                           FontKeys const& _fonts,
+                           TextRendererEvents& eventHandler):
     Renderable { gridMetrics },
+    textRendererEvents_ { eventHandler },
     fontDescriptions_ { _fontDescriptions },
     fonts_ { _fonts },
     textShapingCache_ { ShapingResultCache::create(crispy::StrongHashtableSize { 16384 },
@@ -633,6 +635,8 @@ void TextRenderer::flushTextClusterGroup()
         //            _gridMetrics.cellSize.width,
         //            textClusterGroup_.codepoints.size());
 
+        textRendererEvents_.onBeforeRenderingText();
+
         auto hash = hashTextAndStyle(
             u32string_view(textClusterGroup_.codepoints.data(), textClusterGroup_.codepoints.size()),
             textClusterGroup_.style);
@@ -679,6 +683,7 @@ void TextRenderer::flushTextClusterGroup()
                 pen.x += static_cast<decltype(pen.x)>(advanceX);
             }
         }
+        textRendererEvents_.onAfterRenderingText();
     }
 
     textClusterGroup_.resetAndMovePenForward(textClusterGroup_.cellCount

--- a/src/terminal_renderer/TextRenderer.h
+++ b/src/terminal_renderer/TextRenderer.h
@@ -56,6 +56,14 @@ struct FontKeys
     text::font_key emoji;
 };
 
+struct TextRendererEvents
+{
+    virtual ~TextRendererEvents() = default;
+
+    virtual void onBeforeRenderingText() = 0;
+    virtual void onAfterRenderingText() = 0;
+};
+
 /// Text Rendering Pipeline
 class TextRenderer: public Renderable
 {
@@ -63,7 +71,8 @@ class TextRenderer: public Renderable
     TextRenderer(GridMetrics const& gridMetrics,
                  text::shaper& textShaper,
                  FontDescriptions& fontDescriptions,
-                 FontKeys const& fontKeys);
+                 FontKeys const& fontKeys,
+                 TextRendererEvents& textRendererEventHandler);
 
     void setRenderTarget(RenderTarget& renderTarget, DirectMappingAllocator& directMappingAllocator) override;
     void setTextureAtlas(TextureAtlas& atlas) override;
@@ -135,6 +144,7 @@ class TextRenderer: public Renderable
 
     // general properties
     //
+    TextRendererEvents& textRendererEvents_;
     FontDescriptions& fontDescriptions_;
     FontKeys const& fonts_;
 


### PR DESCRIPTION
Fixes #831 and now it looks like:

![image](https://user-images.githubusercontent.com/56763/192138717-d8b800b2-cbed-45d0-a6aa-fb8db9ec71fb.png)
