### PR TITLE
Fix/cursor shape in vi modes

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -114,6 +114,7 @@
           <li>Fixes statusline being misplaced after resize when being in alt screen (#1091).</li>
           <li>Fixes hyperlinks with IDs (#1088)</li>
           <li>Fixes hyperlink highlight when screen has been scrolled (#1084)</li>
+          <li>Fixes cursor shape changes when entering vi-like normal mode or visual mode.</li>
           <li>Improves mouse selection to be more natural extending into new grid cells.</li>
           <li>Modal mode: Improves how `[m` jumps from the current prompt to the next prompt above it.</li>
           <li>Adds `profiles.*.permissions.display_host_writable_statusline` to allow the user to intervene in `DECSSDT 2` VT sequence to show the host writable statusline.</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1693,7 +1693,7 @@ namespace
                     parseCursorConfig(visualModeNode["cursor"], _usedKeys, basePath + ".visual_mode.cursor"))
             {
                 _usedKeys.emplace(basePath + ".visual_mode.cursor");
-                profile.inputModes.normal.cursor = cursorOpt.value();
+                profile.inputModes.visual.cursor = cursorOpt.value();
             }
         }
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -620,9 +620,9 @@ namespace
         return nullopt;
     }
 
-    optional<config::CursorConfig> parseCursorConfig(YAML::Node rootNode,
+    optional<config::CursorConfig> parseCursorConfig(YAML::Node const& rootNode,
                                                      UsedKeys& usedKeys,
-                                                     std::string basePath)
+                                                     std::string const& basePath)
     {
         if (!rootNode)
             return nullopt;

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1190,6 +1190,10 @@ void TerminalSession::configureCursor(config::CursorConfig const& cursorConfig)
     terminal_.setCursorBlinkingInterval(cursorConfig.cursorBlinkInterval);
     terminal_.setCursorDisplay(cursorConfig.cursorDisplay);
     terminal_.setCursorShape(cursorConfig.cursorShape);
+
+    // Force a redraw of the screen
+    // to ensure the correct cursor shape is displayed.
+    scheduleRedraw();
 }
 
 void TerminalSession::configureDisplay()


### PR DESCRIPTION
Fixes a bug in changing cursor shape based on input mode (insert, normal, visual select).

Switching between insert and normal mode already worked (assuming they have different cursor shape configured), but visual select mode has kind of overridden the normal mode's configuration again.

Refs #1105 