### PR TITLE
Properly escape strings for tcsh

### DIFF
--- a/src/contour/shell-integration/shell-integration.tcsh
+++ b/src/contour/shell-integration/shell-integration.tcsh
@@ -1,2 +1,2 @@
-alias precmd 'echo -n "\033[?2028l\033[>M\033]7;$PWD\033\\";'
-alias postcmd 'echo -n "\033[?2028h";'
+alias precmd 'echo -n "\\e[?2028l\\e[>M\\e]7;$PWD\\e\\\\";'
+alias postcmd 'echo -n "\\e[?2028h";'


### PR DESCRIPTION
## Description

```markdown
The code for tcsh shell integration was missing a round of escapes. This lead to unbalanced quotes and so an error from the shell when it was processed (e.g. when opening a new window).

I also swapped `\033` for `\e` as I think the later will be more readable to people using a C based shell.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Previous code didn't work and printed errors when a new shell started.
```

## How Has This Been Tested?

I just ran it in my shell. 

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
