### PR TITLE
Initial implementation of a custom execution mode to interactively trace through the VT sequences.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Fixes background image being accidentally inverted (Bug introduced in 0.3.3.204).</li>
           <li>Fixes crash in some corner cases of too small fonts (#949).</li>
           <li>Fixes linefeed not inheriting graphics attributes when scrolling up to create a new line (#945).</li>
+          <li>Adds trace mode to single-step through each VT sequence. New actions: `TraceEnter`, `TraceLeave`, `TraceStep`, `TraceBreakAtEmptyQueue` and new mode flag `Trace`.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -84,6 +84,10 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::ToggleInputProtection>("ToggleInputProtection"),
         mapAction<actions::ToggleStatusLine>("ToggleStatusLine"),
         mapAction<actions::ToggleTitleBar>("ToggleTitleBar"),
+        mapAction<actions::TraceBreakAtEmptyQueue>("TraceBreakAtEmptyQueue"),
+        mapAction<actions::TraceEnter>("TraceEnter"),
+        mapAction<actions::TraceLeave>("TraceLeave"),
+        mapAction<actions::TraceStep>("TraceStep"),
         mapAction<actions::ViNormalMode>("ViNormalMode"),
         mapAction<actions::WriteScreen>("WriteScreen"),
     };

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -82,6 +82,10 @@ struct ToggleFullscreen{};
 struct ToggleInputProtection{};
 struct ToggleStatusLine{};
 struct ToggleTitleBar{};
+struct TraceBreakAtEmptyQueue{};
+struct TraceEnter{};
+struct TraceLeave{};
+struct TraceStep{};
 struct ViNormalMode{};
 struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
 // CloseTab
@@ -131,6 +135,10 @@ using Action = std::variant<CancelSelection,
                             ToggleInputProtection,
                             ToggleStatusLine,
                             ToggleTitleBar,
+                            TraceBreakAtEmptyQueue,
+                            TraceEnter,
+                            TraceLeave,
+                            TraceStep,
                             ViNormalMode,
                             WriteScreen>;
 
@@ -200,6 +208,10 @@ DECLARE_ACTION_FMT(ToggleFullscreen)
 DECLARE_ACTION_FMT(ToggleInputProtection)
 DECLARE_ACTION_FMT(ToggleStatusLine)
 DECLARE_ACTION_FMT(ToggleTitleBar)
+DECLARE_ACTION_FMT(TraceBreakAtEmptyQueue)
+DECLARE_ACTION_FMT(TraceEnter)
+DECLARE_ACTION_FMT(TraceLeave)
+DECLARE_ACTION_FMT(TraceStep)
 DECLARE_ACTION_FMT(ViNormalMode)
 DECLARE_ACTION_FMT(WriteScreen)
 // }}}
@@ -267,12 +279,17 @@ struct formatter<contour::actions::Action>
         HANDLE_ACTION(ToggleInputProtection);
         HANDLE_ACTION(ToggleStatusLine);
         HANDLE_ACTION(ToggleTitleBar);
+        HANDLE_ACTION(TraceBreakAtEmptyQueue);
+        HANDLE_ACTION(TraceEnter);
+        HANDLE_ACTION(TraceLeave);
+        HANDLE_ACTION(TraceStep);
         HANDLE_ACTION(ViNormalMode);
         HANDLE_ACTION(WriteScreen);
         // }}}
         return fmt::format_to(ctx.out(), "UNKNOWN ACTION");
     }
 };
+
 template <>
 struct formatter<contour::actions::CopyFormat>
 {

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -684,6 +684,8 @@ namespace
                 flag = MatchModes::Select;
             else if (upperArg == "SEARCH")
                 flag = MatchModes::Search;
+            else if (upperArg == "TRACE")
+                flag = MatchModes::Trace;
             else
             {
                 errorlog()("Unknown input_mapping mode: {}", arg);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -107,7 +107,8 @@ namespace helper
                && testMatchMode(_actualModeFlags, _expected, Flag::AppKeypad)
                && testMatchMode(_actualModeFlags, _expected, Flag::Select)
                && testMatchMode(_actualModeFlags, _expected, Flag::Insert)
-               && testMatchMode(_actualModeFlags, _expected, Flag::Search);
+               && testMatchMode(_actualModeFlags, _expected, Flag::Search)
+               && testMatchMode(_actualModeFlags, _expected, Flag::Trace);
     }
 } // namespace helper
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1007,6 +1007,32 @@ bool TerminalSession::operator()(actions::ToggleTitleBar)
     return true;
 }
 
