### PR TITLE
Allow building Contour on platforms not supporting hardware crypto extension (AES-NI)

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -116,6 +116,7 @@
           <li>Adds normal mode motion `t{char}`, `T{char}`, `f{char}`, `F{char}`, `;`, `,` to move cursor in line till before/after or to given `{char}`.</li>
           <li>Adds config entry `vi_mode_highlight` to color palette to highlight current cursor's line when not in insert mode (aka. in Vi-mode).</li>
           <li>Adds shell integration for fish shell.</li>
+          <li>Contour can now run on platforms not supporting hardware crypto extension for ARM64 nor AES-NI for x86-64. Hardware acceleration support can be configured to be included at compile time.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -30,6 +30,7 @@
 #include <text_shaper/font.h>
 #include <text_shaper/mock_font_locator.h>
 
+#include <crispy/StrongLRUHashtable.h>
 #include <crispy/size.h>
 #include <crispy/stdfs.h>
 

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 # --------------------------------------------------------------------------------------------------------
 # crispy::core
 
+option(STRONGHASH_USE_AES_NI "Build StrongHash with AES-NI support [default: ON]" ON)
+
 set(crispy_SOURCES
     App.cpp App.h
     BufferObject.cpp BufferObject.h
@@ -35,6 +37,10 @@ add_library(crispy-core ${crispy_SOURCES})
 add_library(crispy::core ALIAS crispy-core)
 
 set_target_properties(crispy-core PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+
+if(STRONGHASH_USE_AES_NI)
+    target_compile_definitions(crispy-core PUBLIC -DSTRONGHASH_USE_AES_NI=1)
+endif()
 
 if(MSVC)
     target_compile_definitions(crispy-core PUBLIC NOMINMAX)

--- a/src/crispy/StrongHash.h
+++ b/src/crispy/StrongHash.h
@@ -21,20 +21,26 @@
 #include <string_view>
 #include <type_traits>
 
-#if defined(__x86_64__)
-    #include <immintrin.h>
+// NB: That should be defined via CMakeLists.txt's option()...
+// #define STRONGHASH_USE_AES_NI 1
 
-    #if defined(__AES__)
-        #include <wmmintrin.h>
-    #endif
-#elif defined(__aarch64__)
-    #include <sse2neon/sse2neon.h>
+#if defined(STRONGHASH_USE_AES_NI)
+    #if defined(__x86_64__)
+        #include <immintrin.h>
+
+        #if defined(__AES__)
+            #include <wmmintrin.h>
+        #endif
+    #elif defined(__aarch64__)
+        #include <sse2neon/sse2neon.h>
+
 // The following inline functions were borrowed from:
 // https://github.com/f1ed/emp/blob/master/emp-tool/utils/block.h
 inline __m128i _mm_aesimc_si128(__m128i a) noexcept
 {
     return vreinterpretq_m128i_u8(vaesimcq_u8(vreinterpretq_u8_m128i(a)));
 }
+
 inline __m128i _mm_aesdec_si128(__m128i a, __m128i roundKey) noexcept
 {
     return vreinterpretq_m128i_u8(
@@ -46,6 +52,9 @@ inline __m128i _mm_aesdeclast_si128(__m128i a, __m128i roundKey) noexcept
     return vreinterpretq_m128i_u8(vaesdq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0))
                                   ^ vreinterpretq_u8_m128i(roundKey));
 }
+    #endif
+#else
+    #include <crispy/FNV.h>
 #endif
 
 namespace crispy
@@ -61,7 +70,9 @@ struct StrongHash
 
     StrongHash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept;
 
+#if defined(STRONGHASH_USE_AES_NI)
     explicit StrongHash(__m128i v) noexcept;
+#endif
 
     StrongHash() = default;
     StrongHash(StrongHash const&) = default;
@@ -80,23 +91,48 @@ struct StrongHash
 
     static StrongHash compute(void const* data, size_t n) noexcept;
 
+    // Retrieves the 4th 32-bit component of the internal representation.
+    // TODO: Provide access also to: a, b, c.
+    [[nodiscard]] uint32_t d() const noexcept
+    {
+#if defined(STRONGHASH_USE_AES_NI)
+        return static_cast<uint32_t>(_mm_cvtsi128_si32(value));
+#else
+        return value[3];
+#endif
+    }
+
+#if defined(STRONGHASH_USE_AES_NI)
     __m128i value {};
+#else
+    std::array<uint32_t, 4> value;
+#endif
 };
 
 inline StrongHash::StrongHash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept:
+#if defined(STRONGHASH_USE_AES_NI)
     StrongHash(_mm_xor_si128(
         _mm_set_epi32(static_cast<int>(a), static_cast<int>(b), static_cast<int>(c), static_cast<int>(d)),
         _mm_loadu_si128((__m128i const*) defaultSeed.data())))
