### PR TITLE
VT extension: passive mouse reporting & text selection reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ endif()
 
 include(ContourThirdParties)
 add_subdirectory(src)
+add_subdirectory(examples)
 
 # ----------------------------------------------------------------------------
 # Summary

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(LIBTERMINAL_TESTING)
+    if(UNIX)
+        add_executable(watch-mouse-events watch-mouse-events.cpp)
+        target_link_libraries(watch-mouse-events fmt::fmt-header-only terminal)
+    endif()
+endif()
+

--- a/examples/watch-mouse-events.cpp
+++ b/examples/watch-mouse-events.cpp
@@ -1,0 +1,308 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2022 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <terminal/InputGenerator.h>
+#include <terminal/Sequence.h>
+#include <terminal/primitives.h>
+
+#include <vtparser/Parser.h>
+#include <vtparser/ParserEvents.h>
+
+#include <vtpty/UnixUtils.h>
+
+#include <fmt/format.h>
+
+#include <csignal>
+#include <iostream>
+
+#if defined(__APPLE__)
+    #include <util.h>
+#else
+    #include <termios.h>
+#endif
+
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace std;
+
+namespace
+{
+
+using namespace terminal;
+
+struct BasicParserEvents: public NullParserEvents // {{{
+{
+    Sequence _sequence {};
+    SequenceParameterBuilder _parameterBuilder;
+
+    BasicParserEvents(): _parameterBuilder(_sequence.parameters()) {}
+
+    void collect(char _char) override { _sequence.intermediateCharacters().push_back(_char); }
+
+    void collectLeader(char _leader) noexcept override { _sequence.setLeader(_leader); }
+
+    void clear() noexcept override
+    {
+        _sequence.clearExceptParameters();
+        _parameterBuilder.reset();
+    }
+
+    void paramDigit(char _char) noexcept override
+    {
+        _parameterBuilder.multiplyBy10AndAdd(static_cast<uint8_t>(_char - '0'));
+    }
+
+    void paramSeparator() noexcept override { _parameterBuilder.nextParameter(); }
+
+    void paramSubSeparator() noexcept override { _parameterBuilder.nextSubParameter(); }
+
+    void param(char _char) noexcept override
+    {
+        switch (_char)
+        {
+            case ';': paramSeparator(); break;
+            case ':': paramSubSeparator(); break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9': paramDigit(_char); break;
+        }
+    }
+
+    virtual void handleSequence() = 0;
+
+    void executeSequenceHandler()
+    {
+        _parameterBuilder.fixiate();
+        handleSequence();
+    }
+
+    void dispatchESC(char _finalChar) override
+    {
+        _sequence.setCategory(FunctionCategory::ESC);
+        _sequence.setFinalChar(_finalChar);
+        executeSequenceHandler();
+    }
+
+    void dispatchCSI(char _finalChar) override
+    {
+        _sequence.setCategory(FunctionCategory::CSI);
+        _sequence.setFinalChar(_finalChar);
+        executeSequenceHandler();
+    }
+
+    void startOSC() override { _sequence.setCategory(FunctionCategory::OSC); }
+
+    void putOSC(char _char) override
+    {
+        if (_sequence.intermediateCharacters().size() + 1 < Sequence::MaxOscLength)
+            _sequence.intermediateCharacters().push_back(_char);
+    }
+
+    void dispatchOSC() override
+    {
+        auto const [code, skipCount] = parser::extractCodePrefix(_sequence.intermediateCharacters());
+        _parameterBuilder.set(static_cast<Sequence::Parameter>(code));
+        _sequence.intermediateCharacters().erase(0, skipCount);
+        executeSequenceHandler();
+        clear();
+    }
+
+    void hook(char _finalChar) override
+    {
+        _sequence.setCategory(FunctionCategory::DCS);
+        _sequence.setFinalChar(_finalChar);
+        executeSequenceHandler();
+    }
+};
+// }}}
+
+struct MouseTracker final: public BasicParserEvents
+{
+    static bool running;
+
+    int mouseButton = -1;
+    int line = -1;
+    int column = -1;
+    bool uiHandledHint = false;
+    termios savedTermios;
+
+    parser::Parser<ParserEvents> vtInputParser;
+
+    MouseTracker(): savedTermios { detail::getTerminalSettings(STDIN_FILENO) }, vtInputParser { *this }
+    {
+        auto tio = savedTermios;
+        tio.c_lflag &= static_cast<tcflag_t>(~(ECHO | ICANON));
+        tio.c_cc[VMIN] = 1;  // Report as soon as 1 character is available.
+        tio.c_cc[VTIME] = 0; // Disable timeout (no need).
+        detail::applyTerminalSettings(STDIN_FILENO, tio);
+
+        writeToTTY("\033[?2029h"); // enable passive mouse reporting
+        writeToTTY("\033[?2030h"); // enable text selection reporting
+        writeToTTY("\033[?1003h"); // enable tracking any mouse event
+        writeToTTY("\033[?25l");   // hide text cursor
+
+        signal(SIGINT, signalHandler);
+        signal(SIGTERM, signalHandler);
+        signal(SIGSTOP, signalHandler);
+    }
+
+    ~MouseTracker() override
+    {
+        detail::applyTerminalSettings(STDIN_FILENO, savedTermios);
+        writeToTTY("\033[?2029l"); // disable passive mouse reporting
+        writeToTTY("\033[?2030l"); // disable text selection reporting
+        writeToTTY("\033[?25h");   // show text cursor
+        writeToTTY("\nTerminating\n");
+    }
+
+    static void signalHandler(int signo)
+    {
+        running = false;
+        signal(signo, SIG_DFL);
+    }
+
+    void execute(char /*controlCode*/) override { running = false; }
+
+    void print(char32_t ch) override
+    {
+        if (ch == U'q' || ch == U'Q')
+            running = false;
+    }
+
+    size_t print(std::string_view text, size_t /*columnsUsed*/) override
+    {
+        if (text == "q" || text == "Q")
+            running = false;
+        return 0;
+    }
+
+    int run()
+    {
+        checkPassiveMouseTrackingSupport();
+        while (running)
+        {
+            writeToTTY(fmt::format("\rMouse position {}:{}, 0x{:X}, {} ({})\033[K",
+                                   line,
+                                   column,
+                                   mouseButton,
+                                   uiHandledHint ? "UI handled" : "idle",
+                                   selectionStateString()));
+            processInput();
+        }
+        writeToTTY("\n"sv);
+        return EXIT_SUCCESS;
+    }
+
+    string selectionStateString()
+    {
+        if (selection.mode == 0)
+            return "no text selection";
+        auto const mode = [&]() {
+            switch (selection.mode)
+            {
+                case 1: return "Linear";
+                case 2: return "Full Line";
+                case 3: return "Rectangular";
+                default: return "Unknown";
+            }
+        }();
+
+        return fmt::format("{}; {} .. {}", mode, selection.from, selection.to);
+    }
+
+    void checkPassiveMouseTrackingSupport()
+    {
+        writeToTTY("\033[?2029$p");
+        while (!_decrpm)
+            processInput();
+
+        auto const state = _decrpm.value().second;
+        auto const supported = state == 1 || state == 2;
+        fmt::print("Passive mouse tracking: {}\n", supported ? "supported" : "not supported");
+    }
+
+    void writeToTTY(string_view s) { ::write(STDOUT_FILENO, s.data(), s.size()); }
+
+    void processInput()
+    {
+        char buf[128];
+        auto n = ::read(STDIN_FILENO, buf, sizeof(buf));
+        if (n > 0)
+            vtInputParser.parseFragment(string_view(buf, static_cast<size_t>(n)));
+    }
+
+    void handleSequence() override
+    {
+        if (_sequence.leaderSymbol() == '<' && _sequence.finalChar() == 'M')
+        {
+            // CSI < {ButtonStates} ; {COLUMN} ; {LINE} ; {uiHandledHint} M
+            // NB: button states on param index 0
+            mouseButton = _sequence.param_or(0, 0);
+            column = _sequence.param_or(1, -2);
+            line = _sequence.param_or(2, -2);
+            uiHandledHint = _sequence.param_or(3, 0) != 0;
+        }
+        else if (_sequence.leaderSymbol() == '?' && _sequence.intermediateCharacters() == "$"
+                 && _sequence.finalChar() == 'y' && _sequence.parameterCount() == 2)
+        {
+            // Receive now something like this: CSI ? 2029 ; 0 $ y
+            _decrpm = pair { _sequence.param(0), _sequence.param(1) };
+        }
+        else if (_sequence.leaderSymbol() == '>' && _sequence.finalChar() == 'M')
+        {
+            // CSI > M
+            // CSI > {SelectionMode} ; {StartLine} ; {StartColumn} ; {EndLine} ; EndColumn M
+            if (_sequence.parameterCount() == 0)
+            {
+                selection.mode = 0;
+                selection.from = {};
+                selection.to = {};
+            }
+            else if (_sequence.parameterCount() == 5)
+            {
+                selection.mode = _sequence.param(0);
+                selection.from.line = _sequence.param<LineOffset>(1);
+                selection.from.column = _sequence.param<ColumnOffset>(2);
+                selection.to.line = _sequence.param<LineOffset>(3);
+                selection.to.column = _sequence.param<ColumnOffset>(4);
+            }
+        }
+        _sequence.clear();
+    }
+
+    struct
+    {
+        unsigned mode {};
+        CellLocation from {};
+        CellLocation to {};
+    } selection;
+    std::optional<std::pair<int, int>> _decrpm;
+};
+
+bool MouseTracker::running = true;
+
+} // namespace
+
+int main()
+{
+    auto mouseTracker = MouseTracker {};
+    return mouseTracker.run();
+}

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -114,8 +114,8 @@
           <li>Fixes normal mode's page top (S-H)/ page bottom (S-L) cursor movements to respect scroll offset.</li>
 					<li>Vi Mode search can handle line wrapping and searchText larger than line length (#869) (#870).</li>
           <li>Adds ability to highlight same words on double click via `profile.*.highlight_word_and_matches_on_double_click`.</li>
-          <li>Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
-          <li>Adds VT extension to enable text selection tracking via `CSI ? 2030 h` / `CSI ? 2030 l`.</li>
+          <li>EXPERIMENTAL: Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
+          <li>EXPERIMENTAL: Adds VT extension to enable text selection tracking via `CSI ? 2030 h` / `CSI ? 2030 l`.</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
         <ul>
           <li>Fixes restoring the cursor visibility after leaving alternate screen when application wasn't restoring mode switches in reverse order.</li>
           <li>Fixes country flags rendering due to misleading grapheme cluster segmentation in corner cases.</li>
+          <li>Fixes mouse reporting in primary screen when viewport has been scrolled into the scrollback area.</li>
           <li>Fixes cursor movements for the vi-like cursor (normal mode).</li>
           <li>Fixes Alt+Backspace on OS/X.</li>
           <li>Fixes normal mode's page top (S-H)/ page bottom (S-L) cursor movements to respect scroll offset.</li>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,8 +112,9 @@
           <li>Fixes cursor movements for the vi-like cursor (normal mode).</li>
           <li>Fixes Alt+Backspace on OS/X.</li>
           <li>Fixes normal mode's page top (S-H)/ page bottom (S-L) cursor movements to respect scroll offset.</li>
-          <li>Adds ability to highlight same words on double click via `profile.*.highlight_word_and_matches_on_double_click`.</li>
 					<li>Vi Mode search can handle line wrapping and searchText larger than line length (#869) (#870).</li>
+          <li>Adds ability to highlight same words on double click via `profile.*.highlight_word_and_matches_on_double_click`.</li>
+          <li>Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -115,6 +115,7 @@
 					<li>Vi Mode search can handle line wrapping and searchText larger than line length (#869) (#870).</li>
           <li>Adds ability to highlight same words on double click via `profile.*.highlight_word_and_matches_on_double_click`.</li>
           <li>Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
+          <li>Adds VT extension to enable text selection tracking via `CSI ? 2030 h` / `CSI ? 2030 l`.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -551,7 +551,8 @@ void TerminalSession::sendMousePressEvent(Modifier _modifier,
 
     // First try to pass the mouse event to the application, as it might have requested that.
     auto uiHandledHint = actionHandled || selectionHandled;
-    auto const terminalHandled = terminal().sendMousePressEvent(_modifier, _button, _pixelPosition, uiHandledHint, _now);
+    auto const terminalHandled =
+        terminal().sendMousePressEvent(_modifier, _button, _pixelPosition, uiHandledHint, _now);
 
     if (uiHandledHint || terminalHandled)
         scheduleRedraw();

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -527,26 +527,34 @@ void TerminalSession::sendMousePressEvent(Modifier _modifier,
                                           Timestamp _now)
 {
     // InputLog()("sendMousePressEvent: {} {} at {}", _button, _modifier, currentMousePosition_);
+    bool mouseGrabbed = terminal().isMouseGrabbedByApp();
+
+    auto actionHandled = false;
+    if (!mouseGrabbed)
+    {
+        if (auto const* actions =
+                config::apply(config_.inputMappings.mouseMappings, _button, _modifier, matchModeFlags()))
+        {
+            if (executeAllActions(*actions))
+            {
+                actionHandled = true;
+            }
+        }
+    }
+
+    // clang-format off
+    auto const selectionHandled = !actionHandled
+                                  && !mouseGrabbed
+                                  && _button == MouseButton::Left
+                                  && terminal_.handleMouseSelection(_modifier, _now);
+    // clang-format on
 
     // First try to pass the mouse event to the application, as it might have requested that.
-    if (terminal().sendMousePressEvent(_modifier, _button, _pixelPosition, _now))
-    {
+    auto uiHandledHint = actionHandled || selectionHandled;
+    auto const terminalHandled = terminal().sendMousePressEvent(_modifier, _button, _pixelPosition, uiHandledHint, _now);
+
+    if (uiHandledHint || terminalHandled)
         scheduleRedraw();
-        return;
-    }
-
-    if (auto const* actions =
-            config::apply(config_.inputMappings.mouseMappings, _button, _modifier, matchModeFlags()))
-    {
-        if (executeAllActions(*actions))
-            return;
-    }
-
-    if (_button != MouseButton::Left)
-        return;
-    if (!terminal_.handleMouseSelection(_modifier, _now))
-        return;
-    scheduleRedraw();
 }
 
 void TerminalSession::sendMouseMoveEvent(terminal::Modifier _modifier,
@@ -560,7 +568,8 @@ void TerminalSession::sendMouseMoveEvent(terminal::Modifier _modifier,
     if (!(_pos < terminal().pageSize()))
         return;
 
-    auto const handled = terminal().sendMouseMoveEvent(_modifier, _pos, _pixelPosition, _now);
+    auto const uiHandledHint = false;
+    auto const handled = terminal().sendMouseMoveEvent(_modifier, _pos, _pixelPosition, uiHandledHint, _now);
 
     if (_pos == currentMousePosition_)
         return;
@@ -585,7 +594,8 @@ void TerminalSession::sendMouseReleaseEvent(Modifier _modifier,
                                             PixelCoordinate _pixelPosition,
                                             Timestamp _now)
 {
-    terminal().sendMouseReleaseEvent(_modifier, _button, _pixelPosition, _now);
+    auto const uiHandledHint = false;
+    terminal().sendMouseReleaseEvent(_modifier, _button, _pixelPosition, uiHandledHint, _now);
     scheduleRedraw();
 }
 

--- a/src/terminal/InputGenerator.cpp
+++ b/src/terminal/InputGenerator.cpp
@@ -606,6 +606,10 @@ bool InputGenerator::mouseTransport(MouseEventType _eventType,
                                     CellLocation _pos,
                                     PixelCoordinate _pixelPosition)
 {
+    if (_pos.line.value < 0 || _pos.column.value < 0)
+        // Negative coordinates are not supported. Avoid sending bad values.
+        return true;
+
     switch (mouseTransport_)
     {
         case MouseTransport::Default: // mode: 9

--- a/src/terminal/InputGenerator.h
+++ b/src/terminal/InputGenerator.h
@@ -288,6 +288,9 @@ class InputGenerator
     void setGenerateFocusEvents(bool _enable) noexcept { generateFocusEvents_ = _enable; }
     [[nodiscard]] bool generateFocusEvents() const noexcept { return generateFocusEvents_; }
 
+    void setPassiveMouseTracking(bool v) noexcept { passiveMouseTracking_ = v; }
+    [[nodiscard]] bool passiveMouseTracking() const noexcept { return passiveMouseTracking_; }
+
     bool generate(char32_t _characterEvent, Modifier _modifier);
     bool generate(std::u32string const& _characterEvent, Modifier _modifier);
     bool generate(Key _key, Modifier _modifier);
@@ -295,12 +298,17 @@ class InputGenerator
     bool generateMousePress(Modifier _modifier,
                             MouseButton _button,
                             CellLocation _pos,
-                            PixelCoordinate _pixelPosition);
-    bool generateMouseMove(Modifier _modifier, CellLocation _pos, PixelCoordinate _pixelPosition);
+                            PixelCoordinate _pixelPosition,
+                            bool _uiHandled);
+    bool generateMouseMove(Modifier _modifier,
+                           CellLocation _pos,
+                           PixelCoordinate _pixelPosition,
+                           bool _uiHandled);
     bool generateMouseRelease(Modifier _modifier,
                               MouseButton _button,
                               CellLocation _pos,
-                              PixelCoordinate _pixelPosition);
+                              PixelCoordinate _pixelPosition,
+                              bool _uiHandled);
 
     bool generateFocusInEvent();
     bool generateFocusOutEvent();
@@ -342,17 +350,21 @@ class InputGenerator
                        Modifier _modifier,
                        MouseButton _button,
                        CellLocation _pos,
-                       PixelCoordinate _pixelPosition);
+                       PixelCoordinate _pixelPosition,
+                       bool _uiHandled);
 
     bool mouseTransport(MouseEventType _eventType,
                         uint8_t _button,
                         uint8_t _modifier,
                         CellLocation _pos,
-                        PixelCoordinate _pixelPosition);
+                        PixelCoordinate _pixelPosition,
+                        bool _uiHandled);
+
     bool mouseTransportX10(uint8_t _button, uint8_t _modifier, CellLocation _pos);
     bool mouseTransportExtended(uint8_t _button, uint8_t _modifier, CellLocation _pos);
 
-    bool mouseTransportSGR(MouseEventType _type, uint8_t _button, uint8_t _modifier, int x, int y);
+    bool mouseTransportSGR(
+        MouseEventType _type, uint8_t _button, uint8_t _modifier, int x, int y, bool uiHandled);
 
     bool mouseTransportURXVT(MouseEventType _type, uint8_t _button, uint8_t _modifier, CellLocation _pos);
 
@@ -368,6 +380,7 @@ class InputGenerator
     bool bracketedPaste_ = false;
     bool generateFocusEvents_ = false;
     std::optional<MouseProtocol> mouseProtocol_ = std::nullopt;
+    bool passiveMouseTracking_ = false;
     MouseTransport mouseTransport_ = MouseTransport::Default;
     MouseWheelMode mouseWheelMode_ = MouseWheelMode::Default;
     Sequence pendingSequence_ {};

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -2391,6 +2391,7 @@ namespace impl
                 case 2027: return DECMode::Unicode;
                 case 2028: return DECMode::TextReflow;
                 case 2029: return DECMode::MousePassiveTracking;
+                case 2030: return DECMode::ReportGridCellSelection;
                 case 8452: return DECMode::SixelCursorNextToGraphic;
             }
             return nullopt;

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -2390,6 +2390,7 @@ namespace impl
                 case 2026: return DECMode::BatchedRendering;
                 case 2027: return DECMode::Unicode;
                 case 2028: return DECMode::TextReflow;
+                case 2029: return DECMode::MousePassiveTracking;
                 case 8452: return DECMode::SixelCursorNextToGraphic;
             }
             return nullopt;

--- a/src/terminal/Selector.cpp
+++ b/src/terminal/Selector.cpp
@@ -54,6 +54,7 @@ void Selection::extend(CellLocation _to)
            && "In order extend a selection, the selector must be active (started).");
     state_ = State::InProgress;
     to_ = _to;
