### PR TITLE
Fixes cursor movement over wide characters in normal mode.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
         <ul>
           <li>Fixes restoring the cursor visibility after leaving alternate screen when application wasn't restoring mode switches in reverse order.</li>
           <li>Fixes country flags rendering due to misleading grapheme cluster segmentation in corner cases.</li>
+          <li>Fixes cursor movements for the vi-like cursor (normal mode).</li>
         </ul>
       </description>
     </release>

--- a/src/terminal/Line.h
+++ b/src/terminal/Line.h
@@ -235,12 +235,14 @@ class Line
 
     [[nodiscard]] uint8_t cellWidthAt(ColumnOffset column) const noexcept
     {
+#if 0 // TODO: This optimization - but only when we return actual widths and not always 1.
         if (isTrivialBuffer())
         {
             Require(ColumnOffset(0) <= column);
             Require(column < ColumnOffset::cast_from(size()));
             return 1; // TODO: When trivial line is to support Unicode, this should be adapted here.
         }
+#endif
         return inflatedBuffer().at(unbox<size_t>(column)).width();
     }
 

--- a/src/terminal/ViCommands.cpp
+++ b/src/terminal/ViCommands.cpp
@@ -372,10 +372,10 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         }
         case ViMotion::CharRight: // l
         {
+            auto const cellWidth =
+                std::max(uint8_t { 1 }, terminal.currentScreen().cellWidthAt(cursorPosition));
             auto resultPosition = cursorPosition;
-            auto const rightMargin = ColumnOffset::cast_from(terminal.pageSize().columns - 1);
-            for (unsigned i = 0; i < count && resultPosition.column < rightMargin; ++i)
-                resultPosition = snapToCellRight(resultPosition + ColumnOffset(1));
+            resultPosition.column += ColumnOffset::cast_from(cellWidth);
             return resultPosition;
         }
         case ViMotion::ScreenColumn: // |
@@ -405,15 +405,15 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             return result;
         }
         case ViMotion::LineDown: // j
-            return snapToCell({ min(cursorPosition.line + LineOffset::cast_from(count),
-                                    terminal.pageSize().lines.as<LineOffset>() - 1),
-                                cursorPosition.column });
+            return { min(cursorPosition.line + LineOffset::cast_from(count),
+                         terminal.pageSize().lines.as<LineOffset>() - 1),
+                     cursorPosition.column };
         case ViMotion::LineEnd: // $
             return { cursorPosition.line, terminal.pageSize().columns.as<ColumnOffset>() - 1 };
         case ViMotion::LineUp: // k
-            return snapToCell({ max(cursorPosition.line - LineOffset::cast_from(count),
-                                    -terminal.currentScreen().historyLineCount().as<LineOffset>()),
-                                cursorPosition.column });
+            return { max(cursorPosition.line - LineOffset::cast_from(count),
+                         -terminal.currentScreen().historyLineCount().as<LineOffset>()),
+                     cursorPosition.column };
         case ViMotion::PageDown:
             return { min(cursorPosition.line + LineOffset::cast_from(terminal.pageSize().lines / 2),
                          terminal.pageSize().lines.as<LineOffset>() - 1),


### PR DESCRIPTION
normal mode vertical cursor movements beyond the last character of a new line was snapping to the left. that's more hindering than anything near helpful. 

also, use actual cell width property to decide how many cells to move to the right when having to move to the right.