+// {{{ Trace debug mode
+bool TerminalSession::operator()(actions::TraceBreakAtEmptyQueue)
+{
+    terminal_.setExecutionMode(ExecutionMode::BreakAtEmptyQueue);
+    return true;
+}
+
+bool TerminalSession::operator()(actions::TraceEnter)
+{
+    terminal_.setExecutionMode(ExecutionMode::Waiting);
+    return true;
+}
+
+bool TerminalSession::operator()(actions::TraceLeave)
+{
+    terminal_.setExecutionMode(ExecutionMode::Normal);
+    return true;
+}
+
+bool TerminalSession::operator()(actions::TraceStep)
+{
+    terminal_.setExecutionMode(ExecutionMode::SingleStep);
+    return true;
+}
+// }}}
+
 bool TerminalSession::operator()(actions::ViNormalMode)
 {
     terminal().inputHandler().setMode(ViMode::Normal);
@@ -1219,6 +1245,9 @@ uint8_t TerminalSession::matchModeFlags() const
 
     if (!terminal_.state().searchMode.pattern.empty())
         flags |= static_cast<uint8_t>(MatchModes::Flag::Search);
+
+    if (terminal_.executionMode() != ExecutionMode::Normal)
+        flags |= static_cast<uint8_t>(MatchModes::Flag::Trace);
 
     return flags;
 }

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 
+#include <contour/Actions.h>
 #include <contour/Audio.h>
 #include <contour/Config.h>
 
@@ -169,6 +170,10 @@ class TerminalSession: public QObject, public terminal::Terminal::Events
     bool operator()(actions::ToggleInputProtection);
     bool operator()(actions::ToggleStatusLine);
     bool operator()(actions::ToggleTitleBar);
+    bool operator()(actions::TraceBreakAtEmptyQueue);
+    bool operator()(actions::TraceEnter);
+    bool operator()(actions::TraceLeave);
+    bool operator()(actions::TraceStep);
     bool operator()(actions::ViNormalMode);
     bool operator()(actions::WriteScreen const& _event);
 

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -567,6 +567,8 @@ color_schemes:
 # - Insert    : The Insert input mode is active, that is the default and one way to test
 #               that the input mode is not in normal mode or any of the visual select modes.
 # - Search    : There is a search term currently being edited or already present.
+# - Trace     : The terminal is currently in trace-mode, i.e., each VT sequence can be interactively
+#               single-step executed using custom actions. See TraceEnter/TraceStep/TraceLeave actions.
 #
 # You can combine these modes by concatenating them via | and negate a single one
 # by prefixing with ~.
@@ -638,6 +640,10 @@ color_schemes:
 # - ToggleInputProtection Enables/disables terminal input protection.
 # - ToggleStatusLine  Shows/hides the VT320 compatible Indicator status line.
 # - ToggleTitleBar    Shows/Hides titlebar
+# - TraceBreakAtEmptyQueue Executes any pending VT sequence from the VT sequence buffer in trace mode, then waits.
+# - TraceEnter        Enables trace mode, suspending execution until explicitly requested to continue (See TraceLeave and TraceStep).
+# - TraceLeave        Disables trace mode. Any pending VT sequence will be flushed out and normal execution will be resumed.
+# - TraceStep         Executes a single VT sequence that is to be executed next.
 # - ViNormalMode      Enters Vi-like normal mode. The cursor can then be moved via h/j/k/l movements and text can be selected via v, yanked via y, and clipboard pasted via p.
 # - WriteScreen       Writes VT sequence in `chars` member to the screen (bypassing the application).
 