+    onSelectionUpdated_();
 }
 
 void Selection::complete()
@@ -127,14 +128,18 @@ std::vector<Selection::Range> Selection::ranges() const
 }
 // }}}
 // {{{ LinearSelection
-LinearSelection::LinearSelection(SelectionHelper const& _helper, CellLocation _start):
-    Selection(_helper, _start)
+LinearSelection::LinearSelection(SelectionHelper const& _helper,
+                                 CellLocation _start,
+                                 OnSelectionUpdated onSelectionUpdated):
+    Selection(_helper, _start, std::move(onSelectionUpdated))
 {
 }
 // }}}
 // {{{ WordWiseSelection
-WordWiseSelection::WordWiseSelection(SelectionHelper const& _helper, CellLocation _start):
-    Selection(_helper, _start)
+WordWiseSelection::WordWiseSelection(SelectionHelper const& _helper,
+                                     CellLocation _start,
+                                     OnSelectionUpdated onSelectionUpdated):
+    Selection(_helper, _start, std::move(onSelectionUpdated))
 {
     from_ = extendSelectionBackward(from_);
     to_ = extendSelectionForward(to_);
@@ -215,8 +220,10 @@ void WordWiseSelection::extend(CellLocation _to)
 }
 // }}}
 // {{{ RectangularSelection
