### PR TITLE
Fetch some embeded libs if OS is not supported

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -437,6 +437,11 @@ main()
             ;;
         *)
             echo "OS $ID not supported."
+            fetch_and_unpack_Catch2
+            fetch_and_unpack_fmtlib
+            fetch_and_unpack_gsl
+            fetch_and_unpack_yaml_cpp
+            fetch_and_unpack_range
             ;;
     esac
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -436,12 +436,14 @@ main()
             install_deps_FreeBSD
             ;;
         *)
-            echo "OS $ID not supported."
             fetch_and_unpack_Catch2
             fetch_and_unpack_fmtlib
             fetch_and_unpack_gsl
             fetch_and_unpack_yaml_cpp
             fetch_and_unpack_range
+            echo "OS $ID not supported."
+            echo "Please install the remaining dependencies manually."
+            echo "Most importantly: Qt (including development headers)."
             ;;
     esac
 


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Added fetch of embeded libraries to make it easier to take car of dependencies if OS is not supported
Helps in situations like this #849 
```


## How Has This Been Tested?

- [x] Please describe how you tested your changes.
- - Checked on blank VM that script is fetching dependencies if OS is not supported and cmake in the future use them
- [x] see how your change affects other areas of the code, etc.
- - has no effect
## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