@@ -683,3 +689,8 @@ input_mapping:
     - { mods: [Control, Shift], key: 'H',           action: NoSearchHighlight }
     - { mods: [],               key: 'F3',          action: FocusNextSearchMatch }
     - { mods: [Shift],          key: 'F3',          action: FocusPreviousSearchMatch }
+
+#   - { mods: [Control, Meta],  key: 'E',           action: TraceEnter,             mode: "~Trace" }
+#   - { mods: [Control, Meta],  key: 'E',           action: TraceLeave,             mode: "Trace" }
+#   - { mods: [Control, Meta],  key: 'N',           action: TraceStep,              mode: "Trace" }
+#   - { mods: [Control, Meta],  key: 'F',           action: TraceBreakAtEmptyQueue, mode: "Trace" }

--- a/src/vtbackend/ControlCode.h
+++ b/src/vtbackend/ControlCode.h
@@ -137,6 +137,48 @@ enum class C1_8bit
     APC = 0x9F,  //!< Application Program Command
 };
 
+constexpr std::string_view to_short_string(C0 code)
+{
+    switch (code)
+    {
+        case C0::NUL: return "NUL";
+        case C0::SOH: return "SOH";
+        case C0::STX: return "STX";
+        case C0::ETX: return "ETX";
+        case C0::EOT: return "EOT";
+        case C0::ENQ: return "ENQ";
+        case C0::ACK: return "ACK";
+        case C0::BEL: return "BEL";
+        case C0::BS: return "BS";
+        case C0::HT: return "HT";
+        case C0::LF: return "LF";
+        case C0::VT: return "VT";
+        case C0::FF: return "FF";
+        case C0::CR: return "CR";
+        case C0::SO: return "SO";
+        case C0::SI: return "SI";
+        case C0::DLE: return "DLE";
+        case C0::DC1: return "DC1";
+        case C0::DC2: return "DC2";
+        case C0::DC3: return "DC3";
+        case C0::DC4: return "DC4";
+        case C0::NAK: return "NAK";
+        case C0::SYN: return "SYN";
+        case C0::ETB: return "ETB";
+        case C0::CAN: return "CAN";
+        case C0::EM: return "EM";
+        case C0::SUB: return "SUB";
+        case C0::ESC: return "ESC";
+        case C0::FS: return "FS";
+        case C0::GS: return "GS";
+        case C0::RS: return "RS";
+        case C0::US: return "US";
+        case C0::SP: return "SP";
+        case C0::DEL: return "DEL";
+        default: return "?";
+    }
+}
+
 constexpr std::string_view to_string(C0 code)
 {
     switch (code)

--- a/src/vtbackend/MatchModes.h
+++ b/src/vtbackend/MatchModes.h
@@ -32,6 +32,7 @@ class MatchModes
         Insert = 0x08, // vi-like insert mode
         Select = 0x10, // visual / visual-line / visual-block
         Search = 0x20, // something's in the search buffer
+        Trace = 0x40,
     };
 
     enum class Status
@@ -147,6 +148,7 @@ struct formatter<terminal::MatchModes>
         advance(terminal::MatchModes::Insert, "Insert");
         advance(terminal::MatchModes::Select, "Select");
         advance(terminal::MatchModes::Search, "Search");
+        advance(terminal::MatchModes::Trace, "Trace");
         if (s.empty())
             s = "Any";
         return fmt::format_to(_ctx.out(), "{}", s);

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -541,8 +541,10 @@ void Screen<Cell>::writeCharToCurrentAndAdvance(char32_t _character) noexcept
         cell.reset();
 #endif
 
-    cell.write(
-        _cursor.graphicsRendition, _character, (uint8_t) unicode::width(_character), _cursor.hyperlink);
+    cell.write(_cursor.graphicsRendition,
+               _character,
+               static_cast<uint8_t>(unicode::width(_character)),
+               _cursor.hyperlink);
 
     _lastCursorPosition = _cursor.position;
 
