### PR TITLE
Fixes failing startup due to `background_image.path` pointing to a non-existing file

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
         <ul>
           <li>Fixes statusline clock to show the correct local time.</li>
           <li>Fixes running within OpenGL/ES context.</li>
+          <li>Fixes failing startup due to `background_image.path` pointing to a non-existing file (#928).</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -113,6 +113,12 @@ namespace
     {
         auto const resolvedFileName = homeResolvedPath(fileName, Process::homeDirectory());
 
+        if (!FileSystem::exists(resolvedFileName))
+        {
+            errorlog()("Background image path not found: {}", resolvedFileName.string());
+            return nullptr;
+        }
+
         auto backgroundImage = terminal::BackgroundImage {};
         backgroundImage.location = resolvedFileName;
         backgroundImage.hash = crispy::StrongHash::compute(resolvedFileName.string());


### PR DESCRIPTION
Fixes #928