### PR TITLE
Fix cmake configure on arm64 (mac M1)

### DIFF
--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -52,6 +52,7 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd
     target_compile_options(crispy-core PUBLIC -maes)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) # ARM64
     target_compile_options(crispy-core PUBLIC -march=armv8-a+fp+simd+crypto+crc)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
 else()
     message(WARNING "Target architecture not detected.")
 endif()


### PR DESCRIPTION
## Description

CMake configure on mac M1 would fail with 'Target architecture not detected.'

## Motivation and Context

Allows to build on mac M1

## How Has This Been Tested?

- [x] Building on mac M1
- [x] Running on mac M1

## Checklist:

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
