### PR TITLE
Documentation on mapping backspace to various chars

### DIFF
--- a/docs/configuration/advanced/misc.md
+++ b/docs/configuration/advanced/misc.md
@@ -44,3 +44,14 @@ Default: `true`
 
     reflow_on_resize: true
 
+# Backspace character
+
+There is little consistency between systems as to what should be sent when the
+user presses the backspace key. By default Contour sends ^? but if you prefer
+to send ^H (or something else again) then you can add an entry to the
+`input_mapping` section of your config file like:
+
+```
+- { mods: [], key: BackSpace, action: SendChars, chars: "\x08" }
+- { mods: [Control], key: BackSpace, action: SendChars, chars: "\x7F" }
+```


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Add documentation to show how to make BS send ^H. This is the default for a vt220 IIRC.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
This is a "common" configuration item for people who connect to different systems.
```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.

I read it twice.

- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
