### PR TITLE
Fixes vi cursor color

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Adds VT sequence DECSCA, DECSEL, DECSED and DECSERA to support protected grid areas during erase operations (#29, #30, #31).</li>
           <li>Improve Input Method (IME) handling, visualizing preedit-text.</li>
           <li>Update Unicode data to version 15.0.0 (release). See Announcing The Unicode® Standard, Version 15.0.0.</li>
+          <li>Fixes cursor highlight in VI mode</li>
         </ul>
       </description>
     </release>

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -449,7 +449,8 @@ ColumnCount RenderBufferBuilder<Cell>::renderUtf8Text(CellLocation screenPositio
     auto graphemeClusterSegmenter = unicode::utf8_grapheme_segmenter(text);
     for (u32string const& graphemeCluster: graphemeClusterSegmenter)
     {
-        auto const gridPosition = terminal.viewport().translateScreenToGridCoordinate(screenPosition);
+        auto const gridPosition = terminal.viewport().translateScreenToGridCoordinate(
+            screenPosition + ColumnOffset::cast_from(columnCountRendered));
         auto const [fg, bg] = makeColorsForCell(gridPosition,
                                                 textAttributes.flags,
                                                 textAttributes.foregroundColor,


### PR DESCRIPTION
# Creating a pull request

Thank you for taking the time to create a pull request in this repository!
Please fill out this form before submitting your PR.

Please provide a general summary of your changes in the Title above.

```markdown
Bugfix in vi cursor color.
```

## Description

Describe your changes in detail

```markdown
This pr fixes a bug in vi mode cursor. 
```

## Motivation and Context

If you print some text like `cat someFile` and then switch to VI mode and use vi keybinds to move around, sometimes
cursor is just completely invisible.

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
