### PR TITLE
Avoid slow path on rendering trivial line if possible.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -106,6 +106,7 @@
           <li>Fixes ground-state infinite loop in corner case + refactor and tiny optimization.</li>
           <li>Fixes assertion in optimized bulk text processing.</li>
           <li>Improve throughput performance for scroll-up when custom vertical margins are in effect.</li>
+          <li>Improve rendering performance slightly for so called trivial lines.</li>
           <li>Adds menu entry to Dolphin file manager to open Contour at current working directory.</li>
         </ul>
       </description>

--- a/src/terminal/RenderBufferBuilder.cpp
+++ b/src/terminal/RenderBufferBuilder.cpp
@@ -297,6 +297,7 @@ RenderLine RenderBufferBuilder<Cell>::createRenderLine(TrivialLineBuffer const& 
     auto renderLine = RenderLine {};
     renderLine.lineOffset = lineOffset;
     renderLine.usedColumns = lineBuffer.usedColumns;
+    renderLine.displayWidth = terminal.pageSize().columns;
     renderLine.text = lineBuffer.text.view();
     renderLine.textAttributes = createRenderAttributes(gridPosition, lineBuffer.textAttributes);
     renderLine.fillAttributes = createRenderAttributes(gridPosition, lineBuffer.fillAttributes);
@@ -317,10 +318,10 @@ void RenderBufferBuilder<Cell>::renderTrivialLine(TrivialLineBuffer const& lineB
 
     auto const frontIndex = output.cells.size();
 
-    // TODO: visual selection can alter colors for some columns in this line.
+    // Visual selection can alter colors for some columns in this line.
     // In that case, it seems like we cannot just pass it bare over but have to take the slower path.
     // But that should be fine.
-    bool const canRenderViaSimpleLine = false; // <- Should be false if selection covers this line.
+    bool const canRenderViaSimpleLine = !terminal.isSelected(lineOffset);
 
     if (canRenderViaSimpleLine)
     {

--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -47,7 +47,7 @@ class RenderBufferBuilder
     /// with their grid cells are to be rendered using renderCell().
     ///
     /// @see renderCell
-    void renderTrivialLine(TrivialLineBuffer const& _lineBuffer, LineOffset _lineNo);
+    void renderTrivialLine(TrivialLineBuffer const& lineBuffer, LineOffset lineNo);
 
     /// This call is guaranteed to be invoked when the the full page has been rendered.
     void finish() noexcept {}

--- a/src/terminal/Selector.cpp
+++ b/src/terminal/Selector.cpp
@@ -79,6 +79,11 @@ bool Selection::contains(CellLocation _coord) const noexcept
     return crispy::ascending(from_, _coord, to_) || crispy::ascending(to_, _coord, from_);
 }
 
+bool Selection::containsLine(LineOffset line) const noexcept
+{
+    return crispy::ascending(from_.line, line, to_.line) || crispy::ascending(to_.line, line, from_.line);
+}
+
 bool Selection::intersects(Rect _area) const noexcept
 {
     // TODO: make me more efficient

--- a/src/terminal/Selector.h
+++ b/src/terminal/Selector.h
@@ -90,6 +90,7 @@ class Selection
     /// @returns boolean indicating whether or not given absolute coordinate is within the range of the
     /// selection.
     [[nodiscard]] virtual bool contains(CellLocation _coord) const noexcept;
+    [[nodiscard]] bool containsLine(LineOffset line) const noexcept;
     [[nodiscard]] virtual bool intersects(Rect _area) const noexcept;
 
     /// Tests whether the a selection is currently in progress.

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -520,6 +520,13 @@ class Terminal
         return selection_ && selection_->state() != Selection::State::Waiting && selection_->contains(_coord);
     }
 
+    /// Tests whether given line offset is intersecting with selection.
+    bool isSelected(LineOffset line) const noexcept
+    {
+        return selection_ && selection_->state() != Selection::State::Waiting
+               && selection_->containsLine(line);
+    }
+
     bool isHighlighted(CellLocation _cell) const noexcept;
     bool blinkState() const noexcept { return _slowBlinker.state; }
     bool rapidBlinkState() const noexcept { return _rapidBlinker.state; }


### PR DESCRIPTION
The code was basically there already. But what was missing is the check to see if the fast path could be used for rendering the trivial line the faster way. So if a line is trivial but does contain some kind of visual modifications to it (currently only possible when parts of such line is selected, because that alters the way a cell is rendered in color), then the fast path cannot be used, otherwise it can.