@@ -2068,6 +2070,7 @@ void Screen<Cell>::requestStatusString(RequestStatusString _value)
                 {
                     case ActiveStatusDisplay::Main: return "0$}";
                     case ActiveStatusDisplay::StatusLine: return "1$}";
+                    case ActiveStatusDisplay::IndicatorStatusLine: return "2$}"; // XXX This is not standard
                 }
                 break;
             case RequestStatusString::DECSSDT:

--- a/src/vtbackend/Sequence.cpp
+++ b/src/vtbackend/Sequence.cpp
@@ -1,3 +1,4 @@
+#include <vtbackend/ControlCode.h>
 #include <vtbackend/Sequence.h>
 
 #include <crispy/escape.h>
@@ -53,6 +54,12 @@ std::string Sequence::raw() const
 string Sequence::text() const
 {
     stringstream sstr;
+
+    if (category_ == FunctionCategory::C0)
+    {
+        sstr << to_short_string(ControlCode::C0(finalChar_));
+        return sstr.str();
+    }
 
     sstr << fmt::format("{}", category_);
 

--- a/src/vtbackend/Sequencer.cpp
+++ b/src/vtbackend/Sequencer.cpp
@@ -44,7 +44,7 @@ void Sequencer::error(std::string_view _errorString)
 void Sequencer::print(char32_t codepoint)
 {
     terminal_.state().instructionCounter++;
-    terminal_.activeDisplay().writeText(codepoint);
+    terminal_.sequenceHandler().writeText(codepoint);
 }
 
 size_t Sequencer::print(string_view _chars, size_t cellCount)
@@ -52,7 +52,7 @@ size_t Sequencer::print(string_view _chars, size_t cellCount)
     assert(_chars.size() != 0);
 
     terminal_.state().instructionCounter += _chars.size();
-    terminal_.activeDisplay().writeText(_chars, cellCount);
+    terminal_.sequenceHandler().writeText(_chars, cellCount);
 
     return terminal_.settings().pageSize.columns.as<size_t>()
            - terminal_.currentScreen().cursor().position.column.as<size_t>();
@@ -60,7 +60,7 @@ size_t Sequencer::print(string_view _chars, size_t cellCount)
 
 void Sequencer::execute(char controlCode)
 {
-    terminal_.activeDisplay().executeControlCode(controlCode);
+    terminal_.sequenceHandler().executeControlCode(controlCode);
 }
 
 void Sequencer::collect(char _char)
@@ -167,7 +167,7 @@ size_t Sequencer::maxBulkTextSequenceWidth() const noexcept
 void Sequencer::handleSequence()
 {
     parameterBuilder_.fixiate();
-    terminal_.activeDisplay().processSequence(sequence_);
+    terminal_.sequenceHandler().processSequence(sequence_);
 }
 
 } // namespace terminal

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -576,6 +576,8 @@ enum class ActiveStatusDisplay
 
     // Selects the host-writable status line. The terminal sends data to the status line only.
     StatusLine,
+
+    IndicatorStatusLine,
 };
 
 enum class AnsiMode


### PR DESCRIPTION
## Motivation

Add first class support for executing each VT sequence interactively and see how the display's state changes.
For that, we've added a few new actions to bind to.

You see more if the indicator status line is currently shown, such as:
- you are currently in trace mode
- what is the next VT sequence to be executed.

Also, when the terminal is invoked from within another terminal (i.e. it is connected to a tty itself), then a each executed VT sequence will be logged onto stdout as well.

### example config additions

```yaml
input_mapping:
    - { mods: [Control, Meta],  key: 'E',   mode: "~Trace",action: TraceEnter }
    - { mods: [Control, Meta],  key: 'E',   mode: "Trace", action: TraceLeave }
    - { mods: [Control, Meta],  key: 'N',   mode: "Trace", action: TraceStep }
    - { mods: [Control, Meta],  key: 'F',   mode: "Trace", action: TraceBreakAtEmptyQueue }
```