### PR TITLE
Improvements to vi-like normal mode: Add `M` motion to jump to middle…

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -119,6 +119,7 @@
           <li>Improvements to vi-like normal mode: word motions (`b`, `w`, `e`) now respect configurable word delimiters.</li>
           <li>Improvements to vi-like normal mode: support nested matching pairs, such as `{`, `(` etc in text objects.</li>
           <li>Improvements to vi-like normal mode: Add `%` motion to jump to matching symbol pairs.</li>
+          <li>Improvements to vi-like normal mode: Add `M` motion to jump to middle screen line (same column).</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -573,6 +573,9 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             return { max(cursorPosition.line - LineOffset::cast_from(count),
                          -_terminal.currentScreen().historyLineCount().as<LineOffset>()),
                      cursorPosition.column };
+        case ViMotion::LinesCenter: // M
+            return { max(LineOffset(0), LineOffset::cast_from(_terminal.pageSize().lines / 2 - 1)),
+                     cursorPosition.column };
         case ViMotion::PageDown:
             return { min(cursorPosition.line + LineOffset::cast_from(_terminal.pageSize().lines / 2),
                          _terminal.pageSize().lines.as<LineOffset>() - 1),

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -146,3 +146,17 @@ TEST_CASE("vi.motions: text objects", "[vi]")
         CHECK(selection.to() == 4_lineOffset + 33_columnOffset);
     }
 }
+
+TEST_CASE("vi.motions: M", "[vi]")
+{
+    auto mock = setupMockTerminal("Hello\r\n",
+                                  terminal::PageSize { terminal::LineCount(10), terminal::ColumnCount(40) });
+
+    // first move cursor by one right, to also ensure that column is preserved
+    mock.sendCharPressSequence("lM");
+    CHECK(mock.terminal.state().viCommands.cursorPosition == 4_lineOffset + 1_columnOffset);
+
+    // running M again won't change anything
+    mock.sendCharPressSequence("M");
+    CHECK(mock.terminal.state().viCommands.cursorPosition == 4_lineOffset + 1_columnOffset);
+}

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -395,6 +395,7 @@ bool ViInputHandler::parseTextObject(char32_t ch, Modifier modifier)
         case 'U' | Modifier::Control: return executePendingOrMoveCursor(ViMotion::PageUp);
         case '$'_key: return executePendingOrMoveCursor(ViMotion::LineEnd);
         case '%'_key: return executePendingOrMoveCursor(ViMotion::ParenthesisMatching);
+        case 'M'_key: return executePendingOrMoveCursor(ViMotion::LinesCenter);
         case '0'_key: return executePendingOrMoveCursor(ViMotion::LineBegin);
         case '^'_key: return executePendingOrMoveCursor(ViMotion::LineTextBegin);
         case 'G'_key: return executePendingOrMoveCursor(ViMotion::FileEnd);

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -80,6 +80,7 @@ enum class ViMotion
     LineDown,             // j
     LineEnd,              // $
     LineUp,               // k
+    LinesCenter,          // M
     PageDown,             // <C-D>
     PageUp,               // <C-U>
     PageTop,              // <S-H> (inspired by tmux)
@@ -380,6 +381,7 @@ struct formatter<terminal::ViMotion>
             case ViMotion::LineDown: return fmt::format_to(ctx.out(), "LineDown");
             case ViMotion::LineEnd: return fmt::format_to(ctx.out(), "LineEnd");
             case ViMotion::LineUp: return fmt::format_to(ctx.out(), "LineUp");
+            case ViMotion::LinesCenter: return fmt::format_to(ctx.out(), "LinesCenter");
             case ViMotion::PageDown: return fmt::format_to(ctx.out(), "PageDown");
             case ViMotion::PageUp: return fmt::format_to(ctx.out(), "PageUp");
             case ViMotion::PageTop: return fmt::format_to(ctx.out(), "PageTop");


### PR DESCRIPTION
I actually don't wanna keep pushing new features but work on other stuff. But for some reason I just can't stop improving our vi-like normal mode.

This time we're adding the `M`-motion to vertical align the cursor to the middle of the screen. Tests added as well.

This is actually maybe a good PR to demo on how to easily add a simple motion.