-RectangularSelection::RectangularSelection(SelectionHelper const& _helper, CellLocation _start):
-    Selection(_helper, _start)
+RectangularSelection::RectangularSelection(SelectionHelper const& _helper,
+                                           CellLocation _start,
+                                           OnSelectionUpdated onSelectionUpdated):
+    Selection(_helper, _start, std::move(onSelectionUpdated))
 {
 }
 
@@ -272,8 +279,10 @@ vector<Selection::Range> RectangularSelection::ranges() const
 }
 // }}}
 // {{{ FullLineSelection
-FullLineSelection::FullLineSelection(SelectionHelper const& _helper, CellLocation _start):
-    Selection(_helper, _start)
+FullLineSelection::FullLineSelection(SelectionHelper const& _helper,
+                                     CellLocation _start,
+                                     OnSelectionUpdated onSelectionUpdated):
+    Selection(_helper, _start, std::move(onSelectionUpdated))
 {
     from_.column = ColumnOffset(0);
     to_.column = boxed_cast<ColumnOffset>(helper_.pageSize().columns - 1);

--- a/src/terminal/Selector.h
+++ b/src/terminal/Selector.h
@@ -77,8 +77,13 @@ class Selection
     /// Defines a columnar range at a given line.
     using Range = ColumnRange;
 
-    Selection(SelectionHelper const& _helper, CellLocation _start):
-        helper_ { _helper }, from_ { _start }, to_ { _start }
+    using OnSelectionUpdated = std::function<void()>;
+
+    Selection(SelectionHelper const& _helper, CellLocation _start, OnSelectionUpdated onSelectionUpdated):
+        helper_ { _helper },
+        onSelectionUpdated_ { std::move(onSelectionUpdated) },
+        from_ { _start },
+        to_ { _start }
     {
     }
 
@@ -113,6 +118,7 @@ class Selection
   protected:
     State state_ = State::Waiting;
     SelectionHelper const& helper_;
+    OnSelectionUpdated onSelectionUpdated_;
     CellLocation from_;
     CellLocation to_;
 };
