### PR TITLE
show terminal dimension on resize

### DIFF
--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -171,6 +171,7 @@ ContourApp::ContourApp(): App("contour", "Contour Terminal Emulator", CONTOUR_VE
     link("contour.generate.config", bind(&ContourApp::configAction, this));
     link("contour.generate.integration", bind(&ContourApp::integrationAction, this));
     link("contour.info.vt", bind(&ContourApp::infoVT, this));
+    startedAt = std::chrono::system_clock::now();
 }
 
 template <typename Callback>

--- a/src/contour/ContourApp.h
+++ b/src/contour/ContourApp.h
@@ -15,6 +15,8 @@
 
 #include <crispy/App.h>
 
+#include <chrono>
+
 namespace contour
 {
 
@@ -27,6 +29,7 @@ class ContourApp: public crispy::App
     ContourApp();
 
     crispy::cli::Command parameterDefinition() const override;
+    std::chrono::time_point<std::chrono::system_clock> startedAt;
 
   private:
     int captureAction();

--- a/src/contour/TerminalWindow.cpp
+++ b/src/contour/TerminalWindow.cpp
@@ -16,6 +16,7 @@
 #include <contour/ContourGuiApp.h>
 #include <contour/TerminalWindow.h>
 #include <contour/helper.h>
+#include <chrono>
 
 #if defined(CONTOUR_SCROLLBAR)
     #include <contour/ScrollableDisplay.h>
@@ -133,6 +134,8 @@ TerminalWindow::TerminalWindow(ContourGuiApp& _app): _app { _app }
     terminalWidget_->setFocus();
 
     // statusBar()->showMessage("blurb");
+
+    resizeDialog = new TerminalResizeDialogWidget(this);
 }
 
 config::TerminalProfile const& TerminalWindow::profile() const
@@ -193,8 +196,12 @@ void TerminalWindow::resizeEvent(QResizeEvent* _event)
                  _event->size().height());
 
     QMainWindow::resizeEvent(_event);
-    // centralWidget()->resize(_event->size());
-    // updatePosition();
+
+    // Wait a bit in order to avoid first implicit resizing when calling `ContourGuiApp::newWindow`
+    auto elapsed = std::chrono::system_clock::now() - _app.startedAt;
+    if (elapsed > std::chrono::seconds(2)) {
+        resizeDialog->updateSize(_event->size());
+    }
 }
 
 bool TerminalWindow::event(QEvent* _event)

--- a/src/contour/TerminalWindow.h
+++ b/src/contour/TerminalWindow.h
@@ -18,6 +18,7 @@
 #include <contour/ContourGuiApp.h>
 #include <contour/TerminalSession.h>
 #include <contour/display/TerminalWidget.h>
+#include <contour/display/TerminalResizeDialogWidget.h>
 
 #include <vtbackend/Metrics.h>
 
@@ -81,6 +82,7 @@ class TerminalWindow: public QMainWindow
 #endif
 
     display::TerminalWidget* terminalWidget_ = nullptr;
+    TerminalResizeDialogWidget* resizeDialog = nullptr;
 };
 
 } // namespace contour

--- a/src/contour/display/CMakeLists.txt
+++ b/src/contour/display/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(ContourTerminalDisplay STATIC
     OpenGLRenderer.cpp OpenGLRenderer.h
     ShaderConfig.cpp ShaderConfig.h
     TerminalWidget.cpp TerminalWidget.h
+    TerminalResizeDialogWidget.cpp TerminalResizeDialogWidget.h
     ${QT_RESOURCES}
 )
 set_target_properties(ContourTerminalDisplay PROPERTIES AUTOMOC ON)

--- a/src/contour/display/TerminalResizeDialogWidget.cpp
+++ b/src/contour/display/TerminalResizeDialogWidget.cpp
@@ -1,0 +1,45 @@
+#include "TerminalResizeDialogWidget.h"
+
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QMainWindow>
+#include <QtCore/QTimer>
+
+#include <iostream>
+#include <qtimer.h>
+
+TerminalResizeDialogWidget::TerminalResizeDialogWidget(QMainWindow* parent): parent_ {parent}
+{
+    this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+
+    label_ = new QLabel(this);
+    auto font = QFont();
+    font.setWeight(QFont::Bold);
+    label_->setFont(font);
+
+    layout_ = new QVBoxLayout(this);
+    layout_->addWidget(label_);
+    layout_->setContentsMargins(0, 0, 0, 0);
+    layout_->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+
+    showTimer_ = new QTimer(this);
+    showTimer_->setSingleShot(true);
+    showTimer_->setInterval(800);
+    connect(showTimer_, &QTimer::timeout, [this]() { close(); });
+}
+
+void TerminalResizeDialogWidget::updateSize(const QSize& size)
+{
+    label_->setText(QString("%1 x %2").arg(size.width()).arg(size.height()));
+    center();
+    show();
+    showTimer_->start();
+}
+
+void TerminalResizeDialogWidget::center()
+{
+    auto point = parent_->geometry().center();
+    point.setX(point.x() - label_->width());
+    point.setY(point.y() - label_->height());
+    move(point);
+}

--- a/src/contour/display/TerminalResizeDialogWidget.cpp
+++ b/src/contour/display/TerminalResizeDialogWidget.cpp
@@ -5,9 +5,6 @@
 #include <QtWidgets/QMainWindow>
 #include <QtCore/QTimer>
 
-#include <iostream>
-#include <qtimer.h>
-
 TerminalResizeDialogWidget::TerminalResizeDialogWidget(QMainWindow* parent): parent_ {parent}
 {
     this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);

--- a/src/contour/display/TerminalResizeDialogWidget.h
+++ b/src/contour/display/TerminalResizeDialogWidget.h
@@ -1,6 +1,5 @@
-#include <QDialog>
-#include <qboxlayout.h>
-#include <qmainwindow.h>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QMainWindow>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QLabel>
 
@@ -10,7 +9,7 @@ class TerminalResizeDialogWidget : public QDialog
 
 public:
     TerminalResizeDialogWidget(QMainWindow *parent);
-    ~TerminalResizeDialogWidget() = default;
+    ~TerminalResizeDialogWidget() override = default;
     void updateSize(const QSize& size);
     void center();
 

--- a/src/contour/display/TerminalResizeDialogWidget.h
+++ b/src/contour/display/TerminalResizeDialogWidget.h
@@ -1,0 +1,22 @@
+#include <QDialog>
+#include <qboxlayout.h>
+#include <qmainwindow.h>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QLabel>
+
+class TerminalResizeDialogWidget : public QDialog
+{
+    Q_OBJECT
+
+public:
+    TerminalResizeDialogWidget(QMainWindow *parent);
+    ~TerminalResizeDialogWidget() = default;
+    void updateSize(const QSize& size);
+    void center();
+
+private:
+    QMainWindow* parent_;
+    QLabel* label_;
+    QVBoxLayout* layout_;
+    QTimer* showTimer_;
+};


### PR DESCRIPTION
## Description

```markdown
Display little dialog with terminal dimension on resize window.
```

## Motivation and Context

```markdown
Fix issue: https://github.com/contour-terminal/contour/issues/975
```
https://github.com/contour-terminal/contour/issues/975
## How Has This Been Tested?

Tested manually due the feature pertains to ui scope.

[contour-resize.webm](https://github.com/contour-terminal/contour/assets/43180519/4167d1be-73ea-4ceb-b364-f15f7a6860c8)

