### PR TITLE
Reworks initiating mouse selection in alt-screen mode.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Fixes use of config `bypass_mouse_protocol_modifier` that was ignored.</li>
           <li>Fixes abnormal termination on incomplete foreground/background color-pair specification.</li>
           <li>Fixes `SendChars` input acion to actually send the chars as-is to the standard input of the connected application.</li>
+          <li>Fixes mouse selection to only be initiated if actually meant to, i.e. in alt screen mode only if bypass-modifier was pressed (#1017).</li>
           <li>Adds normal mode motion `[[`, `]]`, `[]`, `][` mimmicking exactly what vim does.</li>
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
           <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -648,18 +648,17 @@ bool Terminal::sendMousePressEvent(Modifier modifier,
                                    bool uiHandledHint)
 {
     if (button == MouseButton::Left)
-        uiHandledHint = handleMouseSelection(modifier) || uiHandledHint;
-
-    if (!allowPassMouseEventToApp(modifier))
-        return false;
+    {
+        _leftMouseButtonPressed = true;
+        if (!allowPassMouseEventToApp(modifier))
+            uiHandledHint = handleMouseSelection(modifier) || uiHandledHint;
+    }
 
     verifyState();
 
-    auto const eventSent = _state.inputGenerator.generateMousePress(
-        modifier, button, _currentMousePosition, pixelPosition, uiHandledHint);
-
-    if (!eventSent)
-        return false;
+    if (allowPassMouseEventToApp(modifier))
+        _state.inputGenerator.generateMousePress(
+            modifier, button, _currentMousePosition, pixelPosition, uiHandledHint);
 
     // TODO: Ctrl+(Left)Click's should still be catched by the terminal iff there's a hyperlink
     // under the current position
@@ -674,7 +673,6 @@ bool Terminal::handleMouseSelection(Modifier modifier)
     double const diff_ms = chrono::duration<double, milli>(_currentTime - _lastClick).count();
     _lastClick = _currentTime;
     _speedClicks = (diff_ms >= 0.0 && diff_ms <= 750.0 ? _speedClicks : 0) % 3 + 1;
-    _leftMouseButtonPressed = true;
 
     auto const startPos = CellLocation {
         _currentMousePosition.line - boxed_cast<LineOffset>(_viewport.scrollOffset()),

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -707,7 +707,8 @@ class Terminal
 
     bool allowPassMouseEventToApp(Modifier currentlyPressedModifier) const noexcept
     {
-        return allowInput() && !allowBypassAppMouseGrabViaModifier(currentlyPressedModifier);
+        return _state.inputGenerator.mouseProtocol().has_value() && allowInput()
+               && !allowBypassAppMouseGrabViaModifier(currentlyPressedModifier);
     }
 
     template <typename BlinkerState>


### PR DESCRIPTION
Fixes mouse selection to only be initiated if actually meant to, i.e. in alt screen mode only if bypass-modifier was pressed 

This should ideally also fix #1017.

/cc @cqexbesd