### PR TITLE
Fix glyphs overlap by creating spacing between tiles in Atlas

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>
+          <li>Fix glyphs overlap for some fonts(#1022)</li>
         </ul>
       </description>
     </release>

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -187,12 +187,14 @@ void Renderer::configureTextureAtlas()
 {
     Require(_renderTarget);
 
-    auto atlasProperties =
-        atlas::AtlasProperties { atlas::Format::RGBA,
-                                 _gridMetrics.cellSize, // Cell size is used as GPU tile size.
-                                 _atlasHashtableSlotCount,
-                                 _atlasTileCount,
-                                 _directMappingAllocator.currentlyAllocatedCount };
+    // create 2px spacing between elements in Atlas
+    auto const atlasCell =
+        ImageSize { _gridMetrics.cellSize.width + Width(1), _gridMetrics.cellSize.height + Height(1) };
+    auto atlasProperties = atlas::AtlasProperties { atlas::Format::RGBA,
+                                                    atlasCell,
+                                                    _atlasHashtableSlotCount,
+                                                    _atlasTileCount,
+                                                    _directMappingAllocator.currentlyAllocatedCount };
 
     Require(atlasProperties.tileCount.value > 0);
 


### PR DESCRIPTION
Closes #1022 