### PR TITLE
Fixes copying text to clipboard stripping TAB-character generated whitespaces.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -113,6 +113,7 @@
           <li>Fixes normal mode's motion `[count]|` that was off by one.</li>
           <li>Fixes switching to normal mode sometimes placing the vi cursor wrong.</li>
           <li>Fixes vi-like normal mode's word motions `w`, `e`, and `b` to better emulate vim's behaviour.</li>
+          <li>Fixes copying text to clipboard stripping TAB-character generated spaces (#982).</li>
           <li>Adds trace mode to single-step through each VT sequence. New actions: `TraceEnter`, `TraceLeave`, `TraceStep`, `TraceBreakAtEmptyQueue` and new mode flag `Trace`.</li>
           <li>Adds implementation for `SO` and `SI` control codes.</li>
           <li>Improvements to text objects in vi-like normal mode (`i)`, `a)`, `i>`, `a>`, `i]`, `a]`, `i}`, `a}`).</li>

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1140,7 +1140,10 @@ namespace
                 text += '\n';
                 currentLine.clear();
             }
-            currentLine += cell.toUtf8();
+            if (cell.empty())
+                currentLine += ' ';
+            else
+                currentLine += cell.toUtf8();
             lastColumn = pos.column;
         }
 


### PR DESCRIPTION
Fixes #982