### PR TITLE
Implements `f`, `F`, `t`, `T`, `;`, `,` for cursor move and yank operations.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Adds normal mode motion `[[`, `]]`, `[]`, `][` mimmicking exactly what vim does.</li>
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
           <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>
+          <li>Adds normal mode motion `t{char}`, `T{char}`, `f{char}`, `F{char}`, `;`, `,` to move cursor in line till before/after or to given `{char}`.</li>
           <li>Adds shell integration for fish shell.</li>
         </ul>
       </description>

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -15,6 +15,7 @@
 
 #include <vtbackend/ViInputHandler.h>
 
+#include <optional>
 #include <utility>
 
 namespace terminal
@@ -41,8 +42,8 @@ class ViCommands: public ViInputHandler::Executor
     void reverseSearchCurrentWord() override;
     void toggleLineMark() override;
     void searchCurrentWord() override;
-    void execute(ViOperator op, ViMotion motion, unsigned count) override;
-    void moveCursor(ViMotion motion, unsigned count) override;
+    void execute(ViOperator op, ViMotion motion, unsigned count, char32_t lastChar = U'\0') override;
+    void moveCursor(ViMotion motion, unsigned count, char32_t lastChar = U'\0') override;
     void select(TextObjectScope scope, TextObject textObject) override;
     void yank(TextObjectScope scope, TextObject textObject) override;
     void yank(ViMotion motion) override;
@@ -73,6 +74,10 @@ class ViCommands: public ViInputHandler::Executor
     [[nodiscard]] CellLocation findEndOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept;
     [[nodiscard]] CellLocation globalCharUp(CellLocation location, char ch, unsigned count) const noexcept;
     [[nodiscard]] CellLocation globalCharDown(CellLocation location, char ch, unsigned count) const noexcept;
+    [[nodiscard]] std::optional<CellLocation> toCharRight(CellLocation startPosition) const noexcept;
+    [[nodiscard]] std::optional<CellLocation> toCharLeft(CellLocation startPosition) const noexcept;
+    [[nodiscard]] std::optional<CellLocation> toCharRight(unsigned count) const noexcept;
+    [[nodiscard]] std::optional<CellLocation> toCharLeft(unsigned count) const noexcept;
     void executeYank(ViMotion motion, unsigned count);
     void executeYank(CellLocation from, CellLocation to);
 
@@ -93,6 +98,8 @@ class ViCommands: public ViInputHandler::Executor
     Terminal& _terminal;
     ViMode _lastMode = ViMode::Insert;
     CursorShape _lastCursorShape = CursorShape::Block;
+    mutable char32_t _lastChar = U'\0';
+    std::optional<ViMotion> _lastCharMotion = std::nullopt;
     bool _lastCursorVisible = true;
 };
 

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -68,41 +68,47 @@ namespace terminal
 
 enum class ViMotion
 {
-    Explicit,             // <special one for explicit operators>
-    Selection,            // <special one for v_ modes>
-    FullLine,             // <special one for full-line motions>
-    CharLeft,             // h
-    CharRight,            // l
-    ScreenColumn,         // |
-    FileBegin,            // gg
-    FileEnd,              // G
-    LineBegin,            // 0
-    LineTextBegin,        // ^
-    LineDown,             // j
-    LineEnd,              // $
-    LineUp,               // k
-    LinesCenter,          // M
-    PageDown,             // <C-D>
-    PageUp,               // <C-U>
-    PageTop,              // <S-H> (inspired by tmux)
-    PageBottom,           // <S-L> (inspired by tmux)
-    ParagraphBackward,    // {
-    ParagraphForward,     // }
-    GlobalCurlyCloseUp,   // []
-    GlobalCurlyCloseDown, // ][
-    GlobalCurlyOpenUp,    // [[
-    GlobalCurlyOpenDown,  // ]]
-    LineMarkUp,           // [m
-    LineMarkDown,         // ]m
-    ParenthesisMatching,  // %
-    SearchResultBackward, // N
-    SearchResultForward,  // n
-    WordBackward,         // b
-    WordEndForward,       // e
-    WordForward,          // w
-    BigWordBackward,      // B
-    BigWordEndForward,    // E
-    BigWordForward,       // W
+    Explicit,              // <special one for explicit operators>
+    Selection,             // <special one for v_ modes>
+    FullLine,              // <special one for full-line motions>
+    CharLeft,              // h
+    CharRight,             // l
+    ScreenColumn,          // |
+    FileBegin,             // gg
+    FileEnd,               // G
+    LineBegin,             // 0
+    LineTextBegin,         // ^
+    LineDown,              // j
+    LineEnd,               // $
+    LineUp,                // k
+    LinesCenter,           // M
+    PageDown,              // <C-D>
+    PageUp,                // <C-U>
+    PageTop,               // <S-H> (inspired by tmux)
+    PageBottom,            // <S-L> (inspired by tmux)
+    ParagraphBackward,     // {
+    ParagraphForward,      // }
+    GlobalCurlyCloseUp,    // []
+    GlobalCurlyCloseDown,  // ][
+    GlobalCurlyOpenUp,     // [[
+    GlobalCurlyOpenDown,   // ]]
+    LineMarkUp,            // [m
+    LineMarkDown,          // ]m
+    ParenthesisMatching,   // %
+    SearchResultBackward,  // N
+    SearchResultForward,   // n
+    WordBackward,          // b
+    WordEndForward,        // e
+    WordForward,           // w
+    BigWordBackward,       // B
+    BigWordEndForward,     // E
+    BigWordForward,        // W
+    TillBeforeCharRight,   // t {char}
+    TillAfterCharLeft,     // T {char}
+    ToCharRight,           // f {char}
+    ToCharLeft,            // F {char}
+    RepeatCharMove,        // ;
+    RepeatCharMoveReverse, // ,
 };
 
 enum class ViOperator
