### PR TITLE
Improves highlight search matching to also work on trivial line buffers (by promoting them on-demand to inflated line buffers).

### DIFF
--- a/src/terminal/RenderBufferBuilder.h
+++ b/src/terminal/RenderBufferBuilder.h
@@ -2,17 +2,12 @@
 
 #include <terminal/RenderBuffer.h>
 #include <terminal/Terminal.h>
+#include <terminal/primitives.h>
 
 #include <optional>
 
 namespace terminal
 {
-
-enum class HighlightSearchMatches
-{
-    No,
-    Yes
-};
 
 /**
  * RenderBufferBuilder<Cell> renders the current screen state into a RenderBuffer.

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -117,9 +117,11 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
 
     /// Renders the full screen by passing every grid cell to the callback.
     template <typename Renderer>
-    RenderPassHints render(Renderer&& _render, ScrollOffset _scrollOffset = {}) const
+    RenderPassHints render(Renderer&& _render,
+                           ScrollOffset _scrollOffset = {},
+                           HighlightSearchMatches highlightSearchMatches = HighlightSearchMatches::Yes) const
     {
-        return _grid.render(std::forward<Renderer>(_render), _scrollOffset);
+        return _grid.render(std::forward<Renderer>(_render), _scrollOffset, highlightSearchMatches);
     }
 
     /// Renders the full screen as text into the given string. Each line will be terminated by LF.

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -384,6 +384,8 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
 
     auto const hoveringHyperlinkGuard = ScopedHyperlinkHover { *this, currentScreen_ };
     auto const mainDisplayReverseVideo = isModeEnabled(terminal::DECMode::ReverseVideo);
+    auto const highlightSearchMatches =
+        state_.searchMode.pattern.empty() ? HighlightSearchMatches::No : HighlightSearchMatches::Yes;
 
     if (isPrimaryScreen())
         _lastRenderPassHints =
@@ -393,7 +395,8 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                                                                            mainDisplayReverseVideo,
                                                                            HighlightSearchMatches::Yes,
                                                                            inputMethodData_ },
-                                  viewport_.scrollOffset());
+                                  viewport_.scrollOffset(),
+                                  highlightSearchMatches);
     else
         _lastRenderPassHints =
             alternateScreen_.render(RenderBufferBuilder<AlternateScreenCell> { *this,
@@ -402,7 +405,8 @@ void Terminal::refreshRenderBufferInternal(RenderBuffer& _output)
                                                                                mainDisplayReverseVideo,
                                                                                HighlightSearchMatches::Yes,
                                                                                inputMethodData_ },
-                                    viewport_.scrollOffset());
+                                    viewport_.scrollOffset(),
+                                    highlightSearchMatches);
 
     switch (state_.statusDisplayType)
     {

--- a/src/terminal/primitives.h
+++ b/src/terminal/primitives.h
@@ -483,6 +483,12 @@ constexpr ColumnOffset& operator-=(ColumnOffset& a, ColumnCount b) noexcept
 }
 // }}}
 
+enum class HighlightSearchMatches
+{
+    No,
+    Yes
+};
+
 enum class ScreenType
 {
     Primary = 0,


### PR DESCRIPTION
we just recently implemented that.
but it only worked on non-trivial lines.
And trivial lines had to be promoted to inflated lines first (e.g. by clicking into them).
This PR actually auto-promotes all line buffers within the viewport to inflated when a search term is to be highlighted.

Doing it the other way (retain being trivial line buffer and operate on that) sounds more expensive, given the cost-beneficial factor.