### PR TITLE
Adds support for mouse in normal mode for selection and normal-mode's cursor placement.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -121,6 +121,7 @@
           <li>Adds ability to explicitly disable a font feature by prefixing the feature with a `-`, such as `-calt`, explicitly enabling via `+` prefix was added as well.</li>
           <li>Adds terminal capability `hs` and `es` to improve status-line feature detection via terminfo.</li>
           <li>Adds normal mode motion: `B`, `B`, `E`.</li>
+          <li>Adds support for mouse in normal mode for selection and normal-mode's cursor placement.</li>
           <li>Changes terminfo entries `tsl`, `fsl` and `dsl` to make use of the host-writable statusline.</li>
           <li>Improvements to text objects in vi-like normal mode (`i)`, `a)`, `i>`, `a>`, `i]`, `a]`, `i}`, `a}`).</li>
           <li>Improvements to vi-like normal mode: yank-motions (`yw`, `y$`, etc).</li>

--- a/src/vtbackend/Selector.cpp
+++ b/src/vtbackend/Selector.cpp
@@ -131,7 +131,7 @@ std::vector<Selection::Range> Selection::ranges() const
 LinearSelection::LinearSelection(SelectionHelper const& helper,
                                  CellLocation start,
                                  OnSelectionUpdated onSelectionUpdated):
-    Selection(helper, start, std::move(onSelectionUpdated))
+    Selection(helper, ViMode::Visual, start, std::move(onSelectionUpdated))
 {
 }
 // }}}
