### PR TITLE
Remove not needed mkdir from build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ It will neither build nor run on any prior Windows OS, due to libterminal making
 ### Compile
 
 ```sh
-mkdir build
 cmake -S . -B build
 cmake --build build/
 


### PR DESCRIPTION


## Description

The `mkdir build` command is redundant, as the `cmake -S . -B build` command itself does create the `build` folder if it doesn't exist.

## Motivation and Context

Small efficiency gain by recommending one command less in the build instructions

## How Has This Been Tested?

- [x] Pressed preview on the markdown editor

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly. (yes, I've just updated documentation)
- [x] I have added tests to cover my changes. - (not needed, no code changed)
- [x] I have gone through all the steps, and have thoroughly read the instructions
