### PR TITLE
Improvements to vi-like normal mode: Add `P` to paste the clipboard with newlines stripped.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -120,6 +120,7 @@
           <li>Improvements to vi-like normal mode: support nested matching pairs, such as `{`, `(` etc in text objects.</li>
           <li>Improvements to vi-like normal mode: Add `%` motion to jump to matching symbol pairs.</li>
           <li>Improvements to vi-like normal mode: Add `M` motion to jump to middle screen line (same column).</li>
+          <li>Improvements to vi-like normal mode: Add `P` to paste the clipboard with newlines stripped.</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -275,6 +275,10 @@ void ViCommands::execute(ViOperator op, ViMotion motion, unsigned count)
             //.
             _terminal.sendPasteFromClipboard(count, false);
             break;
+        case ViOperator::PasteStripped:
+            //.
+            _terminal.sendPasteFromClipboard(count, true);
+            break;
         case ViOperator::ReverseSearchCurrentWord: // TODO: Does this even make sense to have?
             break;
     }
@@ -315,9 +319,9 @@ void ViCommands::yank(ViMotion motion)
     _terminal.screenUpdated();
 }
 
-void ViCommands::paste(unsigned count)
+void ViCommands::paste(unsigned count, bool stripped)
 {
-    _terminal.sendPasteFromClipboard(count, false);
+    _terminal.sendPasteFromClipboard(count, stripped);
 }
 
 CellLocation ViCommands::prev(CellLocation location) const noexcept

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -39,7 +39,7 @@ class ViCommands: public ViInputHandler::Executor
     void select(TextObjectScope scope, TextObject textObject) override;
     void yank(TextObjectScope scope, TextObject textObject) override;
     void yank(ViMotion motion) override;
-    void paste(unsigned count) override;
+    void paste(unsigned count, bool stripped) override;
 
     void searchStart() override;
     void searchDone() override;

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -348,7 +348,8 @@ bool ViInputHandler::executePendingOrMoveCursor(ViMotion motion)
     {
         case ViOperator::MoveCursor: _executor.moveCursor(motion, _count ? _count : 1); break;
         case ViOperator::Yank: _executor.yank(motion); break;
-        case ViOperator::Paste: _executor.paste(_count ? _count : 1); break;
+        case ViOperator::Paste: _executor.paste(_count ? _count : 1, false); break;
+        case ViOperator::PasteStripped: _executor.paste(_count ? _count : 1, true); break;
         case ViOperator::ReverseSearchCurrentWord: _executor.reverseSearchCurrentWord(); break;
     }
 
@@ -494,7 +495,8 @@ void ViInputHandler::handleNormalMode(char32_t ch, Modifier modifier)
         case 'v'_key: toggleMode(ViMode::Visual); return;
         case '#'_key: _executor.reverseSearchCurrentWord(); return;
         case '*'_key: _executor.searchCurrentWord(); return;
-        case 'p'_key: _executor.paste(_count ? _count : 1); return;
+        case 'p'_key: _executor.paste(_count ? _count : 1, false); return;
+        case 'P'_key: _executor.paste(_count ? _count : 1, true); return;
         case 'n'_key: _executor.jumpToNextMatch(_count ? _count : 1); return;
         case 'N'_key: _executor.jumpToPreviousMatch(_count ? _count : 1); return;
         case 'y'_key:

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -100,6 +100,7 @@ enum class ViOperator
     MoveCursor,
     Yank = 'y',
     Paste = 'p',
+    PasteStripped = 'P',
     ReverseSearchCurrentWord = '#',
 };
 
@@ -170,7 +171,7 @@ class ViInputHandler: public InputHandler
         virtual void select(TextObjectScope scope, TextObject textObject) = 0;
         virtual void yank(TextObjectScope scope, TextObject textObject) = 0;
         virtual void yank(ViMotion motion) = 0;
-        virtual void paste(unsigned count) = 0;
+        virtual void paste(unsigned count, bool stripped) = 0;
 
         virtual void modeChanged(ViMode mode) = 0;
 
@@ -347,6 +348,7 @@ struct formatter<terminal::ViOperator>
             case ViOperator::MoveCursor: return fmt::format_to(ctx.out(), "MoveCursor");
             case ViOperator::Yank: return fmt::format_to(ctx.out(), "Yank");
             case ViOperator::Paste: return fmt::format_to(ctx.out(), "Paste");
+            case ViOperator::PasteStripped: return fmt::format_to(ctx.out(), "PasteStripped");
             case ViOperator::ReverseSearchCurrentWord:
                 return fmt::format_to(ctx.out(), "ReverseSearchCurrentWord");
         }


### PR DESCRIPTION
Implemented by accident.

But it's actually useful :)