### PR TITLE
Adds optional parameter `strip` to PasteClipboard configuration action

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -120,6 +120,7 @@
           <li>Adds color scheme key `indicator_statusline.foreground` and `indicator_statusline.background` to customize indicator statusline colors.</li>
           <li>Adds clock to indicator status line.</li>
           <li>Adds current viewport position in scrollback buffer to indicator status line.</li>
+          <li>Adds optional parameter `strip` to PasteClipboard configuration action to allow stripping newlines and normalizing whitespaces.</li>
           <li>EXPERIMENTAL: Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
           <li>EXPERIMENTAL: Adds VT extension to enable text selection tracking via `CSI ? 2030 h` / `CSI ? 2030 l`.</li>
         </ul>

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -40,7 +40,7 @@ struct NewTerminal{ std::optional<std::string> profileName; };
 struct NoSearchHighlight{};
 struct OpenConfiguration{};
 struct OpenFileManager{};
-struct PasteClipboard{};
+struct PasteClipboard{ bool strip = false; };
 struct PasteSelection{};
 struct Quit{};
 struct ReloadConfig{ std::optional<std::string> profileName; };

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -870,6 +870,15 @@ namespace
                 return nullopt;
         }
 
+        if (holds_alternative<actions::PasteClipboard>(action))
+        {
+            if (auto node = _parent["strip"]; node && node.IsScalar())
+            {
+                _usedKeys.emplace(_prefix + ".strip");
+                return actions::PasteClipboard { node.as<bool>() };
+            }
+        }
+
         if (holds_alternative<actions::WriteScreen>(action))
         {
             if (auto chars = _parent["chars"]; chars.IsScalar())

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -94,7 +94,7 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     void inspect() override;
     void notify(std::string_view _title, std::string_view _body) override;
     void onClosed() override;
-    void pasteFromClipboard(unsigned count) override;
+    void pasteFromClipboard(unsigned count, bool strip) override;
     void onSelectionCompleted() override;
     void requestWindowResize(terminal::LineCount, terminal::ColumnCount) override;
     void requestWindowResize(terminal::Width, terminal::Height) override;

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -606,7 +606,7 @@ color_schemes:
 # - NoSearchHighlight Disables current search highlighting, if anything is still highlighted due to a prior search.
 # - OpenConfiguration Opens the configuration file.
 # - OpenFileManager   Opens the current working directory in a system file manager.
-# - PasteClipboard    Pastes clipboard to standard input.
+# - PasteClipboard    Pastes clipboard to standard input. Pass boolean parameter 'strip' to indicate whether or not to strip repetitive whitespaces down to one and newlines to whitespaces.
 # - PasteSelection    Pastes current selection to standard input.
 # - Quit              Quits the application.
 # - ReloadConfig      Forces a configuration reload.
@@ -647,11 +647,11 @@ input_mapping:
     - { mods: [Control, Shift], key: Minus,         action: DecreaseFontSize }
     - { mods: [Control, Shift], key: '_',           action: DecreaseFontSize }
     - { mods: [Control, Shift], key: N,             action: NewTerminal }
-    - { mods: [Control, Shift], key: C,             action: CopySelection }
-    - { mods: [Control, Shift], key: V,             action: PasteClipboard }
+    - { mods: [Control, Shift], key: V,             action: PasteClipboard, strip: false }
+    - { mods: [Control, Alt],   key: V,             action: PasteClipboard, strip: true }
     - { mods: [Control],        key: C,             action: CopySelection, mode: 'Select|Insert' }
     - { mods: [Control],        key: C,             action: CancelSelection, mode: 'Select|Insert' }
-    - { mods: [Control],        key: V,             action: PasteClipboard, mode: 'Select|Insert' }
+    - { mods: [Control],        key: V,             action: PasteClipboard, strip: false, mode: 'Select|Insert' }
     - { mods: [Control],        key: V,             action: CancelSelection, mode: 'Select|Insert' }
     - { mods: [],               key: Escape,        action: CancelSelection, mode: 'Select|Insert' }
     - { mods: [Control, Shift], key: Space,         action: ViNormalMode, mode: 'Insert' }

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 target_compile_features(crispy-core PUBLIC cxx_std_17)
 target_link_libraries(crispy-core PUBLIC ${CRISPY_CORE_LIBS})
 target_include_directories(crispy-core PUBLIC
-    $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
 )
 

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -89,7 +89,10 @@ target_compile_definitions(terminal PRIVATE
     LIBTERMINAL_NAME="${PROJECT_NAME}"
 )
 
-target_include_directories(terminal PUBLIC ${PROJECT_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(terminal PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
+)
 target_link_libraries(terminal PUBLIC vtparser vtpty crispy::core fmt::fmt-header-only range-v3::range-v3 Threads::Threads Microsoft.GSL::GSL)
 if(LIBTERMINAL_LOG_TRACE)
     target_compile_definitions(terminal PUBLIC LIBTERMINAL_LOG_TRACE=1)

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -81,7 +81,7 @@ class Terminal
         virtual void inspect() {}
         virtual void notify(std::string_view /*_title*/, std::string_view /*_body*/) {}
         virtual void onClosed() {}
-        virtual void pasteFromClipboard(unsigned /*count*/) {}
+        virtual void pasteFromClipboard(unsigned /*count*/, bool /*strip*/) {}
         virtual void onSelectionCompleted() {}
         virtual void requestWindowResize(LineCount, ColumnCount) {}
         virtual void requestWindowResize(Width, Height) {}
@@ -293,7 +293,10 @@ class Terminal
     bool sendFocusInEvent();
     bool sendFocusOutEvent();
     void sendPaste(std::string_view _text); // Sends verbatim text in bracketed mode to application.
-    void sendPasteFromClipboard(unsigned count = 1) { eventListener_.pasteFromClipboard(count); }
+    void sendPasteFromClipboard(unsigned count, bool strip)
+    {
+        eventListener_.pasteFromClipboard(count, strip);
+    }
 
     bool handleMouseSelection(Modifier _modifier, Timestamp _now);
 

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -241,7 +241,7 @@ void ViCommands::execute(ViOperator op, ViMotion motion, unsigned count)
             break;
         case ViOperator::Paste:
             //.
-            terminal.sendPasteFromClipboard(count);
+            terminal.sendPasteFromClipboard(count, false);
             break;
         case ViOperator::ReverseSearchCurrentWord: // TODO: Does this even make sense to have?
             break;
@@ -276,7 +276,7 @@ void ViCommands::yank(TextObjectScope scope, TextObject textObject)
 
 void ViCommands::paste(unsigned count)
 {
-    terminal.sendPasteFromClipboard(count);
+    terminal.sendPasteFromClipboard(count, false);
 }
 
 CellLocationRange ViCommands::expandMatchingPair(TextObjectScope scope, char left, char right) const noexcept


### PR DESCRIPTION
this allows pasting text with whitespace normalized and newlines replaced with whitespaces,
in order to allow uses like the following:

[contour-normal-mode-copy-and-use-stripped.webm](https://user-images.githubusercontent.com/56763/207688264-5e84e18d-8a1a-4890-a3b3-030c9cc5e52c.webm)
