### PR TITLE
Fix header dependency changes in gcc 13

### DIFF
--- a/src/crispy/base64.h
+++ b/src/crispy/base64.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
ref: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

## Description

the full build information in #1042 

## Motivation and Context

Why is this change required? What problem does it solve?

the <cstdint> header need to be included explicitly when you compile with GCC 13.

## How Has This Been Tested?

the detailed test information also in #1042 

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
