### PR TITLE
Fixes terminfo `tsl` to how todays apps are using it (e.g. zsh) to simply set the window title.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -106,7 +106,7 @@
     <release version="0.3.12" urgency="medium" type="development">
       <description>
         <ul>
-          <li> ... </li>
+          <li>Fixes terminfo `tsl` to how todays apps are using it (e.g. zsh) to simply set the window title.</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Capabilities.cpp
+++ b/src/vtbackend/Capabilities.cpp
@@ -211,8 +211,9 @@ namespace
         // tsl (to_status_line):
         // 1. DECSSDT 2 (show to host writable status line)
         // 2. DECSASD 1 (set host writable statusline as active target)
-        // 3. CUP 1;%d (move cursor to given column, defaulting to 1)
-        String { "ts"_tcap, "tsl"sv, "\033[2$~\033[1$}\033[1;%dH"sv }, // To status line (used to set window titles)
+        // 3. CUP (move cursor to top left)
+        // 4. ED 2 (clear screen)
+        String { "ts"_tcap, "tsl"sv, "\033[2$~\033[1$}\033[H\033[2J"sv }, // To status line (used to set window titles)
 
         // fsl (from_status_line):
         // 1. DECSASD (set main display as active display target again)


### PR DESCRIPTION
zsh with stock oh-my-zsh seems to use `tsl` / `fsl` terminfo entries to set the window title. This broke however. Also due to one bad part in `tsl`. But generally we adapted `tsl` a bit to also clear the statusline and have it always start with an empty one, when using `tsl`.

To not mess with the users (using oh-my-zsh), another PR needs to follow-up that should add "programmatically showing the host programmable statusline" behind the permission wall (just like font change etc). So users can also configure it in the config file (per profile) how they want the terminal to react to such requests