### PR TITLE
[vtbackend] VtInputHandler: Fixes vi-like motion `t{space}`.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Fixes `SendChars` input acion to actually send the chars as-is to the standard input of the connected application.</li>
           <li>Fixes mouse selection to only be initiated if actually meant to, i.e. in alt screen mode only if bypass-modifier was pressed (#1017).</li>
           <li>Fixes mouse selection within scrolloff setting to not cause the viewport to jump anymore (#1019).</li>
+          <li>Fixes vi-like motion `t{space}` (#1037).</li>
           <li>Adds normal mode motion `[[`, `]]`, `[]`, `][` mimmicking exactly what vim does.</li>
           <li>Adds normal mode motion `[m` and `]m` to jump line marks up/down.</li>
           <li>Adds normal mode motion `mm` to toggle the line mark at the current active cursor position.</li>

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -161,6 +161,18 @@ TEST_CASE("vi.motions: M", "[vi]")
     CHECK(mock.terminal.state().viCommands.cursorPosition == 4_lineOffset + 1_columnOffset);
 }
 
+TEST_CASE("vi.motion: t{char}", "[vi]")
+{
+    auto mock = setupMockTerminal("One.Two..Three and more\r\n"
+                                  "   On the next line.",
+                                  terminal::PageSize { terminal::LineCount(10), terminal::ColumnCount(40) });
+    mock.sendCharPressSequence("te"); // jump to the char before first `e`, which is `n`.
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 1_columnOffset);
+
+    mock.sendCharPressSequence("t "); // jump to the char before first space character, which is `e`.
+    REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 13_columnOffset);
+}
+
 TEST_CASE("vi.motion: b", "[vi]")
 {
     auto mock = setupMockTerminal("One.Two..Three and more\r\n"

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -224,7 +224,7 @@ void ViInputHandler::registerCommand(ModeSelect modes, std::string_view command,
 {
     Require(!!handler);
 
-    auto commandStr = std::string(command.data(), command.size());
+    auto commandStr = crispy::replace(std::string(command.data(), command.size()), "<Space>", " ");
 
     switch (modes)
     {
@@ -440,8 +440,6 @@ bool ViInputHandler::sendCharPressEvent(char32_t ch, Modifier modifier)
         _pendingInput += "<ESC>";
     else if (ch == '\b')
         _pendingInput += "<BS>";
-    else if (ch == ' ')
-        _pendingInput += "<Space>";
     else
         _pendingInput += unicode::convert_to<char>(ch);
 


### PR DESCRIPTION
Thanks @cqexbesd for reporting this to me.

This PR fixes motions like `yt ` but actually anything else that includes whitespace, like `f ` or `F ` etc.

Fixes #1037.