### PR TITLE
Fix background image orientation

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
       <description>
         <ul>
           <li>Fixes `initial_working_directory` setting being ignored (#946).</li>
+          <li>Fixes background image being accidentally inverted (Bug introduced in 0.3.3.204).</li>
           <li>Fixes linefeed not inheriting graphics attributes when scrolling up to create a new line (#945).</li>
         </ul>
       </description>

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -911,6 +911,8 @@ void OpenGLRenderer::setBackgroundImage(shared_ptr<terminal::BackgroundImage con
         DisplayLog()("Background image from disk: {}x{} {}", qImage.width(), qImage.height(), imageFormat);
         _renderStateCache.backgroundImageHash = crispy::StrongHash::compute(filePath.string());
         _renderStateCache.backgroundResolution = qImage.size();
+        // for glTextImage2D image must be inverted
+        qImage.mirror();
         _backgroundImageTexture =
             createAndUploadImage(qImage.size(), imageFormat, rowAlignment, qImage.constBits());
     }


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Add mirroring of the background image to correctly show it
```

## Motivation and Context


```markdown
Right now background image is inverted in contour. 

In _glTextImage2D_ documentation is written :   
_______________________________________________________________________
The first element corresponds to the lower left corner of the texture image. 
Subsequent elements progress left-to-right through the remaining texels in the lowest row of the texture image,
and then in successively higher rows of the texture image. 
The final element corresponds to the upper right corner of the texture image.
_______________________________________________________________________

```

## How Has This Been Tested?

- [x] Please describe how you tested your changes.
  -  Locally checked that now everything is ok
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
