### PR TITLE
Improve vi-mode motions `b` and `w` to better emulate what vim is doing

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,11 +112,12 @@
           <li>Fixes linefeed not inheriting graphics attributes when scrolling up to create a new line (#945).</li>
           <li>Fixes normal mode's motion `[count]|` that was off by one.</li>
           <li>Fixes switching to normal mode sometimes placing the vi cursor wrong.</li>
+          <li>Fixes vi-like normal mode's word motions `w` and `b` to work like in vim.</li>
           <li>Adds trace mode to single-step through each VT sequence. New actions: `TraceEnter`, `TraceLeave`, `TraceStep`, `TraceBreakAtEmptyQueue` and new mode flag `Trace`.</li>
           <li>Adds implementation for `SO` and `SI` control codes.</li>
           <li>Improvements to text objects in vi-like normal mode (`i)`, `a)`, `i>`, `a>`, `i]`, `a]`, `i}`, `a}`).</li>
           <li>Improvements to vi-like normal mode: yank-motions (`yw`, `y$`, etc).</li>
-          <li>Improvements to vi-like normal mode: word motions (`b`, `w`, `e`) now respect configurable word delimiters.</li>
+          <li>Improvements to vi-like normal mode: word motions (`b`, `w`, `e`) now better emulate how vim is working.</li>
           <li>Improvements to vi-like normal mode: support nested matching pairs, such as `{`, `(` etc in text objects.</li>
           <li>Improvements to vi-like normal mode: Add `%` motion to jump to matching symbol pairs.</li>
           <li>Improvements to vi-like normal mode: Add `M` motion to jump to middle screen line (same column).</li>

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -26,9 +26,9 @@ $ThirdParties =
         Macro   = ""
     };
     [ThirdParty]@{
-        Folder  = "libunicode-eb9f2957d1869def3fc8b05c5928f5a3126e71cf";
-        Archive = "libunicode-eb9f2957d1869def3fc8b05c5928f5a3126e71cf.zip";
-        URI     = "https://github.com/contour-terminal/libunicode/archive/eb9f2957d1869def3fc8b05c5928f5a3126e71cf.zip";
+        Folder  = "libunicode-f29b88dd376a19bb203eb772a7b61a5c03f3b8c1";
+        Archive = "libunicode-f29b88dd376a19bb203eb772a7b61a5c03f3b8c1.zip";
+        URI     = "https://github.com/contour-terminal/libunicode/archive/f29b88dd376a19bb203eb772a7b61a5c03f3b8c1.zip";
         Macro   = "libunicode"
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -103,7 +103,7 @@ fetch_and_unpack_embeds()
         termbench_pro
 
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="eb9f2957d1869def3fc8b05c5928f5a3126e71cf"
+        local libunicode_git_sha="f29b88dd376a19bb203eb772a7b61a5c03f3b8c1"
         fetch_and_unpack \
             libunicode-$libunicode_git_sha \
             libunicode-$libunicode_git_sha.tar.gz \

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -160,3 +160,32 @@ TEST_CASE("vi.motions: M", "[vi]")
     mock.sendCharPressSequence("M");
     CHECK(mock.terminal.state().viCommands.cursorPosition == 4_lineOffset + 1_columnOffset);
 }
+
+TEST_CASE("vi.motion: b", "[vi]")
+{
+    auto mock = setupMockTerminal("One.Two..Three and more\r\n"
+                                  "   On the next line.",
+                                  terminal::PageSize { terminal::LineCount(10), terminal::ColumnCount(40) });
+    mock.sendCharPressSequence("j$"); // jump to line 2, at the right-most non-space character.
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 1_lineOffset + 19_columnOffset);
+
+    mock.sendCharPressSequence("b"); // l[ine.]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 1_lineOffset + 15_columnOffset);
+    mock.sendCharPressSequence("2b"); // t[he]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 1_lineOffset + 6_columnOffset);
+    mock.sendCharPressSequence("3b"); // a[nd] -- on line 1
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 15_columnOffset);
+    mock.sendCharPressSequence("b"); // T[hree]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 9_columnOffset);
+    mock.sendCharPressSequence("b"); // .[.]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 7_columnOffset);
+    mock.sendCharPressSequence("b"); // T[wo]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 4_columnOffset);
+    mock.sendCharPressSequence("b"); // .
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 3_columnOffset);
+    mock.sendCharPressSequence("b"); // O[ne]
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 0_columnOffset);
+
+    mock.sendCharPressSequence("b");
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 0_columnOffset);
+}


### PR DESCRIPTION
Improves vi-mode motions `b` and `w` to better emulate what vim is doing. Plus adding tests for it (yay).

