### PR TITLE
Implement locking shifts (S0 / SI)

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Fixes crash in some corner cases of too small fonts (#949).</li>
           <li>Fixes linefeed not inheriting graphics attributes when scrolling up to create a new line (#945).</li>
           <li>Adds trace mode to single-step through each VT sequence. New actions: `TraceEnter`, `TraceLeave`, `TraceStep`, `TraceBreakAtEmptyQueue` and new mode flag `Trace`.</li>
+          <li>Adds implementation for `SO` and `SI` control codes.</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Charset.cpp
+++ b/src/vtbackend/Charset.cpp
@@ -16,7 +16,7 @@
 namespace terminal
 {
 
-constexpr CharsetMap usasciiCharset()
+constexpr CharsetMap usasciiCharset() noexcept
 {
     CharsetMap result {};
 
@@ -29,7 +29,7 @@ constexpr CharsetMap usasciiCharset()
 /// British:
 ///     ESC (A
 ///     Reference: http://vt100.net/docs/vt220-rm/table2-5.html
-constexpr CharsetMap createBritishCharset()
+constexpr CharsetMap createBritishCharset() noexcept
 {
     auto result = usasciiCharset();
     result['#'] = 0x00A3; // U'£';
@@ -38,7 +38,7 @@ constexpr CharsetMap createBritishCharset()
 
 /// German:
 ///     ESC ( K
-constexpr CharsetMap createGermanCharset()
+constexpr CharsetMap createGermanCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -57,7 +57,7 @@ constexpr CharsetMap createGermanCharset()
 /// DEC Special Character and Line Drawing Set.
 ///
 /// Reference: http://vt100.net/docs/vt102-ug/table5-13.html
-constexpr CharsetMap createSpecialCharset()
+constexpr CharsetMap createSpecialCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -99,7 +99,7 @@ constexpr CharsetMap createSpecialCharset()
 /// Dutch:
 ///     ESC ( 4
 ///
-constexpr CharsetMap createDutchCharset()
+constexpr CharsetMap createDutchCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -119,7 +119,7 @@ constexpr CharsetMap createDutchCharset()
 /// Finnish:
 ///     ESC ( C
 ///     ESC ( 5
-constexpr CharsetMap createFinnishCharset()
+constexpr CharsetMap createFinnishCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -138,7 +138,7 @@ constexpr CharsetMap createFinnishCharset()
 
 /// French:
 ///     ESC ( R
-constexpr CharsetMap createFrenchCharset()
+constexpr CharsetMap createFrenchCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -157,7 +157,7 @@ constexpr CharsetMap createFrenchCharset()
 
 /// French Canadian:
 ///     ESC ( Q
-constexpr CharsetMap createFrenchCanadianCharset()
+constexpr CharsetMap createFrenchCanadianCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -178,7 +178,7 @@ constexpr CharsetMap createFrenchCanadianCharset()
 /// Norwegian/Danich:
 ///     ESC ( E
 ///     ESC ( 6
-constexpr CharsetMap createNorwegianDanishCharset()
+constexpr CharsetMap createNorwegianDanishCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -198,7 +198,7 @@ constexpr CharsetMap createNorwegianDanishCharset()
 
 /// Spanish:
 ///     ESC ( Z
-constexpr CharsetMap createSpanishCharset()
+constexpr CharsetMap createSpanishCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -217,7 +217,7 @@ constexpr CharsetMap createSpanishCharset()
 /// Swedish:
 ///     ESC ( H
 ///     ESC ( 7
-constexpr CharsetMap createSwedishCharset()
+constexpr CharsetMap createSwedishCharset() noexcept
 {
     auto result = usasciiCharset();
 
@@ -237,7 +237,7 @@ constexpr CharsetMap createSwedishCharset()
 
 /// Swiss:
 ///     ESC ( =
-constexpr CharsetMap createSwissCharset()
+constexpr CharsetMap createSwissCharset() noexcept
 {
     auto result = usasciiCharset();
 

--- a/src/vtbackend/Charset.h
+++ b/src/vtbackend/Charset.h
@@ -71,8 +71,8 @@ class CharsetMapping
         // TODO: could surely be implemented branchless with a jump-table and computed goto.
         if (code < 127)
         {
-            auto result = map(_shift, static_cast<char>(code));
-            _shift = _selected;
+            auto result = map(_tableForNextGraphic, static_cast<char>(code));
+            _tableForNextGraphic = _selectedTable;
             return result;
         }
         else if (code != 127)
@@ -90,12 +90,12 @@ class CharsetMapping
         return (*_tables[static_cast<size_t>(table)])[static_cast<uint8_t>(code)];
     }
 
-    constexpr void singleShift(CharsetTable table) noexcept { _shift = table; }
+    constexpr void singleShift(CharsetTable table) noexcept { _tableForNextGraphic = table; }
 
-    constexpr void selectDefaultTable(CharsetTable table) noexcept
+    constexpr void lockingShift(CharsetTable table) noexcept
     {
-        _selected = table;
-        _shift = table;
+        _selectedTable = table;
+        _tableForNextGraphic = table;
     }
 
     [[nodiscard]] bool isSelected(CharsetTable table, CharsetId id) const noexcept
@@ -103,18 +103,20 @@ class CharsetMapping
         return _tables[static_cast<size_t>(table)] == charsetMap(id);
     }
 
-    [[nodiscard]] bool isSelected(CharsetId id) const noexcept { return isSelected(currentTable(), id); }
+    [[nodiscard]] bool isSelected(CharsetId id) const noexcept
+    {
+        return isSelected(_tableForNextGraphic, id);
+    }
 
+    // Selects a given designated character set into the table G0, G1, G2, or G3.
     void select(CharsetTable table, CharsetId id) noexcept
     {
         _tables[static_cast<size_t>(table)] = charsetMap(id);
     }
 
-    [[nodiscard]] constexpr CharsetTable currentTable() const noexcept { return _shift; }
-
   private:
-    CharsetTable _shift = CharsetTable::G0;
-    CharsetTable _selected = CharsetTable::G0;
+    CharsetTable _tableForNextGraphic = CharsetTable::G0;
+    CharsetTable _selectedTable = CharsetTable::G0;
 
     using Tables = std::array<CharsetMap const*, 4>;
     Tables _tables;

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -163,10 +163,13 @@ constexpr int compare(FunctionSelector const& a, FunctionDefinition const& b) no
 
 namespace detail // {{{
 {
-    constexpr auto C0(char finalCharacter, std::string_view mnemonic, std::string_view description) noexcept
+    constexpr auto C0(char finalCharacter,
+                      std::string_view mnemonic,
+                      std::string_view description,
+                      VTType vt = VTType::VT100) noexcept
     {
         // clang-format off
-        return FunctionDefinition { FunctionCategory::C0, 0, 0, finalCharacter, 0, 0, VTType::VT100,
+        return FunctionDefinition { FunctionCategory::C0, 0, 0, finalCharacter, 0, 0, vt,
                                     VTExtension::None, mnemonic, description };
         // clang-format on
     }
@@ -303,8 +306,8 @@ constexpr inline auto LF  = detail::C0('\x0A', "LF", "Line Feed");
 constexpr inline auto VT  = detail::C0('\x0B', "VT", "Vertical Tab"); // Even though VT means Vertical Tab, it seems that xterm is doing an IND instead.
 constexpr inline auto FF  = detail::C0('\x0C', "FF", "Form Feed");
 constexpr inline auto CR  = detail::C0('\x0D', "CR", "Carriage Return");
-constexpr inline auto SO  = detail::C0('\x0E', "SO", "Shift Out; Switch to an alternative character set. ");
-constexpr inline auto SI  = detail::C0('\x0F', "SI", "Shift In; Return to regular character set after Shift Out.");
+constexpr inline auto LS1 = detail::C0('\x0E', "LS1", "Shift Out; Maps G1 into GL.", VTType::VT220);
+constexpr inline auto LS0 = detail::C0('\x0F', "LS0", "Shift In; Maps G0 into GL (the default).", VTType::VT220);
 
 // SCS to support (G0, G1, G2, G3)
 // A        UK (British), VT100
@@ -483,8 +486,8 @@ inline auto const& functions() noexcept
             VT,
             FF,
             CR,
-            SO,
-            SI,
+            LS0,
+            LS1,
 
             // ESC
             DECALN,

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -3246,6 +3246,14 @@ void Screen<Cell>::executeControlCode(char controlCode)
             // Even though FF means Form Feed, it seems that xterm is doing an IND instead.
             index();
             break;
+        case LS1.finalSymbol: // LS1 (SO)
+            // Invokes G1 character set into GL. G1 is designated by a select-character-set (SCS) sequence.
+            _cursor.charsets.lockingShift(CharsetTable::G1);
+            break;
+        case LS0.finalSymbol: // LSO (SI)
+            // Invoke G0 character set into GL. G0 is designated by a select-character-set sequence (SCS).
+            _cursor.charsets.lockingShift(CharsetTable::G0);
+            break;
         case 0x0D: moveCursorToBeginOfLine(); break;
         case 0x37: saveCursor(); break;
         case 0x38: restoreCursor(); break;

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <vtbackend/Charset.h>
 #include <vtbackend/MockTerm.h>
 #include <vtbackend/Screen.h>
 #include <vtbackend/Viewport.h>
@@ -33,6 +34,7 @@ using crispy::Size;
 using namespace terminal;
 using namespace terminal::test;
 using namespace std;
+using namespace std::literals::chrono_literals;
 
 namespace // {{{
 {
@@ -3580,6 +3582,42 @@ TEST_CASE("DECSTR", "[screen]")
     REQUIRE(mock.terminal.primaryScreen().savedCursorState().position
             == CellLocation { LineOffset(0), ColumnOffset(0) });
 }
+
+TEST_CASE("LS1 and LS0", "[screen]")
+{
+    auto mock = MockTerm { ColumnCount(8), LineCount(4) };
+
+    auto const writeTickAndRender = [&](auto text) {
+        mock.writeToScreen(text);
+        mock.terminal.tick(1s);
+        mock.terminal.ensureFreshRenderBuffer();
+        logScreenText(mock.terminal.primaryScreen(), fmt::format("writeTickAndRender: {}", e(text)));
+    };
+
+    REQUIRE(mock.terminal.primaryScreen().cursor().charsets.isSelected(CharsetTable::G0, CharsetId::USASCII));
+    REQUIRE(mock.terminal.primaryScreen().cursor().charsets.isSelected(CharsetTable::G1, CharsetId::USASCII));
+    writeTickAndRender("ab");
+    REQUIRE(trimmedTextScreenshot(mock) == "ab");
+
+    // Set G1 to Special
+    mock.writeToScreen("\033)0");
+    REQUIRE(mock.terminal.primaryScreen().cursor().charsets.isSelected(CharsetTable::G1, CharsetId::Special));
+
+    // LS1: load G1 into GL
+    mock.writeToScreen("\x0E");
+    REQUIRE(mock.terminal.primaryScreen().cursor().charsets.isSelected(CharsetId::Special));
+
+    writeTickAndRender("ab");
+    REQUIRE(trimmedTextScreenshot(mock) == "ab▒␉");
+
+    // LS0: load G0 into GL
+    mock.writeToScreen("\x0F");
+    REQUIRE(mock.terminal.primaryScreen().cursor().charsets.isSelected(CharsetId::USASCII));
+
+    writeTickAndRender("ab");
+    REQUIRE(trimmedTextScreenshot(mock) == "ab▒␉ab");
+}
+
 // TODO: Sixel: image that exceeds available lines
 
 // TODO: SetForegroundColor

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -15,6 +15,7 @@
 #include <vtbackend/Screen.h>
 #include <vtbackend/Viewport.h>
 #include <vtbackend/primitives.h>
+#include <vtbackend/test_helpers.h>
 
 #include <crispy/escape.h>
 #include <crispy/utils.h>
@@ -30,39 +31,11 @@
 using crispy::escape;
 using crispy::Size;
 using namespace terminal;
+using namespace terminal::test;
 using namespace std;
 
 namespace // {{{
 {
-template <typename T>
-string mainPageText(Screen<T> const& screen)
-{
-    return screen.renderMainPageText();
-}
-
-template <typename T>
-[[maybe_unused]] void logScreenTextAlways(Screen<T> const& screen, string const& headline = "")
-{
-    fmt::print("{}: ZI={} cursor={} HM={}..{}\n",
-               headline.empty() ? "screen dump"s : headline,
-               screen.grid().zero_index(),
-               screen.realCursorPosition(),
-               screen.margin().horizontal.from,
-               screen.margin().horizontal.to);
-    fmt::print("{}\n", dumpGrid(screen.grid()));
-}
-
-template <typename T>
-void logScreenText(Screen<T> const& screen, string const& headline = "")
-{
-    if (headline.empty())
-        UNSCOPED_INFO("dump:");
-    else
-        UNSCOPED_INFO(headline + ":");
-
-    for (auto const line: ::ranges::views::iota(0, *screen.pageSize().lines))
-        UNSCOPED_INFO(fmt::format("[{}] \"{}\"", line, screen.grid().lineText(LineOffset::cast_from(line))));
-}
 
 // class MockScreen : public MockScreenEvents,
 //                    public Screen<MockScreenEvents> {
@@ -91,12 +64,6 @@ void logScreenText(Screen<T> const& screen, string const& headline = "")
 //         windowTitle = _title;
 //     }
 // };
-
-template <typename S>
-decltype(auto) e(S const& s)
-{
-    return crispy::escape(s);
-}
 
 struct TextRenderBuilder
 {

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -310,6 +310,8 @@ class Terminal
         }
         return changes;
     }
+
+    uint64_t tick(std::chrono::milliseconds delta) { return tick(_currentTime + delta); }
     // }}}
 
     // {{{ RenderBuffer synchronization API

--- a/src/vtbackend/test_helpers.h
+++ b/src/vtbackend/test_helpers.h
@@ -1,0 +1,133 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2023 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vtbackend/MockTerm.h>
+#include <vtbackend/RenderBuffer.h>
+#include <vtbackend/Terminal.h>
+
+#include <crispy/escape.h>
+
+#include <catch2/catch.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace terminal::test
+{
+
+template <typename S>
+[[nodiscard]] inline decltype(auto) e(S const& s)
+{
+    return crispy::escape(s);
+}
+
+/// Takes a textual screenshot using the terminals render buffer.
+[[nodiscard]] inline std::vector<std::string> textScreenshot(terminal::Terminal const& terminal)
+{
+    terminal::RenderBufferRef renderBuffer = terminal.renderBuffer();
+
+    std::vector<std::string> lines;
+    lines.resize(terminal.pageSize().lines.as<size_t>());
+
+    terminal::CellLocation lastPos = {};
+    size_t lastCount = 0;
+    for (terminal::RenderCell const& cell: renderBuffer.buffer.cells)
+    {
+        auto const gap = (cell.position.column + static_cast<int>(lastCount) - 1) - lastPos.column;
+        auto& currentLine = lines.at(unbox<size_t>(cell.position.line));
+        if (*gap > 0) // Did we jump?
+            currentLine.insert(currentLine.end(), unbox<size_t>(gap) - 1, ' ');
+
+        currentLine += unicode::convert_to<char>(std::u32string_view(cell.codepoints));
+        lastPos = cell.position;
+        lastCount = 1;
+    }
+    for (terminal::RenderLine const& line: renderBuffer.buffer.lines)
+    {
+        auto& currentLine = lines.at(unbox<size_t>(line.lineOffset));
+        currentLine = line.text;
+    }
+
+    return lines;
+}
+
+[[nodiscard]] inline std::string trimRight(std::string text)
+{
+    constexpr auto Whitespaces = std::string_view("\x20\t\r\n");
+    while (!text.empty() && Whitespaces.find(text.back()) != Whitespaces.npos)
+        text.resize(text.size() - 1);
+    return text;
+}
+
+[[nodiscard]] inline std::string join(std::vector<std::string> const& lines)
+{
+    std::string output;
+    for (std::string const& line: lines)
+    {
+        output += trimRight(line);
+        output += '\n';
+    }
+    return output;
+}
+
+template <typename T>
+[[nodiscard]] std::string trimmedTextScreenshot(MockTerm<T> const& mt)
+{
+    return trimRight(join(textScreenshot(mt.terminal)));
+}
+
+template <typename T>
+[[nodiscard]] std::string mainPageText(Screen<T> const& screen)
+{
+    return screen.renderMainPageText();
+}
+
+template <typename T>
+void logScreenTextAlways(Screen<T> const& screen, std::string const& headline = "")
+{
+    fmt::print("{}: ZI={} cursor={} HM={}..{}\n",
+               headline.empty() ? "screen dump" : headline,
+               screen.grid().zero_index(),
+               screen.realCursorPosition(),
+               screen.margin().horizontal.from,
+               screen.margin().horizontal.to);
+    fmt::print("{}\n", dumpGrid(screen.grid()));
+}
+
+template <typename T>
+void logScreenTextAlways(MockTerm<T> const& mock, std::string const& headline = "")
+{
+    logScreenTextAlways(mock.terminal.primaryScreen(), headline);
+}
+
+template <typename T>
+void logScreenText(Screen<T> const& screen, std::string const& headline = "")
+{
+    if (headline.empty())
+        UNSCOPED_INFO("dump:");
+    else
+        UNSCOPED_INFO(headline + ":");
+
+    for (auto const line: ::ranges::views::iota(0, *screen.pageSize().lines))
+        UNSCOPED_INFO(fmt::format("[{}] \"{}\"", line, screen.grid().lineText(LineOffset::cast_from(line))));
+}
+
+inline void logScreenText(terminal::Terminal const& terminal, std::string const& headline = "")
+{
+    logScreenText(terminal.primaryScreen(), headline);
+}
+
+} // namespace terminal::test


### PR DESCRIPTION
## Description

Implements locking shifts `LS1` (`SO`) and `LS0` (`SI`).

The first commits are a little cleanup and only the last commit is the actual (trivial) implementation.

## Motivation and Context

Some college was trying out Contour and realized that `SO`/`SI` wasn't being implemented. So here we go.

## How Has This Been Tested?

interactively:

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/56763/211108381-76f5a17f-ba71-4de5-af72-d6c7d5ca3e1a.png">

```sh
printf "\033)0\x0e"; cat README.md ; printf "\x0f"
```

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have updated (or added) the documentation accordingly.
- [x] I have added tests to cover my changes.
