### PR TITLE
Fixes scroll up when infinite history limit set, by allocating more

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -123,6 +123,7 @@
           <li>Adds shell integration for tcsh shell.</li>
           <li>Improve performance of parsing UTF-8 text on ARM64 platfroms through the use SIMD instructions.</li>
           <li>Contour can now run on platforms not supporting hardware crypto extension for ARM64 nor AES-NI for x86-64. Hardware acceleration support can be configured to be included at compile time.</li>
+          <li>Fixes scroll up when infinte history limit is set</li>
         </ul>
       </description>
     </release>

--- a/src/crispy/times.h
+++ b/src/crispy/times.h
@@ -200,6 +200,40 @@ namespace detail
     {
         return detail::Times2D<I, T1, T2> { std::move(a), std::move(b) };
     }
+
+    template <typename I,
+              typename T,
+              typename Callable,
+              typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T>, int> = 0>
+    constexpr void operator|(detail::Times<I, T> times, Callable callable)
+    {
+        for (auto&& i: times)
+            callable(i);
+    }
+
+    template <typename I,
+              typename T,
+              typename Callable,
+              typename std::enable_if_t<std::is_invocable_r_v<void, Callable>, int> = 0>
+    constexpr void operator|(detail::Times<I, T> times, Callable callable)
+    {
+        for ([[maybe_unused]] auto&& i: times)
+            callable();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    template <typename I,
+              typename T1,
+              typename T2,
+              typename Callable,
+              typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T1, T2>, int> = 0>
+    constexpr void operator|(detail::Times2D<I, T1, T2> times, Callable callable)
+    {
+        for (auto&& [i, j]: times)
+            callable(i, j);
+    }
+
 } // namespace detail
 
 // TODO: give random access hints to STL algorithms
@@ -216,43 +250,10 @@ constexpr inline detail::Times<T, T> times(T count)
     return detail::Times<T, T> { T(0), count, T(1) };
 }
 
-template <typename I,
-          typename T,
-          typename Callable,
-          typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T>, int> = 0>
-constexpr void operator|(detail::Times<I, T> times, Callable callable)
-{
-    for (auto&& i: times)
-        callable(i);
-}
-
-template <typename I,
-          typename T,
-          typename Callable,
-          typename std::enable_if_t<std::is_invocable_r_v<void, Callable>, int> = 0>
-constexpr void operator|(detail::Times<I, T> times, Callable callable)
-{
-    for ([[maybe_unused]] auto&& i: times)
-        callable();
-}
-
-// ---------------------------------------------------------------------------------------------------
-
 template <typename T>
 constexpr inline detail::Times2D<T, T, T> times2D(T a, T b)
 {
     return detail::Times2D<T, T, T> { std::move(a), std::move(b) };
-}
-
-template <typename I,
-          typename T1,
-          typename T2,
-          typename Callable,
-          typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T1, T2>, int> = 0>
-constexpr void operator|(detail::Times2D<I, T1, T2> times, Callable callable)
-{
-    for (auto&& [i, j]: times)
-        callable(i, j);
 }
 
 } // namespace crispy


### PR DESCRIPTION
When a scroll up is performed and there are not enough lines available to scroll we evict lines from ring buffer. But if user has set infinite history limit, then contour should allocate all required line before scrolling up.
Fixes #1040 