### PR TITLE
Fixes PasteSelection on mouse middle-click not working

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -553,6 +553,7 @@ void TerminalSession::sendMousePressEvent(Modifier _modifier,
                                           PixelCoordinate _pixelPosition)
 {
     auto const uiHandledHint = false;
+    InputLog()("Mouse press received: {} {}\n", _modifier, _button);
 
     terminal().tick(steady_clock::now());
 

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -656,14 +656,14 @@ bool Terminal::sendMousePressEvent(Modifier modifier,
 
     verifyState();
 
-    if (allowPassMouseEventToApp(modifier))
-        _state.inputGenerator.generateMousePress(
-            modifier, button, _currentMousePosition, pixelPosition, uiHandledHint);
+    auto const eventHandledByApp = allowPassMouseEventToApp(modifier)
+                                   && _state.inputGenerator.generateMousePress(
+                                       modifier, button, _currentMousePosition, pixelPosition, uiHandledHint);
 
     // TODO: Ctrl+(Left)Click's should still be catched by the terminal iff there's a hyperlink
     // under the current position
     flushInput();
-    return !isModeEnabled(DECMode::MousePassiveTracking);
+    return eventHandledByApp && !isModeEnabled(DECMode::MousePassiveTracking);
 }
 
 bool Terminal::handleMouseSelection(Modifier modifier)

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -409,7 +409,13 @@ TEST_CASE("Terminal.TextSelection", "[terminal]")
         Modifier::None, 1_lineOffset + 1_columnOffset, pixelCoordinate, uiHandledHint);
 
     mock.terminal.tick(1s);
-    mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, pixelCoordinate, uiHandledHint);
+    auto const appHandledMouse =
+        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, pixelCoordinate, uiHandledHint);
+
+    // We want to ensure that this call is returning false if the app has not explicitly requested
+    // to listen on mouse events (without passive mode being on).
+    REQUIRE(appHandledMouse == false);
+
     CHECK(mock.terminal.selector()->state() == Selection::State::Waiting);
 
     // Mouse is pressed, but we did not start selecting (by moving the mouse) yet,


### PR DESCRIPTION
Fixes #1036. Sorry for the inconveniences.

This bug was introduced due to a recent refactor of mouse input handling, actually to reduce code complexity. Apparently I have removed too much, but it's working and a little bit tested now. :)