### PR TITLE
feat(ci): Run a quicker `clang-tidy` for verification in the CI automatically

### DIFF
--- a/.github/codechecker/config-verify.json
+++ b/.github/codechecker/config-verify.json
@@ -19,6 +19,12 @@
     "--checker-config", "clang-tidy:readability-identifier-naming.PrivateMemberPrefix='_'",
     "--checker-config", "clang-tidy:readability-identifier-naming.PublicMemberPrefix=\"\"",
     "--checker-config", "clang-tidy:readability-identifier-naming.ScopedEnumConstantCase=CamelCase"
+    "--checker-config", "clang-tidy:readability-identifier-naming.VariableCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.VariableCasePrefix=\"\"",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstexprVariableCase=CamelCase"
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstexprVariableCasePrefix=\"\"",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstantCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstantCasePrefix=\"\"",
   ],
   "parse": [
     "--skip=.github/codechecker/skipfile.txt"

--- a/.github/codechecker/config-verify.json
+++ b/.github/codechecker/config-verify.json
@@ -1,0 +1,26 @@
+{
+  "analyze": [
+    "--analyzers=clang-tidy",
+    "--skip=.github/codechecker/skipfile.txt",
+    "--disable=default",
+    "--disable=clang-diagnostic",
+    "--enable=cert-dcl16-c",
+    "--checker-config", "clang-tidy:cert-dcl16-c:NewSuffixes=L;LL;LU;LLU",
+    "--enable=readability-identifier-naming",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ClassCase=CamelCase",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ClassMemberCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ClassMethodCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstantMemberCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ConstantMemberPrefix='_'",
+    "--checker-config", "clang-tidy:readability-identifier-naming.EnumCase=CamelCase",
+    "--checker-config", "clang-tidy:readability-identifier-naming.EnumConstantCase=CamelCase",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ParameterCase=camelBack",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ParameterPrefix=\"\"",
+    "--checker-config", "clang-tidy:readability-identifier-naming.PrivateMemberPrefix='_'",
+    "--checker-config", "clang-tidy:readability-identifier-naming.PublicMemberPrefix=\"\"",
+    "--checker-config", "clang-tidy:readability-identifier-naming.ScopedEnumConstantCase=CamelCase"
+  ],
+  "parse": [
+    "--skip=.github/codechecker/skipfile.txt"
+  ]
+}

--- a/.github/codechecker/skipfile.txt
+++ b/.github/codechecker/skipfile.txt
@@ -3,8 +3,8 @@
 -*/Build/*
 -*/Build/src/contour/contour_autogen/*
 -*/Build/src/contour/opengl/contour_frontend_opengl_autogen/*
-+*/_deps/sources/libunicode-*/*
-+*/_deps/sources/termbench-pro-*/*
+-*/_deps/sources/libunicode-*/*
+-*/_deps/sources/termbench-pro-*/*
 -*/_deps/sources/*
 -*/_deps/*
-+*/src/contour/*
+-*/src/contour/*

--- a/.github/codechecker/skipfile.txt
+++ b/.github/codechecker/skipfile.txt
@@ -3,7 +3,7 @@
 -*/Build/*
 -*/Build/src/contour/contour_autogen/*
 -*/Build/src/contour/opengl/contour_frontend_opengl_autogen/*
-+_deps/sources/libunicode-*/*
-+_deps/sources/termbench-pro-*/*
--_deps/sources/*
--_deps/*
++*/_deps/sources/libunicode-*/*
++*/_deps/sources/termbench-pro-*/*
+-*/_deps/sources/*
+-*/_deps/*

--- a/.github/codechecker/skipfile.txt
+++ b/.github/codechecker/skipfile.txt
@@ -7,3 +7,4 @@
 +*/_deps/sources/termbench-pro-*/*
 -*/_deps/sources/*
 -*/_deps/*
++*/src/contour/*

--- a/.github/codechecker/skipfile.txt
+++ b/.github/codechecker/skipfile.txt
@@ -7,4 +7,3 @@
 -*/_deps/sources/termbench-pro-*/*
 -*/_deps/sources/*
 -*/_deps/*
--*/src/contour/*

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,3 +1,5 @@
+# This is a **quick** style analysis job that's meaningful to run for
+# every commit whatsoever, just like the continuous build.
 name: Checks
 
 on:
@@ -32,6 +34,14 @@ jobs:
     - name: "Checking for open PR-related TODO items"
       run: ./scripts/check-pr-todos.sh
 
+  editorconfig:
+    name: "Check editorconfig"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: editorconfig-checker/action-editorconfig-checker@main
+      - run: editorconfig-checker
+
   check_clang_format:
     name: "Check C++ style"
     runs-on: ubuntu-20.04
@@ -44,10 +54,63 @@ jobs:
         check-path: 'src'
         #exclude-regex: 'sse2neon.h'
 
-  editorconfig:
-    name: "Check editorconfig"
-    runs-on: ubuntu-20.04
+  clang_tidy:
+    name: "Clang-Tidy verifying checks"
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: editorconfig-checker/action-editorconfig-checker@main
-      - run: editorconfig-checker
+      - name: "Check out repository"
+        uses: actions/checkout@v3
+      - name: "update APT package database"
+        run: sudo apt -q update && sudo apt upgrade -y
+      - name: Installing xmllint for ci-set-vars
+        run: sudo apt -qy install libxml2-utils
+      - name: "Set variables for Contour build-like CI"
+        id: set_vars
+        run: ./scripts/ci-set-vars.sh
+        env:
+          REPOSITORY: "${{ github.event.repository.name }}"
+      - name: "Install build dependencies"
+        # Note: Keep this in sync with that in build.yml!
+        run: sudo ./scripts/install-deps.sh
+      - name: "Post-fix embedded dependency permissions."
+        run: sudo find _deps/sources -exec chown $UID {} \;
+      - name: "Prepare building Contour"
+        # Note: Keep this in sync with that in build.yml!
+        run: |
+          BUILD_DIR="Build" \
+            CMAKE_BUILD_TYPE="Debug" \
+            CXX="g++-11" \
+            ./scripts/ci-prepare-contour.sh
+
+      - name: "Execute Clang-Tidy"
+        uses: whisperity/codechecker-analysis-action@v1
+        id: codechecker
+        continue-on-error: true
+        with:
+          # CodeChecker version. This currently misreports as an 'rc' but is
+          # in fact not an RC...
+          version: '6.21.0'
+          llvm-version: '15'
+
+          config: .github/codechecker/config-verify.json
+
+          build-command: "cd Build && cmake --build . -- -j3"
+
+      - name: "Upload HTML reports"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-codechecker-${{ steps.codechecker.outputs.codechecker-version }}+${{ steps.codechecker.outputs.codechecker-hash }}-llvm-${{ steps.codechecker.outputs.llvm-version }}-results"
+          path: "${{ steps.codechecker.outputs.result-html-dir }}"
+          if-no-files-found: error
+      - name: "Upload analysis failure reproducers"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-codechecker-${{ steps.codechecker.outputs.codechecker-version }}+${{ steps.codechecker.outputs.codechecker-hash }}-llvm-${{ steps.codechecker.outputs.llvm-version }}-failure-zips"
+          path: "${{ steps.codechecker.outputs.analyze-output }}/failed"
+          if-no-files-found: ignore
+
+      - name: "Break build if CodeChecker reported any findings"
+        if: ${{ steps.codechecker.outputs.warnings == 'true' }}
+        run: |
+          echo "::error title=Clang-Tidy::Style and code health verification checks reported."
+          exit 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,8 +60,6 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v3
-      - name: "update APT package database"
-        run: sudo apt -q update && sudo apt upgrade -y
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
       - name: "Set variables for Contour build-like CI"

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -72,8 +72,6 @@ FormatStyle:     none
 CheckOptions:
   - key:             bugprone-easily-swappable-parameters.MinimumLength
     value:           '3'
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
   - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
     value:           '0'
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
@@ -102,27 +100,32 @@ CheckOptions:
     value:           'NULL'
   - key:             modernize-use-default-member-init.UseAssignment
     value:           '1'
-  - key:             readability-identifier-naming.EnumCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.EnumConstantCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.ConstantMemberCase
-    value:           camelBack
-  - key:             readability-identifier-naming.ConstantMemberPrefix
-    value:           '_'
+  # These are *verification* checks. The configuration **MUST** be kept in sync
+  # with .github/codechecker/config-verify.json, otherwise the CI job will
+  # reject the style verification.
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassMemberCase
     value:           camelBack
-  - key:             readability-identifier-naming.PublicMemberPrefix
-    value:           ''
-  - key:             readability-identifier-naming.PrivateMemberPrefix
-    value:           '_'
   - key:             readability-identifier-naming.ClassMethodCase
     value:           camelBack
+  - key:             readability-identifier-naming.ConstantMemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ConstantMemberPrefix
+    value:           '_'
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
   - key:             readability-identifier-naming.ParameterPrefix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMemberPrefix
+    value:           '_'
+  - key:             readability-identifier-naming.PublicMemberPrefix
     value:           ''
   - key:             readability-identifier-naming.ScopedEnumConstantCase
     value:           CamelCase


### PR DESCRIPTION
Some checks are implemented in Clang-Tidy that can be used to verify style-like requirements that pure syntax-based systems, such as Clang-Format is not capable of.

Adds a new CI job using the CodeChecker action that runs **only** these verification checkers (and thus quicker than the full-blown static analysis workflow) and explicitly **breaks** the build if the style things do not match.

(Due to technical reasons with Clang-Tidy configuration, unfortunately, some minor duplication needs to be done between `.clang-tidy` and the CodeChecker config file.)

> supersedes #963