### PR TITLE
Some prep-work for VT text processing optimizations.

### DIFF
--- a/src/terminal/Parser-impl.h
+++ b/src/terminal/Parser-impl.h
@@ -42,6 +42,7 @@ constexpr ParserTable ParserTable::get() // {{{
     auto t = ParserTable {};
 
     // Ground
+    t.entry(State::Ground, Action::GroundStart);
     t.event(State::Ground, Action::Execute, Range { 0x00_b, 0x17_b }, 0x19_b, Range { 0x1C_b, 0x1F_b });
     t.event(State::Ground, Action::Print, Range { 0x20_b, 0x7F_b });
     t.event(State::Ground, Action::Print, Range { 0xA0_b, 0xFF_b });
@@ -246,6 +247,7 @@ void Parser<EventListener, TraceStateChanges>::parseFragment(std::string_view co
             {
                 auto const next = input + cellCount;
                 auto const byteCount = static_cast<size_t>(std::distance(input, next));
+                precedingGraphicCharacter = static_cast<char32_t>(input[cellCount - 1]);
                 assert(byteCount <= chunk.size());
                 assert(cellCount <= maxCharCount);
                 assert(next <= chunk.data() + chunk.size());
@@ -322,6 +324,7 @@ void Parser<EventListener, TraceStateChanges>::handle(ActionClass _actionClass,
 
     switch (_action)
     {
+        case Action::GroundStart: precedingGraphicCharacter = 0; break;
         case Action::Clear: eventListener_.clear(); break;
         case Action::CollectLeader: eventListener_.collectLeader(ch); break;
         case Action::Collect: eventListener_.collect(ch); break;

--- a/src/terminal/Parser-impl.h
+++ b/src/terminal/Parser-impl.h
@@ -264,7 +264,18 @@ void Parser<EventListener, TraceStateChanges>::parseFragment(std::string_view co
                         crispy::escape(std::string_view { input, byteCount }));
 #endif
 
-                maxCharCount = eventListener_.print(std::string_view { input, byteCount }, cellCount);
+                auto const text = std::string_view { input, byteCount };
+                if (utf8DecoderState_.expectedLength == 0)
+                {
+                    maxCharCount = eventListener_.print(text, cellCount);
+                    precedingGraphicCharacter = static_cast<char32_t>(text.back());
+                }
+                else
+                {
+                    for (char const ch: text)
+                        printUtf8Byte(ch);
+                }
+
                 input = next;
 
                 // This optimization is for the `cat`-people.
@@ -305,6 +316,20 @@ void Parser<EventListener, TraceStateChanges>::parseFragment(std::string_view co
 }
 
 template <typename EventListener, bool TraceStateChanges>
+void Parser<EventListener, TraceStateChanges>::printUtf8Byte(char ch)
+{
+    unicode::ConvertResult const r = unicode::from_utf8(utf8DecoderState_, (uint8_t) ch);
+    if (std::holds_alternative<unicode::Incomplete>(r))
+        return;
+
+    auto constexpr ReplacementCharacter = char32_t { 0xFFFD };
+    auto const codepoint = std::holds_alternative<unicode::Success>(r) ? std::get<unicode::Success>(r).value
+                                                                       : ReplacementCharacter;
+    eventListener_.print(codepoint);
+    precedingGraphicCharacter = codepoint;
+}
+
+template <typename EventListener, bool TraceStateChanges>
 void Parser<EventListener, TraceStateChanges>::handle(ActionClass _actionClass,
                                                       Action _action,
                                                       uint8_t codepoint)
@@ -335,7 +360,7 @@ void Parser<EventListener, TraceStateChanges>::handle(ActionClass _actionClass,
         case Action::Execute: eventListener_.execute(ch); break;
         case Action::ESC_Dispatch: eventListener_.dispatchESC(ch); break;
         case Action::CSI_Dispatch: eventListener_.dispatchCSI(ch); break;
-        case Action::Print: eventListener_.print(ch); break;
+        case Action::Print: printUtf8Byte(ch); break;
         case Action::OSC_Start: eventListener_.startOSC(); break;
         case Action::OSC_Put: eventListener_.putOSC(ch); break;
         case Action::OSC_End: eventListener_.dispatchOSC(); break;

--- a/src/terminal/Parser.h
+++ b/src/terminal/Parser.h
@@ -19,6 +19,7 @@
 #include <crispy/range.h>
 
 #include <unicode/convert.h>
+#include <unicode/utf8.h>
 
 #include <fmt/format.h>
 
@@ -657,11 +658,13 @@ class Parser
 
   private:
     void handle(ActionClass _actionClass, Action _action, uint8_t _char);
+    void printUtf8Byte(char ch);
 
     // private properties
     //
     State state_ = State::Ground;
     EventListener& eventListener_;
+    unicode::utf8_decoder_state utf8DecoderState_ = {};
 };
 
 /// @returns parsed tuple with OSC code and offset to first data parameter byte.

--- a/src/terminal/Parser.h
+++ b/src/terminal/Parser.h
@@ -355,6 +355,13 @@ enum class Action : uint8_t
      * to allow the OSC handler to finish neatly.
      */
     OSC_End,
+
+    /**
+     * This action is called when Ground state is entered. The previous graphic character is then
+     * being reset to 0 such that the grapheme cluster segmentation algorithm won't accidentally
+     * mix up with older text.
+     */
+    GroundStart,
 };
 
 constexpr State& operator++(State& s) noexcept
@@ -409,6 +416,7 @@ constexpr std::string_view to_string(Action action)
     switch (action)
     {
         case Action::Undefined: return "Undefined";
+        case Action::GroundStart: return "GroundStart";
         case Action::Ignore: return "Ignore";
         case Action::Execute: return "Execute";
         case Action::Print: return "Print";
@@ -644,6 +652,8 @@ class Parser
     void parseFragment(std::string_view s, size_t maxCharCount);
 
     [[nodiscard]] State state() const noexcept { return state_; }
+
+    char32_t precedingGraphicCharacter = 0;
 
   private:
     void handle(ActionClass _actionClass, Action _action, uint8_t _char);

--- a/src/terminal/ParserEvents.h
+++ b/src/terminal/ParserEvents.h
@@ -39,7 +39,7 @@ class ParserEvents
      * be displayed. 20 (SP) and 7F (DEL) have special behaviour in later VT series, as
      * described in ground.
      */
-    virtual void print(char _text) = 0;
+    virtual void print(char32_t _text) = 0;
 
     /**
      * Optimization that passes in ASCII chars between [0x20 .. 0x7F].
@@ -166,7 +166,7 @@ class BasicParserEvents: public ParserEvents
 {
   public:
     void error(std::string_view const&) override {}
-    void print(char) override {}
+    void print(char32_t) override {}
     size_t print(std::string_view, size_t) override { return 0; }
     void execute(char) override {}
     void clear() override {}

--- a/src/terminal/Parser_test.cpp
+++ b/src/terminal/Parser_test.cpp
@@ -30,7 +30,7 @@ class MockParserEvents: public terminal::BasicParserEvents
     size_t maxCharCount = 80;
 
     void error(string_view const& _msg) override { INFO(fmt::format("Parser error received. {}", _msg)); }
-    void print(char ch) override { text += ch; }
+    void print(char32_t ch) override { text += unicode::convert_to<char>(ch); }
     size_t print(std::string_view s, size_t cellCount) override
     {
         text += s;

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -3448,14 +3448,14 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
         case ICH: insertCharacters(seq.param_or(0, ColumnCount { 1 })); break;
         case IL: insertLines(seq.param_or(0, LineCount { 1 })); break;
         case REP:
-            if (_terminal.state().precedingGraphicCharacter)
+            if (precedingGraphicCharacter())
             {
                 auto const requestedCount = seq.param<size_t>(0);
                 auto const availableColumns =
                     (margin().horizontal.to - cursor().position.column).template as<size_t>();
                 auto const effectiveCount = min(requestedCount, availableColumns);
                 for (size_t i = 0; i < effectiveCount; i++)
-                    writeText(_terminal.state().precedingGraphicCharacter);
+                    writeText(precedingGraphicCharacter());
             }
             break;
         case RM: {

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -607,7 +607,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     }
     [[nodiscard]] char32_t precedingGraphicCharacter() const noexcept
     {
-        return _state.precedingGraphicCharacter;
+        return _state.parser.precedingGraphicCharacter;
     }
 
     void applyAndLog(FunctionDefinition const& function, Sequence const& seq);

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -53,7 +53,7 @@ void Sequencer::print(char _char)
     auto const codepoint =
         holds_alternative<unicode::Success>(r) ? get<unicode::Success>(r).value : ReplacementCharacter;
     terminal_.activeDisplay().writeText(codepoint);
-    terminal_.state().precedingGraphicCharacter = codepoint;
+    terminal_.state().parser.precedingGraphicCharacter = codepoint;
 }
 
 size_t Sequencer::print(string_view _chars, size_t cellCount)
@@ -64,7 +64,7 @@ size_t Sequencer::print(string_view _chars, size_t cellCount)
     {
         terminal_.state().instructionCounter += _chars.size();
         terminal_.activeDisplay().writeText(_chars, cellCount);
-        terminal_.state().precedingGraphicCharacter = static_cast<char32_t>(_chars.back());
+        terminal_.state().parser.precedingGraphicCharacter = static_cast<char32_t>(_chars.back());
     }
     else
         for (char const ch: _chars)

--- a/src/terminal/Sequencer.h
+++ b/src/terminal/Sequencer.h
@@ -138,7 +138,7 @@ class Sequencer
     // ParserEvents
     //
     void error(std::string_view _errorString);
-    void print(char _text);
+    void print(char32_t _codepoint);
     size_t print(std::string_view _chars, size_t cellCount);
     void execute(char _controlCode);
     void clear() noexcept;
@@ -169,13 +169,11 @@ class Sequencer
     }
 
   private:
-    void resetUtf8DecoderState() noexcept;
     void handleSequence();
 
     // private data
     //
     Terminal& terminal_;
-    unicode::utf8_decoder_state utf8DecoderState_ = {};
     Sequence sequence_ {};
     SequenceParameterBuilder parameterBuilder_;
 
@@ -184,16 +182,10 @@ class Sequencer
 };
 
 // {{{ inlines
-inline void Sequencer::resetUtf8DecoderState() noexcept
-{
-    utf8DecoderState_ = {};
-}
-
 inline void Sequencer::clear() noexcept
 {
     sequence_.clearExceptParameters();
     parameterBuilder_.reset();
-    resetUtf8DecoderState();
 }
 
 inline void Sequencer::paramDigit(char _char) noexcept

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -211,7 +211,6 @@ struct TerminalState
     ViCommands viCommands;
     ViInputHandler inputHandler;
 
-    char32_t precedingGraphicCharacter = {};
     bool terminating = false;
 };
 

--- a/src/terminal/bench-headless.cpp
+++ b/src/terminal/bench-headless.cpp
@@ -53,7 +53,7 @@ class NullParserEvents
 {
   public:
     void error(std::string_view /*_errorString*/) {}
-    void print(char /*_text*/) {}
+    void print(char32_t /*_text*/) {}
     size_t print(std::string_view /*chars*/, size_t /*cellCount*/) { return 4096; }
     void execute(char /*_controlCode*/) {}
     void clear() {}


### PR DESCRIPTION
Prepares some generally applicable code refactors ahead of #692.

These refactors are being merged separately because they do not change semantics but simply shift responsibility from other places into the parser.

Specifically:

- Parser now has knowledge of the last (previous) graphic character.
- Parser now handles UTF-8 to UTF-32 conversion itself (rather than Sequencer/Screen.)