### PR TITLE
Deploy docs only from master branch commits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,6 @@ on:
       - '.github/workflows/docs.yml'
     branches:
       - master
-      - edge
-  pull_request:
-    branches:
-      - master
 
 concurrency:
   group: docs-${{ github.ref }}


### PR DESCRIPTION
We need to update  web page only when we make commits in master, otherwise if someone creates a pull request into master branch this person can update our web page