### PR TITLE
Fix/column number

### DIFF
--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -528,15 +528,18 @@ void TerminalWidget::initializeGL()
 
 void TerminalWidget::resizeGL(int _width, int _height)
 {
-    QOpenGLWidget::resizeGL(_width, _height);
+    Width const width =
+        profile().scrollbarPosition == config::ScrollBarPosition::Hidden
+            ? Width::cast_from(_width - qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent))
+            : Width::cast_from(_width);
+    QOpenGLWidget::resizeGL(width.as<int>(), _height);
 
     if (!session_)
         return;
 
-    auto const qtBaseWidgetSize =
-        terminal::ImageSize { Width::cast_from(_width), Height::cast_from(_height) };
+    auto const qtBaseWidgetSize = terminal::ImageSize { width, Height::cast_from(_height) };
     auto const newPixelSize = qtBaseWidgetSize * contentScale();
-    DisplayLog()("Resizing view to {}x{} virtual ({} actual).", _width, _height, newPixelSize);
+    DisplayLog()("Resizing view to {}x{} virtual ({} actual).", width, _height, newPixelSize);
     applyResize(newPixelSize, *session_, *renderer_);
 }
 


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
In default config
When scrollbar is hidden, the terminal viewport is actually 81 cols because the scrollbar space is also used for columns too. So here I subtract scrollBar width from total width. This keeps the number columns same for both hidden scrollbar and visible scrollbar.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Because if terminal width is specified to be 80 cols then it should be 80 cols for both scrollbar hidden and visible.
```

## How Has This Been Tested?

- [x] Please describe how you tested your changes.
Run `printf '\e[18t'` to check number of columns.
- [x] see how your change affects other areas of the code, etc.
It doesn't affect other parts of code
## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
