### PR TITLE
Fix font inheritance for profiles

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1602,6 +1602,7 @@ namespace
                      "regular",
                      profile.fonts.regular);
 
+        profile.fonts.bold = profile.fonts.regular;
         profile.fonts.bold.weight = text::font_weight::bold;
         softLoadFont(profile.fonts.textShapingEngine,
                      _usedKeys,
@@ -1610,6 +1611,7 @@ namespace
                      "bold",
                      profile.fonts.bold);
 
+        profile.fonts.italic = profile.fonts.regular;
         profile.fonts.italic.slant = text::font_slant::italic;
         softLoadFont(profile.fonts.textShapingEngine,
                      _usedKeys,


### PR DESCRIPTION
At the moment font settings for bold and italic does not inherit font family from regular font.
This cause errors during rendering, this fix usage of same font family for regular bold and italic text