### PR TITLE
Fixes search term rendering highlighting for search terms containing whitespaces

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
       <description>
         <ul>
           <li>Do not clear search term when entering search editor again.</li>
+          <li>Fixes search term rendering highlighting for search terms containing whitespaces (#966).</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/RenderBufferBuilder.h
+++ b/src/vtbackend/RenderBufferBuilder.h
@@ -127,9 +127,7 @@ class RenderBufferBuilder
 
     int _prevWidth = 0;
     bool _prevHasCursor = false;
-    State _state = State::Gap;
     LineOffset _lineNr = LineOffset(0);
-    bool _isNewLine = false;
     bool _useCursorlineColoring = false;
 
     // Offset into the search pattern that has been already matched.


### PR DESCRIPTION
Without this PR, search terms containing whitespaces where highlighted wrong in the render buffer output. This was due to the whitespace optimization. This PR disables the optimization due to the added complexity iff it would also need to handle proper search term match colorization when whitespaces were to be matched properly, too.


Closes #966