+#else
+    value { a, b, c, d }
+#endif
 {
 }
 
+#if defined(STRONGHASH_USE_AES_NI)
 inline StrongHash::StrongHash(__m128i v) noexcept: value { v }
 {
 }
+#endif
 
 inline bool operator==(StrongHash a, StrongHash b) noexcept
 {
+#if defined(STRONGHASH_USE_AES_NI)
     return _mm_movemask_epi8(_mm_cmpeq_epi32(a.value, b.value)) == 0xFFFF;
+#else
+    return a.value == b.value;
+#endif
 }
 
 inline bool operator!=(StrongHash a, StrongHash b) noexcept
@@ -106,6 +142,7 @@ inline bool operator!=(StrongHash a, StrongHash b) noexcept
 
 inline StrongHash operator*(StrongHash const& a, StrongHash const& b) noexcept
 {
+#if defined(STRONGHASH_USE_AES_NI)
     // TODO AES-NI fallback
     __m128i hashValue = a.value;
 
@@ -116,6 +153,12 @@ inline StrongHash operator*(StrongHash const& a, StrongHash const& b) noexcept
     hashValue = _mm_aesdec_si128(hashValue, _mm_setzero_si128());
 
     return StrongHash { hashValue };
+#else
+    return StrongHash { FNV<uint32_t, uint32_t>()(a.value[0], b.value[0]),
+                        FNV<uint32_t, uint32_t>()(a.value[1], b.value[1]),
+                        FNV<uint32_t, uint32_t>()(a.value[2], b.value[2]),
+                        FNV<uint32_t, uint32_t>()(a.value[3], b.value[3]) };
+#endif
 }
 
 inline StrongHash operator*(StrongHash a, uint32_t b) noexcept
@@ -127,8 +170,7 @@ template <typename T>
 StrongHash StrongHash::compute(std::basic_string_view<T> text) noexcept
 {
     // return compute(value.data(), value.size());
-    StrongHash hash;
-    hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
+    auto hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
     for (auto const codepoint: text)
         hash = hash * codepoint; // StrongHash(0, 0, 0, static_cast<uint32_t>(codepoint));
     return hash;
@@ -138,8 +180,7 @@ template <typename T, typename Alloc>
 StrongHash StrongHash::compute(std::basic_string<T, Alloc> const& text) noexcept
 {
     // return compute(value.data(), value.size());
-    StrongHash hash;
-    hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
+    auto hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
     for (T const codepoint: text)
         hash = hash * static_cast<uint32_t>(codepoint);
     return hash;
@@ -153,8 +194,7 @@ StrongHash StrongHash::compute(T const& value) noexcept
 
 inline StrongHash StrongHash::compute(void const* data, size_t n) noexcept
 {
-    // TODO AES-NI fallback
-
+#if defined(STRONGHASH_USE_AES_NI)
     static_assert(sizeof(__m128i) == 16);
     auto constexpr ChunkSize = static_cast<int>(sizeof(__m128i));
 
@@ -189,6 +229,16 @@ inline StrongHash StrongHash::compute(void const* data, size_t n) noexcept
     }
 
     return StrongHash { hashValue };
+#else
+    auto const* i = (uint8_t const*) data;
+    auto const* e = i + n;
+    auto const result = FNV<uint8_t, uint64_t>()(i, e);
+    auto constexpr a = 0;
+    auto constexpr b = 0;
+    auto const c = static_cast<uint32_t>((result >> 32) & 0xFFFFFFFFu);
+    auto const d = static_cast<uint32_t>(result & 0xFFFFFFFFu);
+    return StrongHash { a, b, c, d };
+#endif
 }
 
 inline std::string to_string(StrongHash const& hash)
@@ -216,7 +266,11 @@ inline std::string to_structured_string(StrongHash const& hash)
 
 inline int to_integer(StrongHash hash) noexcept
 {
+#if defined(STRONGHASH_USE_AES_NI)
     return _mm_cvtsi128_si32(hash.value);
+#else
+    return static_cast<int>(hash.value.back());
+#endif
 }
 
 template <typename T>
@@ -225,23 +279,44 @@ struct StrongHasher
     StrongHash operator()(T const&) noexcept; // Specialize and implement me.
 };
 
