### PR TITLE
Fixes default config entry `draw_bold_text_with_bright_colors` (renamed from `bold_is_bright`).

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Fixes VT sequence `DECSTR` (soft reset) to not move the cursor to home position.</li>
           <li>Fixes cursor movements for the vi-like cursor (normal mode).</li>
           <li>Fixes Alt+Backspace on OS/X.</li>
+          <li>Fixes default config entry `profiles.*.draw_bold_text_with_bright_colors` (it was renamed from `profiles.*.bold_is_bright`). Please rename this in your existing configuration if not done yet.</li>
           <li>Fixes normal mode's page top (S-H)/ page bottom (S-L) cursor movements to respect scroll offset.</li>
 					<li>Vi Mode search can handle line wrapping and searchText larger than line length (#869) (#870).</li>
           <li>Adds ability to highlight same words on double click via `profile.*.highlight_word_and_matches_on_double_click`.</li>

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -331,7 +331,13 @@ profiles:
             # Defaults to "emoji".
             emoji: "emoji"
 
-        bold_is_bright: false
+        # Indicates whether or not bold text should be rendered in bright colors,
+        # for indexed colors.
+        #
+        # If disabled, normal color will be used instead.
+        #
+        # Default: false
+        draw_bold_text_with_bright_colors: false
 
         # Terminal cursor display configuration
         cursor:

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -71,6 +71,9 @@ struct ColorPalette
     /// This value is used by draw_bold_text_with_bright_colors in profile configuration.
     ///
     /// If disabled, normal color will be used instead.
+    ///
+    /// TODO: This should be part of Config's Profile instead of being here. That sounds just wrong.
+    /// TODO: And even the naming sounds wrong. Better would be makeIndexedColorsBrightForBoldText or similar.
     bool useBrightColors = false;
 
     Palette palette = []() constexpr


### PR DESCRIPTION
it was renamed some time ago already, but apparently the default config file wasn't updated respectively. Sorry about that.