### PR TITLE
clear search when switch to insert mode

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Fixes search term rendering highlighting for search terms containing whitespaces (#966).</li>
           <li>Fixes rendering in cases of glyphs with inverted orientation (#1115).</li>
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>
+          <li>Clear search term when switch to insert vi mode (#1135)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -271,6 +271,7 @@ void ViCommands::modeChanged(ViMode mode)
             _terminal.setMode(DECMode::VisibleCursor, _lastCursorVisible);
             _terminal.setCursorShape(_lastCursorShape);
             _terminal.viewport().forceScrollToBottom();
+            _terminal.clearSearch();
             _terminal.popStatusDisplay();
             _terminal.screenUpdated();
             break;

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -201,3 +201,17 @@ TEST_CASE("vi.motion: b", "[vi]")
     mock.sendCharPressSequence("b");
     REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 0_columnOffset);
 }
+
+
+TEST_CASE("ViCommands:modeChanged", "[vi]")
+{
+    auto mock = setupMockTerminal("Hello\r\n",
+                                  terminal::PageSize { terminal::LineCount(10), terminal::ColumnCount(40) });
+
+    SECTION("clearSearch() must be invoked when switch to ViMode::Insert")
+    {
+        mock.terminal.setNewSearchTerm(U"search_term", true);
+        mock.terminal.state().inputHandler.setMode(terminal::ViMode::Insert);
+        REQUIRE(mock.terminal.state().searchMode.pattern.empty());
+    }
+}

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -202,7 +202,6 @@ TEST_CASE("vi.motion: b", "[vi]")
     REQUIRE(mock.terminal.state().viCommands.cursorPosition == 0_lineOffset + 0_columnOffset);
 }
 
-
 TEST_CASE("ViCommands:modeChanged", "[vi]")
 {
     auto mock = setupMockTerminal("Hello\r\n",


### PR DESCRIPTION
## Description

There is a weird behavior when entering insert vi mode if you were previously doing searches. 
When you search for a term an then switch to insert vi mode, the search term is not deleted.  So the search term continues being evaluated if you still using the terminal.

## Demo of current behavior

[vi-search-mode.webm](https://github.com/contour-terminal/contour/assets/43180519/4b7ef934-91d2-44a5-aec1-39b4801fe9fa)


```markdown
Clear search term when switch to insert vi mode
```

## Motivation and Context

```markdown
Do not execute search term while using insert vi mode
```

## How Has This Been Tested?

- Manually
- Unit tests

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [X] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have gone through all the steps, and have thoroughly read the instructions
