### PR TITLE
Linux: Adds support for writing to utmp/wtmp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -610,7 +610,6 @@ jobs:
           CMAKE_CXX_STANDARD=20
           if [[ "${{ matrix.os_version }}" = "22.04" ]]; then
             EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DCONTOUR_QT_VERSION=5"
-
           fi
           BUILD_DIR="build" \
             CMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -121,6 +121,7 @@
           <li>Adds `gui.shader` log option for the output of shader configuration procedure (#715).</li>
           <li>Adds config entry `profiles.*.status_line.position` to change statusline position to be either bottom (default) or top.</li>
           <li>Adds config entry `profiles.*.status_line.sync_to_window_title` to synchronize the window title with the host writable statusline (if it was denied to be shown).</li>
+          <li>Linux: Adds support for writing to utmp/wtmp.</li>
           <li>Extends `ViNormalMode` to toggle between insert and normal mode rather than just entering normal mode.</li>
           <li>Modal mode: Adds Return key to also move the cursor down (like vim).</li>
           <li>Model mode: Adds text object `im` and `am` to select the range between two line marks.</li>

--- a/scripts/ci/notcurses-install-deps.sh
+++ b/scripts/ci/notcurses-install-deps.sh
@@ -24,7 +24,8 @@ sudo apt install -y \
             libharfbuzz0b \
             libqt5core5a \
             libqt5gui5 \
-            libqt5network5 \
             libqt5multimedia5 \
+            libqt5network5 \
             libqt5x11extras5 \
+            libutempter0 \
             libyaml-cpp0.7

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -169,6 +169,7 @@ install_deps_popos()
         libqt5gui5
         libqt5opengl5-dev
         libqt5x11extras5-dev
+        libutempter-dev
         libx11-xcb-dev
         libyaml-cpp-dev
         make
@@ -209,6 +210,7 @@ install_deps_ubuntu()
         libfontconfig1-dev
         libfreetype6-dev
         libharfbuzz-dev
+        libutempter-dev
         libx11-xcb-dev
         libyaml-cpp-dev
         make
@@ -317,6 +319,7 @@ install_deps_arch()
         ninja \
         pkg-config \
         range-v3 \
+        libutempter \
         yaml-cpp \
     "
 
@@ -361,6 +364,7 @@ install_deps_suse()
         libqt5-qtbase-devel
         libqt5-qtmultimedia-devel
         libqt5-qtx11extras-devel
+        libutempter-devel
         libxcb-devel
         ncurses-devel
         ninja
@@ -387,6 +391,7 @@ install_deps_fedora()
         ninja-build
         pkgconf
         range-v3-devel
+        libutempter-devel
         yaml-cpp-devel
     "
 

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -7,6 +7,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     set(FREEBSD TRUE)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+endif()
+
 option(CONTOUR_PERF_STATS "Enables debug printing some performance stats." OFF)
 option(CONTOUR_VT_METRICS "Enables collecting and exit-printing some VT usage metrics." OFF)
 option(CONTOUR_SCROLLBAR "Enables scrollbar in GUI frontend." ON)
@@ -294,6 +298,10 @@ else()
         set(DEPENDS_EXTRA ", libyaml-cpp0.5v5")
     elseif("${LSB_RELEASE_NUMBER}" STREQUAL "20.04")
         set(DEPENDS_EXTRA ", libyaml-cpp0.6")
+    endif()
+
+    if(LINUX)
+        set(DEPENDS_EXTRA ", libutempter0")
     endif()
 
 

--- a/src/vtpty/CMakeLists.txt
+++ b/src/vtpty/CMakeLists.txt
@@ -29,6 +29,7 @@ set(vtpty_HEADERS
 if(LINUX)
     set(vtpty_HEADERS ${vtpty_HEADERS} LinuxPty.h)
     set(vtpty_SOURCES ${vtpty_SOURCES} LinuxPty.cpp)
+    set(vtpty_LIBRARIES ${vtpty_LIBRARIES} utempter)
 endif()
 
 if(UNIX)


### PR DESCRIPTION
@cqexbesd noted that we're not logging to utmp. Using `libutempter` on Linux this is simply 2 calls to get it done.