### PR TITLE
Print \n after fatal error messages

### DIFF
--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -238,12 +238,13 @@ int App::run(int argc, char const* argv[])
             if (parameters().get<bool>(name))
                 return handler();
 
-        std::cerr << fmt::format("Usage error.\n");
+        std::cerr << fmt::format("Usage error.\n") << endl;
         return EXIT_FAILURE;
     }
     catch (exception const& e)
     {
-        std::cerr << fmt::format("Unhandled error caught. {}", e.what());
+        std::cerr << fmt::format("Unhandled error caught. {}", e.what())
+			<< endl;
         return EXIT_FAILURE;
     }
 }

--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -238,13 +238,12 @@ int App::run(int argc, char const* argv[])
             if (parameters().get<bool>(name))
                 return handler();
 
-        std::cerr << fmt::format("Usage error.\n") << endl;
+        std::cerr << "Usage error." << endl;
         return EXIT_FAILURE;
     }
     catch (exception const& e)
     {
-        std::cerr << fmt::format("Unhandled error caught. {}", e.what())
-			<< endl;
+        std::cerr << fmt::format("Unhandled error caught. {}", e.what()) << endl;
         return EXIT_FAILURE;
     }
 }


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Add `endl` to `cout` lines when printing fatal error messages.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Currently fatal error messages get shell prompts appended.
```

## How Has This Been Tested?

- I ran `countour debug` and made sure there was a new line.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
