### PR TITLE
Fixes restoring the cursor visibility after leaving alternate screen when application wasn't restoring mode switches in reverse order.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -103,6 +103,14 @@
 
     -->
 
+    <release version="0.3.8" urgency="medium" type="development">
+      <description>
+        <ul>
+          <li>Fixes restoring the cursor visibility after leaving alternate screen when application wasn't restoring mode switches in reverse order.</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="0.3.7" urgency="medium" type="development">
       <description>
         <ul>

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -460,7 +460,8 @@ class Terminal
 
     bool cursorCurrentlyVisible() const noexcept
     {
-        return state_.cursor.visible && (cursorDisplay_ == CursorDisplay::Steady || cursorBlinkState_);
+        return isModeEnabled(DECMode::VisibleCursor)
+               && (cursorDisplay_ == CursorDisplay::Steady || cursorBlinkState_);
     }
 
     bool isBlinkOnScreen() const noexcept { return _lastRenderPassHints.containsBlinkingCells; }

--- a/src/terminal/TerminalState.h
+++ b/src/terminal/TerminalState.h
@@ -98,7 +98,6 @@ struct Cursor
     CellLocation position { LineOffset(0), ColumnOffset(0) };
     bool autoWrap = true; // false;
     bool originMode = false;
-    bool visible = true;
     GraphicsAttributes graphicsRendition {};
     CharsetMapping charsets {};
     HyperlinkId hyperlink {};
@@ -262,11 +261,7 @@ struct formatter<terminal::Cursor>
     template <typename FormatContext>
     auto format(const terminal::Cursor cursor, FormatContext& ctx)
     {
-        return fmt::format_to(ctx.out(),
-                              "({}:{}{})",
-                              cursor.position.line,
-                              cursor.position.column,
-                              cursor.visible ? "" : ", (invis)");
+        return fmt::format_to(ctx.out(), "{}", cursor.position);
     }
 };
 


### PR DESCRIPTION
I found this bug because [slides](https://github.com/maaslalani/slides) did not restore mode switches in reverse order during exit.