### PR TITLE
[vtbackend] Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Fixes use of config `bypass_mouse_protocol_modifier` that was ignored.</li>
           <li>Adds normal mode motion `[[`, `]]`, `[]`, `][` mimmicking exactly what vim does.</li>
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
+          <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>
           <li>Adds shell integration for fish shell.</li>
         </ul>
       </description>

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -76,6 +76,7 @@ class ScreenBase: public SequenceHandler
     [[nodiscard]] virtual bool compareCellTextAt(CellLocation position, char codepoint) const noexcept = 0;
     [[nodiscard]] virtual std::string cellTextAt(CellLocation position) const noexcept = 0;
     [[nodiscard]] virtual LineFlags lineFlagsAt(LineOffset line) const noexcept = 0;
+    virtual void enableLineFlags(LineOffset lineOffset, LineFlags flags, bool enable) noexcept = 0;
     [[nodiscard]] virtual std::string lineTextAt(LineOffset line,
                                                  bool stripLeadingSpaces = true,
                                                  bool stripTrailingSpaces = true) const noexcept = 0;
@@ -527,6 +528,11 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] LineFlags lineFlagsAt(LineOffset line) const noexcept override
     {
         return _grid.lineAt(line).flags();
+    }
+
+    void enableLineFlags(LineOffset lineOffset, LineFlags flags, bool enable) noexcept override
+    {
+        _grid.lineAt(lineOffset).setFlag(flags, enable);
     }
 
     [[nodiscard]] std::string lineTextAt(LineOffset line,

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -296,6 +296,13 @@ void ViCommands::reverseSearchCurrentWord()
     jumpToPreviousMatch(1);
 }
 
+void ViCommands::toggleLineMark()
+{
+    auto const currentLineFlags = _terminal.currentScreen().lineFlagsAt(cursorPosition.line);
+    _terminal.currentScreen().enableLineFlags(
+        cursorPosition.line, LineFlags::Marked, !unsigned(currentLineFlags & LineFlags::Marked));
+}
+
 void ViCommands::searchCurrentWord()
 {
     auto const [wordUnderCursor, range] = _terminal.extractWordUnderCursor(cursorPosition);

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -39,6 +39,7 @@ class ViCommands: public ViInputHandler::Executor
     void scrollViewport(ScrollOffset delta) override;
     void modeChanged(ViMode mode) override;
     void reverseSearchCurrentWord() override;
+    void toggleLineMark() override;
     void searchCurrentWord() override;
     void execute(ViOperator op, ViMotion motion, unsigned count) override;
     void moveCursor(ViMotion motion, unsigned count) override;

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -160,6 +160,7 @@ void ViInputHandler::registerAllCommands()
     registerCommand(ModeSelect::Normal, "C-V", [this]() { toggleMode(ViMode::VisualBlock); });
     registerCommand(ModeSelect::Normal, "/", [this]() { startSearch(); });
     registerCommand(ModeSelect::Normal, "#", [this]() { _executor.reverseSearchCurrentWord(); });
+    registerCommand(ModeSelect::Normal, "mm", [this]() { _executor.toggleLineMark(); });
     registerCommand(ModeSelect::Normal, "*", [this]() { _executor.searchCurrentWord(); });
     registerCommand(ModeSelect::Normal, "p", [this]() { _executor.paste(count(), false); });
     registerCommand(ModeSelect::Normal, "P", [this]() { _executor.paste(count(), true); });

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -179,7 +179,10 @@ class ViInputHandler: public InputHandler
         // This is like pressing # in Vi.
         virtual void reverseSearchCurrentWord() = 0;
 
-        // similar to reverse search, but searching forward.
+        // Toggle line mark (see LineFlags::Flagged).
+        virtual void toggleLineMark() = 0;
+
+        // Similar to reverse search, but searching forward.
         virtual void searchCurrentWord() = 0;
     };
 


### PR DESCRIPTION
I by accident wished to be able to set a mark in between of my very large command output, such that I can keep browsing up (in normal mode), but have a very quick way to jump back to the reading position I just was at.

There we go. Type in `mm` in normal mode to set/toggle the line mark at the current active cursor's line position. and then use `[m` and `]m` to jump up/down by line marks.
