### PR TITLE
Adds config entry `vi_mode_highlight` to color palette to highlight current line in non-insert mode

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
           <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>
           <li>Adds normal mode motion `t{char}`, `T{char}`, `f{char}`, `F{char}`, `;`, `,` to move cursor in line till before/after or to given `{char}`.</li>
+          <li>Adds config entry `vi_mode_highlight` to color palette to highlight current cursor's line when not in insert mode (aka. in Vi-mode).</li>
           <li>Adds shell integration for fish shell.</li>
         </ul>
       </description>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1001,6 +1001,9 @@ namespace
         if (auto p = parseCellRGBColorAndAlphaPair(_usedKeys, _basePath, _node, "vi_mode_highlight"))
             colors.yankHighlight = p.value();
 
+        if (auto p = parseCellRGBColorAndAlphaPair(_usedKeys, _basePath, _node, "vi_mode_cursorline"))
+            colors.normalModeCursorline = p.value();
+
         if (auto p = parseRGBColorPair(
                 _usedKeys, _basePath, _node, "indicator_statusline", colors.indicatorStatusLine))
             colors.indicatorStatusLine = p.value();

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -470,6 +470,15 @@ color_schemes:
             background: '#ffa500'
             background_alpha: 0.5
 
+        # Color override for the current cursor's line when in vi_mode:
+        # The value format is equivalent to how selection colors and alpha contribution is defined.
+        # To disable cursorline in vi_mode, set foreground to CellForeground and background to CellBackground.
+        vi_mode_cursorline:
+            foreground: '#ffffff'
+            foreground_alpha: 0.2
+            background: '#808080'
+            background_alpha: 0.3
+
         # The text selection color can be customized here.
         # Leaving a value empty will default to the inverse of the content's color values.
         #

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -130,6 +130,8 @@ struct ColorPalette
     CellRGBColorAndAlphaPair wordHighlightCurrent { CellForegroundColor {}, 1.0f, RGBColor{0x90, 0x90, 0x90}, 0.6f };
 
     CellRGBColorAndAlphaPair selection { CellBackgroundColor {}, 1.0f, CellForegroundColor {}, 1.0f };
+
+    CellRGBColorAndAlphaPair normalModeCursorline = { 0xFFFFFF_rgb, 0.2f, 0x404000_rgb, 0.3f };
     // clang-format on
 
     RGBColorPair indicatorStatusLine = { 0x000000_rgb, 0x808080_rgb };

--- a/src/vtbackend/RenderBufferBuilder.h
+++ b/src/vtbackend/RenderBufferBuilder.h
@@ -50,6 +50,8 @@ class RenderBufferBuilder
     void finish() noexcept {}
 
   private:
+    [[nodiscard]] bool isCursorLine(LineOffset line) const noexcept;
+
     [[nodiscard]] std::optional<RenderCursor> renderCursor() const;
 
     [[nodiscard]] static RenderCell makeRenderCellExplicit(ColorPalette const& colorPalette,
@@ -128,6 +130,7 @@ class RenderBufferBuilder
     State state = State::Gap;
     LineOffset lineNr = LineOffset(0);
     bool isNewLine = false;
+    bool _useCursorlineColoring = false;
 
     // Offset into the search pattern that has been already matched.
     size_t searchPatternOffset = 0;


### PR DESCRIPTION
I did it quickly actually because I keep searching for my cursor, and this helps finding it quicker. Hopefully helpful to others too (it's possible to disable).