### PR TITLE
Allow colorizing the indicator status line differently when TE is not in focus.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
           <li>Fixes statusline clock to show the correct local time.</li>
           <li>Fixes running within OpenGL/ES context.</li>
           <li>Fixes failing startup due to `background_image.path` pointing to a non-existing file (#928).</li>
+          <li>Adds config entry `indicator_statusline_inactive` colorscheme key to colorize the status line differently when the terminal is currently not in focus.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -969,6 +969,13 @@ namespace
                 _usedKeys, _basePath, _node, "indicator_statusline", colors.indicatorStatusLine))
             colors.indicatorStatusLine = p.value();
 
+        if (auto p = parseRGBColorPair(_usedKeys,
+                                       _basePath,
+                                       _node,
+                                       "indicator_statusline_inactive",
+                                       colors.indicatorStatusLineInactive))
+            colors.indicatorStatusLineInactive = p.value();
+
         if (auto cursor = _node["cursor"]; cursor)
         {
             _usedKeys.emplace(_basePath + ".cursor");

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -512,6 +512,14 @@ color_schemes:
             # Default: default foreground
             background: '#000000'
 
+        # Alternate colors to be used for the indicator status line when
+        # this terminal is currently not in focus.
+        indicator_statusline_inactive:
+            # Default: default background
+            foreground: '#808080'
+            # Default: default foreground
+            background: '#000000'
+
         # Normal colors
         normal:
             black:   '#000000'

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -128,6 +128,7 @@ struct ColorPalette
     // clang-format on
 
     RGBColorPair indicatorStatusLine = { 0x000000_rgb, 0x808080_rgb };
+    RGBColorPair indicatorStatusLineInactive = { 0x000000_rgb, 0x808080_rgb };
 };
 
 enum class ColorTarget

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -465,15 +465,18 @@ void Terminal::updateIndicatorStatusLine()
     auto savedCursor = state_.cursor;
     auto const savedWrapPending = state_.wrapPending;
 
+    auto const colors =
+        state_.focused ? colorPalette().indicatorStatusLine : colorPalette().indicatorStatusLineInactive;
+
     currentScreen_ = indicatorStatusScreen_;
     state_.activeStatusDisplay = ActiveStatusDisplay::StatusLine;
 
     // Prepare old status line's cursor position and some other flags.
     state_.cursor = {};
-    state_.cursor.graphicsRendition.foregroundColor = colorPalette().indicatorStatusLine.foreground;
-    state_.cursor.graphicsRendition.backgroundColor = colorPalette().indicatorStatusLine.background;
     state_.wrapPending = false;
     indicatorStatusScreen_.updateCursorIterator();
+    state_.cursor.graphicsRendition.foregroundColor = colors.foreground;
+    state_.cursor.graphicsRendition.backgroundColor = colors.background;
 
     // Run status-line update.
     // We cannot use VT writing here, because we shall not interfere with the application's VT state.


### PR DESCRIPTION
turned out to be incredibly useful when having multiple TEs to not look too invasive.

[contour-indicator-statusline-focus-colors.webm](https://user-images.githubusercontent.com/56763/209105430-59c73b19-29a9-4a35-8c9d-e8f850a1d458.webm)
