### PR TITLE
Avoid using utempter within Flatpak environment

### DIFF
--- a/src/vtpty/CMakeLists.txt
+++ b/src/vtpty/CMakeLists.txt
@@ -9,6 +9,10 @@ else()
     set(PLATFORM_SUFFIX "_unix")
 endif()
 
+if(EXISTS "/.flatpak-info")
+    set(FLATPAK TRUE)
+endif()
+
 set(vtpty_LIBRARIES crispy::core fmt::fmt-header-only Microsoft.GSL::GSL)
 
 set(vtpty_SOURCES
@@ -29,7 +33,9 @@ set(vtpty_HEADERS
 if(LINUX)
     set(vtpty_HEADERS ${vtpty_HEADERS} LinuxPty.h)
     set(vtpty_SOURCES ${vtpty_SOURCES} LinuxPty.cpp)
-    set(vtpty_LIBRARIES ${vtpty_LIBRARIES} utempter)
+    if(NOT FLATPAK)
+        set(vtpty_LIBRARIES ${vtpty_LIBRARIES} utempter)
+    endif()
 endif()
 
 if(UNIX)
@@ -42,6 +48,9 @@ endif()
 
 add_library(vtpty STATIC ${vtpty_SOURCES} ${vtpty_HEADERS})
 set_target_properties(vtpty PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+if(FLATPAK)
+    target_compile_definitions(vtpty PRIVATE FLATPAK=1)
+endif()
 target_include_directories(vtpty PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>

--- a/src/vtpty/LinuxPty.cpp
+++ b/src/vtpty/LinuxPty.cpp
@@ -39,7 +39,10 @@
 #include <pty.h>
 #include <pwd.h>
 #include <unistd.h>
-#include <utempter.h>
+
+#if !defined(FLATPAK)
+    #include <utempter.h>
+#endif
 
 using std::array;
 using std::max;
@@ -228,13 +231,17 @@ void LinuxPty::start()
     if (epoll_ctl(_epollFd, EPOLL_CTL_ADD, _stdoutFastPipe.reader(), &ev) < 0)
         throw runtime_error { "epoll setup failed to add stdout-fastpipe. "s + strerror(errno) };
 
+#if !defined(FLATPAK)
     utempter_add_record(_masterFd, hostnameForUtmp());
+#endif
 }
 
 LinuxPty::~LinuxPty()
 {
     PtyLog()("PTY destroying master (file descriptor {}).", _masterFd);
+#if !defined(FLATPAK)
     utempter_remove_record(_masterFd);
+#endif
     detail::saveClose(&_eventFd);
     detail::saveClose(&_epollFd);
     detail::saveClose(&_masterFd);


### PR DESCRIPTION
I had to apply this in order to release on Flathub (Flatpak). Seems like libutempter isn't really possible (as of right now) on it. We can re-evaluate in the future, if there's any interest.