### PR TITLE
[vi mode] add `B`, `W`, `E` and properly respect word boundaries in word text object (`iw` / `aw`).

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -120,6 +120,7 @@
           <li>Adds implementation for `SO` and `SI` control codes.</li>
           <li>Adds ability to explicitly disable a font feature by prefixing the feature with a `-`, such as `-calt`, explicitly enabling via `+` prefix was added as well.</li>
           <li>Adds terminal capability `hs` and `es` to improve status-line feature detection via terminfo.</li>
+          <li>Adds normal mode motion: `B`, `B`, `E`.</li>
           <li>Changes terminfo entries `tsl`, `fsl` and `dsl` to make use of the host-writable statusline.</li>
           <li>Improvements to text objects in vi-like normal mode (`i)`, `a)`, `i>`, `a>`, `i]`, `a]`, `i}`, `a}`).</li>
           <li>Improvements to vi-like normal mode: yank-motions (`yw`, `y$`, etc).</li>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -567,10 +567,12 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
         case TextObject::RoundBrackets: return expandMatchingPair(scope, '(', ')');
         case TextObject::SingleQuotes: return expandMatchingPair(scope, '\'', '\'');
         case TextObject::SquareBrackets: return expandMatchingPair(scope, '[', ']');
-        case TextObject::Word:
-            // TODO
-        case TextObject::BigWord:
-        {
+        case TextObject::Word: {
+            a = findBeginOfWordAt(a, JumpOver::No);
+            b = findEndOfWordAt(b, JumpOver::No);
+            break;
+        }
+        case TextObject::BigWord: {
             while (a.column.value > 0 && !_terminal.currentScreen().isCellEmpty(prev(a)))
                 a = prev(a);
             while (b.column < rightMargin && !_terminal.currentScreen().isCellEmpty(next(b)))

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -22,6 +22,12 @@ namespace terminal
 
 class Terminal;
 
+enum class JumpOver
+{
+    Yes,
+    No
+};
+
 /**
  * Implements the Vi commands for a Terminal as emitted by ViInputHandler.
  */
@@ -62,6 +68,8 @@ class ViCommands: public ViInputHandler::Executor
     [[nodiscard]] CellLocationRange expandMatchingPair(TextObjectScope scope,
                                                        char lhs,
                                                        char rhs) const noexcept;
+    [[nodiscard]] CellLocation findBeginOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept;
+    [[nodiscard]] CellLocation findEndOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept;
     void executeYank(ViMotion motion, unsigned count);
     void executeYank(CellLocation from, CellLocation to);
 

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -84,6 +84,7 @@ namespace
             case '`': return TextObject::BackQuotes;
             case 'p': return TextObject::Paragraph;
             case 'w': return TextObject::Word;
+            case 'W': return TextObject::BigWord;
             case '{': return TextObject::CurlyBrackets;
             case '}': return TextObject::CurlyBrackets;
             default: return nullopt;
@@ -417,6 +418,9 @@ bool ViInputHandler::parseTextObject(char32_t ch, Modifier modifier)
         case '{'_key: return executePendingOrMoveCursor(ViMotion::ParagraphBackward);
         case '|'_key: return executePendingOrMoveCursor(ViMotion::ScreenColumn);
         case '}'_key: return executePendingOrMoveCursor(ViMotion::ParagraphForward);
+        case 'W'_key: return executePendingOrMoveCursor(ViMotion::BigWordForward);
+        case 'B'_key: return executePendingOrMoveCursor(ViMotion::BigWordBackward);
+        case 'E'_key: return executePendingOrMoveCursor(ViMotion::BigWordEndForward);
     }
 
     if (modifier.any())

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -93,6 +93,9 @@ enum class ViMotion
     WordBackward,         // b
     WordEndForward,       // e
     WordForward,          // w
+    BigWordBackward,      // B
+    BigWordEndForward,    // E
+    BigWordForward,       // W
 };
 
 enum class ViOperator
@@ -133,6 +136,7 @@ enum class TextObject
     BackQuotes = '`',     // i`  a`
     SquareBrackets = '[', // i[  a[
     Word = 'w',           // iw  aw
+    BigWord = 'W',        // iW  aW
 };
 
 enum class TextObjectScope
@@ -327,6 +331,7 @@ struct formatter<terminal::TextObject>
             case TextObject::SingleQuotes: return fmt::format_to(ctx.out(), "SingleQuotes");
             case TextObject::SquareBrackets: return fmt::format_to(ctx.out(), "SquareBrackets");
             case TextObject::Word: return fmt::format_to(ctx.out(), "Word");
+            case TextObject::BigWord: return fmt::format_to(ctx.out(), "BigWord");
         }
         return fmt::format_to(ctx.out(), "({})", static_cast<unsigned>(value));
     }
@@ -396,6 +401,9 @@ struct formatter<terminal::ViMotion>
             case ViMotion::WordBackward: return fmt::format_to(ctx.out(), "WordBackward");
             case ViMotion::WordEndForward: return fmt::format_to(ctx.out(), "WordEndForward");
             case ViMotion::WordForward: return fmt::format_to(ctx.out(), "WordForward");
+            case ViMotion::BigWordBackward: return fmt::format_to(ctx.out(), "BigWordBackward");
+            case ViMotion::BigWordEndForward: return fmt::format_to(ctx.out(), "BigWordEndForward");
+            case ViMotion::BigWordForward: return fmt::format_to(ctx.out(), "BigWordForward");
         }
         return fmt::format_to(ctx.out(), "({})", static_cast<unsigned>(motion));
     }


### PR DESCRIPTION
even more modal mode improvements. yay