### PR TITLE
Fixes running within OpenGL/ES context.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
       <description>
         <ul>
           <li>Fixes statusline clock to show the correct local time.</li>
+          <li>Fixes running within OpenGL/ES context.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/ShaderConfig.cpp
+++ b/src/contour/display/ShaderConfig.cpp
@@ -42,11 +42,7 @@ namespace
 
 bool useOpenGLES() noexcept
 {
-#if defined(__linux__)
-    return true;
-#else
     return QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES;
-#endif
 }
 
 QSurfaceFormat createSurfaceFormat()
@@ -56,7 +52,7 @@ QSurfaceFormat createSurfaceFormat()
     if (useOpenGLES())
     {
         format.setRenderableType(QSurfaceFormat::OpenGLES);
-        format.setVersion(3, 3);
+        format.setVersion(3, 0);
     }
     else
     {


### PR DESCRIPTION
This at least helps me running Contour via Flatpak on ARM64, as (for some reason), it only works through OpenGL/ES.

Not sure this would also help #927 / Wayland.