### PR TITLE
Invert direction for downwards glyphs

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
         <ul>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Fixes search term rendering highlighting for search terms containing whitespaces (#966).</li>
+          <li>Fixes rendering in cases of glyphs with inverted orientation (#1115).</li>
         </ul>
       </description>
     </release>

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -837,7 +837,13 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
     }
 
     // y-position relative to cell-bottom of glyphs top.
-    auto const yMax = _gridMetrics.baseline + glyph.position.y;
+    auto yMax = _gridMetrics.baseline + glyph.position.y;
+
+    if(yMax < 0)
+    {
+        RasterizerLog()("Encountered glyph with inverted direction, swaping to normal");
+        yMax *= -1;
+    }
 
     // y-position relative to cell-bottom of the glyphs bottom.
     auto const yMin = yMax - glyph.bitmapSize.height.as<int>();

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -839,10 +839,10 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
     // y-position relative to cell-bottom of glyphs top.
     auto yMax = _gridMetrics.baseline + glyph.position.y;
 
-    if(yMax < 0)
+    if (yMax < 0)
     {
         RasterizerLog()("Encountered glyph with inverted direction, swaping to normal");
-        yMax *= -1;
+        yMax = std::abs(yMax);
     }
 
     // y-position relative to cell-bottom of the glyphs bottom.


### PR DESCRIPTION
Closes #1115  
See https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_glyphslotrec
`bitmap_top` can  be negative, meaning that glyph direction is downward, this PR fixes the crash when contour can not display such glyphs, this is itself a hack since this is not how properly handle this case i suppose.
For example such figures still can be generated in contour 
![image](https://github.com/contour-terminal/contour/assets/44506630/7139fd3d-6f71-4589-8e53-9de368c515e6)
 