+template <>
+struct StrongHasher<uint64_t>
+{
+    inline StrongHash operator()(uint64_t v) noexcept
+    {
+        auto const c = static_cast<uint32_t>((v >> 32) & 0xFFFFFFFFu);
+        auto const d = static_cast<uint32_t>(v & 0xFFFFFFFFu);
+#if defined(STRONGHASH_USE_AES_NI)
+        return StrongHash { _mm_set_epi32(0, 0, c, d) };
+#else
+        return StrongHash { 0, 0, c, d };
+#endif
+    }
+};
 // {{{ some standard hash implementations
 namespace detail
 {
     template <typename T>
     struct StdHash32
     {
-        inline StrongHash operator()(T v) noexcept { return StrongHash { _mm_set_epi32(0, 0, 0, v) }; }
+        inline StrongHash operator()(T v) noexcept
+        {
+#if defined(STRONGHASH_USE_AES_NI)
+            return StrongHash { _mm_set_epi32(0, 0, 0, v) };
+#else
+            return StrongHash { 0, 0, 0, static_cast<uint32_t>(v) };
+#endif
+        }
     };
 } // namespace detail
 
 // clang-format off
 template <> struct StrongHasher<char>: public detail::StdHash32<char> { };
 template <> struct StrongHasher<unsigned char>: public detail::StdHash32<char> { };
-template <> struct StrongHasher<short>: public detail::StdHash32<short> { };
-template <> struct StrongHasher<unsigned short>: public detail::StdHash32<unsigned short> { };
-template <> struct StrongHasher<int>: public detail::StdHash32<int> { };
-template <> struct StrongHasher<unsigned int>: public detail::StdHash32<int> { };
+template <> struct StrongHasher<int16_t>: public detail::StdHash32<int16_t> { };
+template <> struct StrongHasher<uint16_t>: public detail::StdHash32<uint16_t> { };
+template <> struct StrongHasher<int32_t>: public detail::StdHash32<int32_t> { };
+template <> struct StrongHasher<uint32_t>: public detail::StdHash32<uint32_t> { };
 // clang-format on
 // }}}
 

--- a/src/crispy/StrongLRUCache.h
+++ b/src/crispy/StrongLRUCache.h
@@ -22,12 +22,6 @@
 #include <stdexcept>
 #include <vector>
 
-#if defined(__x86_64__)
-    #include <immintrin.h>
-#elif defined(__aarch64__)
-    #include <sse2neon/sse2neon.h>
-#endif
-
 #define DEBUG_STRONG_LRU_CACHE 1
 
 #if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_CACHE)

--- a/src/crispy/StrongLRUCache_test.cpp
+++ b/src/crispy/StrongLRUCache_test.cpp
@@ -243,7 +243,7 @@ struct CollidingHasher
         // Since the hashtable lookup only looks at the
         // least significant 32 bit, this will always cause
         // a hash-table entry collision.
-        return StrongHash { _mm_set_epi32(0, 0, v, 0) };
+        return StrongHash { 0, 0, static_cast<uint32_t>(v), 0 };
     }
 };
 // clang-format on

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -22,12 +22,6 @@
 #include <stdexcept>
 #include <vector>
 
-#if defined(__x86_64__)
-    #include <immintrin.h>
-#elif defined(__aarch64__)
-    #include <sse2neon/sse2neon.h>
-#endif
-
 #define DEBUG_STRONG_LRU_HASHTABLE 1
 
 #if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_HASHTABLE)
@@ -410,7 +404,7 @@ inline size_t StrongLRUHashtable<Value>::storageSize() const noexcept
 template <typename Value>
 inline uint32_t* StrongLRUHashtable<Value>::hashTableSlot(StrongHash const& hash) noexcept
 {
-    auto const index = static_cast<uint32_t>(_mm_cvtsi128_si32(hash.value));
+    auto const index = hash.d();
     auto const slot = index & _hashMask;
     return _hashTable + slot;
 }

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -27,7 +27,6 @@
 
 #include <vtparser/ParserExtension.h>
 
-#include <crispy/StrongLRUCache.h>
 #include <crispy/algorithm.h>
 #include <crispy/logstore.h>
 #include <crispy/size.h>


### PR DESCRIPTION
Also adds compile time option: `STRONGHASH_USE_AES_NI` (default: ON)

@lhecker, just in case you are reading this, I did not find anymore what links you gave me last time we talked about it. But this seems to at least get it working on non crypto-enabed hardware (e.g. Raspberry Pi 4) :-)

In the long run, we might want to further refactor the code a bit to not depend on crypto hashes entirely for the usecases we are having, which are:

We are currently using hash keys for:

- texture atlas tiles for glyphs - we could simply use glyph keys here
- texture atlas tiles for box drawing glyphs - same as for regular text / emoji glyphs
- texture atlas tiles for image fragments (used for image display in the TE - this might only need some minor tweaks to not depend on crypto
- background image content hash - could probably be living completely without that idea

It's probably the easiest to just touch `StrongHash` implementation in order to provide alternative implementations, because  things like LRU cache and LRU hash-table are a hard requirement.