### PR TITLE
Don't go past the end of terminal screen in vim mode.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -124,6 +124,7 @@
           <li>Adds optional parameter `strip` to PasteClipboard configuration action to allow stripping newlines and normalizing whitespaces.</li>
           <li>EXPERIMENTAL: Adds VT extension to enable passive mouse tracking via `CSI ? 2029 h` / `CSI ? 2029 l`. Passive mouse tracking enables the application to get notified on mouse events while still allowing mouse selection.</li>
           <li>EXPERIMENTAL: Adds VT extension to enable text selection tracking via `CSI ? 2030 h` / `CSI ? 2030 l`.</li>
+          <li>Fixes cursor going beyond the terminal screnn in vim mode, move right motion (#917)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -381,6 +381,8 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
                 std::max(uint8_t { 1 }, terminal.currentScreen().cellWidthAt(cursorPosition));
             auto resultPosition = cursorPosition;
             resultPosition.column += ColumnOffset::cast_from(cellWidth);
+            resultPosition.column =
+                min(resultPosition.column, ColumnOffset::cast_from(terminal.pageSize().columns - 1));
             return resultPosition;
         }
         case ViMotion::ScreenColumn: // |


### PR DESCRIPTION
## Description
Closes #917 
Describe your changes in detail
```markdown
The cursor was going past the right end, changed so that cursor cannot get past the right end
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown

```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
see #917 
- [x] see how your change affects other areas of the code, etc.
Doesn't affect any.
## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
