### PR TITLE
Update install-deps.sh script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
           envs: 'MYTOKEN MYTOKEN2'
           usesh: true
           copyback: false
-          prepare: pkg install -y curl
+          prepare: pkg install -y wget
           run: |
             set -ex
             pwd

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -43,10 +43,10 @@ fetch_and_unpack()
     FULL_DISTFILE="$SYSDEPS_DIST_DIR/$DISTFILE"
 
     if ! test -f "$FULL_DISTFILE"; then
-        if which curl &>/dev/null; then
-            curl -L -o "$FULL_DISTFILE" "$URL"
-        elif which wget &>/dev/null; then
+        if which wget &>/dev/null; then
             wget -O "$FULL_DISTFILE" "$URL"
+        elif which curl &>/dev/null; then
+            curl -L -o "$FULL_DISTFILE" "$URL"
         elif which fetch &>/dev/null; then
             # FreeBSD
             fetch -o "$FULL_DISTFILE" "$URL"
@@ -172,6 +172,7 @@ install_deps_popos()
         libx11-xcb-dev
         libyaml-cpp-dev
         make
+        ninja-build
         ncurses-bin
         pkg-config
         qtbase5-dev
@@ -211,6 +212,7 @@ install_deps_ubuntu()
         libx11-xcb-dev
         libyaml-cpp-dev
         make
+        ninja-build
         ncurses-bin
         pkg-config
     "


### PR DESCRIPTION
On newly installed ubuntu running `./scripts/install-deps.sh ` cause error 
` ./scripts/install-deps.sh : 47 curl not found` 
Also, while we are installing `ninja` on all platform `ubuntu` and `pop os` were missing