### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ via the CLI (see below), these currently exist for zsh, fish and tcsh.
 
 ## Installing from source
 
-It's best installed from supported package managers, but if you want
-to build from source, it is recommended to execute the `scripts/install-deps.sh` script.
+Contour is best installed from supported package managers, but you can build
+from source by following the instruction below.
 
-### Prerequisites UNIX-like systems (Linux, FreeBSD, OS/X)
+### UNIX-like systems (Linux, FreeBSD, OS/X)
+
+#### Prerequisites
 
 ```sh
 ./scripts/install-deps.sh
@@ -95,19 +97,45 @@ to build from source, it is recommended to execute the `scripts/install-deps.sh`
 This script *might* ask you for the administrator password if a package dependency
 can be insalled via the system package manager.
 
-### Prerequisites Windows 10 or newer
+#### Compile
+
+```sh
+cmake -S . -B build -G Ninja
+cmake --build build/
+
+# Optionally, if you want to install from source
+cmake --build build/ --target install
+```
+
+#### Windows 10 or newer
+
+#### Prerequisites
 
 For Windows, you must have Windows 10, 2018 Fall Creators Update, and Visual Studio 2019, installed.
 It will neither build nor run on any prior Windows OS, due to libterminal making use of [ConPTY API](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/).
 
-```psh
-.\scripts\install-deps.ps1
+1. Set up [vcpkg](https://vcpkg.io/en/getting-started.html), preferably somewhere high up in the folder hierarchy, and add the folder to your `PATH`.
+
+```
+cd C:\
+git clone git clone https://github.com/Microsoft/vcpkg.git
+.\vcpkg\bootstrap-vcpkg.bat
 ```
 
-### Compile
+2. Install Visual Studio Build Tools (make sure to select the CLI tools for
+   C++, which you might need to do in the separate components tab).
+3. Install Qt6 (i.e. to C:\Qt)
+4. Open the _developer_ version of Powershell.
+5. In the `contour` source folder execute `.\scripts\install-deps.ps1`. This step may take a _very_ long time.
 
-```sh
-cmake -S . -B build -G Ninja
+
+#### Compile
+
+In the _developer_ version of Powershell:
+
+```psh
+# change paths accordingly if you installed QT and vcpkg to somewhere else
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.5.0\msvc2019_64\lib\cmake
 cmake --build build/
 
 # Optionally, if you want to install from source

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Click the following button install Contour from the Flathub store.
 
 ## Configuration
 
-In order to set up Contour, it is necessary to modify the configuration file `contour.yml`, which is initially generated in the `$HOME/.config/contour` directory.
+In order to set up Contour, it is necessary to modify the configuration file
+`contour.yml`, which is initially generated in the `$HOME/.config/contour`
+directory. Some features also require shell integration. These can be generated
+via the CLI (see below), these currently exist for zsh, fish and tcsh.
 
 ## Installing from source
 


### PR DESCRIPTION
## Description

Two updates to the README:

Compiling on Windows is not possible based on the current instructions.
Add additional instructions regarding prerequisites that need to be
manually installed and the necessary flags for the build tools so these
are also found during compilation. Restructure the installing from
source part to separate the two different type of instructions (i.e.
Windows from everything else with more sane development environment).

The shell integration was previously hidden in the CLI options. Add an
explicit mention of them at the configuration part.



## How Has This Been Tested?

N/A

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
