### PR TITLE
Handle case when config file is corrupted

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1640,7 +1640,7 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     }
     catch (exception const& e)
     {
-        errorlog()("Configuration file is corrupter. {}",e.what() );
+        errorlog()("Configuration file is corrupted. {}",e.what() );
         auto _newfileName = _fileName;
         _newfileName.replace_filename("default_contour.yml");
         createDefaultConfig(_newfileName);

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1633,9 +1633,19 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     _config.backingFilePath = _fileName;
     createFileIfNotExists(_config.backingFilePath);
     auto usedKeys = UsedKeys {};
-
-    YAML::Node doc = YAML::LoadFile(_fileName.string());
-
+    YAML::Node doc;
+    try
+    {
+        doc = YAML::LoadFile(_fileName.string());
+    }
+    catch (exception const& e)
+    {
+        errorlog()("Configuration file is corrupter. {}",e.what() );
+        auto _newfileName = _fileName;
+        _newfileName.replace_filename("default_contour.yml");
+        createDefaultConfig(_newfileName);
+        return loadConfigFromFile(_config,_newfileName);
+    }
     tryLoadValue(usedKeys, doc, "word_delimiters", _config.wordDelimiters);
 
     if (auto opt =

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1641,8 +1641,8 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     catch (exception const& e)
     {
         errorlog()("Configuration file is corrupted. {}", e.what());
-        auto _newfileName = _fileName;
-        _newfileName.replace_filename("default_contour.yml");
+        auto newfileName = _fileName;
+        newfileName.replace_filename("default_contour.yml");
         createDefaultConfig(_newfileName);
         return loadConfigFromFile(_config, _newfileName);
     }

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1640,11 +1640,11 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
     }
     catch (exception const& e)
     {
-        errorlog()("Configuration file is corrupted. {}",e.what() );
+        errorlog()("Configuration file is corrupted. {}", e.what());
         auto _newfileName = _fileName;
         _newfileName.replace_filename("default_contour.yml");
         createDefaultConfig(_newfileName);
-        return loadConfigFromFile(_config,_newfileName);
+        return loadConfigFromFile(_config, _newfileName);
     }
     tryLoadValue(usedKeys, doc, "word_delimiters", _config.wordDelimiters);
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1643,8 +1643,8 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
         errorlog()("Configuration file is corrupted. {}", e.what());
         auto newfileName = _fileName;
         newfileName.replace_filename("default_contour.yml");
-        createDefaultConfig(_newfileName);
-        return loadConfigFromFile(_config, _newfileName);
+        createDefaultConfig(newfileName);
+        return loadConfigFromFile(_config, newfileName);
     }
     tryLoadValue(usedKeys, doc, "word_delimiters", _config.wordDelimiters);
 


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Added exception handling on wrong read of provided config file
by creation of valid configuration file and loading it
```

## Motivation and Context

Why is this change required? What problem does it solve?

Fixes  #886 
## How Has This Been Tested?

- [x] Please describe how you tested your changes.
- - checked that on bad configure file contour will create new configure file and load it
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
