### PR TITLE
Update VCPKG to latest release (currently used one yields 404 on some packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,7 +348,7 @@ jobs:
         with:
           vcpkgArguments: catch2 fmt freetype fontconfig harfbuzz yaml-cpp range-v3
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
-          vcpkgGitCommitId: e69dd972ba64840955f46704ecce6241bf607c0f
+          vcpkgGitCommitId: 2023.04.15
           vcpkgTriplet: x64-windows
       - name: "create build directory"
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           vcpkgArguments: catch2 fmt freetype fontconfig harfbuzz yaml-cpp range-v3
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
-          vcpkgGitCommitId: e69dd972ba64840955f46704ecce6241bf607c0f
+          vcpkgGitCommitId: 2023.04.15
           vcpkgTriplet: x64-windows
       - name: Cache Qt
         id: cache-qt


### PR DESCRIPTION
this hopefully fixes the Windows build failures on CI.