### PR TITLE
install-deps script to use qt5 by default (again, and for now).

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.4.*"
+          #version: "6.4.*"
+          version: "5.15.*"
           modules: qtmultimedia
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: "create build directory"
@@ -122,14 +123,15 @@ jobs:
           set -ex
           #brew update
           ./scripts/install-deps.sh
-          brew install qt6 openssl
+          brew install qt5 openssl
       - name: "Create build directory"
         run: mkdir build
       - name: "Generate build files"
         run: |
           cmake . \
                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                -DCONTOUR_BUILD_WITH_QT6=ON \
+                -DQt5_DIR="$(brew --prefix qt5)/lib/cmake/Qt5" \
+                -DCONTOUR_BUILD_WITH_QT6=OFF \
                 -B build/
       - name: "Build"
         run: cmake --build build/

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -291,7 +291,7 @@ install_deps_arch()
     fetch_and_unpack_fmtlib
     [ x$PREPARE_ONLY_EMBEDS = xON ] && return
 
-    sudo pacman -S -y \
+    packages="
         catch2 \
         cmake \
         extra-cmake-modules \
@@ -302,13 +302,27 @@ install_deps_arch()
         microsoft-gsl \
         ninja \
         pkg-config \
-        qt6-5compat \
-        qt6-base \
-        qt6-declarative \
-        qt6-multimedia \
-        qt6-wayland \
         range-v3 \
-        yaml-cpp
+        yaml-cpp \
+    "
+
+    if test x$QTVER = x6; then
+        packages="$packages \
+            qt6-5compat \
+            qt6-base \
+            qt6-declarative \
+            qt6-multimedia \
+            qt6-wayland \
+        "
+    else
+        packages="$packages \
+            qt5-base \
+            qt5-multimedia \
+            qt5-x11extras \
+        "
+    fi
+
+    sudo pacman -S -y $packages
 }
 
 install_deps_suse()


### PR DESCRIPTION
soft revert to qt5 for the next release (or two?).

the qml pr will continue to focus being based on top of qt6 (rather than qt5).