### PR TITLE
Model mode: Adds text object `im` and `am` to select the range between two line marks

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -122,6 +122,7 @@
           <li>Adds config entry `profiles.*.status_line.sync_to_window_title` to synchronize the window title with the host writable statusline (if it was denied to be shown).</li>
           <li>Extends `ViNormalMode` to toggle between insert and normal mode rather than just entering normal mode.</li>
           <li>Modal mode: Adds Return key to also move the cursor down (like vim).</li>
+          <li>Model mode: Adds text object `im` and `am` to select the range between two line marks.</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -597,6 +597,25 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
         case TextObject::BackQuotes: return expandMatchingPair(scope, '`', '`');
         case TextObject::CurlyBrackets: return expandMatchingPair(scope, '{', '}');
         case TextObject::DoubleQuotes: return expandMatchingPair(scope, '"', '"');
+        case TextObject::LineMark:
+            // Walk the line upwards until we find a marked line.
+            while (
+                a.line > gridTop
+                && !(unsigned(_terminal.currentScreen().lineFlagsAt(a.line)) & unsigned(LineFlags::Marked)))
+                --a.line;
+            if (scope == TextObjectScope::Inner && a != cursorPosition)
+                ++a.line;
+            // Walk the line downwards until we find a marked line.
+            while (
+                b.line < gridBottom
+                && !(unsigned(_terminal.currentScreen().lineFlagsAt(b.line)) & unsigned(LineFlags::Marked)))
+                ++b.line;
+            if (scope == TextObjectScope::Inner && b != cursorPosition)
+                --b.line;
+            // Span the range from left most column to right most column.
+            a.column = ColumnOffset(0);
+            b.column = rightMargin;
+            break;
         case TextObject::Paragraph:
             while (a.line > gridTop && !_terminal.currentScreen().isLineEmpty(a.line - 1))
                 --a.line;

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -128,8 +128,9 @@ void ViInputHandler::registerAllCommands()
         // clang-format on
     } };
 
-    auto constexpr textObjectMappings = std::array<std::pair<char, TextObject>, 14> { {
+    auto constexpr textObjectMappings = std::array<std::pair<char, TextObject>, 15> { {
         { '"', TextObject::DoubleQuotes },
+        { 'm', TextObject::LineMark },
         { '(', TextObject::RoundBrackets },
         { ')', TextObject::RoundBrackets },
         { '<', TextObject::AngleBrackets },

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -125,6 +125,7 @@ enum class TextObject
     AngleBrackets = '<',  // i<  a<
     CurlyBrackets = '{',  // i{  a{
     DoubleQuotes = '"',   // i"  a"
+    LineMark = 'm',       // im  am
     Paragraph = 'p',      // ip  ap
     RoundBrackets = '(',  // i(  a(
     SingleQuotes = '\'',  // i'  a'
@@ -308,6 +309,7 @@ struct formatter<terminal::TextObject>
             case TextObject::BackQuotes: return fmt::format_to(ctx.out(), "BackQuotes");
             case TextObject::CurlyBrackets: return fmt::format_to(ctx.out(), "CurlyBrackets");
             case TextObject::DoubleQuotes: return fmt::format_to(ctx.out(), "DoubleQuotes");
+            case TextObject::LineMark: return fmt::format_to(ctx.out(), "LineMark");
             case TextObject::Paragraph: return fmt::format_to(ctx.out(), "Paragraph");
             case TextObject::RoundBrackets: return fmt::format_to(ctx.out(), "RoundBrackets");
             case TextObject::SingleQuotes: return fmt::format_to(ctx.out(), "SingleQuotes");


### PR DESCRIPTION
example use is e.g.

- `vim`, `vam`
- `yim`, `yam`