@@ -159,8 +165,8 @@ class ViInputHandler: public InputHandler
       public:
         virtual ~Executor() = default;
 
-        virtual void execute(ViOperator op, ViMotion motion, unsigned count) = 0;
-        virtual void moveCursor(ViMotion motion, unsigned count) = 0;
+        virtual void execute(ViOperator op, ViMotion motion, unsigned count, char32_t lastChar = U'\0') = 0;
+        virtual void moveCursor(ViMotion motion, unsigned count, char32_t lastChar = U'\0') = 0;
         virtual void select(TextObjectScope scope, TextObject textObject) = 0;
         virtual void yank(TextObjectScope scope, TextObject textObject) = 0;
         virtual void yank(ViMotion motion) = 0;
@@ -254,6 +260,7 @@ class ViInputHandler: public InputHandler
     CommandHandlerMap _normalMode;
     CommandHandlerMap _visualMode;
     unsigned _count = 0;
+    char32_t _lastChar = 0;
     Executor& _executor;
 };
 
@@ -379,6 +386,12 @@ struct formatter<terminal::ViMotion>
             case ViMotion::BigWordBackward: return fmt::format_to(ctx.out(), "BigWordBackward");
             case ViMotion::BigWordEndForward: return fmt::format_to(ctx.out(), "BigWordEndForward");
             case ViMotion::BigWordForward: return fmt::format_to(ctx.out(), "BigWordForward");
+            case ViMotion::TillBeforeCharRight: return fmt::format_to(ctx.out(), "TillBeforeCharRight");
+            case ViMotion::TillAfterCharLeft: return fmt::format_to(ctx.out(), "TillAfterCharLeft");
+            case ViMotion::ToCharRight: return fmt::format_to(ctx.out(), "ToCharRight");
+            case ViMotion::ToCharLeft: return fmt::format_to(ctx.out(), "ToCharLeft");
+            case ViMotion::RepeatCharMove: return fmt::format_to(ctx.out(), "RepeatCharMove");
+            case ViMotion::RepeatCharMoveReverse: return fmt::format_to(ctx.out(), "RepeatCharMoveReverse");
             case ViMotion::GlobalCurlyCloseUp: return fmt::format_to(ctx.out(), "GlobalCurlyCloseUp");
             case ViMotion::GlobalCurlyCloseDown: return fmt::format_to(ctx.out(), "GlobalCurlyCloseDown");
             case ViMotion::GlobalCurlyOpenUp: return fmt::format_to(ctx.out(), "GlobalCurlyOpenUp");


### PR DESCRIPTION
Implements `f`, `F`, `t`, `T`, `;`, `,` for cursor move and yank operations. Refs #973.