@@ -120,7 +126,9 @@ class Selection
 class RectangularSelection: public Selection
 {
   public:
-    RectangularSelection(SelectionHelper const& _helper, CellLocation _start);
+    RectangularSelection(SelectionHelper const& _helper,
+                         CellLocation _start,
+                         OnSelectionUpdated onSelectionUpdated);
     [[nodiscard]] bool contains(CellLocation _coord) const noexcept override;
     [[nodiscard]] bool intersects(Rect _area) const noexcept override;
     [[nodiscard]] std::vector<Range> ranges() const override;
@@ -129,13 +137,17 @@ class RectangularSelection: public Selection
 class LinearSelection: public Selection
 {
   public:
-    LinearSelection(SelectionHelper const& _helper, CellLocation _start);
+    LinearSelection(SelectionHelper const& _helper,
+                    CellLocation _start,
+                    OnSelectionUpdated onSelectionUpdated);
 };
 
 class WordWiseSelection: public Selection
 {
   public:
-    WordWiseSelection(SelectionHelper const& _helper, CellLocation _start);
+    WordWiseSelection(SelectionHelper const& _helper,
+                      CellLocation _start,
+                      OnSelectionUpdated onSelectionUpdated);
 
     void extend(CellLocation _to) override;
 
@@ -146,7 +158,9 @@ class WordWiseSelection: public Selection
 class FullLineSelection: public Selection
 {
   public:
-    explicit FullLineSelection(SelectionHelper const& _helper, CellLocation _start);
+    explicit FullLineSelection(SelectionHelper const& _helper,
+                               CellLocation _start,
+                               OnSelectionUpdated onSelectionUpdated);
     void extend(CellLocation _to) override;
 };
 

--- a/src/terminal/Selector_test.cpp
+++ b/src/terminal/Selector_test.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Selector.Linear", "[selector]")
     SECTION("single-cell")
     { // "b"
         auto const pos = CellLocation { LineOffset(1), ColumnOffset(1) };
-        auto selector = LinearSelection(selectionHelper, pos);
+        auto selector = LinearSelection(selectionHelper, pos, []() {});
         selector.extend(pos);
         selector.complete();
 
@@ -125,7 +125,7 @@ TEST_CASE("Selector.Linear", "[selector]")
     SECTION("forward single-line")
     { // "b,c"
         auto const pos = CellLocation { LineOffset(1), ColumnOffset(1) };
-        auto selector = LinearSelection(selectionHelper, pos);
+        auto selector = LinearSelection(selectionHelper, pos, []() {});
         selector.extend(CellLocation { LineOffset(1), ColumnOffset(3) });
         selector.complete();
 
@@ -145,7 +145,7 @@ TEST_CASE("Selector.Linear", "[selector]")
     SECTION("forward multi-line")
     { // "b,cdefg,hi\n1234"
         auto const pos = CellLocation { LineOffset(1), ColumnOffset(1) };
-        auto selector = LinearSelection(selectionHelper, pos);
+        auto selector = LinearSelection(selectionHelper, pos, []() {});
         selector.extend(CellLocation { LineOffset(2), ColumnOffset(3) });
         selector.complete();
 
@@ -181,7 +181,8 @@ TEST_CASE("Selector.Linear", "[selector]")
          2 | "bar"
         */
 
-        auto selector = LinearSelection(selectionHelper, CellLocation { LineOffset(-2), ColumnOffset(6) });
+        auto selector =
+            LinearSelection(selectionHelper, CellLocation { LineOffset(-2), ColumnOffset(6) }, []() {});
         selector.extend(CellLocation { LineOffset(-1), ColumnOffset(2) });
         selector.complete();
 
@@ -217,7 +218,8 @@ TEST_CASE("Selector.Linear", "[selector]")
          2 | ""
         */
 
-        auto selector = LinearSelection(selectionHelper, CellLocation { LineOffset(-2), ColumnOffset(8) });
+        auto selector =
+            LinearSelection(selectionHelper, CellLocation { LineOffset(-2), ColumnOffset(8) }, []() {});
         selector.extend(CellLocation { LineOffset(0), ColumnOffset(1) });
         selector.complete();
 

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -663,7 +663,7 @@ bool Terminal::sendMouseMoveEvent(Modifier _modifier,
 
     // Do not handle mouse-move events in sub-cell dimensions.
     if (allowInput() && respectMouseProtocol_
-        && state_.inputGenerator.generateMouseMove(_modifier, currentMousePosition_, _pixelPosition))
+        && state_.inputGenerator.generateMouseMove(_modifier, relativePos, _pixelPosition))
     {
         flushInput();
         return true;

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -269,6 +269,8 @@ class Terminal
     void setMouseProtocolBypassModifier(Modifier _value) { mouseProtocolBypassModifier_ = _value; }
     void setMouseBlockSelectionModifier(Modifier _value) { mouseBlockSelectionModifier_ = _value; }
 
+    bool isMouseGrabbedByApp() const noexcept;
+
     // {{{ input proxy
     using Timestamp = std::chrono::steady_clock::time_point;
     bool sendKeyPressEvent(Key _key, Modifier _modifier, Timestamp _now);
@@ -276,14 +278,17 @@ class Terminal
     bool sendMousePressEvent(Modifier _modifier,
                              MouseButton _button,
                              PixelCoordinate _pixelPosition,
+                             bool _uiHandledHint,
                              Timestamp _now);
     bool sendMouseMoveEvent(Modifier _modifier,
                             CellLocation _pos,
                             PixelCoordinate _pixelPosition,
+                             bool _uiHandledHint,
                             Timestamp _now);
     bool sendMouseReleaseEvent(Modifier _modifier,
                                MouseButton _button,
                                PixelCoordinate _pixelPosition,
+                             bool _uiHandledHint,
                                Timestamp _now);
     bool sendFocusInEvent();
     bool sendFocusOutEvent();

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -283,12 +283,12 @@ class Terminal
     bool sendMouseMoveEvent(Modifier _modifier,
                             CellLocation _pos,
                             PixelCoordinate _pixelPosition,
-                             bool _uiHandledHint,
+                            bool _uiHandledHint,
                             Timestamp _now);
     bool sendMouseReleaseEvent(Modifier _modifier,
                                MouseButton _button,
                                PixelCoordinate _pixelPosition,
-                             bool _uiHandledHint,
+                               bool _uiHandledHint,
                                Timestamp _now);
     bool sendFocusInEvent();
     bool sendFocusOutEvent();
@@ -636,6 +636,15 @@ class Terminal
     }
 
     [[nodiscard]] terminal::SelectionHelper& selectionHelper() noexcept { return selectionHelper_; }
+
+    [[nodiscard]] Selection::OnSelectionUpdated selectionUpdatedHelper()
+    {
+        return [this]() {
+            onSelectionUpdated();
+        };
+    }
+
+    void onSelectionUpdated();
 
     [[nodiscard]] ViInputHandler& inputHandler() noexcept { return state_.inputHandler; }
     [[nodiscard]] ViInputHandler const& inputHandler() const noexcept { return state_.inputHandler; }

--- a/src/terminal/TerminalState.cpp
+++ b/src/terminal/TerminalState.cpp
@@ -111,6 +111,7 @@ std::string to_string(DECMode _mode)
         case DECMode::MouseSGRPixels: return "MouseSGRPixels";
         case DECMode::MouseAlternateScroll: return "MouseAlternateScroll";
         case DECMode::MousePassiveTracking: return "MousePassiveTracking";
+        case DECMode::ReportGridCellSelection: return "ReportGridCellSelection";
         case DECMode::BatchedRendering: return "BatchedRendering";
         case DECMode::Unicode: return "Unicode";
         case DECMode::TextReflow: return "TextReflow";

--- a/src/terminal/TerminalState.cpp
+++ b/src/terminal/TerminalState.cpp
@@ -110,6 +110,7 @@ std::string to_string(DECMode _mode)
         case DECMode::MouseURXVT: return "MouseURXVT";
         case DECMode::MouseSGRPixels: return "MouseSGRPixels";
         case DECMode::MouseAlternateScroll: return "MouseAlternateScroll";
+        case DECMode::MousePassiveTracking: return "MousePassiveTracking";
         case DECMode::BatchedRendering: return "BatchedRendering";
         case DECMode::Unicode: return "Unicode";
         case DECMode::TextReflow: return "TextReflow";

--- a/src/terminal/ViCommands.cpp
+++ b/src/terminal/ViCommands.cpp
@@ -136,18 +136,21 @@ void ViCommands::modeChanged(ViMode mode)
             terminal.screenUpdated();
             break;
         case ViMode::Visual:
-            terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.setSelector(make_unique<LinearSelection>(
+                terminal.selectionHelper(), selectFrom, terminal.selectionUpdatedHelper()));
             terminal.selector()->extend(cursorPosition);
             terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             break;
         case ViMode::VisualLine:
-            terminal.setSelector(make_unique<FullLineSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.setSelector(make_unique<FullLineSelection>(
+                terminal.selectionHelper(), selectFrom, terminal.selectionUpdatedHelper()));
             terminal.selector()->extend(cursorPosition);
             terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
             break;
         case ViMode::VisualBlock:
-            terminal.setSelector(make_unique<RectangularSelection>(terminal.selectionHelper(), selectFrom));
+            terminal.setSelector(make_unique<RectangularSelection>(
+                terminal.selectionHelper(), selectFrom, terminal.selectionUpdatedHelper()));
             terminal.selector()->extend(cursorPosition);
             terminal.pushStatusDisplay(StatusDisplayType::Indicator);
             terminal.screenUpdated();
@@ -212,7 +215,8 @@ void ViCommands::executeYank(CellLocation from, CellLocation to)
     // Maybe via a event API to inform that a non-visual selection
     // has happened and that it can now either be instantly destroyed
     // or delayed (N msecs, configurable),
-    terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), from));
+    terminal.setSelector(
+        make_unique<LinearSelection>(terminal.selectionHelper(), from, terminal.selectionUpdatedHelper()));
     terminal.selector()->extend(to);
     auto const text = terminal.extractSelectionText();
     terminal.copyToClipboard(text);
@@ -255,7 +259,8 @@ void ViCommands::select(TextObjectScope scope, TextObject textObject)
                textObject,
                from,
                to);
-    terminal.setSelector(make_unique<LinearSelection>(terminal.selectionHelper(), from));
+    terminal.setSelector(
+        make_unique<LinearSelection>(terminal.selectionHelper(), from, terminal.selectionUpdatedHelper()));
     terminal.selector()->extend(to);
     terminal.screenUpdated();
 }

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -680,6 +680,10 @@ enum class DECMode
     // Default: Enabled (if supported by terminal).
     TextReflow = 2028,
 
+    // Tell the terminal emulator that the application is only passively tracking on mouse events.
+    // This for example might be used by the terminal emulator to still allow mouse selection.
+    MousePassiveTracking = 2029,
+
     // If enabled (default, as per spec), then the cursor is left next to the graphic,
     // that is, the text cursor is placed at the position of the sixel cursor.
     // If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
@@ -765,6 +769,7 @@ constexpr unsigned toDECModeNum(DECMode m)
         case DECMode::MouseURXVT: return 1015;
         case DECMode::MouseSGRPixels: return 1016;
         case DECMode::MouseAlternateScroll: return 1007;
+        case DECMode::MousePassiveTracking: return 2029;
         case DECMode::BatchedRendering: return 2026;
         case DECMode::Unicode: return 2027;
         case DECMode::TextReflow: return 2028;
@@ -809,6 +814,7 @@ constexpr bool isValidDECMode(unsigned int _mode) noexcept
         case DECMode::MouseURXVT:
         case DECMode::MouseSGRPixels:
         case DECMode::MouseAlternateScroll:
+        case DECMode::MousePassiveTracking:
         case DECMode::BatchedRendering:
         case DECMode::Unicode:
         case DECMode::TextReflow:

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -684,6 +684,10 @@ enum class DECMode
     // This for example might be used by the terminal emulator to still allow mouse selection.
     MousePassiveTracking = 2029,
 
+    // If enabled, UI text selection will be reported to the application for the regions
+    // intersecting with the main page area.
+    ReportGridCellSelection = 2030,
+
     // If enabled (default, as per spec), then the cursor is left next to the graphic,
     // that is, the text cursor is placed at the position of the sixel cursor.
     // If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
@@ -770,6 +774,7 @@ constexpr unsigned toDECModeNum(DECMode m)
         case DECMode::MouseSGRPixels: return 1016;
         case DECMode::MouseAlternateScroll: return 1007;
         case DECMode::MousePassiveTracking: return 2029;
+        case DECMode::ReportGridCellSelection: return 2030;
         case DECMode::BatchedRendering: return 2026;
         case DECMode::Unicode: return 2027;
         case DECMode::TextReflow: return 2028;
@@ -815,6 +820,7 @@ constexpr bool isValidDECMode(unsigned int _mode) noexcept
         case DECMode::MouseSGRPixels:
         case DECMode::MouseAlternateScroll:
         case DECMode::MousePassiveTracking:
+        case DECMode::ReportGridCellSelection:
         case DECMode::BatchedRendering:
         case DECMode::Unicode:
         case DECMode::TextReflow:


### PR DESCRIPTION
The drafted spec WAS is here: https://gist.github.com/christianparpart/bf82bc3a8ad7f3abeee3ada41c3178a9
but NOW located here: https://github.com/contour-terminal/vt-extensions

This adds support for allowing the terminal application to request mouse events, passively, i.e. the user can still select text as he'd be able to do when no app has requested mouse event tracking.

This feature does make sense in situations where the shell (ZSH, fish, bash, ...) might want to implement:

- reposition the cursor to where the mouse has been clicked in the command prompt
- tooltips of the command the mouse cursor is currently hovering

The problem without implementing such a VT extension is, that shells would never try to implement such features, as the user experience (no mouse-based select support) would be drained. Having this extension should be a win-win situation.

@jerch, @lhecker, @dankamongmen do you see any major problem here?  Would you guys be interested in something like this on your end, too?