@@ -139,7 +139,7 @@ LinearSelection::LinearSelection(SelectionHelper const& helper,
 WordWiseSelection::WordWiseSelection(SelectionHelper const& helper,
                                      CellLocation start,
                                      OnSelectionUpdated onSelectionUpdated):
-    Selection(helper, start, std::move(onSelectionUpdated))
+    Selection(helper, ViMode::Visual, start, std::move(onSelectionUpdated))
 {
     _from = extendSelectionBackward(_from);
     _to = extendSelectionForward(_to);
@@ -223,7 +223,7 @@ void WordWiseSelection::extend(CellLocation to)
 RectangularSelection::RectangularSelection(SelectionHelper const& helper,
                                            CellLocation start,
                                            OnSelectionUpdated onSelectionUpdated):
-    Selection(helper, start, std::move(onSelectionUpdated))
+    Selection(helper, ViMode::VisualBlock, start, std::move(onSelectionUpdated))
 {
 }
 
@@ -282,7 +282,7 @@ vector<Selection::Range> RectangularSelection::ranges() const
 FullLineSelection::FullLineSelection(SelectionHelper const& helper,
                                      CellLocation start,
                                      OnSelectionUpdated onSelectionUpdated):
-    Selection(helper, start, std::move(onSelectionUpdated))
+    Selection(helper, ViMode::VisualLine, start, std::move(onSelectionUpdated))
 {
     _from.column = ColumnOffset(0);
     _to.column = boxed_cast<ColumnOffset>(_helper.pageSize().columns - 1);

--- a/src/vtbackend/Selector.h
+++ b/src/vtbackend/Selector.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <vtbackend/InputGenerator.h>
+#include <vtbackend/ViInputHandler.h>
 
 #include <crispy/size.h>
 #include <crispy/times.h>
@@ -79,8 +80,12 @@ class Selection
 
     using OnSelectionUpdated = std::function<void()>;
 
-    Selection(SelectionHelper const& helper, CellLocation start, OnSelectionUpdated onSelectionUpdated):
+    Selection(SelectionHelper const& helper,
+              ViMode viMode,
+              CellLocation start,
+              OnSelectionUpdated onSelectionUpdated):
         _helper { helper },
+        _viMode { viMode },
         _onSelectionUpdated { std::move(onSelectionUpdated) },
         _from { start },
         _to { start }
@@ -97,6 +102,8 @@ class Selection
     [[nodiscard]] virtual bool contains(CellLocation coord) const noexcept;
     [[nodiscard]] bool containsLine(LineOffset line) const noexcept;
     [[nodiscard]] virtual bool intersects(Rect area) const noexcept;
+
+    [[nodiscard]] ViMode viMode() const noexcept { return _viMode; }
 
     /// Tests whether the a selection is currently in progress.
     [[nodiscard]] constexpr State state() const noexcept { return _state; }
@@ -118,6 +125,7 @@ class Selection
   protected:
     State _state = State::Waiting;
     SelectionHelper const& _helper;
+    ViMode _viMode;
     OnSelectionUpdated _onSelectionUpdated;
     CellLocation _from;
     CellLocation _to;

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -107,24 +107,6 @@ enum class ViOperator
     ReverseSearchCurrentWord = '#',
 };
 
-enum class ViMode
-{
-    /// Vi-like normal-mode.
-    Normal, // <Escape>, <C-[>
-
-    /// Vi-like insert/terminal mode.
-    Insert, // i
-
-    /// Vi-like visual select mode.
-    Visual, // v
-
-    /// Vi-like visual line-select mode.
-    VisualLine, // V
-
-    /// Vi-like visual block-select mode.
-    VisualBlock, // <C-V>
-};
-
 enum class TextObject
 {
     AngleBrackets = '<',  // i<  a<
@@ -263,29 +245,6 @@ class ViInputHandler: public InputHandler
 
 namespace fmt // {{{
 {
-template <>
-struct formatter<terminal::ViMode>
-{
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(terminal::ViMode mode, FormatContext& ctx)
-    {
-        using terminal::ViMode;
-        switch (mode)
-        {
-            case ViMode::Normal: return fmt::format_to(ctx.out(), "Normal");
-            case ViMode::Insert: return fmt::format_to(ctx.out(), "Insert");
-            case ViMode::Visual: return fmt::format_to(ctx.out(), "Visual");
-            case ViMode::VisualLine: return fmt::format_to(ctx.out(), "VisualLine");
-            case ViMode::VisualBlock: return fmt::format_to(ctx.out(), "VisualBlock");
-        }
-        return fmt::format_to(ctx.out(), "({})", static_cast<unsigned>(mode));
-    }
-};
 
 template <>
 struct formatter<terminal::TextObjectScope>

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -710,6 +710,24 @@ enum class DynamicColorName
     HighlightBackgroundColor,
 };
 
+enum class ViMode
+{
+    /// Vi-like normal-mode.
+    Normal, // <Escape>, <C-[>
+
+    /// Vi-like insert/terminal mode.
+    Insert, // i
+
+    /// Vi-like visual select mode.
+    Visual, // v
+
+    /// Vi-like visual line-select mode.
+    VisualLine, // V
+
+    /// Vi-like visual block-select mode.
+    VisualBlock, // <C-V>
+};
+
 std::string to_string(GraphicsRendition s);
 
 constexpr unsigned toAnsiModeNum(AnsiMode m)
@@ -987,6 +1005,30 @@ struct formatter<terminal::PixelCoordinate>
     auto format(const terminal::PixelCoordinate coord, FormatContext& ctx)
     {
         return fmt::format_to(ctx.out(), "{}:{}", coord.x.value, coord.y.value);
+    }
+};
+
+template <>
+struct formatter<terminal::ViMode>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(terminal::ViMode mode, FormatContext& ctx)
+    {
+        using terminal::ViMode;
+        switch (mode)
+        {
+            case ViMode::Normal: return fmt::format_to(ctx.out(), "Normal");
+            case ViMode::Insert: return fmt::format_to(ctx.out(), "Insert");
+            case ViMode::Visual: return fmt::format_to(ctx.out(), "Visual");
+            case ViMode::VisualLine: return fmt::format_to(ctx.out(), "VisualLine");
+            case ViMode::VisualBlock: return fmt::format_to(ctx.out(), "VisualBlock");
+        }
+        return fmt::format_to(ctx.out(), "({})", static_cast<unsigned>(mode));
     }
 };
 


### PR DESCRIPTION
Enables the use of mouse while being in normal mode, to

- [x] allow placing the normal mode cursor via mouse click
- [x] initiate creating a selection via mouse; which can be later on continued via keyboard (fun fact).
- [x] basic auto-scrolling outside viewport by ensuring viewport's scrolloff.