### PR TITLE
Fix of resize when next line is trivial

### DIFF
--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -797,6 +797,7 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
                 }
                 else // line is not wrapped
                 {
+                    flushLogicalLine();
                     if (line.isTrivialBuffer())
                     {
                         auto& buffer = line.trivialBuffer();
@@ -805,7 +806,6 @@ CellLocation Grid<Cell>::resize(PageSize _newSize, CellLocation _currentCursorPo
                     }
                     else
                     {
-                        flushLogicalLine();
                         // logLogicalLine(line.flags(), " - start new logical line");
                         appendToLogicalLine(line.cells());
                         logicalLineFlags = line.flags() & ~LineFlags::Wrapped;


### PR DESCRIPTION
## Description


 fixes  #877

## Context

On resize, when we need to unwrap line we add it into  `logicalLineBuffer`, and on next iteration we need to flush it, what was happening before is that in case of `trivialLine` we were skipping flush until we encounter non trivial line, this should not happen 

## How Has This Been Tested?

- [x] Please describe how you tested your changes.
 - checked locally that issue is fixed
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
