### PR TITLE
Fixes `SendChars` input acion to actually send the chars as-is to the standard input of the connected application.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
           <li>Fixes normal mode motion `J` and `K` that got accidentally unimplemented and make it also available to visual mode.</li>
           <li>Fixes use of config `bypass_mouse_protocol_modifier` that was ignored.</li>
           <li>Fixes abnormal termination on incomplete foreground/background color-pair specification.</li>
+          <li>Fixes `SendChars` input acion to actually send the chars as-is to the standard input of the connected application.</li>
           <li>Adds normal mode motion `[[`, `]]`, `[]`, `][` mimmicking exactly what vim does.</li>
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
           <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -929,14 +929,12 @@ bool TerminalSession::operator()(actions::SearchReverse)
     return true;
 }
 
-bool TerminalSession::operator()(actions::SendChars const& _event)
+bool TerminalSession::operator()(actions::SendChars const& event)
 {
-    auto const now = steady_clock::now();
-
-    for (auto const ch: _event.chars)
-    {
-        terminal().sendCharPressEvent(static_cast<char32_t>(ch), terminal::Modifier::None, now);
-    }
+    // auto const now = steady_clock::now();
+    // for (auto const ch: event.chars)
+    //     terminal().sendCharPressEvent(static_cast<char32_t>(ch), terminal::Modifier::None, now);
+    terminal().sendRawInput(event.chars);
     return true;
 }
 

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -899,6 +899,24 @@ void Terminal::sendPaste(string_view text)
     flushInput();
 }
 
+void Terminal::sendRawInput(string_view text)
+{
+    if (!allowInput())
+        return;
+
+    if (_state.inputHandler.isEditingSearch())
+    {
+        InputLog()("Sending raw input to search input: {}", crispy::escape(text));
+        _state.searchMode.pattern += unicode::convert_to<char32_t>(text);
+        screenUpdated();
+        return;
+    }
+
+    InputLog()("Sending raw input to stdin: {}", crispy::escape(text));
+    _state.inputGenerator.generateRaw(text);
+    flushInput();
+}
+
 bool Terminal::hasInput() const noexcept
 {
     return !_state.inputGenerator.peek().empty();

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -263,6 +263,7 @@ class Terminal
     {
         _eventListener.pasteFromClipboard(count, strip);
     }
+    void sendRawInput(std::string_view text);
 
     void inputModeChanged(ViMode mode) { _eventListener.inputModeChanged(mode); }
     void updateHighlights() { _eventListener.updateHighlights(); }


### PR DESCRIPTION
With this patch, you can now actually use the `SendChars` action to send the (escaped) bytes RAW to the applications stdin, bypassing any further input mapping. This is what users might have expected anyways.