### PR TITLE
Streamline naming in crispy and naming check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,6 +417,10 @@ jobs:
       - name: Install Clang
         if: ${{ startsWith(matrix.compiler, 'Clang') }}
         run: sudo apt install -y clang-${{ steps.extract_matrix.outputs.CC_VERSION }}
+      - name: Install Clang-Tidy
+        if: ${{ startsWith(matrix.compiler, 'Clang') }}
+        run: sudo apt install -y clang-tidy-${{ steps.extract_matrix.outputs.CC_VERSION }}
+
       - name: "create build directory"
         run: mkdir build
       - name: CMake version
@@ -427,7 +431,8 @@ jobs:
           CC_VER=$( echo "${{ matrix.compiler }}" | awk '{ print $2; }')
           test "${CC_NAME}" = "clang" && CC_EXE="clang++"
           test "${CC_NAME}" = "gcc"   && CC_EXE="g++"
-          [[ "${{ matrix.compiler }}" = "GCC 8" ]] || EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DPEDANTIC_COMPILER_WERROR=ON"
+          test "${{ matrix.compiler }}" = "GCC 8"  && EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DPEDANTIC_COMPILER_WERROR=ON"
+          test "${{ startsWith(matrix.compiler, 'Clang') }}" = "true" && EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DENABLE_TIDY=ON"
           BUILD_DIR="build" \
             CMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
             CXX="${CC_EXE}-${CC_VER}" \

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -2,7 +2,7 @@
 option(ENABLE_TIDY "Enable clang-tidy [default: OFF]" OFF)
 if(ENABLE_TIDY)
     find_program(CLANG_TIDY_EXE
-        NAMES clang-tidy-9 clang-tidy-8 clang-tidy-7 clang-tidy
+        NAMES clang-tidy
         DOC "Path to clang-tidy executable")
     if(NOT CLANG_TIDY_EXE)
         message(STATUS "[clang-tidy] Not found.")

--- a/scripts/ci-prepare-contour.sh
+++ b/scripts/ci-prepare-contour.sh
@@ -9,8 +9,6 @@ prepare_build_ubuntu()
 {
    cmake \
       -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-      -DPEDANTIC_COMPILER="ON" \
-      -DPEDANTIC_COMPILER_WERROR="OFF" \
       -S . -B ${BUILD_DIR} \
       ${EXTRA_CMAKE_FLAGS}
 }

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -23,6 +23,7 @@ Checks: >-
   cppcoreguidelines-*,
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-macro-usage,

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include "contour/Actions.h"
+#include "crispy/StrongHash.h"
 #include "vtbackend/ColorPalette.h"
 #include "vtbackend/primitives.h"
 
@@ -88,7 +89,7 @@ namespace contour::config
 
 namespace
 {
-    auto const ConfigLog = logstore::Category("config", "Logs configuration file loading.");
+    auto const ConfigLog = logstore::category("config", "Logs configuration file loading.");
 
     string processIdAsString()
     {
@@ -126,7 +127,7 @@ namespace
 
         auto backgroundImage = terminal::BackgroundImage {};
         backgroundImage.location = resolvedFileName;
-        backgroundImage.hash = crispy::StrongHash::compute(resolvedFileName.string());
+        backgroundImage.hash = crispy::strong_hash::compute(resolvedFileName.string());
         backgroundImage.opacity = opacity;
         backgroundImage.blur = blur;
 
@@ -307,7 +308,7 @@ namespace
                               vector<string_view> const& _keys,
                               size_t _offset,
                               T& _store,
-                              logstore::MessageBuilder const& _logger)
+                              logstore::message_builder const& _logger)
     {
         string parentKey = _basePath;
         for (size_t i = 0; i < _offset; ++i)
@@ -351,7 +352,7 @@ namespace
                       vector<string_view> const& _keys,
                       size_t _offset,
                       T& _store,
-                      logstore::MessageBuilder _logger)
+                      logstore::message_builder _logger)
     {
         string parentKey;
         for (size_t i = 0; i < _offset; ++i)
@@ -394,7 +395,7 @@ namespace
                       vector<string_view> const& _keys,
                       size_t _offset,
                       crispy::boxed<T, U>& _store,
-                      logstore::MessageBuilder const& _logger)
+                      logstore::message_builder const& _logger)
     {
         return tryLoadValue(_usedKeys, _root, _keys, _offset, _store.value, _logger);
     }
@@ -404,7 +405,7 @@ namespace
                       YAML::Node const& _root,
                       string const& _path,
                       T& _store,
-                      logstore::MessageBuilder const& _logger)
+                      logstore::message_builder& _logger)
     {
         auto const keys = crispy::split(_path, '.');
         _usedKeys.emplace(_path);
@@ -416,7 +417,7 @@ namespace
                       YAML::Node const& _root,
                       string const& _path,
                       crispy::boxed<T, U>& _store,
-                      logstore::MessageBuilder const& _logger)
+                      logstore::message_builder const& _logger)
     {
         return tryLoadValue(_usedKeys, _root, _path, _store.value, _logger);
     }
@@ -427,7 +428,7 @@ namespace
                       string const& _parentPath,
                       string const& _key,
                       T& _store,
-                      logstore::MessageBuilder const& _logger)
+                      logstore::message_builder const& _logger)
     {
         auto const path = fmt::format("{}.{}", _parentPath, _key);
         return tryLoadValue(_usedKeys, _doc, path, _store, _logger);
@@ -439,7 +440,7 @@ namespace
                               string const& _parentPath,
                               string const& _childKeyPath,
                               T& _store,
-                              logstore::MessageBuilder const& _logger)
+                              logstore::message_builder const& _logger)
     {
         // return tryLoadValue(_usedKeys, _node, _childKeyPath, _store); // XXX _parentPath
         auto const keys = crispy::split(_childKeyPath, '.');
@@ -458,7 +459,7 @@ namespace
                       string const& _parentPath,
                       string const& _key,
                       crispy::boxed<T, U>& _store,
-                      logstore::MessageBuilder const& _logger)
+                      logstore::message_builder const& _logger)
     {
         return tryLoadChild(_usedKeys, _doc, _parentPath, _key, _store.value, _logger);
     }
@@ -1311,7 +1312,7 @@ namespace
                                std::string const& _parentPath,
                                std::string const& _profileName,
                                unordered_map<string, terminal::ColorPalette> const& _colorschemes,
-                               logstore::MessageBuilder _logger)
+                               logstore::message_builder _logger)
     {
 
         if (auto colors = _profile["colors"]; colors) // {{{
@@ -1829,7 +1830,7 @@ std::string defaultConfigString()
 
 error_code createDefaultConfig(FileSystem::path const& _path)
 {
-    FileSystemError ec;
+    file_system_error ec;
     if (!_path.parent_path().empty())
     {
         FileSystem::create_directories(_path.parent_path(), ec);
@@ -1959,7 +1960,7 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
 
         if (!logFilePath.empty())
         {
-            _config.loggingSink = make_shared<logstore::Sink>(logEnabled, make_shared<ofstream>(logFilePath));
+            _config.loggingSink = make_shared<logstore::sink>(logEnabled, make_shared<ofstream>(logFilePath));
             logstore::set_sink(*_config.loggingSink);
         }
     }
@@ -2067,7 +2068,7 @@ void loadConfigFromFile(Config& _config, FileSystem::path const& _fileName)
             errorlog()("default_profile \"{}\" not found in profiles list.",
                        escape(_config.defaultProfileName));
         }
-        auto dummy = logstore::Category("dymmy", "empty logger", logstore::Category::State::Disabled);
+        auto dummy = logstore::category("dymmy", "empty logger", logstore::category::state::Disabled);
 
         for (auto i = profiles.begin(); i != profiles.end(); ++i)
         {

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -20,6 +20,7 @@
 
 #include <text_shaper/mock_font_locator.h>
 
+#include <crispy/StrongHash.h>
 #include <crispy/escape.h>
 #include <crispy/logstore.h>
 #include <crispy/overloaded.h>
@@ -45,7 +46,6 @@
 #include <vector>
 
 #include "contour/Actions.h"
-#include "crispy/StrongHash.h"
 #include "vtbackend/ColorPalette.h"
 #include "vtbackend/primitives.h"
 

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -232,14 +232,14 @@ struct Config
     // This value is rounted up to a value equal to the power of two.
     //
     // Default: 4096
-    crispy::StrongHashtableSize textureAtlasHashtableSlots = crispy::StrongHashtableSize { 4096 };
+    crispy::strong_hashtable_size textureAtlasHashtableSlots = crispy::strong_hashtable_size { 4096 };
 
     /// Number of tiles that must fit at lest into the texture atlas,
     /// excluding US-ASCII glyphs, cursor shapes and decorations.
     ///
     /// Value must be at least as large as grid cells available in the current view.
     /// This value is automatically adjusted if too small.
-    crispy::LRUCapacity textureAtlasTileCount = crispy::LRUCapacity { 4000 };
+    crispy::lru_capacity textureAtlasTileCount = crispy::lru_capacity { 4000 };
 
     // Configures the size of the PTY read buffer.
     // Changing this value may result in better or worse throughput performance.
@@ -288,7 +288,7 @@ struct Config
     InputMappings inputMappings;
 
     bool spawnNewProcess = false;
-    std::shared_ptr<logstore::Sink> loggingSink;
+    std::shared_ptr<logstore::sink> loggingSink;
 
     bool sixelScrolling = true;
     terminal::ImageSize maxImageSize = {}; // default to runtime system screen size.

--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -36,6 +36,8 @@
 #include <iostream>
 #include <memory>
 
+#include "crispy/CLI.h"
+
 #if !defined(_WIN32)
     #include <sys/ioctl.h>
 
@@ -73,7 +75,7 @@ namespace
             << "Stack Trace:\r\n"
             << "------------\r\n";
 
-        auto stackTrace = crispy::StackTrace();
+        auto stackTrace = crispy::stack_trace();
         auto symbols = stackTrace.symbols();
         for (auto const& symbol: symbols)
             out << symbol << "\r\n";
@@ -126,9 +128,9 @@ namespace
 } // namespace
 // }}}
 
-ContourApp::ContourApp(): App("contour", "Contour Terminal Emulator", CONTOUR_VERSION_STRING, "Apache-2.0")
+ContourApp::ContourApp(): app("contour", "Contour Terminal Emulator", CONTOUR_VERSION_STRING, "Apache-2.0")
 {
-    using Project = crispy::cli::about::Project;
+    using Project = crispy::cli::about::project;
     crispy::cli::about::registerProjects(
 #if defined(CONTOUR_BUILD_WITH_MIMALLOC)
         Project { "mimalloc", "", "" },
@@ -144,7 +146,7 @@ ContourApp::ContourApp(): App("contour", "Contour Terminal Emulator", CONTOUR_VE
         Project { "fmt", "MIT", "https://github.com/fmtlib/fmt" });
 
 #if defined(__linux__)
-    auto crashLogDirPath = crispy::App::instance()->localStateDir() / "crash";
+    auto crashLogDirPath = crispy::app::instance()->localStateDir() / "crash";
     FileSystem::create_directories(crashLogDirPath);
     crashLogDir = crashLogDirPath.string();
     // signal(SIGSEGV, segvHandler);
@@ -174,7 +176,7 @@ ContourApp::ContourApp(): App("contour", "Contour Terminal Emulator", CONTOUR_VE
 }
 
 template <typename Callback>
-auto withOutput(crispy::cli::FlagStore const& _flags, std::string const& _name, Callback _callback)
+auto withOutput(crispy::cli::flag_store const& _flags, std::string const& _name, Callback _callback)
 {
     std::ostream* out = &cout;
 
@@ -191,16 +193,16 @@ auto withOutput(crispy::cli::FlagStore const& _flags, std::string const& _name, 
 
 int ContourApp::infoVT()
 {
-    using Category = terminal::FunctionCategory;
+    using category = terminal::FunctionCategory;
     using std::pair;
     using terminal::VTExtension;
     using namespace std::string_view_literals;
 
-    for (auto const& [category, headline]: { pair { Category::C0, "Control Codes"sv },
-                                             pair { Category::ESC, "Escape Sequences"sv },
-                                             pair { Category::CSI, "Control Sequences"sv },
-                                             pair { Category::OSC, "Operating System Commands"sv },
-                                             pair { Category::DCS, "Device Control Sequences"sv } })
+    for (auto const& [category, headline]: { pair { category::C0, "Control Codes"sv },
+                                             pair { category::ESC, "Escape Sequences"sv },
+                                             pair { category::CSI, "Control Sequences"sv },
+                                             pair { category::OSC, "Operating System Commands"sv },
+                                             pair { category::DCS, "Device Control Sequences"sv } })
     {
         fmt::print("{}\n", headline);
         fmt::print("{}\n\n", string(headline.size(), '='));
@@ -301,105 +303,105 @@ int ContourApp::profileAction()
     return EXIT_SUCCESS;
 }
 
-crispy::cli::Command ContourApp::parameterDefinition() const
+crispy::cli::command ContourApp::parameterDefinition() const
 {
-    return CLI::Command {
+    return CLI::command {
         "contour",
         "Contour Terminal Emulator " CONTOUR_VERSION_STRING
         " - https://github.com/contour-terminal/contour/ ;-)",
-        CLI::OptionList {},
-        CLI::CommandList {
-            CLI::Command { "help", "Shows this help and exits." },
-            CLI::Command { "version", "Shows the version and exits." },
-            CLI::Command { "license",
+        CLI::option_list {},
+        CLI::command_list {
+            CLI::command { "help", "Shows this help and exits." },
+            CLI::command { "version", "Shows the version and exits." },
+            CLI::command { "license",
                            "Shows the license, and project URL of the used projects and Contour." },
-            CLI::Command { "list-debug-tags", "Lists all available debug tags and exits." },
-            CLI::Command {
+            CLI::command { "list-debug-tags", "Lists all available debug tags and exits." },
+            CLI::command {
                 "info",
                 "General informational outputs.",
-                CLI::OptionList {},
-                CLI::CommandList {
-                    CLI::Command { "vt", "Prints general information about supported VT sequences." },
+                CLI::option_list {},
+                CLI::command_list {
+                    CLI::command { "vt", "Prints general information about supported VT sequences." },
                 } },
-            CLI::Command {
+            CLI::command {
                 "generate",
                 "Generation utilities.",
-                CLI::OptionList {},
-                CLI::CommandList {
-                    CLI::Command { "parser-table",
+                CLI::option_list {},
+                CLI::command_list {
+                    CLI::command { "parser-table",
                                    "Dumps VT parser's state machine in dot-file format to stdout." },
-                    CLI::Command {
+                    CLI::command {
                         "terminfo",
                         "Generates the terminfo source file that will reflect the features of this version "
                         "of contour. Using - as value will write to stdout instead.",
                         {
-                            CLI::Option { "to",
-                                          CLI::Value { ""s },
+                            CLI::option { "to",
+                                          CLI::value { ""s },
                                           "Output file name to store the screen capture to. If - (dash) is "
                                           "given, the output will be written to standard output.",
                                           "FILE",
-                                          CLI::Presence::Required },
+                                          CLI::presence::Required },
                         } },
-                    CLI::Command {
+                    CLI::command {
                         "config",
                         "Generates configuration file with the default configuration.",
-                        CLI::OptionList {
-                            CLI::Option { "to",
-                                          CLI::Value { ""s },
+                        CLI::option_list {
+                            CLI::option { "to",
+                                          CLI::value { ""s },
                                           "Output file name to store the config file to. If - (dash) is "
                                           "given, the output will be written to standard output.",
                                           "FILE",
-                                          CLI::Presence::Required },
+                                          CLI::presence::Required },
                         } },
-                    CLI::Command {
+                    CLI::command {
                         "integration",
                         "Generates shell integration script.",
-                        CLI::OptionList {
-                            CLI::Option { "shell",
-                                          CLI::Value { ""s },
+                        CLI::option_list {
+                            CLI::option { "shell",
+                                          CLI::value { ""s },
                                           "Shell name to create the integration for. "
                                           "Supported shells: fish, zsh, tcsh",
                                           "SHELL",
-                                          CLI::Presence::Required },
-                            CLI::Option { "to",
-                                          CLI::Value { ""s },
+                                          CLI::presence::Required },
+                            CLI::option { "to",
+                                          CLI::value { ""s },
                                           "Output file name to store the shell integration file to. If - "
                                           "(dash) is given, the output will be written to standard output.",
                                           "FILE",
-                                          CLI::Presence::Required },
+                                          CLI::presence::Required },
                         } } } },
-            CLI::Command {
+            CLI::command {
                 "capture",
                 "Captures the screen buffer of the currently running terminal.",
                 {
-                    CLI::Option { "logical",
-                                  CLI::Value { false },
+                    CLI::option { "logical",
+                                  CLI::value { false },
                                   "Tells the terminal to use logical lines for counting and capturing." },
-                    CLI::Option { "words",
-                                  CLI::Value { false },
+                    CLI::option { "words",
+                                  CLI::value { false },
                                   "Splits each line into words and outputs only one word per line." },
-                    CLI::Option { "timeout",
-                                  CLI::Value { 1.0 },
+                    CLI::option { "timeout",
+                                  CLI::value { 1.0 },
                                   "Sets timeout seconds to wait for terminal to respond.",
                                   "SECONDS" },
-                    CLI::Option { "lines", CLI::Value { 0u }, "The number of lines to capture", "COUNT" },
-                    CLI::Option { "to",
-                                  CLI::Value { ""s },
+                    CLI::option { "lines", CLI::value { 0u }, "The number of lines to capture", "COUNT" },
+                    CLI::option { "to",
+                                  CLI::value { ""s },
                                   "Output file name to store the screen capture to. If - (dash) is given, "
                                   "the capture will be written to standard output.",
                                   "FILE",
-                                  CLI::Presence::Required },
+                                  CLI::presence::Required },
                 } },
-            CLI::Command {
+            CLI::command {
                 "set",
                 "Sets various aspects of the connected terminal.",
-                CLI::OptionList {},
-                CLI::CommandList { CLI::Command {
+                CLI::option_list {},
+                CLI::command_list { CLI::command {
                     "profile",
                     "Changes the terminal profile of the currently attached terminal to the given value.",
-                    CLI::OptionList {
-                        CLI::Option { "to",
-                                      CLI::Value { ""s },
+                    CLI::option_list {
+                        CLI::option { "to",
+                                      CLI::value { ""s },
                                       "Profile name to activate in the currently connected terminal.",
                                       "NAME" } } } } } }
     };

--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -21,6 +21,7 @@
 #include <vtparser/Parser.h>
 
 #include <crispy/App.h>
+#include <crispy/CLI.h>
 #include <crispy/StackTrace.h>
 #include <crispy/utils.h>
 
@@ -35,8 +36,6 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-
-#include "crispy/CLI.h"
 
 #if !defined(_WIN32)
     #include <sys/ioctl.h>

--- a/src/contour/ContourApp.h
+++ b/src/contour/ContourApp.h
@@ -21,12 +21,12 @@ namespace contour
 /// Contour TUI application.
 ///
 /// TODO: provide special installable targets in debian packageS (cmake and PPA)
-class ContourApp: public crispy::App
+class ContourApp: public crispy::app
 {
   public:
     ContourApp();
 
-    crispy::cli::Command parameterDefinition() const override;
+    crispy::cli::command parameterDefinition() const override;
 
   private:
     int captureAction();

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -32,6 +32,8 @@
 #include <iostream>
 #include <vector>
 
+#include "crispy/CLI.h"
+
 using std::bind;
 using std::cerr;
 using std::get;
@@ -65,24 +67,24 @@ int ContourGuiApp::run(int argc, char const* argv[])
     return ContourApp::run(argc, argv);
 }
 
-crispy::cli::Command ContourGuiApp::parameterDefinition() const
+crispy::cli::command ContourGuiApp::parameterDefinition() const
 {
     auto command = ContourApp::parameterDefinition();
 
     command.children.insert(
         command.children.begin(),
-        CLI::Command {
+        CLI::command {
             "font-locator",
             "Inspects font locator service.",
-            CLI::OptionList {
-                CLI::Option { "config",
-                              CLI::Value { contour::config::defaultConfigFilePath() },
+            CLI::option_list {
+                CLI::option { "config",
+                              CLI::value { contour::config::defaultConfigFilePath() },
                               "Path to configuration file to load at startup.",
                               "FILE" },
-                CLI::Option {
-                    "profile", CLI::Value { ""s }, "Terminal Profile to load (overriding config).", "NAME" },
-                CLI::Option { "debug",
-                              CLI::Value { ""s },
+                CLI::option {
+                    "profile", CLI::value { ""s }, "Terminal Profile to load (overriding config).", "NAME" },
+                CLI::option { "debug",
+                              CLI::value { ""s },
                               "Enables debug logging, using a comma (,) seperated list of tags.",
                               "TAGS" },
             },
@@ -90,60 +92,60 @@ crispy::cli::Command ContourGuiApp::parameterDefinition() const
 
     command.children.insert(
         command.children.begin(),
-        CLI::Command {
+        CLI::command {
             "terminal",
             "Spawns a new terminal application.",
-            CLI::OptionList {
-                CLI::Option { "config",
-                              CLI::Value { contour::config::defaultConfigFilePath() },
+            CLI::option_list {
+                CLI::option { "config",
+                              CLI::value { contour::config::defaultConfigFilePath() },
                               "Path to configuration file to load at startup.",
                               "FILE" },
-                CLI::Option {
-                    "profile", CLI::Value { ""s }, "Terminal Profile to load (overriding config).", "NAME" },
-                CLI::Option { "debug",
-                              CLI::Value { ""s },
+                CLI::option {
+                    "profile", CLI::value { ""s }, "Terminal Profile to load (overriding config).", "NAME" },
+                CLI::option { "debug",
+                              CLI::value { ""s },
                               "Enables debug logging, using a comma (,) seperated list of tags.",
                               "TAGS" },
-                CLI::Option { "live-config", CLI::Value { false }, "Enables live config reloading." },
-                CLI::Option {
+                CLI::option { "live-config", CLI::value { false }, "Enables live config reloading." },
+                CLI::option {
                     "dump-state-at-exit",
-                    CLI::Value { ""s },
+                    CLI::value { ""s },
                     "Dumps internal state at exit into the given directory. This is for debugging contour.",
                     "PATH" },
-                CLI::Option { "early-exit-threshold",
-                              CLI::Value { 6u },
+                CLI::option { "early-exit-threshold",
+                              CLI::value { 6u },
                               "If the spawned process exits earlier than the given threshold seconds, an "
                               "error message will be printed and the window not closed immediately." },
-                CLI::Option { "working-directory",
-                              CLI::Value { ""s },
+                CLI::option { "working-directory",
+                              CLI::value { ""s },
                               "Sets initial working directory (overriding config).",
                               "DIRECTORY" },
-                CLI::Option {
+                CLI::option {
                     "class",
-                    CLI::Value { ""s },
+                    CLI::value { ""s },
                     "Sets the class part of the WM_CLASS property for the window (overriding config).",
                     "WM_CLASS" },
-                CLI::Option {
-                    "platform", CLI::Value { ""s }, "Sets the QPA platform.", "PLATFORM[:OPTIONS]" },
-                CLI::Option { "session",
-                              CLI::Value { ""s },
+                CLI::option {
+                    "platform", CLI::value { ""s }, "Sets the QPA platform.", "PLATFORM[:OPTIONS]" },
+                CLI::option { "session",
+                              CLI::value { ""s },
                               "Sets the sessioni ID used for resuming a prior session.",
                               "SESSION_ID" },
 #if defined(__linux__)
-                CLI::Option {
-                    "display", CLI::Value { ""s }, "Sets the X11 display to connect to.", "DISPLAY_ID" },
+                CLI::option {
+                    "display", CLI::value { ""s }, "Sets the X11 display to connect to.", "DISPLAY_ID" },
 #endif
-                CLI::Option {
-                    CLI::OptionName { 'e', "execute" },
-                    CLI::Value { ""s },
+                CLI::option {
+                    CLI::option_name { 'e', "execute" },
+                    CLI::value { ""s },
                     "DEPRECATED: Program to execute instead of running the shell as configured.",
                     "PROGRAM",
-                    CLI::Presence::Optional,
-                    CLI::Deprecated { "Only supported for compatibility with very old KDE desktops." } },
+                    CLI::presence::Optional,
+                    CLI::deprecated { "Only supported for compatibility with very old KDE desktops." } },
             },
-            CLI::CommandList {},
-            CLI::CommandSelect::Implicit,
-            CLI::Verbatim { "PROGRAM ARGS...",
+            CLI::command_list {},
+            CLI::command_select::Implicit,
+            CLI::verbatim { "PROGRAM ARGS...",
                             "Executes given program instead of the one provided in the configuration." } });
 
     return command;

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -47,7 +47,7 @@ class ContourGuiApp: public QObject, public ContourApp
     static ContourGuiApp* instance() { return static_cast<ContourGuiApp*>(ContourApp::instance()); }
 
     int run(int argc, char const* argv[]) override;
-    crispy::cli::Command parameterDefinition() const override;
+    crispy::cli::command parameterDefinition() const override;
 
     void newWindow();
     void showNotification(std::string_view _title, std::string_view _content);

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -336,7 +336,7 @@ void TerminalSession::requestPermission(config::Permission _allowedByConfig, Gua
                 SessionLog()("Permission for {} requires asking user.", role);
                 switch (role)
                 {
-                    // clang-format off
+                        // clang-format off
                     case GuardedRole::ChangeFont: emit requestPermissionForFontChange(); break;
                     case GuardedRole::CaptureBuffer: emit requestPermissionForBufferCapture(); break;
                     case GuardedRole::ShowHostWritableStatusLine: emit requestPermissionForShowHostWritableStatusLine(); break;

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -336,7 +336,7 @@ void TerminalSession::requestPermission(config::Permission _allowedByConfig, Gua
                 SessionLog()("Permission for {} requires asking user.", role);
                 switch (role)
                 {
-                        // clang-format off
+                    // clang-format off
                     case GuardedRole::ChangeFont: emit requestPermissionForFontChange(); break;
                     case GuardedRole::CaptureBuffer: emit requestPermissionForBufferCapture(); break;
                     case GuardedRole::ShowHostWritableStatusLine: emit requestPermissionForShowHostWritableStatusLine(); break;

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -429,7 +429,7 @@ struct formatter<contour::GuardedRole>
     {
         switch (value)
         {
-            // clang-format off
+                // clang-format off
             case contour::GuardedRole::ChangeFont: return fmt::format_to(ctx.out(), "Change Font");
             case contour::GuardedRole::CaptureBuffer: return fmt::format_to(ctx.out(), "Capture Buffer");
             case contour::GuardedRole::ShowHostWritableStatusLine:  return fmt::format_to(ctx.out(), "show Host Writable Statusline");

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -29,6 +29,8 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QImage>
 
+#include "crispy/ImageSize.h"
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     #include <QtOpenGL/QOpenGLPixelTransferOptions>
 #else
@@ -196,9 +198,9 @@ namespace
 
 OpenGLRenderer::OpenGLRenderer(ShaderConfig textShaderConfig,
                                ShaderConfig rectShaderConfig,
-                               ImageSize viewSize,
-                               ImageSize targetSurfaceSize,
-                               ImageSize /*textureTileSize*/,
+                               crispy::image_size viewSize,
+                               crispy::image_size targetSurfaceSize,
+                               crispy::image_size /*textureTileSize*/,
                                terminal::rasterizer::PageMargin margin):
     _startTime { chrono::steady_clock::now().time_since_epoch() },
     _viewSize { viewSize },
@@ -210,7 +212,7 @@ OpenGLRenderer::OpenGLRenderer(ShaderConfig textShaderConfig,
     setRenderSize(targetSurfaceSize);
 }
 
-void OpenGLRenderer::setRenderSize(ImageSize targetSurfaceSize)
+void OpenGLRenderer::setRenderSize(crispy::image_size targetSurfaceSize)
 {
     if (_renderTargetSize == targetSurfaceSize)
         return;

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -18,6 +18,7 @@
 
 #include <vtrasterizer/TextureAtlas.h>
 
+#include <crispy/ImageSize.h>
 #include <crispy/algorithm.h>
 #include <crispy/assert.h>
 #include <crispy/defines.h>
@@ -28,8 +29,6 @@
 #include <QtCore/QtGlobal>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QImage>
-
-#include "crispy/ImageSize.h"
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     #include <QtOpenGL/QOpenGLPixelTransferOptions>

--- a/src/contour/display/OpenGLRenderer.h
+++ b/src/contour/display/OpenGLRenderer.h
@@ -23,6 +23,9 @@
 
 #include <QtGui/QMatrix4x4>
 #include <QtGui/QOpenGLExtraFunctions>
+
+#include "crispy/ImageSize.h"
+#include "crispy/StrongHash.h"
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     #include <QtOpenGL/QOpenGLShaderProgram>
     #include <QtOpenGL/QOpenGLTexture>
@@ -68,9 +71,9 @@ class OpenGLRenderer final:
      */
     OpenGLRenderer(ShaderConfig textShaderConfig,
                    ShaderConfig rectShaderConfig,
-                   crispy::ImageSize viewSize,
-                   crispy::ImageSize renderSize,
-                   crispy::ImageSize textureTileSize,
+                   crispy::image_size viewSize,
+                   crispy::image_size renderSize,
+                   crispy::image_size textureTileSize,
                    terminal::rasterizer::PageMargin margin);
 
     ~OpenGLRenderer() override;
@@ -84,9 +87,9 @@ class OpenGLRenderer final:
     void renderTile(RenderTile tile) override;
 
     // RenderTarget implementation
-    void setRenderSize(crispy::ImageSize _size) override;
+    void setRenderSize(crispy::image_size _size) override;
     void setTranslation(float x, float y, float z) noexcept;
-    void setViewSize(crispy::ImageSize size) noexcept { _viewSize = size; }
+    void setViewSize(crispy::image_size size) noexcept { _viewSize = size; }
     void setModelMatrix(QMatrix4x4 matrix) noexcept;
     void setMargin(terminal::rasterizer::PageMargin _margin) noexcept override;
     std::optional<AtlasTextureScreenshot> readAtlas() override;
@@ -95,7 +98,7 @@ class OpenGLRenderer final:
     void renderRectangle(int x, int y, Width, Height, RGBAColor color) override;
     void execute(std::chrono::steady_clock::time_point now) override;
 
-    std::pair<crispy::ImageSize, std::vector<uint8_t>> takeScreenshot();
+    std::pair<crispy::image_size, std::vector<uint8_t>> takeScreenshot();
 
     void clearCache() override;
 
@@ -124,7 +127,7 @@ class OpenGLRenderer final:
     int maxTextureDepth();
     int maxTextureSize();
     int maxTextureUnits();
-    crispy::ImageSize renderBufferSize();
+    crispy::image_size renderBufferSize();
 
     GLuint createAndUploadImage(QSize imageSize,
                                 terminal::ImageFormat format,
@@ -175,8 +178,8 @@ class OpenGLRenderer final:
 
     bool _initialized = false;
     std::chrono::steady_clock::time_point _startTime;
-    crispy::ImageSize _viewSize;
-    crispy::ImageSize _renderTargetSize;
+    crispy::image_size _viewSize;
+    crispy::image_size _renderTargetSize;
     QMatrix4x4 _projectionMatrix;
     QMatrix4x4 _viewMatrix;
     QMatrix4x4 _modelMatrix;
@@ -234,7 +237,7 @@ class OpenGLRenderer final:
         float backgroundImageOpacity = 1.0f;
         bool backgroundImageBlur = false;
         QSize backgroundResolution;
-        crispy::StrongHash backgroundImageHash;
+        crispy::strong_hash backgroundImageHash;
     } _renderStateCache;
 };
 

--- a/src/contour/display/OpenGLRenderer.h
+++ b/src/contour/display/OpenGLRenderer.h
@@ -21,11 +21,11 @@
 #include <vtrasterizer/RenderTarget.h>
 #include <vtrasterizer/TextureAtlas.h>
 
+#include <crispy/ImageSize.h>
+#include <crispy/StrongHash.h>
+
 #include <QtGui/QMatrix4x4>
 #include <QtGui/QOpenGLExtraFunctions>
-
-#include "crispy/ImageSize.h"
-#include "crispy/StrongHash.h"
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     #include <QtOpenGL/QOpenGLShaderProgram>
     #include <QtOpenGL/QOpenGLTexture>

--- a/src/contour/display/ShaderConfig.cpp
+++ b/src/contour/display/ShaderConfig.cpp
@@ -31,7 +31,7 @@ using namespace std::string_literals;
 namespace contour::display
 {
 
-auto const ShaderLog = logstore::Category("gui.shader", "Logs shader configuration");
+auto const ShaderLog = logstore::category("gui.shader", "Logs shader configuration");
 
 namespace
 {

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -468,7 +468,7 @@ void TerminalWidget::logDisplayInfo()
     auto const fontSizeInPx = static_cast<int>(ceil((
         profile().fonts.size.pt / 72.0) * average(fontDPI())
     ));
-    auto const normalScreenSize = crispy::ImageSize {
+    auto const normalScreenSize = crispy::image_size {
         Width::cast_from(window()->screen()->size().width()),
         Height::cast_from(window()->screen()->size().height())
     };
@@ -1026,7 +1026,7 @@ void TerminalWidget::doDumpState()
     Require(renderer_);
 
     // clang-format off
-    auto const targetBaseDir = session_->app().dumpStateAtExit().value_or(crispy::App::instance()->localStateDir() / "dump");
+    auto const targetBaseDir = session_->app().dumpStateAtExit().value_or(crispy::app::instance()->localStateDir() / "dump");
     auto const workDirName = FileSystem::path(fmt::format("contour-dump-{:%Y-%m-%d-%H-%M-%S}", chrono::system_clock::now()));
     auto const targetDir = targetBaseDir / workDirName;
     auto const latestDirName = FileSystem::path("latest");

--- a/src/contour/display/TerminalWidget.h
+++ b/src/contour/display/TerminalWidget.h
@@ -231,7 +231,7 @@ class TerminalWidget: public QQuickItem
     void updateSizeProperties();
 
     void statsSummary();
-    void doResize(crispy::size _size);
+    void doResize(crispy::size size);
 
     [[nodiscard]] terminal::rasterizer::GridMetrics const& gridMetrics() const noexcept
     {

--- a/src/contour/display/TerminalWidget.h
+++ b/src/contour/display/TerminalWidget.h
@@ -231,7 +231,7 @@ class TerminalWidget: public QQuickItem
     void updateSizeProperties();
 
     void statsSummary();
-    void doResize(crispy::Size _size);
+    void doResize(crispy::size _size);
 
     [[nodiscard]] terminal::rasterizer::GridMetrics const& gridMetrics() const noexcept
     {

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -49,8 +49,8 @@ using std::variant;
 using std::vector;
 using std::chrono::steady_clock;
 
-using crispy::Point;
-using crispy::Size;
+using crispy::point;
+using crispy::size;
 using crispy::Zero;
 
 using terminal::Height;

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -43,10 +43,10 @@ namespace contour
 {
 
 auto inline const DisplayLog =
-    logstore::Category("gui.display", "Logs display driver details (e.g. OpenGL).");
+    logstore::category("gui.display", "Logs display driver details (e.g. OpenGL).");
 auto inline const InputLog =
-    logstore::Category("gui.input", "Logs input driver details (e.g. GUI input events).");
-auto inline const SessionLog = logstore::Category("gui.session", "VT terminal session logs");
+    logstore::category("gui.input", "Logs input driver details (e.g. GUI input events).");
+auto inline const SessionLog = logstore::category("gui.session", "VT terminal session logs");
 
 namespace detail
 {
@@ -171,8 +171,8 @@ terminal::rasterizer::PageMargin computeMargin(terminal::ImageSize _cellSize,
 terminal::rasterizer::FontDescriptions sanitizeFontDescription(terminal::rasterizer::FontDescriptions _fonts,
                                                                text::DPI _screenDPI);
 
-constexpr terminal::PageSize pageSizeForPixels(crispy::ImageSize viewSize,
-                                               crispy::ImageSize cellSize) noexcept
+constexpr terminal::PageSize pageSizeForPixels(crispy::image_size viewSize,
+                                               crispy::image_size cellSize) noexcept
 {
     return terminal::PageSize { boxed_cast<terminal::LineCount>((viewSize / cellSize).height),
                                 boxed_cast<terminal::ColumnCount>((viewSize / cellSize).width) };

--- a/src/crispy/.clang-tidy
+++ b/src/crispy/.clang-tidy
@@ -9,5 +9,7 @@ CheckOptions:
     value: lower_case
   - key:   readability-identifier-naming.ClassCase
     value: lower_case
+  - key:   readability-identifier-naming.StructCase
+    value: lower_case
   - key:   readability-identifier-naming.TypeAliasCase
     value: lower_case

--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -24,8 +24,6 @@
 #include <numeric>
 #include <optional>
 
-#include "logstore.h"
-
 #if !defined(_WIN32)
     #include <sys/ioctl.h>
 

--- a/src/crispy/App.h
+++ b/src/crispy/App.h
@@ -25,16 +25,16 @@ namespace crispy
 {
 
 /// General purpose Application main with CLI parameter handling and stuff.
-class App
+class app
 {
   public:
-    App(std::string appName, std::string appTitle, std::string appVersion, std::string appLicense);
-    virtual ~App();
+    app(std::string appName, std::string appTitle, std::string appVersion, std::string appLicense);
+    virtual ~app();
 
-    static App* instance() noexcept { return _instance; }
+    static app* instance() noexcept { return _instance; }
 
-    [[nodiscard]] virtual crispy::cli::Command parameterDefinition() const = 0;
-    [[nodiscard]] cli::FlagStore const& parameters() const noexcept { return _flags.value(); }
+    [[nodiscard]] virtual crispy::cli::command parameterDefinition() const = 0;
+    [[nodiscard]] cli::flag_store const& parameters() const noexcept { return _flags.value(); }
 
     void link(std::string command, std::function<int()> handler);
 
@@ -54,15 +54,15 @@ class App
     int licenseAction();
     int helpAction();
 
-    static App* _instance; // NOLINT(readability-identifier-naming)
+    static app* _instance; // NOLINT(readability-identifier-naming)
 
     std::string _appName;
     std::string _appTitle;
     std::string _appVersion;
     std::string _appLicense;
     FileSystem::path _localStateDir;
-    std::optional<crispy::cli::Command> _syntax;
-    std::optional<crispy::cli::FlagStore> _flags;
+    std::optional<crispy::cli::command> _syntax;
+    std::optional<crispy::cli::flag_store> _flags;
     std::map<std::string, std::function<int()>> _handlers;
 };
 

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -11,13 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "BufferObject.h"
+
 #include <crispy/BufferObject.h>
 
 namespace crispy
 {
 
-template class BufferObject<char>;
+template class buffer_object<char>;
 template class BufferFragment<char>;
-template class BufferObjectPool<char>;
+template class buffer_object_pool<char>;
 
 } // namespace crispy

--- a/src/crispy/BufferObject_test.cpp
+++ b/src/crispy/BufferObject_test.cpp
@@ -16,7 +16,7 @@
 
 #include <catch2/catch.hpp>
 
-TEST_CASE("BufferObject", "[BufferObject]")
+TEST_CASE("buffer_object", "[buffer_object]")
 {
     // TODO
 }

--- a/src/crispy/CLI_test.cpp
+++ b/src/crispy/CLI_test.cpp
@@ -58,76 +58,76 @@ using namespace std::string_literals;
 
 TEST_CASE("CLI.option.type.bool")
 {
-    auto const cmd = cli::Command {
+    auto const cmd = cli::command {
         "contour",
         "help here",
-        cli::OptionList { cli::Option { "verbose"sv, cli::Value { false }, "Help text here"sv } },
+        cli::option_list { cli::option { "verbose"sv, cli::value { false }, "Help text here"sv } },
     };
 
     SECTION("set")
     {
-        auto const args = cli::StringViewList { "contour", "verbose" };
-        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        auto const args = cli::string_view_list { "contour", "verbose" };
+        optional<cli::flag_store> const flagsOpt = cli::parse(cmd, args);
         REQUIRE(flagsOpt.has_value());
-        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value { true });
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::value { true });
     }
 
     SECTION("set true")
     {
-        auto const args = cli::StringViewList { "contour", "verbose", "true" };
-        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        auto const args = cli::string_view_list { "contour", "verbose", "true" };
+        optional<cli::flag_store> const flagsOpt = cli::parse(cmd, args);
         REQUIRE(flagsOpt.has_value());
-        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value { true });
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::value { true });
     }
 
     SECTION("set true")
     {
-        auto const args = cli::StringViewList { "contour", "verbose", "false" };
-        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        auto const args = cli::string_view_list { "contour", "verbose", "false" };
+        optional<cli::flag_store> const flagsOpt = cli::parse(cmd, args);
         REQUIRE(flagsOpt.has_value());
-        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value { false });
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::value { false });
     }
 
     SECTION("unset")
     {
-        auto const args = cli::StringViewList { "contour" };
-        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        auto const args = cli::string_view_list { "contour" };
+        optional<cli::flag_store> const flagsOpt = cli::parse(cmd, args);
         REQUIRE(flagsOpt.has_value());
-        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value { false });
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::value { false });
     }
 }
 
 TEST_CASE("CLI.contour-full-test")
 {
-    auto const cmd = cli::Command {
+    auto const cmd = cli::command {
         "contour",
         "help here",
-        cli::OptionList {
-            cli::Option { "debug"sv, cli::Value { ""s }, "Help text here"sv },
-            cli::Option { "config", cli::Value { "~/.config/contour/contour.yml"s }, "Help text there"sv },
-            cli::Option { "profile", cli::Value { ""s }, "Help text over here"sv } },
-        cli::CommandList { cli::Command { "capture",
-                                          "some capture help text",
-                                          {
-                                              cli::Option { "logical", cli::Value { false }, "help there" },
-                                              cli::Option { "timeout", cli::Value { 1.0 }, "help here" },
-                                              cli::Option { "output", cli::Value { ""s } },
-                                          } } }
+        cli::option_list {
+            cli::option { "debug"sv, cli::value { ""s }, "Help text here"sv },
+            cli::option { "config", cli::value { "~/.config/contour/contour.yml"s }, "Help text there"sv },
+            cli::option { "profile", cli::value { ""s }, "Help text over here"sv } },
+        cli::command_list { cli::command { "capture",
+                                           "some capture help text",
+                                           {
+                                               cli::option { "logical", cli::value { false }, "help there" },
+                                               cli::option { "timeout", cli::value { 1.0 }, "help here" },
+                                               cli::option { "output", cli::value { ""s } },
+                                           } } }
     };
 
-    auto const args = cli::StringViewList { "contour", "capture", "logical", "output", "out.vt" };
-    optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+    auto const args = cli::string_view_list { "contour", "capture", "logical", "output", "out.vt" };
+    optional<cli::flag_store> const flagsOpt = cli::parse(cmd, args);
     REQUIRE(flagsOpt.has_value());
 
-    cli::FlagStore const& flags = flagsOpt.value();
+    cli::flag_store const& flags = flagsOpt.value();
 
     CHECK(flags.values.size() == 8);
-    CHECK(flags.values.at("contour") == cli::Value { true }); // command
-    CHECK(flags.values.at("contour.debug") == cli::Value { ""s });
-    CHECK(flags.values.at("contour.config") == cli::Value { "~/.config/contour/contour.yml"s });
-    CHECK(flags.values.at("contour.profile") == cli::Value { ""s });
-    CHECK(flags.values.at("contour.capture") == cli::Value { true }); // command
-    CHECK(flags.values.at("contour.capture.logical") == cli::Value { true });
-    CHECK(flags.values.at("contour.capture.output") == cli::Value { "out.vt"s });
-    CHECK(flags.values.at("contour.capture.timeout") == cli::Value { 1.0 });
+    CHECK(flags.values.at("contour") == cli::value { true }); // command
+    CHECK(flags.values.at("contour.debug") == cli::value { ""s });
+    CHECK(flags.values.at("contour.config") == cli::value { "~/.config/contour/contour.yml"s });
+    CHECK(flags.values.at("contour.profile") == cli::value { ""s });
+    CHECK(flags.values.at("contour.capture") == cli::value { true }); // command
+    CHECK(flags.values.at("contour.capture.logical") == cli::value { true });
+    CHECK(flags.values.at("contour.capture.output") == cli::value { "out.vt"s });
+    CHECK(flags.values.at("contour.capture.timeout") == cli::value { 1.0 });
 }

--- a/src/crispy/Comparison.h
+++ b/src/crispy/Comparison.h
@@ -16,7 +16,7 @@
 namespace crispy
 {
 
-enum class Comparison
+enum class comparison
 {
     Less,
     Equal,
@@ -24,14 +24,14 @@ enum class Comparison
 };
 
 template <typename T>
-constexpr Comparison strongCompare(T const& a, T const& b)
+constexpr comparison strongCompare(T const& a, T const& b)
 {
     if (a < b)
-        return Comparison::Less;
+        return comparison::Less;
     else if (a == b)
-        return Comparison::Equal;
+        return comparison::Equal;
     else
-        return Comparison::Greater;
+        return comparison::Greater;
 }
 
 } // namespace crispy

--- a/src/crispy/FNV.h
+++ b/src/crispy/FNV.h
@@ -14,11 +14,11 @@ namespace crispy
  * @see http://en.wikipedia.org/wiki/Fowler-Noll-Vo_hash_function
  */
 template <typename T, typename U = size_t>
-class FNV
+class fnv
 {
   public:
-    constexpr FNV() noexcept: _basis { 2166136261llu }, _prime { 16777619llu } {}
-    constexpr FNV(U prime, U basis) noexcept: _basis(basis), _prime(prime) {}
+    constexpr fnv() noexcept: _basis { 2166136261llu }, _prime { 16777619llu } {}
+    constexpr fnv(U prime, U basis) noexcept: _basis(basis), _prime(prime) {}
 
     [[nodiscard]] constexpr U prime() const noexcept { return _prime; }
     [[nodiscard]] constexpr U basis() const noexcept { return _basis; }

--- a/src/crispy/ImageSize.h
+++ b/src/crispy/ImageSize.h
@@ -7,25 +7,25 @@ namespace crispy
 
 namespace detail::tags
 {
-    struct Width
+    struct width
     {
     };
-    struct Height
+    struct height
     {
     };
 } // namespace detail::tags
 
 /// Representsthe width in pixels of an image (see ImageSize).
-using Width = crispy::boxed<unsigned, detail::tags::Width>;
+using width = crispy::boxed<unsigned, detail::tags::width>;
 
 /// Representsthe height in pixels of an image (see ImageSize).
-using Height = crispy::boxed<unsigned, detail::tags::Height>;
+using height = crispy::boxed<unsigned, detail::tags::height>;
 
 /// ImageSize represents the 2-dimensional size of an image (pixmap).
-struct ImageSize
+struct image_size
 {
-    Width width;
-    Height height;
+    crispy::width width;
+    crispy::height height;
 
     [[nodiscard]] constexpr size_t area() const noexcept
     {
@@ -33,51 +33,51 @@ struct ImageSize
     }
 };
 
-constexpr bool operator==(ImageSize a, ImageSize b) noexcept
+constexpr bool operator==(image_size a, image_size b) noexcept
 {
     return a.width == b.width && a.height == b.height;
 }
-constexpr bool operator!=(ImageSize a, ImageSize b) noexcept
+constexpr bool operator!=(image_size a, image_size b) noexcept
 {
     return !(a == b);
 }
 
-constexpr bool operator<(ImageSize a, ImageSize b) noexcept
+constexpr bool operator<(image_size a, image_size b) noexcept
 {
     return a.width < b.width || (a.width == b.width && a.height < b.height);
 }
 
-inline ImageSize operator+(ImageSize a, ImageSize b) noexcept
+inline image_size operator+(image_size a, image_size b) noexcept
 {
-    return ImageSize { a.width + b.width, a.height + b.height };
+    return image_size { a.width + b.width, a.height + b.height };
 }
 
-inline ImageSize operator-(ImageSize a, ImageSize b) noexcept
+inline image_size operator-(image_size a, image_size b) noexcept
 {
-    return ImageSize { a.width - b.width, a.height - b.height };
+    return image_size { a.width - b.width, a.height - b.height };
 }
 
-inline ImageSize operator*(ImageSize a, double scalar) noexcept
+inline image_size operator*(image_size a, double scalar) noexcept
 {
-    return ImageSize { Width::cast_from(ceil(double(*a.width) * scalar)),
-                       Height::cast_from(ceil(double(*a.height) * scalar)) };
+    return image_size { width::cast_from(ceil(double(*a.width) * scalar)),
+                        height::cast_from(ceil(double(*a.height) * scalar)) };
 }
 
-inline ImageSize operator/(ImageSize a, double scalar) noexcept
+inline image_size operator/(image_size a, double scalar) noexcept
 {
-    return ImageSize { Width::cast_from(ceil(double(*a.width) / scalar)),
-                       Height::cast_from(ceil(double(*a.height) / scalar)) };
+    return image_size { width::cast_from(ceil(double(*a.width) / scalar)),
+                        height::cast_from(ceil(double(*a.height) / scalar)) };
 }
 
-constexpr ImageSize operator/(ImageSize a, ImageSize b) noexcept
+constexpr image_size operator/(image_size a, image_size b) noexcept
 {
-    return ImageSize { a.width / b.width, a.height / b.height };
+    return image_size { a.width / b.width, a.height / b.height };
 }
 
 } // namespace crispy
 
 template <>
-struct fmt::formatter<crispy::ImageSize>
+struct fmt::formatter<crispy::image_size>
 {
     template <typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
@@ -85,7 +85,7 @@ struct fmt::formatter<crispy::ImageSize>
         return ctx.begin();
     }
     template <typename FormatContext>
-    auto format(crispy::ImageSize value, FormatContext& ctx)
+    auto format(crispy::image_size value, FormatContext& ctx)
     {
         return fmt::format_to(ctx.out(), "{}x{}", value.width, value.height);
     }

--- a/src/crispy/LRUCache.h
+++ b/src/crispy/LRUCache.h
@@ -26,20 +26,20 @@ namespace crispy
 
 /// Implements LRU (Least recently used) cache.
 template <typename Key, typename Value>
-class LRUCache
+class lru_cache
 {
   public:
-    struct Item
+    struct item
     {
         Key key;
         Value value;
     };
-    using ItemList = std::list<Item>;
+    using item_list = std::list<item>;
 
-    using iterator = typename ItemList::iterator;
-    using const_iterator = typename ItemList::const_iterator;
+    using iterator = typename item_list::iterator;
+    using const_iterator = typename item_list::const_iterator;
 
-    explicit LRUCache(std::size_t capacity): _capacity { capacity } {}
+    explicit lru_cache(std::size_t capacity): _capacity { capacity } {}
 
     [[nodiscard]] std::size_t size() const noexcept { return _items.size(); }
     [[nodiscard]] std::size_t capacity() const noexcept { return _capacity; }
@@ -54,7 +54,7 @@ class LRUCache
 
     [[nodiscard]] bool contains(Key key) const noexcept { return _itemByKeyMapping.count(key) != 0; }
 
-    [[nodiscard]] Value* try_get(Key key) const { return const_cast<LRUCache*>(this)->try_get(key); }
+    [[nodiscard]] Value* try_get(Key key) const { return const_cast<lru_cache*>(this)->try_get(key); }
 
     [[nodiscard]] Value* try_get(Key key)
     {
@@ -147,7 +147,7 @@ class LRUCache
         std::vector<Key> result;
         result.resize(_items.size());
         size_t i = 0;
-        for (Item const& item: _items)
+        for (item const& item: _items)
             result[i++] = item.key;
         return result;
     }
@@ -191,14 +191,14 @@ class LRUCache
 
     iterator emplaceItemToFront(Key key, Value&& value)
     {
-        _items.emplace_front(Item { key, std::move(value) });
+        _items.emplace_front(item { key, std::move(value) });
         _itemByKeyMapping.emplace(key, _items.begin());
         return _items.begin();
     }
 
     // private data
     //
-    std::list<Item> _items;
+    std::list<item> _items;
     std::unordered_map<Key, iterator> _itemByKeyMapping;
     std::size_t _capacity;
 };

--- a/src/crispy/LRUCache_test.cpp
+++ b/src/crispy/LRUCache_test.cpp
@@ -28,8 +28,8 @@ using namespace std::string_view_literals;
 // {
 //     std::ostream& out = std::cout;
 //
-//     out << fmt::format("LRUCache({}/{}): {}\n", cache.size(), cache.capacity(), header);
-//     for (typename crispy::LRUCache<A, B>::Item const& item: cache)
+//     out << fmt::format("lru_cache({}/{}): {}\n", cache.size(), cache.capacity(), header);
+//     for (typename crispy::lru_cache<A, B>::Item const& item: cache)
 //     {
 //         out << fmt::format("{}: {}\n", item.key, item.value);
 //     }
@@ -49,25 +49,25 @@ static std::string join(std::vector<T> const& list, std::string_view delimiter =
     return s;
 }
 
-TEST_CASE("LRUCache.ctor", "[lrucache]")
+TEST_CASE("lru_cache.ctor", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(4);
+    auto cache = crispy::lru_cache<int, int>(4);
     CHECK(cache.size() == 0);
     CHECK(cache.capacity() == 4);
 }
 
-TEST_CASE("LRUCache.at", "[lrucache]")
+TEST_CASE("lru_cache.at", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(2);
+    auto cache = crispy::lru_cache<int, int>(2);
 
     CHECK_THROWS_AS(cache.at(2), std::out_of_range);
     cache[2] = 4;
     CHECK_NOTHROW(cache.at(2));
 }
 
-TEST_CASE("LRUCache.get_or_emplace", "[lrucache]")
+TEST_CASE("lru_cache.get_or_emplace", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(2);
+    auto cache = crispy::lru_cache<int, int>(2);
 
     int& a = cache.get_or_emplace(2, []() { return 4; });
     CHECK(a == 4);
@@ -101,9 +101,9 @@ TEST_CASE("LRUCache.get_or_emplace", "[lrucache]")
     CHECK(cache.size() == 2);
 }
 
-TEST_CASE("LRUCache.operator[]", "[lrucache]")
+TEST_CASE("lru_cache.operator[]", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(2);
+    auto cache = crispy::lru_cache<int, int>(2);
 
     (void) cache[2];
     CHECK(join(cache.keys()) == "2"sv);
@@ -135,9 +135,9 @@ TEST_CASE("LRUCache.operator[]", "[lrucache]")
     CHECK_FALSE(cache.contains(4)); // thrown out
 }
 
-TEST_CASE("LRUCache.clear", "[lrucache]")
+TEST_CASE("lru_cache.clear", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(4);
+    auto cache = crispy::lru_cache<int, int>(4);
     cache[2] = 4;
     cache[3] = 6;
     CHECK(cache.size() == 2);
@@ -145,9 +145,9 @@ TEST_CASE("LRUCache.clear", "[lrucache]")
     CHECK(cache.size() == 0);
 }
 
-TEST_CASE("LRUCache.try_emplace", "[lrucache]")
+TEST_CASE("lru_cache.try_emplace", "[lrucache]")
 {
-    auto cache = crispy::LRUCache<int, int>(2);
+    auto cache = crispy::lru_cache<int, int>(2);
     auto rv = cache.try_emplace(2, []() { return 4; });
     CHECK(rv);
     CHECK(join(cache.keys()) == "2");

--- a/src/crispy/Owned.h
+++ b/src/crispy/Owned.h
@@ -23,20 +23,20 @@ namespace crispy
  * used within packed structs.
  */
 template <typename T>
-struct CRISPY_PACKED Owned
+struct CRISPY_PACKED owned
 {
   public:
-    ~Owned() { reset(); }
-    Owned() noexcept = default;
-    Owned(Owned&& v) noexcept: _ptr { v.release() } {}
-    Owned& operator=(Owned&& v) noexcept
+    ~owned() { reset(); }
+    owned() noexcept = default;
+    owned(owned&& v) noexcept: _ptr { v.release() } {}
+    owned& operator=(owned&& v) noexcept
     {
         _ptr = v.release();
         return *this;
     }
 
-    Owned(Owned const& v) noexcept = delete;
-    Owned& operator=(Owned const& v) = delete;
+    owned(owned const& v) noexcept = delete;
+    owned& operator=(owned const& v) = delete;
 
     [[nodiscard]] T* get() noexcept { return _ptr; }
     [[nodiscard]] T const* get() const noexcept { return _ptr; }

--- a/src/crispy/StackTrace.cpp
+++ b/src/crispy/StackTrace.cpp
@@ -56,11 +56,11 @@ constexpr size_t MAX_FRAMES { 128 };
 constexpr size_t SKIP_FRAMES { 0 };
 
 #if defined(__linux__) || defined(__APPLE__)
-struct pipe_wrap // {{{
+struct system_wrap // {{{
 {
     int pfd[2];
 
-    pipe_wrap(): pfd { -1, -1 }
+    system_wrap(): pfd { -1, -1 }
     {
         if (pipe(pfd))
             perror("pipe");
@@ -70,7 +70,7 @@ struct pipe_wrap // {{{
     [[nodiscard]] int reader() noexcept { return pfd[0]; }
     [[nodiscard]] int writer() noexcept { return pfd[1]; }
 
-    ~pipe_wrap() { close(); }
+    ~system_wrap() { close(); }
 
     void close()
     {
@@ -105,7 +105,7 @@ optional<debug_info> stack_trace::getDebugInfoForFrame(void const* frameAddress)
         return nullopt;
 
 #if defined(__linux__)
-    auto pipe = pipe_wrap();
+    auto pipe = system_wrap();
     if (!pipe.good())
         return nullopt;
     pid_t childPid = fork();

--- a/src/crispy/StackTrace.h
+++ b/src/crispy/StackTrace.h
@@ -7,20 +7,20 @@
 namespace crispy
 {
 
-struct DebugInfo
+struct debug_info
 {
     std::string text;
 };
 
-class StackTrace
+class stack_trace
 {
   public:
-    StackTrace();
-    StackTrace(StackTrace&&) = default;
-    StackTrace& operator=(StackTrace&&) = default;
-    StackTrace(const StackTrace&) = default;
-    StackTrace& operator=(const StackTrace&) = default;
-    ~StackTrace() = default;
+    stack_trace();
+    stack_trace(stack_trace&&) = default;
+    stack_trace& operator=(stack_trace&&) = default;
+    stack_trace(const stack_trace&) = default;
+    stack_trace& operator=(const stack_trace&) = default;
+    ~stack_trace() = default;
 
     [[nodiscard]] std::vector<std::string> symbols() const;
     [[nodiscard]] size_t size() const noexcept { return _frames.size(); }
@@ -28,7 +28,7 @@ class StackTrace
 
     static std::string demangleSymbol(const char* symbol);
     static std::vector<void*> getFrames(size_t skip = 2, size_t max = 64);
-    static std::optional<DebugInfo> getDebugInfoForFrame(void const* frameAddress);
+    static std::optional<debug_info> getDebugInfoForFrame(void const* frameAddress);
 
   private:
     std::vector<void*> _frames;

--- a/src/crispy/StrongHash.h
+++ b/src/crispy/StrongHash.h
@@ -33,7 +33,7 @@
 namespace crispy
 {
 
-struct StrongHash
+struct strong_hash
 {
     // some random seed
     static constexpr std::array<unsigned char, 16> defaultSeed = {
@@ -41,28 +41,28 @@ struct StrongHash
         114, 188, 209, 2, 232, 4, 178, 176, 240, 216, 201, 127, 40, 41, 95, 143,
     };
 
-    StrongHash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept;
+    strong_hash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept;
 
 #if defined(STRONGHASH_USE_INTRINSICS)
-    explicit StrongHash(Intrinsics::m128i v) noexcept;
+    explicit strong_hash(Intrinsics::m128i v) noexcept;
 #endif
 
-    StrongHash() = default;
-    StrongHash(StrongHash const&) = default;
-    StrongHash& operator=(StrongHash const&) = default;
-    StrongHash(StrongHash&&) noexcept = default;
-    StrongHash& operator=(StrongHash&&) noexcept = default;
+    strong_hash() = default;
+    strong_hash(strong_hash const&) = default;
+    strong_hash& operator=(strong_hash const&) = default;
+    strong_hash(strong_hash&&) noexcept = default;
+    strong_hash& operator=(strong_hash&&) noexcept = default;
 
     template <typename T>
-    static StrongHash compute(T const& value) noexcept;
+    static strong_hash compute(T const& value) noexcept;
 
     template <typename T>
-    static StrongHash compute(std::basic_string_view<T> text) noexcept;
+    static strong_hash compute(std::basic_string_view<T> text) noexcept;
 
     template <typename T, typename Alloc>
-    static StrongHash compute(std::basic_string<T, Alloc> const& text) noexcept;
+    static strong_hash compute(std::basic_string<T, Alloc> const& text) noexcept;
 
-    static StrongHash compute(void const* data, size_t n) noexcept;
+    static strong_hash compute(void const* data, size_t n) noexcept;
 
     // Retrieves the 4th 32-bit component of the internal representation.
     // TODO: Provide access also to: a, b, c.
@@ -82,10 +82,10 @@ struct StrongHash
 #endif
 };
 
-inline StrongHash::StrongHash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept:
+inline strong_hash::strong_hash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) noexcept:
 #if defined(STRONGHASH_USE_INTRINSICS)
-    StrongHash(Intrinsics::xor128(Intrinsics::load32(a, b, c, d),
-                                  Intrinsics::loadUnaligned((__m128i const*) defaultSeed.data())))
+    strong_hash(Intrinsics::xor128(Intrinsics::load32(a, b, c, d),
+                                   Intrinsics::loadUnaligned((__m128i const*) defaultSeed.data())))
 #else
     value { a, b, c, d }
 #endif
@@ -93,12 +93,12 @@ inline StrongHash::StrongHash(uint32_t a, uint32_t b, uint32_t c, uint32_t d) no
 }
 
 #if defined(STRONGHASH_USE_INTRINSICS)
-inline StrongHash::StrongHash(__m128i v) noexcept: value { v }
+inline strong_hash::strong_hash(__m128i v) noexcept: value { v }
 {
 }
 #endif
 
-inline bool operator==(StrongHash a, StrongHash b) noexcept
+inline bool operator==(strong_hash a, strong_hash b) noexcept
 {
 #if defined(STRONGHASH_USE_INTRINSICS)
     return Intrinsics::compare(a.value, b.value);
@@ -107,12 +107,12 @@ inline bool operator==(StrongHash a, StrongHash b) noexcept
 #endif
 }
 
-inline bool operator!=(StrongHash a, StrongHash b) noexcept
+inline bool operator!=(strong_hash a, strong_hash b) noexcept
 {
     return !(a == b);
 }
 
-inline StrongHash operator*(StrongHash const& a, StrongHash const& b) noexcept
+inline strong_hash operator*(strong_hash const& a, strong_hash const& b) noexcept
 {
 #if defined(STRONGHASH_USE_INTRINSICS)
     Intrinsics::m128i hashValue = a.value;
@@ -123,47 +123,47 @@ inline StrongHash operator*(StrongHash const& a, StrongHash const& b) noexcept
     hashValue = Intrinsics::aesdec(hashValue, Intrinsics::setzero());
     hashValue = Intrinsics::aesdec(hashValue, Intrinsics::setzero());
 
-    return StrongHash { hashValue };
+    return strong_hash { hashValue };
 #else
-    return StrongHash { FNV<uint32_t, uint32_t>()(a.value[0], b.value[0]),
-                        FNV<uint32_t, uint32_t>()(a.value[1], b.value[1]),
-                        FNV<uint32_t, uint32_t>()(a.value[2], b.value[2]),
-                        FNV<uint32_t, uint32_t>()(a.value[3], b.value[3]) };
+    return strong_hash { fnv<uint32_t, uint32_t>()(a.value[0], b.value[0]),
+                         fnv<uint32_t, uint32_t>()(a.value[1], b.value[1]),
+                         fnv<uint32_t, uint32_t>()(a.value[2], b.value[2]),
+                         fnv<uint32_t, uint32_t>()(a.value[3], b.value[3]) };
 #endif
 }
 
-inline StrongHash operator*(StrongHash a, uint32_t b) noexcept
+inline strong_hash operator*(strong_hash a, uint32_t b) noexcept
 {
-    return a * StrongHash(0, 0, 0, b);
+    return a * strong_hash(0, 0, 0, b);
 }
 
 template <typename T>
-StrongHash StrongHash::compute(std::basic_string_view<T> text) noexcept
+strong_hash strong_hash::compute(std::basic_string_view<T> text) noexcept
 {
     // return compute(value.data(), value.size());
-    auto hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
+    auto hash = strong_hash(0, 0, 0, static_cast<uint32_t>(text.size()));
     for (auto const codepoint: text)
         hash = hash * codepoint; // StrongHash(0, 0, 0, static_cast<uint32_t>(codepoint));
     return hash;
 }
 
 template <typename T, typename Alloc>
-StrongHash StrongHash::compute(std::basic_string<T, Alloc> const& text) noexcept
+strong_hash strong_hash::compute(std::basic_string<T, Alloc> const& text) noexcept
 {
     // return compute(value.data(), value.size());
-    auto hash = StrongHash(0, 0, 0, static_cast<uint32_t>(text.size()));
+    auto hash = strong_hash(0, 0, 0, static_cast<uint32_t>(text.size()));
     for (T const codepoint: text)
         hash = hash * static_cast<uint32_t>(codepoint);
     return hash;
 }
 
 template <typename T>
-StrongHash StrongHash::compute(T const& value) noexcept
+strong_hash strong_hash::compute(T const& value) noexcept
 {
     return compute(&value, sizeof(value));
 }
 
-inline StrongHash StrongHash::compute(void const* data, size_t n) noexcept
+inline strong_hash strong_hash::compute(void const* data, size_t n) noexcept
 {
 #if defined(STRONGHASH_USE_INTRINSICS)
     static_assert(sizeof(__m128i) == 16);
@@ -199,27 +199,27 @@ inline StrongHash StrongHash::compute(void const* data, size_t n) noexcept
         hashValue = Intrinsics::aesdec(hashValue, Intrinsics::setzero());
     }
 
-    return StrongHash { hashValue };
+    return strong_hash { hashValue };
 #else
     auto const* i = (uint8_t const*) data;
     auto const* e = i + n;
-    auto const result = FNV<uint8_t, uint64_t>()(i, e);
+    auto const result = fnv<uint8_t, uint64_t>()(i, e);
     auto constexpr a = 0;
     auto constexpr b = 0;
     auto const c = static_cast<uint32_t>((result >> 32) & 0xFFFFFFFFu);
     auto const d = static_cast<uint32_t>(result & 0xFFFFFFFFu);
-    return StrongHash { a, b, c, d };
+    return strong_hash { a, b, c, d };
 #endif
 }
 
-inline std::string to_string(StrongHash const& hash)
+inline std::string to_string(strong_hash const& hash)
 {
     uint32_t u32[4];
     std::memcpy(u32, &hash, sizeof(hash));
     return fmt::format("{:04X}{:04X}{:04X}{:04X}", u32[0], u32[1], u32[2], u32[3]);
 }
 
-inline std::string to_structured_string(StrongHash const& hash)
+inline std::string to_structured_string(strong_hash const& hash)
 {
     uint32_t u32[4];
     std::memcpy(u32, &hash, sizeof(hash));
@@ -235,7 +235,7 @@ inline std::string to_structured_string(StrongHash const& hash)
     return s;
 }
 
-inline int to_integer(StrongHash hash) noexcept
+inline int to_integer(strong_hash hash) noexcept
 {
 #if defined(STRONGHASH_USE_INTRINSICS)
     return Intrinsics::castToInt32(hash.value);
@@ -245,22 +245,22 @@ inline int to_integer(StrongHash hash) noexcept
 }
 
 template <typename T>
-struct StrongHasher
+struct strong_hasher
 {
-    StrongHash operator()(T const&) noexcept; // Specialize and implement me.
+    strong_hash operator()(T const&) noexcept; // Specialize and implement me.
 };
 
 template <>
-struct StrongHasher<uint64_t>
+struct strong_hasher<uint64_t>
 {
-    inline StrongHash operator()(uint64_t v) noexcept
+    inline strong_hash operator()(uint64_t v) noexcept
     {
         auto const c = static_cast<uint32_t>((v >> 32) & 0xFFFFFFFFu);
         auto const d = static_cast<uint32_t>(v & 0xFFFFFFFFu);
 #if defined(STRONGHASH_USE_INTRINSICS)
-        return StrongHash { Intrinsics::load32(0, 0, c, d) };
+        return strong_hash { Intrinsics::load32(0, 0, c, d) };
 #else
-        return StrongHash { 0, 0, c, d };
+        return strong_hash { 0, 0, c, d };
 #endif
     }
 };
@@ -268,51 +268,51 @@ struct StrongHasher<uint64_t>
 namespace detail
 {
     template <typename T>
-    struct StdHash32
+    struct std_hash32
     {
-        inline StrongHash operator()(T v) noexcept
+        inline strong_hash operator()(T v) noexcept
         {
 #if defined(STRONGHASH_USE_INTRINSICS)
-            return StrongHash { Intrinsics::load32(0, 0, 0, v) };
+            return strong_hash { Intrinsics::load32(0, 0, 0, v) };
 #else
-            return StrongHash { 0, 0, 0, static_cast<uint32_t>(v) };
+            return strong_hash { 0, 0, 0, static_cast<uint32_t>(v) };
 #endif
         }
     };
 } // namespace detail
 
 // clang-format off
-template <> struct StrongHasher<char>: public detail::StdHash32<char> { };
-template <> struct StrongHasher<unsigned char>: public detail::StdHash32<char> { };
-template <> struct StrongHasher<int16_t>: public detail::StdHash32<int16_t> { };
-template <> struct StrongHasher<uint16_t>: public detail::StdHash32<uint16_t> { };
-template <> struct StrongHasher<int32_t>: public detail::StdHash32<int32_t> { };
-template <> struct StrongHasher<uint32_t>: public detail::StdHash32<uint32_t> { };
+template <> struct strong_hasher<char>: public detail::std_hash32<char> { };
+template <> struct strong_hasher<unsigned char>: public detail::std_hash32<char> { };
+template <> struct strong_hasher<int16_t>: public detail::std_hash32<int16_t> { };
+template <> struct strong_hasher<uint16_t>: public detail::std_hash32<uint16_t> { };
+template <> struct strong_hasher<int32_t>: public detail::std_hash32<int32_t> { };
+template <> struct strong_hasher<uint32_t>: public detail::std_hash32<uint32_t> { };
 // clang-format on
 // }}}
 
 template <class Char, class Allocator>
-struct StrongHasher<std::basic_string<Char, Allocator>>
+struct strong_hasher<std::basic_string<Char, Allocator>>
 {
-    inline StrongHash operator()(std::basic_string<Char, Allocator> const& v) noexcept
+    inline strong_hash operator()(std::basic_string<Char, Allocator> const& v) noexcept
     {
-        return StrongHasher<int> {}((int) std::hash<std::basic_string<Char, Allocator>> {}(v));
+        return strong_hasher<int> {}((int) std::hash<std::basic_string<Char, Allocator>> {}(v));
     }
 };
 
 template <typename U>
-struct StrongHasher<std::basic_string_view<U>>
+struct strong_hasher<std::basic_string_view<U>>
 {
-    inline StrongHash operator()(std::basic_string_view<U> v) noexcept
+    inline strong_hash operator()(std::basic_string_view<U> v) noexcept
     {
-        return StrongHasher<int> {}((int) std::hash<std::basic_string_view<U>> {}(v));
+        return strong_hasher<int> {}((int) std::hash<std::basic_string_view<U>> {}(v));
     }
 };
 
 } // namespace crispy
 
 template <>
-struct fmt::formatter<crispy::StrongHash>
+struct fmt::formatter<crispy::strong_hash>
 {
     template <typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
@@ -320,7 +320,7 @@ struct fmt::formatter<crispy::StrongHash>
         return ctx.begin();
     }
     template <typename FormatContext>
-    auto format(crispy::StrongHash const& hash, FormatContext& ctx)
+    auto format(crispy::strong_hash const& hash, FormatContext& ctx)
     {
         return fmt::format_to(ctx.out(), "{}", to_structured_string(hash));
     }

--- a/src/crispy/StrongLRUCache.h
+++ b/src/crispy/StrongLRUCache.h
@@ -22,8 +22,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include "StrongHash.h"
-
 #define DEBUG_STRONG_LRU_CACHE 1
 
 #if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_CACHE)

--- a/src/crispy/StrongLRUCache.h
+++ b/src/crispy/StrongLRUCache.h
@@ -22,6 +22,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "StrongHash.h"
+
 #define DEBUG_STRONG_LRU_CACHE 1
 
 #if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_CACHE)
@@ -35,7 +37,7 @@ namespace crispy
 namespace detail
 {
     template <typename Key, typename Value>
-    struct LRUCacheEntry
+    struct lru_cache_entry
     {
         Key key {};
         Value value {};
@@ -51,16 +53,16 @@ namespace detail
 //     memory region instead of two.
 //     Or even overloading operator new of StrongLRUCache
 //     and put the dynamic data at the end of the primary data.
-template <typename Key, typename Value, typename Hasher = StrongHasher<Key>>
-class StrongLRUCache
+template <typename Key, typename Value, typename Hasher = strong_hasher<Key>>
+class strong_lru_cache
 {
   public:
-    StrongLRUCache(StrongHashtableSize hashCount, LRUCapacity entryCount, std::string name = "");
-    StrongLRUCache(StrongLRUCache&&) noexcept = default;
-    StrongLRUCache(StrongLRUCache const&) noexcept = delete;
-    StrongLRUCache& operator=(StrongLRUCache&&) noexcept = default;
-    StrongLRUCache& operator=(StrongLRUCache const&) noexcept = delete;
-    ~StrongLRUCache() = default;
+    strong_lru_cache(strong_hashtable_size hashCount, lru_capacity entryCount, std::string name = "");
+    strong_lru_cache(strong_lru_cache&&) noexcept = default;
+    strong_lru_cache(strong_lru_cache const&) noexcept = delete;
+    strong_lru_cache& operator=(strong_lru_cache&&) noexcept = default;
+    strong_lru_cache& operator=(strong_lru_cache const&) noexcept = delete;
+    ~strong_lru_cache() = default;
 
     /// Returns the actual number of entries currently hold in this cache.
     [[nodiscard]] size_t size() const noexcept;
@@ -70,7 +72,7 @@ class StrongLRUCache
 
     /// Returns gathered stats and clears the local stats state to start
     /// counting from zero again.
-    LRUHashtableStats fetchAndClearStats() noexcept;
+    lru_hashtable_stats fetchAndClearStats() noexcept;
 
     /// Clears all entries from the cache.
     void clear();
@@ -121,130 +123,130 @@ class StrongLRUCache
     void inspect(std::ostream& output) const;
 
   private:
-    using Entry = detail::LRUCacheEntry<Key, Value>;
-    using Hashtable = StrongLRUHashtable<Entry>;
-    using HashtablePtr = typename Hashtable::Ptr;
+    using entry = detail::lru_cache_entry<Key, Value>;
+    using hashtable = strong_lru_hashtable<entry>;
+    using hashtable_ptr = typename hashtable::ptr;
 
-    HashtablePtr _hashtable;
+    hashtable_ptr _hashtable;
 };
 
 // {{{ implementation
 
 template <typename Key, typename Value, typename Hasher>
-StrongLRUCache<Key, Value, Hasher>::StrongLRUCache(StrongHashtableSize hashCount,
-                                                   LRUCapacity entryCount,
-                                                   std::string name):
-    _hashtable { Hashtable::create(hashCount, entryCount, std::move(name)) }
+strong_lru_cache<Key, Value, Hasher>::strong_lru_cache(strong_hashtable_size hashCount,
+                                                       lru_capacity entryCount,
+                                                       std::string name):
+    _hashtable { hashtable::create(hashCount, entryCount, std::move(name)) }
 {
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline size_t StrongLRUCache<Key, Value, Hasher>::size() const noexcept
+inline size_t strong_lru_cache<Key, Value, Hasher>::size() const noexcept
 {
     return _hashtable->size();
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline size_t StrongLRUCache<Key, Value, Hasher>::capacity() const noexcept
+inline size_t strong_lru_cache<Key, Value, Hasher>::capacity() const noexcept
 {
     return _hashtable->capacity();
 }
 
 template <typename Key, typename Value, typename Hasher>
-LRUHashtableStats StrongLRUCache<Key, Value, Hasher>::fetchAndClearStats() noexcept
+lru_hashtable_stats strong_lru_cache<Key, Value, Hasher>::fetchAndClearStats() noexcept
 {
     return _hashtable->fetchAndClearStats();
 }
 
 template <typename Key, typename Value, typename Hasher>
-void StrongLRUCache<Key, Value, Hasher>::clear()
+void strong_lru_cache<Key, Value, Hasher>::clear()
 {
     _hashtable->clear();
 }
 
 template <typename Key, typename Value, typename Hasher>
-void StrongLRUCache<Key, Value, Hasher>::remove(Key key)
+void strong_lru_cache<Key, Value, Hasher>::remove(Key key)
 {
     _hashtable->remove(Hasher {}(key));
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline void StrongLRUCache<Key, Value, Hasher>::touch(Key key) noexcept
+inline void strong_lru_cache<Key, Value, Hasher>::touch(Key key) noexcept
 {
     _hashtable->touch(Hasher {}(key));
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline bool StrongLRUCache<Key, Value, Hasher>::contains(Key key) const noexcept
+inline bool strong_lru_cache<Key, Value, Hasher>::contains(Key key) const noexcept
 {
     return _hashtable->contains(Hasher {}(key));
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline Value* StrongLRUCache<Key, Value, Hasher>::try_get(Key key) noexcept
+inline Value* strong_lru_cache<Key, Value, Hasher>::try_get(Key key) noexcept
 {
-    if (Entry* e = _hashtable->try_get(Hasher {}(key)))
+    if (entry* e = _hashtable->try_get(Hasher {}(key)))
         return &e->value;
     return nullptr;
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline Value const* StrongLRUCache<Key, Value, Hasher>::try_get(Key key) const noexcept
+inline Value const* strong_lru_cache<Key, Value, Hasher>::try_get(Key key) const noexcept
 {
-    if (Entry const* e = _hashtable->try_get(Hasher {}(key)))
+    if (entry const* e = _hashtable->try_get(Hasher {}(key)))
         return &e->value;
     return nullptr;
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline Value& StrongLRUCache<Key, Value, Hasher>::at(Key key)
+inline Value& strong_lru_cache<Key, Value, Hasher>::at(Key key)
 {
     return _hashtable->at(Hasher {}(key)).value;
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline Value& StrongLRUCache<Key, Value, Hasher>::operator[](Key key) noexcept
+inline Value& strong_lru_cache<Key, Value, Hasher>::operator[](Key key) noexcept
 {
-    return _hashtable->get_or_emplace(Hasher {}(key), [&](auto) { return Entry { key, Value {} }; }).value;
+    return _hashtable->get_or_emplace(Hasher {}(key), [&](auto) { return entry { key, Value {} }; }).value;
 }
 
 template <typename Key, typename Value, typename Hasher>
 template <typename ValueConstructFn>
-inline bool StrongLRUCache<Key, Value, Hasher>::try_emplace(Key key, ValueConstructFn constructValue)
+inline bool strong_lru_cache<Key, Value, Hasher>::try_emplace(Key key, ValueConstructFn constructValue)
 {
     return _hashtable->try_emplace(Hasher {}(key), [&](auto v) {
-        return Entry { key, constructValue(std::move(v)) };
+        return entry { key, constructValue(std::move(v)) };
     });
 }
 
 template <typename Key, typename Value, typename Hasher>
 template <typename ValueConstructFn>
-inline Value& StrongLRUCache<Key, Value, Hasher>::get_or_emplace(Key key, ValueConstructFn constructValue)
+inline Value& strong_lru_cache<Key, Value, Hasher>::get_or_emplace(Key key, ValueConstructFn constructValue)
 {
     return _hashtable->get_or_emplace(Hasher {}(key),
                                       [&](auto v) {
-                                          return Entry { key, constructValue(v) };
+                                          return entry { key, constructValue(v) };
                                       })
         .value;
 }
 
 template <typename Key, typename Value, typename Hasher>
-inline Value& StrongLRUCache<Key, Value, Hasher>::emplace(Key key, Value value) noexcept
+inline Value& strong_lru_cache<Key, Value, Hasher>::emplace(Key key, Value value) noexcept
 {
-    return _hashtable->emplace(Hasher {}(key), Entry { key, std::move(value) }).value;
+    return _hashtable->emplace(Hasher {}(key), entry { key, std::move(value) }).value;
 }
 
 template <typename Key, typename Value, typename Hasher>
-std::vector<Key> StrongLRUCache<Key, Value, Hasher>::keys() const
+std::vector<Key> strong_lru_cache<Key, Value, Hasher>::keys() const
 {
     auto result = std::vector<Key> {};
-    for (StrongHash const& hash: _hashtable->hashes())
+    for (strong_hash const& hash: _hashtable->hashes())
         result.emplace_back(_hashtable->peek(hash).key);
     return result;
 }
 
 template <typename Key, typename Value, typename Hasher>
-void StrongLRUCache<Key, Value, Hasher>::inspect(std::ostream& output) const
+void strong_lru_cache<Key, Value, Hasher>::inspect(std::ostream& output) const
 {
     _hashtable->inspect(output);
 }
@@ -255,10 +257,10 @@ void StrongLRUCache<Key, Value, Hasher>::inspect(std::ostream& output) const
 
 // {{{ fmt
 template <typename K, typename V>
-struct fmt::formatter<crispy::detail::LRUCacheEntry<K, V>>
+struct fmt::formatter<crispy::detail::lru_cache_entry<K, V>>
 {
     static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(crispy::detail::LRUCacheEntry<K, V> const& entry, format_context& ctx)
+    static auto format(crispy::detail::lru_cache_entry<K, V> const& entry, format_context& ctx)
         -> format_context::iterator
     {
         return fmt::format_to(ctx.out(), "{}: {}", entry.key, entry.value);

--- a/src/crispy/StrongLRUCache_test.cpp
+++ b/src/crispy/StrongLRUCache_test.cpp
@@ -23,9 +23,9 @@ using namespace crispy;
 using namespace std;
 using namespace std::string_view_literals;
 
-TEST_CASE("StrongLRUCache.operator_index", "")
+TEST_CASE("strong_lru_cache.operator_index", "")
 {
-    auto cache = StrongLRUCache<int, string_view>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string_view>(strong_hashtable_size { 8 }, lru_capacity { 4 });
 
     cache[1] = "1"sv;
     REQUIRE(cache[1] == "1"sv);
@@ -52,9 +52,9 @@ TEST_CASE("StrongLRUCache.operator_index", "")
     REQUIRE(joinHumanReadable(cache.keys()) == "6, 5, 4, 3");
 }
 
-TEST_CASE("StrongLRUCache.at", "")
+TEST_CASE("strong_lru_cache.at", "")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -63,9 +63,9 @@ TEST_CASE("StrongLRUCache.at", "")
     CHECK_NOTHROW(cache.at(1));
 }
 
-TEST_CASE("StrongLRUCache.clear", "[lrucache]")
+TEST_CASE("strong_lru_cache.clear", "[lrucache]")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -75,9 +75,9 @@ TEST_CASE("StrongLRUCache.clear", "[lrucache]")
     CHECK(cache.size() == 0);
 }
 
-TEST_CASE("StrongLRUCache.touch", "")
+TEST_CASE("strong_lru_cache.touch", "")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -99,9 +99,9 @@ TEST_CASE("StrongLRUCache.touch", "")
     REQUIRE(joinHumanReadable(cache.keys()) == "1, 3, 4, 2");
 }
 
-TEST_CASE("StrongLRUCache.contains", "")
+TEST_CASE("strong_lru_cache.contains", "")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -123,9 +123,9 @@ TEST_CASE("StrongLRUCache.contains", "")
     REQUIRE(joinHumanReadable(cache.keys()) == "1, 3, 4, 2");
 }
 
-TEST_CASE("StrongLRUCache.try_emplace", "")
+TEST_CASE("strong_lru_cache.try_emplace", "")
 {
-    auto cache = StrongLRUCache<int, int>(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cache = strong_lru_cache<int, int>(strong_hashtable_size { 4 }, lru_capacity { 2 });
 
     auto rv = cache.try_emplace(2, [](auto) { return 4; });
     CHECK(rv);
@@ -145,9 +145,9 @@ TEST_CASE("StrongLRUCache.try_emplace", "")
     CHECK(cache.at(3) == 6);
 }
 
-TEST_CASE("StrongLRUCache.try_get", "")
+TEST_CASE("strong_lru_cache.try_get", "")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -175,9 +175,9 @@ TEST_CASE("StrongLRUCache.try_get", "")
     REQUIRE(joinHumanReadable(cache.keys()) == "1, 3, 4, 2");
 }
 
-TEST_CASE("StrongLRUCache.get_or_emplace", "[lrucache]")
+TEST_CASE("strong_lru_cache.get_or_emplace", "[lrucache]")
 {
-    auto cache = StrongLRUCache<int, int>(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cache = strong_lru_cache<int, int>(strong_hashtable_size { 4 }, lru_capacity { 2 });
 
     int& a = cache.get_or_emplace(2, [](auto) { return 4; });
     CHECK(a == 4);
@@ -211,9 +211,9 @@ TEST_CASE("StrongLRUCache.get_or_emplace", "[lrucache]")
     CHECK(cache.size() == 2);
 }
 
-TEST_CASE("StrongLRUCache.remove", "")
+TEST_CASE("strong_lru_cache.remove", "")
 {
-    auto cache = StrongLRUCache<int, string>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache = strong_lru_cache<int, string>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = std::to_string(i);
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
@@ -236,21 +236,22 @@ TEST_CASE("StrongLRUCache.remove", "")
 }
 
 // clang-format off
-struct CollidingHasher
+struct colliding_hasher
 {
-    StrongHash operator()(int v) noexcept
+    strong_hash operator()(int v) noexcept
     {
         // Since the hashtable lookup only looks at the
         // least significant 32 bit, this will always cause
         // a hash-table entry collision.
-        return StrongHash { 0, 0, static_cast<uint32_t>(v), 0 };
+        return strong_hash { 0, 0, static_cast<uint32_t>(v), 0 };
     }
 };
 // clang-format on
 
-TEST_CASE("StrongLRUCache.insert_with_cache_collision", "")
+TEST_CASE("strong_lru_cache.insert_with_cache_collision", "")
 {
-    auto cache = StrongLRUCache<int, int, CollidingHasher>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache =
+        strong_lru_cache<int, int, colliding_hasher>(strong_hashtable_size { 8 }, lru_capacity { 4 });
 
     cache[1] = 1;
     REQUIRE(joinHumanReadable(cache.keys()) == "1");
@@ -265,9 +266,10 @@ TEST_CASE("StrongLRUCache.insert_with_cache_collision", "")
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");
 }
 
-TEST_CASE("StrongLRUCache.remove_with_hashTable_lookup_collision", "")
+TEST_CASE("strong_lru_cache.remove_with_hashTable_lookup_collision", "")
 {
-    auto cache = StrongLRUCache<int, int, CollidingHasher>(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cache =
+        strong_lru_cache<int, int, colliding_hasher>(strong_hashtable_size { 8 }, lru_capacity { 4 });
     for (int i = 1; i <= 4; ++i)
         cache[i] = 2 * i;
     REQUIRE(joinHumanReadable(cache.keys()) == "4, 3, 2, 1");

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -22,6 +22,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "StrongHash.h"
+
 #define DEBUG_STRONG_LRU_HASHTABLE 1
 
 #if defined(NDEBUG) && defined(DEBUG_STRONG_LRU_HASHTABLE)
@@ -42,7 +44,7 @@ namespace detail
 } // namespace detail
 // }}}
 
-struct LRUHashtableStats
+struct lru_hashtable_stats
 {
     uint32_t hits;
     uint32_t misses;
@@ -52,10 +54,10 @@ struct LRUHashtableStats
 
 // {{{ fmt
 template <>
-struct fmt::formatter<crispy::LRUHashtableStats>
+struct fmt::formatter<crispy::lru_hashtable_stats>
 {
     static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(crispy::LRUHashtableStats stats, format_context& ctx) -> format_context::iterator
+    static auto format(crispy::lru_hashtable_stats stats, format_context& ctx) -> format_context::iterator
     {
         return fmt::format_to(
             ctx.out(),
@@ -73,13 +75,13 @@ struct fmt::formatter<crispy::LRUHashtableStats>
 namespace crispy
 {
 // Defines the number of hashes the hashtable can store.
-struct StrongHashtableSize
+struct strong_hashtable_size
 {
     uint32_t value;
 };
 
 // Number of entries the LRU StrongLRUHashtable can store at most.
-struct LRUCapacity
+struct lru_capacity
 {
     uint32_t value;
 };
@@ -90,25 +92,25 @@ struct LRUCapacity
 // NOTE!
 //     Cache locality could be further improved by having one single
 //     memory region instead of two.
-//     Or even overloading operator new of StrongLRUHashtable
+//     Or even overloading operator new of strong_lru_hashtable
 //     and put the dynamic data at the end of the primary data.
 template <typename Value>
-class StrongLRUHashtable
+class strong_lru_hashtable
 {
   private:
-    StrongLRUHashtable(StrongHashtableSize hashCount, LRUCapacity entryCount, std::string name);
+    strong_lru_hashtable(strong_hashtable_size hashCount, lru_capacity entryCount, std::string name);
 
   public:
-    ~StrongLRUHashtable();
+    ~strong_lru_hashtable();
 
-    using Ptr = std::unique_ptr<StrongLRUHashtable, std::function<void(StrongLRUHashtable*)>>;
+    using ptr = std::unique_ptr<strong_lru_hashtable, std::function<void(strong_lru_hashtable*)>>;
 
-    [[nodiscard]] static constexpr inline size_t requiredMemorySize(StrongHashtableSize hashCount,
-                                                                    LRUCapacity entryCount);
+    [[nodiscard]] static constexpr inline size_t requiredMemorySize(strong_hashtable_size hashCount,
+                                                                    lru_capacity entryCount);
 
     template <typename Allocator = std::allocator<unsigned char>>
-    [[nodiscard]] static Ptr create(StrongHashtableSize hashCount,
-                                    LRUCapacity entryCount,
+    [[nodiscard]] static ptr create(strong_hashtable_size hashCount,
+                                    lru_capacity entryCount,
                                     std::string name = "");
 
     /// Returns the actual number of entries currently hold in this hashtable.
@@ -122,48 +124,48 @@ class StrongLRUHashtable
 
     /// Returns gathered stats and clears the local stats state to start
     /// counting from zero again.
-    LRUHashtableStats fetchAndClearStats() noexcept;
+    lru_hashtable_stats fetchAndClearStats() noexcept;
 
     /// Clears all entries from the hashtable.
     void clear();
 
     // Deletes the hash entry and its associated value from the LRU hashtable
-    void remove(StrongHash const& hash);
+    void remove(strong_hash const& hash);
 
     /// Touches a given hash key, putting it to the front of the LRU chain.
     /// Nothing is done if the hash key was not found.
-    void touch(StrongHash const& hash) noexcept;
+    void touch(strong_hash const& hash) noexcept;
 
     /// Returns an ordered list of keys in this hash.
     /// Ordering is from most recent to least recent access.
-    [[nodiscard]] std::vector<StrongHash> hashes() const;
+    [[nodiscard]] std::vector<strong_hash> hashes() const;
 
     /// Tests for the exitence of the given hash key in this hash table.
-    [[nodiscard]] bool contains(StrongHash const& hash) const noexcept;
+    [[nodiscard]] bool contains(strong_hash const& hash) const noexcept;
 
     /// Returns the value for the given hash key if found, nullptr otherwise.
-    [[nodiscard]] Value* try_get(StrongHash const& hash) noexcept;
-    [[nodiscard]] Value const* try_get(StrongHash const& hash) const noexcept;
+    [[nodiscard]] Value* try_get(strong_hash const& hash) noexcept;
+    [[nodiscard]] Value const* try_get(strong_hash const& hash) const noexcept;
 
     /// Returns the value for the given hash key,
     /// throwing std::out_of_range if hash key was not found.
-    [[nodiscard]] Value& at(StrongHash const& hash);
+    [[nodiscard]] Value& at(strong_hash const& hash);
 
     /// like at() but does not change LRU order.
-    [[nodiscard]] Value& peek(StrongHash const& hash);
-    [[nodiscard]] Value const& peek(StrongHash const& hash) const;
+    [[nodiscard]] Value& peek(strong_hash const& hash);
+    [[nodiscard]] Value const& peek(strong_hash const& hash) const;
 
     /// Returns the value for the given hash key, default-constructing it in case
     /// if it wasn't in the hashtable just yet.
-    [[nodiscard]] Value& operator[](StrongHash const& hash) noexcept;
+    [[nodiscard]] Value& operator[](strong_hash const& hash) noexcept;
 
     /// Assignes the given value to the given hash key.
     /// If the hash key was not found, it is being created,
     /// otherwise the value will be re-assigned with the new value.
-    Value& emplace(StrongHash const& hash, Value value) noexcept;
+    Value& emplace(strong_hash const& hash, Value value) noexcept;
 
     template <typename ValueConstructFn>
-    Value& emplace(StrongHash const& hash, ValueConstructFn constructValue) noexcept;
+    Value& emplace(strong_hash const& hash, ValueConstructFn constructValue) noexcept;
 
     /// Conditionally creates a new item to the LRU-Cache iff its hash key
     /// was not present yet.
@@ -171,12 +173,12 @@ class StrongLRUHashtable
     /// @retval true the hash key did not exist in hashtable yet, a new value was constructed.
     /// @retval false The hash key is already in the hashtable, no entry was constructed.
     template <typename ValueConstructFn>
-    [[nodiscard]] bool try_emplace(StrongHash const& hash, ValueConstructFn constructValue);
+    [[nodiscard]] bool try_emplace(strong_hash const& hash, ValueConstructFn constructValue);
 
     /// Always returns either the existing item by the given hash key, if found,
     /// or a newly created one by invoking constructValue().
     template <typename ValueConstructFn>
-    [[nodiscard]] Value& get_or_emplace(StrongHash const& hash, ValueConstructFn constructValue);
+    [[nodiscard]] Value& get_or_emplace(strong_hash const& hash, ValueConstructFn constructValue);
 
     /**
      * Like get_or_emplace but allows failure in @p constructValue call to cause the hash entry not
@@ -187,7 +189,7 @@ class StrongLRUHashtable
      * If creation has failed, nullptr is returned instead.
      */
     template <typename ValueConstructFn>
-    [[nodiscard]] Value* get_or_try_emplace(StrongHash const& hash, ValueConstructFn constructValue);
+    [[nodiscard]] Value* get_or_try_emplace(strong_hash const& hash, ValueConstructFn constructValue);
 
     /// Retrieves the value stored at the given entry index.
     [[nodiscard]] Value& valueAtEntryIndex(uint32_t entryIndex) noexcept;
@@ -198,21 +200,23 @@ class StrongLRUHashtable
     void inspect(std::ostream& output) const;
 
     // {{{ public detail
-    struct NextWithSameHash
+    struct next_with_same_hash
     {
-        explicit NextWithSameHash(uint32_t v): value { v } {}
+        explicit next_with_same_hash(uint32_t v): value { v } {}
         uint32_t value;
     };
 
-    struct Entry
+    struct entry
     {
-        Entry(Entry const&) = default;
-        Entry(Entry&&) noexcept = default;
-        Entry& operator=(Entry const&) = default;
-        Entry& operator=(Entry&&) noexcept = default;
-        Entry(NextWithSameHash initialNextWithSameHash): nextWithSameHash { initialNextWithSameHash.value } {}
+        entry(entry const&) = default;
+        entry(entry&&) noexcept = default;
+        entry& operator=(entry const&) = default;
+        entry& operator=(entry&&) noexcept = default;
+        entry(next_with_same_hash initialNextWithSameHash): nextWithSameHash { initialNextWithSameHash.value }
+        {
+        }
 
-        StrongHash hashValue {};
+        strong_hash hashValue {};
 
         uint32_t prevInLRU = 0;
         uint32_t nextInLRU = 0;
@@ -229,24 +233,24 @@ class StrongLRUHashtable
   private:
     // {{{ details
     // Maps the given hash hash key to a slot in the hash table.
-    [[nodiscard]] uint32_t* hashTableSlot(StrongHash const& hash) noexcept;
+    [[nodiscard]] uint32_t* hashTableSlot(strong_hash const& hash) noexcept;
 
     // Returns entry index to an unused entry, possibly by evicting
     // the least recently used entry if no free entries are available.
     //
     // This entry is not inserted into the LRU-chain yet.
-    [[nodiscard]] uint32_t allocateEntry(StrongHash const& hash, uint32_t* slot);
+    [[nodiscard]] uint32_t allocateEntry(strong_hash const& hash, uint32_t* slot);
 
     // Relinks the given entry to the front of the LRU-chain.
     void linkToLRUChainHead(uint32_t entryIndex) noexcept;
 
     // Unlinks given entry from LRU chain without touching the entry itself.
-    void unlinkFromLRUChain(Entry& entry) noexcept;
+    void unlinkFromLRUChain(entry& entry) noexcept;
 
     // Returns the index to the entry associated with the given hash key.
     // If the hash key was not found and force is set to true, it'll be created,
     // otherwise 0 is returned.
-    [[nodiscard]] uint32_t findEntry(StrongHash const& hash, bool force);
+    [[nodiscard]] uint32_t findEntry(strong_hash const& hash, bool force);
 
     // Evicts the least recently used entry in the LRU chain
     // and links it to the unused-entries chain.
@@ -256,20 +260,20 @@ class StrongLRUHashtable
 
     int validateChange(int adj);
 
-    [[nodiscard]] Entry& sentinelEntry() noexcept { return _entries[0]; }
-    [[nodiscard]] Entry const& sentinelEntry() const noexcept { return _entries[0]; }
+    [[nodiscard]] entry& sentinelEntry() noexcept { return _entries[0]; }
+    [[nodiscard]] entry const& sentinelEntry() const noexcept { return _entries[0]; }
     // }}}
 
-    LRUHashtableStats _stats;
+    lru_hashtable_stats _stats;
     uint32_t _hashMask;
-    StrongHashtableSize _hashCount;
+    strong_hashtable_size _hashCount;
     uint32_t _size = 0;
-    LRUCapacity _capacity;
+    lru_capacity _capacity;
     std::string _name;
 
     // The hash table maps hash codes to indices into the entry table.
     uint32_t* _hashTable;
-    Entry* _entries;
+    entry* _entries;
 
 #if defined(DEBUG_STRONG_LRU_HASHTABLE)
     int _lastLRUCount = 0;
@@ -279,9 +283,9 @@ class StrongLRUHashtable
 // {{{ implementation
 
 template <typename Value>
-StrongLRUHashtable<Value>::StrongLRUHashtable(StrongHashtableSize hashCount,
-                                              LRUCapacity entryCount,
-                                              std::string name):
+strong_lru_hashtable<Value>::strong_lru_hashtable(strong_hashtable_size hashCount,
+                                                  lru_capacity entryCount,
+                                                  std::string name):
     _stats {},
     _hashMask { hashCount.value - 1 },
     _hashCount { hashCount },
@@ -289,12 +293,12 @@ StrongLRUHashtable<Value>::StrongLRUHashtable(StrongHashtableSize hashCount,
     _name { std::move(name) },
     _hashTable { (uint32_t*) (this + 1) },
     _entries { [this]() {
-        constexpr uintptr_t Alignment = std::alignment_of_v<Entry>;
+        constexpr uintptr_t Alignment = std::alignment_of_v<entry>;
         static_assert(detail::isPowerOfTwo(Alignment));
         constexpr uintptr_t AlignMask = Alignment - 1;
 
         auto* hashTableEnd = _hashTable + _hashCount.value;
-        auto* entryTable = (Entry*) (uintptr_t((char*) hashTableEnd + AlignMask) & ~AlignMask);
+        auto* entryTable = (entry*) (uintptr_t((char*) hashTableEnd + AlignMask) & ~AlignMask);
 
         return entryTable;
     }() }
@@ -307,37 +311,37 @@ StrongLRUHashtable<Value>::StrongLRUHashtable(StrongHashtableSize hashCount,
 
     for (uint32_t entryIndex = 0; entryIndex <= entryCount.value; ++entryIndex)
     {
-        Entry* entry = _entries + entryIndex;
-        new (entry) Entry(NextWithSameHash(entryIndex + 1));
+        entry* ent = _entries + entryIndex;
+        new (ent) entry(next_with_same_hash(entryIndex + 1));
     }
-    new (_entries + entryCount.value) Entry(NextWithSameHash(0));
+    new (_entries + entryCount.value) entry(next_with_same_hash(0));
 }
 
 template <typename Value>
-StrongLRUHashtable<Value>::~StrongLRUHashtable()
+strong_lru_hashtable<Value>::~strong_lru_hashtable()
 {
     std::destroy_n(_entries, 1 + _capacity.value);
 }
 
 template <typename Value>
-constexpr inline size_t StrongLRUHashtable<Value>::requiredMemorySize(StrongHashtableSize hashCount,
-                                                                      LRUCapacity entryCount)
+constexpr inline size_t strong_lru_hashtable<Value>::requiredMemorySize(strong_hashtable_size hashCount,
+                                                                        lru_capacity entryCount)
 {
     Require(detail::isPowerOfTwo(hashCount.value)); // Hash capacity must be power of 2.
     Require(hashCount.value >= 1);
     Require(entryCount.value >= 2);
 
     auto const hashSize = hashCount.value * sizeof(uint32_t);
-    auto const entrySize = (1 + entryCount.value) * sizeof(Entry) + std::alignment_of_v<Entry>;
-    auto const totalSize = sizeof(StrongLRUHashtable) + hashSize + entrySize;
+    auto const entrySize = (1 + entryCount.value) * sizeof(entry) + std::alignment_of_v<entry>;
+    auto const totalSize = sizeof(strong_lru_hashtable) + hashSize + entrySize;
     return totalSize;
 }
 
 template <typename Value>
 template <typename Allocator>
-auto StrongLRUHashtable<Value>::create(StrongHashtableSize hashCount,
-                                       LRUCapacity entryCount,
-                                       std::string name) -> Ptr
+auto strong_lru_hashtable<Value>::create(strong_hashtable_size hashCount,
+                                         lru_capacity entryCount,
+                                         std::string name) -> ptr
 {
     // payload memory layout
     // =====================
@@ -351,50 +355,50 @@ auto StrongLRUHashtable<Value>::create(StrongHashtableSize hashCount,
 
     Allocator allocator;
     auto const size = requiredMemorySize(hashCount, entryCount);
-    auto* obj = (StrongLRUHashtable*) allocator.allocate(size);
+    auto* obj = (strong_lru_hashtable*) allocator.allocate(size);
 
     // clang-format off
     if (!obj)
-        return Ptr { nullptr, [](auto) {} };
+        return ptr { nullptr, [](auto) {} };
     // clang-format on
 
     memset((void*) obj, 0, size);
-    new (obj) StrongLRUHashtable(hashCount, entryCount, std::move(name));
+    new (obj) strong_lru_hashtable(hashCount, entryCount, std::move(name));
 
     auto deleter = [size, allocator = std::move(allocator)](auto p) mutable {
         std::destroy_n(p, 1);
         allocator.deallocate(reinterpret_cast<unsigned char*>(p), size);
     };
 
-    return Ptr(obj, std::move(deleter));
+    return ptr(obj, std::move(deleter));
 }
 
 template <typename Value>
-inline size_t StrongLRUHashtable<Value>::size() const noexcept
+inline size_t strong_lru_hashtable<Value>::size() const noexcept
 {
     return _size;
 }
 
 template <typename Value>
-inline size_t StrongLRUHashtable<Value>::capacity() const noexcept
+inline size_t strong_lru_hashtable<Value>::capacity() const noexcept
 {
     return _capacity.value;
 }
 
 template <typename Value>
-inline size_t StrongLRUHashtable<Value>::storageSize() const noexcept
+inline size_t strong_lru_hashtable<Value>::storageSize() const noexcept
 {
     auto const hashTableSize = _hashCount.value * sizeof(uint32_t);
 
     // +1 for sentinel entry in the front
     // +1 for alignment
-    auto const entryTableSize = (1 + _capacity.value) * sizeof(Entry);
+    auto const entryTableSize = (1 + _capacity.value) * sizeof(entry);
 
-    return sizeof(StrongLRUHashtable) + hashTableSize + entryTableSize;
+    return sizeof(strong_lru_hashtable) + hashTableSize + entryTableSize;
 }
 
 template <typename Value>
-inline uint32_t* StrongLRUHashtable<Value>::hashTableSlot(StrongHash const& hash) noexcept
+inline uint32_t* strong_lru_hashtable<Value>::hashTableSlot(strong_hash const& hash) noexcept
 {
     auto const index = hash.d();
     auto const slot = index & _hashMask;
@@ -402,21 +406,21 @@ inline uint32_t* StrongLRUHashtable<Value>::hashTableSlot(StrongHash const& hash
 }
 
 template <typename Value>
-LRUHashtableStats StrongLRUHashtable<Value>::fetchAndClearStats() noexcept
+lru_hashtable_stats strong_lru_hashtable<Value>::fetchAndClearStats() noexcept
 {
     auto st = _stats;
-    _stats = LRUHashtableStats {};
+    _stats = lru_hashtable_stats {};
     return st;
 }
 
 template <typename Value>
-void StrongLRUHashtable<Value>::clear()
+void strong_lru_hashtable<Value>::clear()
 {
-    Entry& sentinel = sentinelEntry();
+    entry& sentinel = sentinelEntry();
     auto entryIndex = sentinel.nextInLRU;
     while (entryIndex)
     {
-        Entry& entry = _entries[entryIndex];
+        entry& entry = _entries[entryIndex];
         entry.value.reset();
         entryIndex = entry.nextInLRU;
     }
@@ -425,10 +429,10 @@ void StrongLRUHashtable<Value>::clear()
 
     while (entryIndex <= _capacity.value)
     {
-        _entries[entryIndex] = Entry(NextWithSameHash(1 + entryIndex));
+        _entries[entryIndex] = entry(next_with_same_hash(1 + entryIndex));
         ++entryIndex;
     }
-    _entries[_capacity.value] = Entry(NextWithSameHash(0));
+    _entries[_capacity.value] = entry(next_with_same_hash(0));
 
     auto const oldSize = static_cast<int>(_size);
     _size = 0;
@@ -436,44 +440,44 @@ void StrongLRUHashtable<Value>::clear()
 }
 
 template <typename Value>
-void StrongLRUHashtable<Value>::remove(StrongHash const& hash)
+void strong_lru_hashtable<Value>::remove(strong_hash const& hash)
 {
     uint32_t* slot = hashTableSlot(hash);
     uint32_t entryIndex = *slot;
     uint32_t prevWithSameHash = 0;
-    Entry* entry = nullptr;
+    entry* ent = nullptr;
 
     while (entryIndex)
     {
-        entry = _entries + entryIndex;
-        if (entry->hashValue == hash)
+        ent = _entries + entryIndex;
+        if (ent->hashValue == hash)
             break;
         prevWithSameHash = entryIndex;
-        entryIndex = entry->nextWithSameHash;
+        entryIndex = ent->nextWithSameHash;
     }
 
     if (entryIndex == 0)
         return;
 
-    Entry& prev = _entries[entry->prevInLRU];
-    Entry& next = _entries[entry->nextInLRU];
+    entry& prev = _entries[ent->prevInLRU];
+    entry& next = _entries[ent->nextInLRU];
 
     // unlink from LRU chain
-    prev.nextInLRU = entry->nextInLRU;
-    next.prevInLRU = entry->prevInLRU;
+    prev.nextInLRU = ent->nextInLRU;
+    next.prevInLRU = ent->prevInLRU;
     if (prevWithSameHash)
     {
         Require(_entries[prevWithSameHash].nextWithSameHash == entryIndex);
-        _entries[prevWithSameHash].nextWithSameHash = entry->nextWithSameHash;
+        _entries[prevWithSameHash].nextWithSameHash = ent->nextWithSameHash;
     }
     else
-        *slot = entry->nextWithSameHash;
+        *slot = ent->nextWithSameHash;
 
     // relink into free-chain
-    Entry& sentinel = sentinelEntry();
-    entry->prevInLRU = 0;
-    entry->nextInLRU = sentinel.nextInLRU;
-    entry->nextWithSameHash = sentinel.nextWithSameHash;
+    entry& sentinel = sentinelEntry();
+    ent->prevInLRU = 0;
+    ent->nextInLRU = sentinel.nextInLRU;
+    ent->nextWithSameHash = sentinel.nextWithSameHash;
     sentinel.nextWithSameHash = entryIndex;
 
     --_size;
@@ -482,19 +486,19 @@ void StrongLRUHashtable<Value>::remove(StrongHash const& hash)
 }
 
 template <typename Value>
-inline void StrongLRUHashtable<Value>::touch(StrongHash const& hash) noexcept
+inline void strong_lru_hashtable<Value>::touch(strong_hash const& hash) noexcept
 {
     (void) findEntry(hash, false);
 }
 
 template <typename Value>
-inline bool StrongLRUHashtable<Value>::contains(StrongHash const& hash) const noexcept
+inline bool strong_lru_hashtable<Value>::contains(strong_hash const& hash) const noexcept
 {
-    return const_cast<StrongLRUHashtable*>(this)->findEntry(hash, false) != 0;
+    return const_cast<strong_lru_hashtable*>(this)->findEntry(hash, false) != 0;
 }
 
 template <typename Value>
-inline Value* StrongLRUHashtable<Value>::try_get(StrongHash const& hash) noexcept
+inline Value* strong_lru_hashtable<Value>::try_get(strong_hash const& hash) noexcept
 {
     uint32_t const entryIndex = findEntry(hash, false);
     if (!entryIndex)
@@ -503,13 +507,13 @@ inline Value* StrongLRUHashtable<Value>::try_get(StrongHash const& hash) noexcep
 }
 
 template <typename Value>
-inline Value const* StrongLRUHashtable<Value>::try_get(StrongHash const& hash) const noexcept
+inline Value const* strong_lru_hashtable<Value>::try_get(strong_hash const& hash) const noexcept
 {
-    return const_cast<StrongLRUHashtable*>(this)->try_get(hash);
+    return const_cast<strong_lru_hashtable*>(this)->try_get(hash);
 }
 
 template <typename Value>
-inline Value& StrongLRUHashtable<Value>::at(StrongHash const& hash)
+inline Value& strong_lru_hashtable<Value>::at(strong_hash const& hash)
 {
     uint32_t const entryIndex = findEntry(hash, false);
     if (!entryIndex)
@@ -518,13 +522,13 @@ inline Value& StrongLRUHashtable<Value>::at(StrongHash const& hash)
 }
 
 template <typename Value>
-inline Value& StrongLRUHashtable<Value>::peek(StrongHash const& hash)
+inline Value& strong_lru_hashtable<Value>::peek(strong_hash const& hash)
 {
     uint32_t* slot = hashTableSlot(hash);
     uint32_t entryIndex = *slot;
     while (entryIndex)
     {
-        Entry& entry = _entries[entryIndex];
+        entry& entry = _entries[entryIndex];
         if (entry.hashValue == hash)
             return *entry.value;
         entryIndex = entry.nextWithSameHash;
@@ -534,13 +538,13 @@ inline Value& StrongLRUHashtable<Value>::peek(StrongHash const& hash)
 }
 
 template <typename Value>
-inline Value const& StrongLRUHashtable<Value>::peek(StrongHash const& hash) const
+inline Value const& strong_lru_hashtable<Value>::peek(strong_hash const& hash) const
 {
-    return const_cast<StrongLRUHashtable*>(this)->peek(hash);
+    return const_cast<strong_lru_hashtable*>(this)->peek(hash);
 }
 
 template <typename Value>
-inline Value& StrongLRUHashtable<Value>::operator[](StrongHash const& hash) noexcept
+inline Value& strong_lru_hashtable<Value>::operator[](strong_hash const& hash) noexcept
 {
     uint32_t const entryIndex = findEntry(hash, true);
     return *_entries[entryIndex].value;
@@ -548,7 +552,7 @@ inline Value& StrongLRUHashtable<Value>::operator[](StrongHash const& hash) noex
 
 template <typename Value>
 template <typename ValueConstructFn>
-inline bool StrongLRUHashtable<Value>::try_emplace(StrongHash const& hash, ValueConstructFn constructValue)
+inline bool strong_lru_hashtable<Value>::try_emplace(strong_hash const& hash, ValueConstructFn constructValue)
 {
     if (contains(hash))
         return false;
@@ -560,15 +564,15 @@ inline bool StrongLRUHashtable<Value>::try_emplace(StrongHash const& hash, Value
 
 template <typename Value>
 template <typename ValueConstructFn>
-inline Value& StrongLRUHashtable<Value>::get_or_emplace(StrongHash const& hash,
-                                                        ValueConstructFn constructValue)
+inline Value& strong_lru_hashtable<Value>::get_or_emplace(strong_hash const& hash,
+                                                          ValueConstructFn constructValue)
 {
     uint32_t* slot = hashTableSlot(hash);
 
     uint32_t entryIndex = *slot;
     while (entryIndex)
     {
-        Entry& candidateEntry = _entries[entryIndex];
+        entry& candidateEntry = _entries[entryIndex];
         if (candidateEntry.hashValue == hash)
         {
             ++_stats.hits;
@@ -584,22 +588,22 @@ inline Value& StrongLRUHashtable<Value>::get_or_emplace(StrongHash const& hash,
     ++_stats.misses;
 
     entryIndex = allocateEntry(hash, slot);
-    Entry& result = _entries[entryIndex];
+    entry& result = _entries[entryIndex];
     result.value.emplace(constructValue(entryIndex)); // TODO: not yet exception safe
     return *result.value;
 }
 
 template <typename Value>
 template <typename ValueConstructFn>
-inline Value* StrongLRUHashtable<Value>::get_or_try_emplace(StrongHash const& hash,
-                                                            ValueConstructFn constructValue)
+inline Value* strong_lru_hashtable<Value>::get_or_try_emplace(strong_hash const& hash,
+                                                              ValueConstructFn constructValue)
 {
     uint32_t* slot = hashTableSlot(hash);
 
     uint32_t entryIndex = *slot;
     while (entryIndex)
     {
-        Entry& candidateEntry = _entries[entryIndex];
+        entry& candidateEntry = _entries[entryIndex];
         if (candidateEntry.hashValue == hash)
         {
             ++_stats.hits;
@@ -615,7 +619,7 @@ inline Value* StrongLRUHashtable<Value>::get_or_try_emplace(StrongHash const& ha
     ++_stats.misses;
 
     entryIndex = allocateEntry(hash, slot);
-    Entry& result = _entries[entryIndex];
+    entry& result = _entries[entryIndex];
 
     Require(1 <= entryIndex && entryIndex <= _capacity.value);
     std::optional<Value> constructedValue = constructValue(entryIndex);
@@ -630,19 +634,19 @@ inline Value* StrongLRUHashtable<Value>::get_or_try_emplace(StrongHash const& ha
 }
 
 template <typename Value>
-Value& StrongLRUHashtable<Value>::valueAtEntryIndex(uint32_t entryIndex) noexcept
+Value& strong_lru_hashtable<Value>::valueAtEntryIndex(uint32_t entryIndex) noexcept
 {
     return _entries[entryIndex];
 }
 
 template <typename Value>
-Value const& StrongLRUHashtable<Value>::valueAtEntryIndex(uint32_t entryIndex) const noexcept
+Value const& strong_lru_hashtable<Value>::valueAtEntryIndex(uint32_t entryIndex) const noexcept
 {
     return _entries[entryIndex];
 }
 
 template <typename Value>
-inline Value& StrongLRUHashtable<Value>::emplace(StrongHash const& hash, Value value) noexcept
+inline Value& strong_lru_hashtable<Value>::emplace(strong_hash const& hash, Value value) noexcept
 {
     uint32_t const entryIndex = findEntry(hash, true);
     return *_entries[entryIndex].value = std::move(value);
@@ -650,7 +654,7 @@ inline Value& StrongLRUHashtable<Value>::emplace(StrongHash const& hash, Value v
 
 template <typename Value>
 template <typename ValueConstructFn>
-Value& StrongLRUHashtable<Value>::emplace(StrongHash const& hash, ValueConstructFn constructValue) noexcept
+Value& strong_lru_hashtable<Value>::emplace(strong_hash const& hash, ValueConstructFn constructValue) noexcept
 {
     uint32_t const entryIndex = findEntry(hash, true);
     _entries[entryIndex].value.emplace(constructValue(entryIndex));
@@ -658,13 +662,13 @@ Value& StrongLRUHashtable<Value>::emplace(StrongHash const& hash, ValueConstruct
 }
 
 template <typename Value>
-std::vector<StrongHash> StrongLRUHashtable<Value>::hashes() const
+std::vector<strong_hash> strong_lru_hashtable<Value>::hashes() const
 {
-    auto result = std::vector<StrongHash> {};
-    Entry const& sentinel = sentinelEntry();
+    auto result = std::vector<strong_hash> {};
+    entry const& sentinel = sentinelEntry();
     for (uint32_t entryIndex = sentinel.nextInLRU; entryIndex != 0;)
     {
-        Entry const& entry = _entries[entryIndex];
+        entry const& entry = _entries[entryIndex];
         result.emplace_back(entry.hashValue);
         entryIndex = entry.nextInLRU;
     }
@@ -674,14 +678,14 @@ std::vector<StrongHash> StrongLRUHashtable<Value>::hashes() const
 }
 
 template <typename Value>
-void StrongLRUHashtable<Value>::inspect(std::ostream& output) const
+void strong_lru_hashtable<Value>::inspect(std::ostream& output) const
 {
-    Entry const& sentinel = sentinelEntry();
+    entry const& sentinel = sentinelEntry();
     uint32_t entryIndex = sentinel.prevInLRU;
     uint32_t hashSlotCollisions = 0;
     while (entryIndex != 0)
     {
-        Entry const& entry = _entries[entryIndex];
+        entry const& entry = _entries[entryIndex];
         // output << fmt::format("  entry[{:03}]   : LRU: {} <- -> {}, alt: {}; := {}\n",
         //                       entryIndex,
         //                       entry.prevInLRU,
@@ -723,14 +727,14 @@ void StrongLRUHashtable<Value>::inspect(std::ostream& output) const
 
 // {{{ helpers
 template <typename Value>
-uint32_t StrongLRUHashtable<Value>::findEntry(StrongHash const& hash, bool force)
+uint32_t strong_lru_hashtable<Value>::findEntry(strong_hash const& hash, bool force)
 {
     uint32_t* slot = hashTableSlot(hash);
     uint32_t entryIndex = *slot;
-    Entry* result = nullptr;
+    entry* result = nullptr;
     while (entryIndex)
     {
-        Entry& entry = _entries[entryIndex];
+        entry& entry = _entries[entryIndex];
         if (entry.hashValue == hash)
         {
             result = &entry;
@@ -763,24 +767,24 @@ uint32_t StrongLRUHashtable<Value>::findEntry(StrongHash const& hash, bool force
 }
 
 template <typename Value>
-inline void StrongLRUHashtable<Value>::unlinkFromLRUChain(Entry& entry) noexcept
+inline void strong_lru_hashtable<Value>::unlinkFromLRUChain(entry& ent) noexcept
 {
-    Entry& prev = _entries[entry.prevInLRU];
-    Entry& next = _entries[entry.nextInLRU];
-    prev.nextInLRU = entry.nextInLRU;
-    next.prevInLRU = entry.prevInLRU;
+    entry& prev = _entries[ent.prevInLRU];
+    entry& next = _entries[ent.nextInLRU];
+    prev.nextInLRU = ent.nextInLRU;
+    next.prevInLRU = ent.prevInLRU;
 
     validateChange(-1);
 }
 
 template <typename Value>
-inline void StrongLRUHashtable<Value>::linkToLRUChainHead(uint32_t entryIndex) noexcept
+inline void strong_lru_hashtable<Value>::linkToLRUChainHead(uint32_t entryIndex) noexcept
 {
     // The entry must be already unlinked
 
-    Entry& sentinel = sentinelEntry();
-    Entry& oldHead = _entries[sentinel.nextInLRU];
-    Entry& newHead = _entries[entryIndex];
+    entry& sentinel = sentinelEntry();
+    entry& oldHead = _entries[sentinel.nextInLRU];
+    entry& newHead = _entries[entryIndex];
 
     newHead.nextInLRU = sentinel.nextInLRU;
     newHead.prevInLRU = 0;
@@ -795,9 +799,9 @@ inline void StrongLRUHashtable<Value>::linkToLRUChainHead(uint32_t entryIndex) n
 }
 
 template <typename Value>
-uint32_t StrongLRUHashtable<Value>::allocateEntry(StrongHash const& hash, uint32_t* slot)
+uint32_t strong_lru_hashtable<Value>::allocateEntry(strong_hash const& hash, uint32_t* slot)
 {
-    Entry& sentinel = sentinelEntry();
+    entry& sentinel = sentinelEntry();
 
     if (sentinel.nextWithSameHash == 0)
         recycle();
@@ -807,7 +811,7 @@ uint32_t StrongLRUHashtable<Value>::allocateEntry(StrongHash const& hash, uint32
     uint32_t poppedEntryIndex = sentinel.nextWithSameHash;
     Require(1 <= poppedEntryIndex && poppedEntryIndex <= _capacity.value);
 
-    Entry& poppedEntry = _entries[poppedEntryIndex];
+    entry& poppedEntry = _entries[poppedEntryIndex];
     sentinel.nextWithSameHash = poppedEntry.nextWithSameHash;
     poppedEntry.nextWithSameHash = 0;
 
@@ -822,23 +826,23 @@ uint32_t StrongLRUHashtable<Value>::allocateEntry(StrongHash const& hash, uint32
 }
 
 template <typename Value>
-void StrongLRUHashtable<Value>::recycle()
+void strong_lru_hashtable<Value>::recycle()
 {
     Require(_size == _capacity.value);
 
-    Entry& sentinel = sentinelEntry();
+    entry& sentinel = sentinelEntry();
     Require(sentinel.prevInLRU != 0);
 
     uint32_t const entryIndex = sentinel.prevInLRU;
-    Entry& entry = _entries[entryIndex];
-    Entry& prev = _entries[entry.prevInLRU];
+    entry& ent = _entries[entryIndex];
+    entry& prev = _entries[ent.prevInLRU];
 
     prev.nextInLRU = 0;
-    sentinel.prevInLRU = entry.prevInLRU;
+    sentinel.prevInLRU = ent.prevInLRU;
 
     validateChange(-1);
 
-    uint32_t* nextIndex = hashTableSlot(entry.hashValue);
+    uint32_t* nextIndex = hashTableSlot(ent.hashValue);
     while (*nextIndex != entryIndex)
     {
         Require(*nextIndex != 0);
@@ -846,25 +850,25 @@ void StrongLRUHashtable<Value>::recycle()
     }
 
     Guarantee(*nextIndex == entryIndex);
-    *nextIndex = entry.nextWithSameHash;
-    entry.nextWithSameHash = sentinel.nextWithSameHash;
+    *nextIndex = ent.nextWithSameHash;
+    ent.nextWithSameHash = sentinel.nextWithSameHash;
     sentinel.nextWithSameHash = entryIndex;
 
     ++_stats.recycles;
 }
 
 template <typename Value>
-inline int StrongLRUHashtable<Value>::validateChange(int adj)
+inline int strong_lru_hashtable<Value>::validateChange(int adj)
 {
 #if defined(DEBUG_STRONG_LRU_HASHTABLE)
     int count = 0;
 
-    Entry& sentinel = sentinelEntry();
+    entry& sentinel = sentinelEntry();
     size_t lastOrdering = sentinel.ordering;
 
     for (uint32_t entryIndex = sentinel.nextInLRU; entryIndex != 0;)
     {
-        Entry& entry = _entries[entryIndex];
+        entry& entry = _entries[entryIndex];
         Require(entry.ordering < lastOrdering);
         lastOrdering = entry.ordering;
         entryIndex = entry.nextInLRU;

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -80,7 +80,7 @@ struct strong_hashtable_size
     uint32_t value;
 };
 
-// Number of entries the LRU StrongLRUHashtable can store at most.
+// Number of entries the LRU strong_lru_hashtable can store at most.
 struct lru_capacity
 {
     uint32_t value;

--- a/src/crispy/StrongLRUHashtable_test.cpp
+++ b/src/crispy/StrongLRUHashtable_test.cpp
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <crispy/StrongHash.h>
 #include <crispy/StrongLRUHashtable.h>
 #include <crispy/utils.h>
 
@@ -18,9 +19,6 @@
 
 #include <iostream>
 #include <string_view>
-
-#include "StrongHash.h"
-#include "StrongLRUHashtable.h"
 
 using namespace crispy;
 using namespace std;
@@ -88,7 +86,7 @@ TEST_CASE("strong_hash", "")
     REQUIRE(a != f);
 }
 
-TEST_CASE("StrongLRUHashtable.operator_index", "")
+TEST_CASE("strong_lru_hashtable.operator_index", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -118,7 +116,7 @@ TEST_CASE("StrongLRUHashtable.operator_index", "")
     REQUIRE(joinHumanReadable(cache.hashes()) == sh(6, 5, 4, 3));
 }
 
-TEST_CASE("StrongLRUHashtable.at", "")
+TEST_CASE("strong_lru_hashtable.at", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -130,7 +128,7 @@ TEST_CASE("StrongLRUHashtable.at", "")
     CHECK_NOTHROW(cache.at(h(1)));
 }
 
-TEST_CASE("StrongLRUHashtable.clear", "[lrucache]")
+TEST_CASE("strong_lru_hashtable.clear", "[lrucache]")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -143,7 +141,7 @@ TEST_CASE("StrongLRUHashtable.clear", "[lrucache]")
     CHECK(cache.size() == 0);
 }
 
-TEST_CASE("StrongLRUHashtable.touch", "")
+TEST_CASE("strong_lru_hashtable.touch", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -168,7 +166,7 @@ TEST_CASE("StrongLRUHashtable.touch", "")
     REQUIRE(joinHumanReadable(cache.hashes()) == sh(1, 3, 4, 2));
 }
 
-TEST_CASE("StrongLRUHashtable.contains", "")
+TEST_CASE("strong_lru_hashtable.contains", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -193,7 +191,7 @@ TEST_CASE("StrongLRUHashtable.contains", "")
     REQUIRE(joinHumanReadable(cache.hashes()) == sh(1, 3, 4, 2));
 }
 
-TEST_CASE("StrongLRUHashtable.try_emplace", "")
+TEST_CASE("strong_lru_hashtable.try_emplace", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
@@ -216,7 +214,7 @@ TEST_CASE("StrongLRUHashtable.try_emplace", "")
     CHECK(cache.at(h(3)) == 6);
 }
 
-TEST_CASE("StrongLRUHashtable.try_get", "")
+TEST_CASE("strong_lru_hashtable.try_get", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -247,7 +245,7 @@ TEST_CASE("StrongLRUHashtable.try_get", "")
     REQUIRE(joinHumanReadable(cache.hashes()) == sh(1, 3, 4, 2));
 }
 
-TEST_CASE("StrongLRUHashtable.get_or_try_emplace.recursive", "[lrucache]")
+TEST_CASE("strong_lru_hashtable.get_or_try_emplace.recursive", "[lrucache]")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
@@ -265,7 +263,7 @@ TEST_CASE("StrongLRUHashtable.get_or_try_emplace.recursive", "[lrucache]")
     CHECK(*b == -2);
 }
 
-TEST_CASE("StrongLRUHashtable.get_or_try_emplace", "[lrucache]")
+TEST_CASE("strong_lru_hashtable.get_or_try_emplace", "[lrucache]")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
@@ -303,7 +301,7 @@ TEST_CASE("StrongLRUHashtable.get_or_try_emplace", "[lrucache]")
     CHECK(joinHumanReadable(cache.hashes()) == sh(4, 3));
 }
 
-TEST_CASE("StrongLRUHashtable.get_or_emplace", "[lrucache]")
+TEST_CASE("strong_lru_hashtable.get_or_emplace", "[lrucache]")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
@@ -340,7 +338,7 @@ TEST_CASE("StrongLRUHashtable.get_or_emplace", "[lrucache]")
     CHECK(cache.size() == 2);
 }
 
-TEST_CASE("StrongLRUHashtable.remove", "")
+TEST_CASE("strong_lru_hashtable.remove", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -365,7 +363,7 @@ TEST_CASE("StrongLRUHashtable.remove", "")
     REQUIRE(joinHumanReadable(cache.hashes()).empty());
 }
 
-TEST_CASE("StrongLRUHashtable.insert_with_cache_collision", "")
+TEST_CASE("strong_lru_hashtable.insert_with_cache_collision", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -386,7 +384,7 @@ TEST_CASE("StrongLRUHashtable.insert_with_cache_collision", "")
     // cache.inspect(cout);
 }
 
-TEST_CASE("StrongLRUHashtable.remove_with_hashTable_lookup_collision", "")
+TEST_CASE("strong_lru_hashtable.remove_with_hashTable_lookup_collision", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
@@ -411,7 +409,7 @@ TEST_CASE("StrongLRUHashtable.remove_with_hashTable_lookup_collision", "")
     REQUIRE(joinHumanReadable(cache.hashes()).empty());
 }
 
-TEST_CASE("StrongLRUHashtable.peek", "")
+TEST_CASE("strong_lru_hashtable.peek", "")
 {
     auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;

--- a/src/crispy/StrongLRUHashtable_test.cpp
+++ b/src/crispy/StrongLRUHashtable_test.cpp
@@ -19,6 +19,9 @@
 #include <iostream>
 #include <string_view>
 
+#include "StrongHash.h"
+#include "StrongLRUHashtable.h"
+
 using namespace crispy;
 using namespace std;
 using namespace std::string_view_literals;
@@ -27,9 +30,9 @@ namespace
 {
 // simple 32-bit hash
 template <typename T>
-inline StrongHash h(T v)
+inline strong_hash h(T v)
 {
-    return StrongHash(0, 0, 0, static_cast<uint32_t>(v));
+    return strong_hash(0, 0, 0, static_cast<uint32_t>(v));
 }
 
 template <typename T>
@@ -47,9 +50,9 @@ inline string sh(Value first, Value second, Values... remaining)
 }
 
 template <typename T>
-StrongHash collidingHash(T v) noexcept
+strong_hash collidingHash(T v) noexcept
 {
-    return StrongHash(0, 0, static_cast<uint32_t>(v), 0);
+    return strong_hash(0, 0, static_cast<uint32_t>(v), 0);
 }
 
 template <typename T>
@@ -67,15 +70,15 @@ inline string ch(Value first, Value second, Values... remaining)
 }
 } // namespace
 
-TEST_CASE("StrongHash", "")
+TEST_CASE("strong_hash", "")
 {
-    auto empty = StrongHash::compute("");
-    auto a = StrongHash::compute("A");
-    auto b = StrongHash::compute("AB");
-    auto c = StrongHash::compute("ABC");
-    auto d = StrongHash::compute("ABCD");
-    auto e = StrongHash::compute("ABCDE");
-    auto f = StrongHash::compute("ABCDEF");
+    auto empty = strong_hash::compute("");
+    auto a = strong_hash::compute("A");
+    auto b = strong_hash::compute("AB");
+    auto c = strong_hash::compute("ABC");
+    auto d = strong_hash::compute("ABCD");
+    auto e = strong_hash::compute("ABCDE");
+    auto f = strong_hash::compute("ABCDEF");
 
     REQUIRE(a != empty);
     REQUIRE(a != b);
@@ -87,7 +90,7 @@ TEST_CASE("StrongHash", "")
 
 TEST_CASE("StrongLRUHashtable.operator_index", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
 
     cache[h(1)] = 2;
@@ -117,7 +120,7 @@ TEST_CASE("StrongLRUHashtable.operator_index", "")
 
 TEST_CASE("StrongLRUHashtable.at", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;
@@ -129,7 +132,7 @@ TEST_CASE("StrongLRUHashtable.at", "")
 
 TEST_CASE("StrongLRUHashtable.clear", "[lrucache]")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;
@@ -142,7 +145,7 @@ TEST_CASE("StrongLRUHashtable.clear", "[lrucache]")
 
 TEST_CASE("StrongLRUHashtable.touch", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;
@@ -167,7 +170,7 @@ TEST_CASE("StrongLRUHashtable.touch", "")
 
 TEST_CASE("StrongLRUHashtable.contains", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = i;
@@ -192,7 +195,7 @@ TEST_CASE("StrongLRUHashtable.contains", "")
 
 TEST_CASE("StrongLRUHashtable.try_emplace", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
 
     auto rv = cache.try_emplace(h(2), [](auto) { return 4; });
@@ -215,7 +218,7 @@ TEST_CASE("StrongLRUHashtable.try_emplace", "")
 
 TEST_CASE("StrongLRUHashtable.try_get", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;
@@ -246,7 +249,7 @@ TEST_CASE("StrongLRUHashtable.try_get", "")
 
 TEST_CASE("StrongLRUHashtable.get_or_try_emplace.recursive", "[lrucache]")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
 
     int* b = nullptr;
@@ -264,7 +267,7 @@ TEST_CASE("StrongLRUHashtable.get_or_try_emplace.recursive", "[lrucache]")
 
 TEST_CASE("StrongLRUHashtable.get_or_try_emplace", "[lrucache]")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
 
     int* a = nullptr;
@@ -302,7 +305,7 @@ TEST_CASE("StrongLRUHashtable.get_or_try_emplace", "[lrucache]")
 
 TEST_CASE("StrongLRUHashtable.get_or_emplace", "[lrucache]")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 4 }, LRUCapacity { 2 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 4 }, lru_capacity { 2 });
     auto& cache = *cachePtr;
 
     int& a = cache.get_or_emplace(h(2), [](auto) { return 4; });
@@ -339,7 +342,7 @@ TEST_CASE("StrongLRUHashtable.get_or_emplace", "[lrucache]")
 
 TEST_CASE("StrongLRUHashtable.remove", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;
@@ -364,7 +367,7 @@ TEST_CASE("StrongLRUHashtable.remove", "")
 
 TEST_CASE("StrongLRUHashtable.insert_with_cache_collision", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
 
     cache[collidingHash(1)] = 1;
@@ -385,7 +388,7 @@ TEST_CASE("StrongLRUHashtable.insert_with_cache_collision", "")
 
 TEST_CASE("StrongLRUHashtable.remove_with_hashTable_lookup_collision", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[collidingHash(i)] = 2 * i;
@@ -410,7 +413,7 @@ TEST_CASE("StrongLRUHashtable.remove_with_hashTable_lookup_collision", "")
 
 TEST_CASE("StrongLRUHashtable.peek", "")
 {
-    auto cachePtr = StrongLRUHashtable<int>::create(StrongHashtableSize { 8 }, LRUCapacity { 4 });
+    auto cachePtr = strong_lru_hashtable<int>::create(strong_hashtable_size { 8 }, lru_capacity { 4 });
     auto& cache = *cachePtr;
     for (int i = 1; i <= 4; ++i)
         cache[h(i)] = 2 * i;

--- a/src/crispy/TrieMap.h
+++ b/src/crispy/TrieMap.h
@@ -23,18 +23,18 @@ namespace crispy
 {
 
 // clang-format off
-struct NoMatch {};
-struct PartialMatch {};
-template <typename T> struct ExactMatch { T const& value; };
-template <typename T> using TrieMatch = std::variant<ExactMatch<T>, PartialMatch, NoMatch>;
+struct no_match {};
+struct partial_match {};
+template <typename T> struct exact_match { T const& value; };
+template <typename T> using trie_match = std::variant<exact_match<T>, partial_match, no_match>;
 // clang-format on
 
 namespace detail
 {
     template <typename Value>
-    struct TrieNode
+    struct trie_node
     {
-        std::array<std::unique_ptr<TrieNode<Value>>, 256> children;
+        std::array<std::unique_ptr<trie_node<Value>>, 256> children;
         std::optional<Value> value;
     };
 } // namespace detail
@@ -44,7 +44,7 @@ namespace detail
 /// While this is a general purpose Trie data structure,
 /// I only implemented as much as was needed to fit the purpose.
 template <typename Key, typename Value>
-class TrieMap
+class trie_map
 {
   public:
     void insert(Key const& key, Value value);
@@ -52,33 +52,33 @@ class TrieMap
 
     [[nodiscard]] size_t size() const noexcept { return _size; }
 
-    [[nodiscard]] TrieMatch<Value> search(Key const& key, bool allowWhildcardDot = false) const noexcept;
+    [[nodiscard]] trie_match<Value> search(Key const& key, bool allowWhildcardDot = false) const noexcept;
     [[nodiscard]] bool contains(Key const& key) const noexcept;
 
   private:
-    detail::TrieNode<Value> _root;
+    detail::trie_node<Value> _root;
     size_t _size = 0;
 };
 
 template <typename Key, typename Value>
-void TrieMap<Key, Value>::clear()
+void trie_map<Key, Value>::clear()
 {
-    for (std::unique_ptr<detail::TrieNode<Value>>& childNode: _root.children)
+    for (std::unique_ptr<detail::trie_node<Value>>& childNode: _root.children)
         childNode.reset();
     _size = 0;
 }
 
 template <typename Key, typename Value>
-void TrieMap<Key, Value>::insert(Key const& key, Value value)
+void trie_map<Key, Value>::insert(Key const& key, Value value)
 {
     assert(!key.empty());
 
-    detail::TrieNode<Value>* currentNode = &_root;
+    detail::trie_node<Value>* currentNode = &_root;
     for (auto const element: key)
     {
         auto const childIndex = static_cast<uint8_t>(element);
         if (!currentNode->children[childIndex])
-            currentNode->children[childIndex] = std::make_unique<detail::TrieNode<Value>>();
+            currentNode->children[childIndex] = std::make_unique<detail::trie_node<Value>>();
         currentNode = currentNode->children[childIndex].get();
     }
 
@@ -91,9 +91,9 @@ void TrieMap<Key, Value>::insert(Key const& key, Value value)
 }
 
 template <typename Key, typename Value>
-TrieMatch<Value> TrieMap<Key, Value>::search(Key const& key, bool allowWhildcardDot) const noexcept
+trie_match<Value> trie_map<Key, Value>::search(Key const& key, bool allowWhildcardDot) const noexcept
 {
-    detail::TrieNode<Value> const* currentNode = &_root;
+    detail::trie_node<Value> const* currentNode = &_root;
     for (auto const element: key)
     {
         auto const childIndex = static_cast<uint8_t>(element);
@@ -102,19 +102,19 @@ TrieMatch<Value> TrieMap<Key, Value>::search(Key const& key, bool allowWhildcard
         else if (allowWhildcardDot && currentNode->children[static_cast<uint8_t>('.')])
             currentNode = currentNode->children[static_cast<uint8_t>('.')].get();
         else
-            return NoMatch {};
+            return no_match {};
     }
 
     if (currentNode->value.has_value())
-        return ExactMatch<Value> { currentNode->value.value() };
+        return exact_match<Value> { currentNode->value.value() };
 
-    return PartialMatch {};
+    return partial_match {};
 }
 
 template <typename Key, typename Value>
-bool TrieMap<Key, Value>::contains(Key const& key) const noexcept
+bool trie_map<Key, Value>::contains(Key const& key) const noexcept
 {
-    return std::holds_alternative<ExactMatch<Value>>(search(key));
+    return std::holds_alternative<exact_match<Value>>(search(key));
 }
 
 } // namespace crispy

--- a/src/crispy/TrieMap_test.cpp
+++ b/src/crispy/TrieMap_test.cpp
@@ -19,9 +19,11 @@
 #include <exception>
 #include <iostream>
 
-TEST_CASE("TrieMap.simple")
+#include "TrieMap.h"
+
+TEST_CASE("trie_map.simple")
 {
-    auto m = crispy::TrieMap<std::string, int> {};
+    auto m = crispy::trie_map<std::string, int> {};
 
     m.insert("aa", 1);
     m.insert("aba", 2);
@@ -29,21 +31,21 @@ TEST_CASE("TrieMap.simple")
     REQUIRE(m.size() == 3);
 
     auto const aa = m.search("aa");
-    CHECK(std::get<crispy::ExactMatch<int>>(aa).value == 1);
+    CHECK(std::get<crispy::exact_match<int>>(aa).value == 1);
 
     auto const ab = m.search("ab");
-    REQUIRE(std::holds_alternative<crispy::PartialMatch>(ab));
+    REQUIRE(std::holds_alternative<crispy::partial_match>(ab));
 
     auto const aba = m.search("aba");
-    REQUIRE(std::holds_alternative<crispy::ExactMatch<int>>(aba));
-    CHECK(std::get<crispy::ExactMatch<int>>(aba).value == 2);
+    REQUIRE(std::holds_alternative<crispy::exact_match<int>>(aba));
+    CHECK(std::get<crispy::exact_match<int>>(aba).value == 2);
 
     auto const abb = m.search("abb");
-    REQUIRE(std::holds_alternative<crispy::ExactMatch<int>>(abb));
-    CHECK(std::get<crispy::ExactMatch<int>>(abb).value == 3);
+    REQUIRE(std::holds_alternative<crispy::exact_match<int>>(abb));
+    CHECK(std::get<crispy::exact_match<int>>(abb).value == 3);
 
     auto const abz = m.search("abz");
-    REQUIRE(std::holds_alternative<crispy::NoMatch>(abz));
+    REQUIRE(std::holds_alternative<crispy::no_match>(abz));
 
     m.clear();
     REQUIRE(m.size() == 0);

--- a/src/crispy/TrieMap_test.cpp
+++ b/src/crispy/TrieMap_test.cpp
@@ -19,8 +19,6 @@
 #include <exception>
 #include <iostream>
 
-#include "TrieMap.h"
-
 TEST_CASE("trie_map.simple")
 {
     auto m = crispy::trie_map<std::string, int> {};

--- a/src/crispy/assert.h
+++ b/src/crispy/assert.h
@@ -107,7 +107,7 @@ inline void set_fail_handler(fail_handler_t handler)
                                logstore::source_location location = logstore::source_location::current())
 {
     auto static FatalLog =
-        logstore::Category("fatal", "Fatal error Logger", logstore::Category::State::Enabled);
+        logstore::category("fatal", "Fatal error Logger", logstore::category::state::Enabled);
 
     if (!message.empty())
         FatalLog(location)("Fatal error. {}", message);

--- a/src/crispy/boxed.h
+++ b/src/crispy/boxed.h
@@ -173,19 +173,19 @@ template <typename A, typename B>
 struct numeric_limits<crispy::boxed<A, B>>
 {
     using value_type = A;
-    using Boxed = crispy::boxed<A, B>;
+    using boxed = crispy::boxed<A, B>;
 
     // clang-format off
     // NOLINTBEGIN(readability-identifier-naming)
-    static Boxed min() noexcept { return Boxed { std::numeric_limits<A>::min() }; }
-    static Boxed max() noexcept { return Boxed { std::numeric_limits<A>::max() }; }
-    static Boxed lowest() noexcept { return Boxed { std::numeric_limits<A>::lowest() }; }
-    static Boxed epsilon() noexcept { return Boxed { std::numeric_limits<A>::epsilon() }; }
-    static Boxed round_error() noexcept { return Boxed { std::numeric_limits<A>::round_error() }; }
-    static Boxed infinity() noexcept { return Boxed { std::numeric_limits<A>::infinity() }; }
-    static Boxed quiet_NaN() noexcept { return Boxed { std::numeric_limits<A>::quiet_NaN() }; }
-    static Boxed signaling_NaN() noexcept { return Boxed { std::numeric_limits<A>::signaling_NaNinfinity() }; }
-    static Boxed denorm_min() noexcept { return Boxed { std::numeric_limits<A>::denorm_min() }; }
+    static boxed min() noexcept { return boxed { std::numeric_limits<A>::min() }; }
+    static boxed max() noexcept { return boxed { std::numeric_limits<A>::max() }; }
+    static boxed lowest() noexcept { return boxed { std::numeric_limits<A>::lowest() }; }
+    static boxed epsilon() noexcept { return boxed { std::numeric_limits<A>::epsilon() }; }
+    static boxed round_error() noexcept { return boxed { std::numeric_limits<A>::round_error() }; }
+    static boxed infinity() noexcept { return boxed { std::numeric_limits<A>::infinity() }; }
+    static boxed quiet_NaN() noexcept { return boxed { std::numeric_limits<A>::quiet_NaN() }; }
+    static boxed signaling_NaN() noexcept { return boxed { std::numeric_limits<A>::signaling_NaNinfinity() }; }
+    static boxed denorm_min() noexcept { return boxed { std::numeric_limits<A>::denorm_min() }; }
     // NOLINTEND(readability-identifier-naming)
     // clang-format on
 };

--- a/src/crispy/escape.h
+++ b/src/crispy/escape.h
@@ -75,7 +75,7 @@ inline std::string unescape(std::string_view escapedText)
     std::string out;
     out.reserve(escapedText.size());
 
-    enum class state
+    enum class state_type
     {
         Text,
         Escape,
@@ -84,91 +84,91 @@ inline std::string unescape(std::string_view escapedText)
         Hex1,
         Hex2
     };
-    state stateText = state::Text;
+    state_type state = state_type::Text;
     char buf[3] = {};
 
     for (char const ch: escapedText)
     {
-        switch (stateText)
+        switch (state)
         {
-            case state::Text:
+            case state_type::Text:
                 if (ch == '\\')
-                    stateText = state::Escape;
+                    state = state_type::Escape;
                 else
                     out.push_back(ch);
                 break;
-            case state::Escape:
+            case state_type::Escape:
                 switch (ch)
                 {
                     case '0':
                         //.
-                        stateText = state::Octal1;
+                        state = state_type::Octal1;
                         break;
                     case 'x':
                         //.
-                        stateText = state::Hex1;
+                        state = state_type::Hex1;
                         break;
                     case 'e':
-                        stateText = state::Text;
+                        state = state_type::Text;
                         out.push_back('\033');
                         break;
                     case 'a':
                         out.push_back(0x07);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 'b':
                         out.push_back(0x08);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 't':
                         out.push_back(0x09);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 'n':
                         out.push_back(0x0A);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 'v':
                         out.push_back(0x0B);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 'f':
                         out.push_back(0x0C);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case 'r':
                         out.push_back(0x0D);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     case '\\':
                         out.push_back('\\');
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                     default:
                         // Unknown escape sequence, so just continue as text.
                         out.push_back('\\');
                         out.push_back(ch);
-                        stateText = state::Text;
+                        state = state_type::Text;
                         break;
                 }
                 break;
-            case state::Octal1:
+            case state_type::Octal1:
                 buf[0] = ch;
-                stateText = state::Octal2;
+                state = state_type::Octal2;
                 break;
-            case state::Octal2:
+            case state_type::Octal2:
                 buf[1] = ch;
                 out.push_back(static_cast<char>(strtoul(buf, nullptr, 8)));
-                stateText = state::Text;
+                state = state_type::Text;
                 break;
-            case state::Hex1:
+            case state_type::Hex1:
                 buf[0] = ch;
-                stateText = state::Hex2;
+                state = state_type::Hex2;
                 break;
-            case state::Hex2:
+            case state_type::Hex2:
                 buf[1] = ch;
                 out.push_back(static_cast<char>(strtoul(buf, nullptr, 16)));
-                stateText = state::Text;
+                state = state_type::Text;
                 break;
         }
     }

--- a/src/crispy/escape.h
+++ b/src/crispy/escape.h
@@ -25,13 +25,13 @@
 namespace crispy
 {
 
-enum class NumericEscape
+enum class numeric_escape
 {
     Octal,
     Hex
 };
 
-inline std::string escape(uint8_t ch, NumericEscape numericEscape = NumericEscape::Hex)
+inline std::string escape(uint8_t ch, numeric_escape numericEscape = numeric_escape::Hex)
 {
     switch (ch)
     {
@@ -44,7 +44,7 @@ inline std::string escape(uint8_t ch, NumericEscape numericEscape = NumericEscap
         default:
             if (0x20 <= ch && ch < 0x7E)
                 return fmt::format("{}", static_cast<char>(ch));
-            else if (numericEscape == NumericEscape::Hex)
+            else if (numericEscape == numeric_escape::Hex)
                 return fmt::format("\\x{:02x}", static_cast<uint8_t>(ch) & 0xFF);
             else
                 return fmt::format("\\{:03o}", static_cast<uint8_t>(ch) & 0xFF);
@@ -52,7 +52,7 @@ inline std::string escape(uint8_t ch, NumericEscape numericEscape = NumericEscap
 }
 
 template <typename T>
-inline std::string escape(T begin, T end, NumericEscape numericEscape = NumericEscape::Hex)
+inline std::string escape(T begin, T end, numeric_escape numericEscape = numeric_escape::Hex)
 {
     static_assert(sizeof(*std::declval<T>()) == 1,
                   "should be only 1 byte, such as: char, char8_t, uint8_t, byte, ...");
@@ -65,7 +65,7 @@ inline std::string escape(T begin, T end, NumericEscape numericEscape = NumericE
     return result;
 }
 
-inline std::string escape(std::string_view s, NumericEscape numericEscape = NumericEscape::Hex)
+inline std::string escape(std::string_view s, numeric_escape numericEscape = numeric_escape::Hex)
 {
     return escape(begin(s), end(s), numericEscape);
 }
@@ -75,7 +75,7 @@ inline std::string unescape(std::string_view escapedText)
     std::string out;
     out.reserve(escapedText.size());
 
-    enum class State
+    enum class state
     {
         Text,
         Escape,
@@ -84,91 +84,91 @@ inline std::string unescape(std::string_view escapedText)
         Hex1,
         Hex2
     };
-    State state = State::Text;
+    state stateText = state::Text;
     char buf[3] = {};
 
     for (char const ch: escapedText)
     {
-        switch (state)
+        switch (stateText)
         {
-            case State::Text:
+            case state::Text:
                 if (ch == '\\')
-                    state = State::Escape;
+                    stateText = state::Escape;
                 else
                     out.push_back(ch);
                 break;
-            case State::Escape:
+            case state::Escape:
                 switch (ch)
                 {
                     case '0':
                         //.
-                        state = State::Octal1;
+                        stateText = state::Octal1;
                         break;
                     case 'x':
                         //.
-                        state = State::Hex1;
+                        stateText = state::Hex1;
                         break;
                     case 'e':
-                        state = State::Text;
+                        stateText = state::Text;
                         out.push_back('\033');
                         break;
                     case 'a':
                         out.push_back(0x07);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 'b':
                         out.push_back(0x08);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 't':
                         out.push_back(0x09);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 'n':
                         out.push_back(0x0A);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 'v':
                         out.push_back(0x0B);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 'f':
                         out.push_back(0x0C);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case 'r':
                         out.push_back(0x0D);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     case '\\':
                         out.push_back('\\');
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                     default:
                         // Unknown escape sequence, so just continue as text.
                         out.push_back('\\');
                         out.push_back(ch);
-                        state = State::Text;
+                        stateText = state::Text;
                         break;
                 }
                 break;
-            case State::Octal1:
+            case state::Octal1:
                 buf[0] = ch;
-                state = State::Octal2;
+                stateText = state::Octal2;
                 break;
-            case State::Octal2:
+            case state::Octal2:
                 buf[1] = ch;
                 out.push_back(static_cast<char>(strtoul(buf, nullptr, 8)));
-                state = State::Text;
+                stateText = state::Text;
                 break;
-            case State::Hex1:
+            case state::Hex1:
                 buf[0] = ch;
-                state = State::Hex2;
+                stateText = state::Hex2;
                 break;
-            case State::Hex2:
+            case state::Hex2:
                 buf[1] = ch;
                 out.push_back(static_cast<char>(strtoul(buf, nullptr, 16)));
-                state = State::Text;
+                stateText = state::Text;
                 break;
         }
     }

--- a/src/crispy/logstore.cpp
+++ b/src/crispy/logstore.cpp
@@ -16,35 +16,35 @@
 namespace logstore
 {
 
-Sink::Sink(bool enabled, Writer writer): _enabled { enabled }, _writer { std::move(writer) }
+sink::sink(bool enabled, writer wr): _enabled { enabled }, _writer { std::move(wr) }
 {
 }
 
-Sink::Sink(bool enabled, std::ostream& output):
-    Sink(enabled, [out = &output](std::string_view text) {
+sink::sink(bool enabled, std::ostream& output):
+    sink(enabled, [out = &output](std::string_view text) {
         *out << text;
         out->flush();
     })
 {
 }
 
-Sink::Sink(bool enabled, std::shared_ptr<std::ostream> f):
-    Sink(enabled, [f = std::move(f)](std::string_view text) {
+sink::sink(bool enabled, std::shared_ptr<std::ostream> f):
+    sink(enabled, [f = std::move(f)](std::string_view text) {
         *f << text;
         f->flush();
     })
 {
 }
 
-Sink& Sink::console()
+sink& sink::console()
 {
-    static auto instance = Sink(false, std::cout);
+    static auto instance = sink(false, std::cout);
     return instance;
 }
 
-Sink& Sink::error_console() // NOLINT(readability-identifier-naming)
+sink& sink::error_console() // NOLINT(readability-identifier-naming)
 {
-    static auto instance = Sink(true, std::cerr);
+    static auto instance = sink(true, std::cerr);
     return instance;
 }
 

--- a/src/crispy/logstore.h
+++ b/src/crispy/logstore.h
@@ -42,13 +42,13 @@
 namespace logstore
 {
 
-class Category;
-class Sink;
+class category;
+class sink;
 
-class SourceLocation
+class source_location
 {
   public:
-    SourceLocation(char const* filename, int line, char const* functionName) noexcept:
+    source_location(char const* filename, int line, char const* functionName) noexcept:
         _fileName { filename }, _line { line }, _functionName { functionName }
     {
     }
@@ -57,9 +57,9 @@ class SourceLocation
     [[nodiscard]] int line() const noexcept { return _line; }
     [[nodiscard]] char const* function_name() const noexcept { return _functionName; }
 
-    static SourceLocation current() noexcept
+    static source_location current() noexcept
     {
-        return SourceLocation(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION());
+        return source_location(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION());
     }
 
   private:
@@ -68,49 +68,41 @@ class SourceLocation
     char const* _functionName;
 };
 
-// #if __has_include(<source_location>) && !defined(_WIN32)
-// using source_location = std::source_location;
-// #elif __has_include(<experimental/source_location>)
-// using source_location = std::experimental::source_location;
-// #else
-using source_location = SourceLocation;
-// #endif
-
-class MessageBuilder
+class message_builder
 {
   private:
-    Category const& _category;
+    category const& _category;
     source_location _location;
     std::string _buffer;
 
   public:
-    explicit MessageBuilder(Category const& cat, source_location loc = source_location::current());
+    explicit message_builder(category const& cat, source_location loc = source_location::current());
 
-    [[nodiscard]] Category const& category() const noexcept { return _category; }
+    [[nodiscard]] category const& get_category() const noexcept { return _category; }
     [[nodiscard]] source_location const& location() const noexcept { return _location; }
 
     [[nodiscard]] std::string const& text() const noexcept { return _buffer; }
 
-    MessageBuilder& append(std::string_view msg)
+    message_builder& append(std::string_view msg)
     {
         _buffer += msg;
         return *this;
     }
 
     template <typename... T>
-    MessageBuilder& append(fmt::format_string<T...> fmt, T&&... args)
+    message_builder& append(fmt::format_string<T...> fmt, T&&... args)
     {
         _buffer += fmt::vformat(fmt, fmt::make_format_args(args...));
         return *this;
     }
 
-    MessageBuilder& operator()(std::string const& msg)
+    message_builder& operator()(std::string const& msg)
     {
         _buffer += msg;
         return *this;
     }
     template <typename... T>
-    MessageBuilder& operator()(fmt::format_string<T...> fmt, T&&... args)
+    message_builder& operator()(fmt::format_string<T...> fmt, T&&... args)
     {
         _buffer += fmt::vformat(fmt, fmt::make_format_args(args...));
         return *this;
@@ -118,114 +110,114 @@ class MessageBuilder
 
     [[nodiscard]] std::string message() const;
 
-    ~MessageBuilder();
+    ~message_builder();
 };
 
-/// Defines a logging Category, such as: error, warning, metrics, vt.backend, or renderer.
+/// Defines a logging category, such as: error, warning, metrics, vt.backend, or renderer.
 ///
 /// A program can have multiple logging categories, all pointing to the same
 /// or each to an individual logging sink.
-class Category
+class category
 {
   public:
-    using Formatter = std::function<std::string(MessageBuilder const&)>;
-    enum class State
+    using formatter = std::function<std::string(message_builder const&)>;
+    enum class state
     {
         Enabled,
         Disabled
     };
-    enum class Visibility
+    enum class visibility
     {
         Public,
         Hidden
     };
 
-    Category(std::string_view name,
+    category(std::string_view name,
              std::string_view desc,
-             State state = State::Disabled,
-             Visibility visibility = Visibility::Public) noexcept;
-    ~Category();
+             state state = state::Disabled,
+             visibility visibility = visibility::Public) noexcept;
+    ~category();
 
     [[nodiscard]] std::string_view name() const noexcept { return _name; }
     [[nodiscard]] std::string_view description() const noexcept { return _description; }
 
-    [[nodiscard]] bool is_enabled() const noexcept { return _state == State::Enabled; }
-    void enable(bool enabled = true) noexcept { _state = enabled ? State::Enabled : State::Disabled; }
-    void disable() noexcept { _state = State::Disabled; }
+    [[nodiscard]] bool is_enabled() const noexcept { return _state == state::Enabled; }
+    void enable(bool enabled = true) noexcept { _state = enabled ? state::Enabled : state::Disabled; }
+    void disable() noexcept { _state = state::Disabled; }
 
-    [[nodiscard]] bool visible() const noexcept { return _visibility == Visibility::Public; }
-    void set_visible(bool visible) { _visibility = visible ? Visibility::Public : Visibility::Hidden; }
+    [[nodiscard]] bool visible() const noexcept { return _visibility == visibility::Public; }
+    void set_visible(bool visible) { _visibility = visible ? visibility::Public : visibility::Hidden; }
 
     operator bool() const noexcept { return is_enabled(); }
 
-    [[nodiscard]] Formatter const& formatter() const { return _formatter; }
-    void set_formatter(Formatter formatter) { _formatter = std::move(formatter); }
+    [[nodiscard]] formatter const& get_formatter() const { return _formatter; }
+    void set_formatter(formatter formatter) { _formatter = std::move(formatter); }
 
-    void set_sink(logstore::Sink& s) { _sink = s; }
-    [[nodiscard]] logstore::Sink& sink() const noexcept { return _sink.get(); }
+    void set_sink(logstore::sink& s) { _sink = s; }
+    [[nodiscard]] logstore::sink& sink() const noexcept { return _sink.get(); }
 
-    [[nodiscard]] MessageBuilder build(source_location location = source_location::current()) const
+    [[nodiscard]] message_builder build(source_location location = source_location::current()) const
     {
-        return MessageBuilder(*this, location);
+        return message_builder(*this, location);
     }
 
-    [[nodiscard]] MessageBuilder operator()(source_location location = source_location::current()) const
+    [[nodiscard]] message_builder operator()(source_location location = source_location::current()) const
     {
-        return MessageBuilder(*this, location);
+        return message_builder(*this, location);
     }
 
-    static std::string defaultFormatter(MessageBuilder const& message);
+    static std::string defaultFormatter(message_builder const& message);
 
   private:
     std::string_view _name;
     std::string_view _description;
-    State _state;
-    Visibility _visibility;
-    Formatter _formatter;
-    std::reference_wrapper<logstore::Sink> _sink;
+    state _state;
+    visibility _visibility;
+    formatter _formatter;
+    std::reference_wrapper<logstore::sink> _sink;
 };
 
-/// Logging Sink API.
+/// Logging sink API.
 ///
 /// Such as the console, a log file, or UDP endpoint.
-class Sink
+class sink
 {
   public:
-    using Writer = std::function<void(std::string_view const&)>;
+    using writer = std::function<void(std::string_view const&)>;
 
-    Sink(bool enabled, Writer writer);
-    Sink(bool enabled, std::ostream& output);
-    Sink(bool enabled, std::shared_ptr<std::ostream> f);
+    sink(bool enabled, writer writer);
+    sink(bool enabled, std::ostream& output);
+    sink(bool enabled, std::shared_ptr<std::ostream> f);
 
-    void set_writer(Writer writer);
+    void set_writer(writer writer);
 
     /// Writes given built message to this sink.
-    void write(MessageBuilder const& message);
+    void write(message_builder const& message);
 
     void set_enabled(bool enabled) { _enabled = enabled; }
 
     /// Retrieves reference to standard debug-logging sink.
-    static Sink& console();
-    static Sink& error_console(); // NOLINT(readability-identifier-naming)
+    static sink& console();
+    static sink& error_console(); // NOLINT(readability-identifier-naming)
 
   private:
     bool _enabled;
-    Writer _writer;
+    writer _writer;
 };
 
-std::vector<std::reference_wrapper<Category>>& get();
-Category* get(std::string_view categoryName);
-void set_sink(Sink& sink);
-void set_formatter(Category::Formatter const& f);
+std::vector<std::reference_wrapper<category>>& get();
+category* get(std::string_view categoryName);
+void set_sink(sink& sink);
+void set_formatter(category::formatter const& f);
 void enable(std::string_view categoryName, bool enabled = true);
 void disable(std::string_view categoryName);
 void configure(std::string_view filterString);
 
 // {{{ implementation
-inline std::string MessageBuilder::message() const
+inline std::string message_builder::message() const
 {
-    if (_category.formatter())
-        return _category.formatter()(*this);
+    if (_category.get_formatter())
+        return _category.get_formatter()(*this);
     else if (!_buffer.empty() && _buffer.back() == '\n')
         return _buffer;
     else if (!_buffer.empty())
@@ -234,13 +226,13 @@ inline std::string MessageBuilder::message() const
         return "";
 }
 
-inline std::vector<std::reference_wrapper<Category>>& get()
+inline std::vector<std::reference_wrapper<category>>& get()
 {
-    static std::vector<std::reference_wrapper<Category>> logStore;
+    static std::vector<std::reference_wrapper<category>> logStore;
     return logStore;
 }
 
-inline Category* get(std::string_view categoryName)
+inline category* get(std::string_view categoryName)
 {
     for (auto const& cat: get())
         if (cat.get().name() == categoryName)
@@ -248,13 +240,13 @@ inline Category* get(std::string_view categoryName)
     return nullptr;
 }
 
-inline void set_sink(Sink& s)
+inline void set_sink(sink& s)
 {
     for (auto const& cat: get())
         cat.get().set_sink(s);
 }
 
-inline void set_formatter(Category::Formatter const& f)
+inline void set_formatter(category::formatter const& f)
 {
     for (auto const& cat: get())
         cat.get().set_formatter(f);
@@ -296,31 +288,31 @@ inline void configure(std::string_view filterString)
     }
 }
 
-inline MessageBuilder::MessageBuilder(logstore::Category const& cat, source_location location):
+inline message_builder::message_builder(logstore::category const& cat, source_location location):
     _category { cat }, _location { location }
 {
 }
 
-inline MessageBuilder::~MessageBuilder()
+inline message_builder::~message_builder()
 {
     _category.sink().write(*this);
 }
 
-inline Category::Category(std::string_view name,
+inline category::category(std::string_view name,
                           std::string_view desc,
-                          State state,
-                          Visibility visibility) noexcept:
+                          state state,
+                          visibility visibility) noexcept:
     _name { name },
     _description { desc },
     _state { state },
     _visibility { visibility },
-    _sink { logstore::Sink::console() }
+    _sink { logstore::sink::console() }
 {
-    assert(std::none_of(get().begin(), get().end(), [&](Category const& x) { return x.name() == _name; }));
+    assert(std::none_of(get().begin(), get().end(), [&](category const& x) { return x.name() == _name; }));
     get().emplace_back(*this);
 }
 
-inline Category::~Category()
+inline category::~category()
 {
     for (auto i = get().begin(), e = get().end(); i != e; ++i)
     {
@@ -332,28 +324,28 @@ inline Category::~Category()
     }
 }
 
-inline std::string Category::defaultFormatter(MessageBuilder const& message)
+inline std::string category::defaultFormatter(message_builder const& message)
 {
     return fmt::format("[{}:{}:{}]: {}\n",
-                       message.category().name(),
+                       message.get_category().name(),
                        message.location().file_name(),
                        message.location().line(),
                        message.text());
 }
 
-inline void Sink::write(MessageBuilder const& message)
+inline void sink::write(message_builder const& message)
 {
-    if (_enabled && message.category().is_enabled())
+    if (_enabled && message.get_category().is_enabled())
         _writer(message.message());
 }
 
-inline void Sink::set_writer(Writer writer)
+inline void sink::set_writer(writer writer)
 {
     _writer = std::move(writer);
 }
 // }}}
 
-auto inline ErrorLog = logstore::Category("error", "Error Logger", Category::State::Enabled);
+auto inline ErrorLog = logstore::category("error", "Error Logger", category::state::Enabled);
 
 #define errorlog() (::logstore::ErrorLog())
 

--- a/src/crispy/logstore.h
+++ b/src/crispy/logstore.h
@@ -28,6 +28,12 @@
 #include <string_view>
 #include <vector>
 
+#if defined __has_include
+    #if __cpp_lib_source_location
+        #include <source_location>
+    #endif
+#endif
+
 // NB: Don't do that now. It seems to only cause problems, such as
 // __has_include reports presense and in can in fact be included, but it's
 // not giving us the expected std::...source_location, wow.
@@ -45,10 +51,10 @@ namespace logstore
 class category;
 class sink;
 
-class source_location
+class source_location_custom
 {
   public:
-    source_location(char const* filename, int line, char const* functionName) noexcept:
+    source_location_custom(char const* filename, int line, char const* functionName) noexcept:
         _fileName { filename }, _line { line }, _functionName { functionName }
     {
     }
@@ -57,9 +63,9 @@ class source_location
     [[nodiscard]] int line() const noexcept { return _line; }
     [[nodiscard]] char const* function_name() const noexcept { return _functionName; }
 
-    static source_location current() noexcept
+    static source_location_custom current() noexcept
     {
-        return source_location(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION());
+        return source_location_custom(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION());
     }
 
   private:
@@ -67,6 +73,14 @@ class source_location
     int _line;
     char const* _functionName;
 };
+
+#if defined __has_include
+    #if defined __cpp_lib_source_location
+using source_location = std::source_location;
+    #else
+using source_location = source_location_custom;
+    #endif
+#endif
 
 class message_builder
 {

--- a/src/crispy/point.h
+++ b/src/crispy/point.h
@@ -20,7 +20,7 @@
 namespace crispy
 {
 
-struct [[nodiscard]] Point
+struct [[nodiscard]] point
 {
     int x {};
     int y {};
@@ -29,36 +29,36 @@ struct [[nodiscard]] Point
 template <typename T>
 constexpr inline T Zero {};
 template <>
-constexpr inline Point Zero<Point> = Point { 0, 0 };
+constexpr inline point Zero<point> = point { 0, 0 };
 
-constexpr Point operator*(Point p, double s) noexcept
+constexpr point operator*(point p, double s) noexcept
 {
-    return Point {
+    return point {
         static_cast<int>(static_cast<double>(p.x) * s),
         static_cast<int>(static_cast<double>(p.y) * s),
     };
 }
 
-constexpr Point operator+(Point a, Point b) noexcept
+constexpr point operator+(point a, point b) noexcept
 {
-    return Point { a.x + b.x, a.y + b.y };
+    return point { a.x + b.x, a.y + b.y };
 }
 
-constexpr Point& operator+=(Point& a, Point b) noexcept
+constexpr point& operator+=(point& a, point b) noexcept
 {
     a.x += b.x;
     a.y += b.y;
     return a;
 }
 
-constexpr void swap(Point& a, Point& b) noexcept
+constexpr void swap(point& a, point& b) noexcept
 {
-    Point const c = a;
+    point const c = a;
     a = b;
     b = c;
 }
 
-constexpr inline int compare(Point const& a, Point const& b) noexcept
+constexpr inline int compare(point const& a, point const& b) noexcept
 {
     if (auto const dr = a.y - b.y; dr != 0)
         return dr;
@@ -66,32 +66,32 @@ constexpr inline int compare(Point const& a, Point const& b) noexcept
         return a.x - b.x;
 }
 
-constexpr inline bool operator<(Point const& a, Point const& b) noexcept
+constexpr inline bool operator<(point const& a, point const& b) noexcept
 {
     return compare(a, b) < 0;
 }
 
-constexpr inline bool operator<=(Point const& a, Point const& b) noexcept
+constexpr inline bool operator<=(point const& a, point const& b) noexcept
 {
     return compare(a, b) <= 0;
 }
 
-constexpr inline bool operator>(Point const& a, Point const& b) noexcept
+constexpr inline bool operator>(point const& a, point const& b) noexcept
 {
     return compare(a, b) > 0;
 }
 
-constexpr inline bool operator>=(Point const& a, Point const& b) noexcept
+constexpr inline bool operator>=(point const& a, point const& b) noexcept
 {
     return compare(a, b) >= 0;
 }
 
-constexpr inline bool operator==(Point const& a, Point const& b) noexcept
+constexpr inline bool operator==(point const& a, point const& b) noexcept
 {
     return a.x == b.x && a.y == b.y;
 }
 
-constexpr inline bool operator!=(Point const& a, Point const& b) noexcept
+constexpr inline bool operator!=(point const& a, point const& b) noexcept
 {
     return !(a == b);
 }
@@ -99,10 +99,10 @@ constexpr inline bool operator!=(Point const& a, Point const& b) noexcept
 } // namespace crispy
 
 template <>
-struct fmt::formatter<crispy::Point>
+struct fmt::formatter<crispy::point>
 {
     static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(crispy::Point coord, format_context& ctx) -> format_context::iterator
+    static auto format(crispy::point coord, format_context& ctx) -> format_context::iterator
     {
         return fmt::format_to(ctx.out(), "({}, {})", coord.x, coord.y);
     }

--- a/src/crispy/size.h
+++ b/src/crispy/size.h
@@ -10,7 +10,7 @@
 namespace crispy
 {
 
-struct [[nodiscard]] Size
+struct [[nodiscard]] size
 {
     int width;
     int height;
@@ -44,11 +44,11 @@ struct [[nodiscard]] Size
       private:
         int _width;
         int _next;
-        Point _coord { 0, 0 };
+        point _coord { 0, 0 };
 
-        constexpr Point makeCoordinate(int offset) const noexcept
+        constexpr point makeCoordinate(int offset) const noexcept
         {
-            return Point { offset % _width, offset / _width };
+            return point { offset % _width, offset / _width };
         }
     };
 
@@ -56,67 +56,67 @@ struct [[nodiscard]] Size
     [[nodiscard]] constexpr iterator end() const noexcept { return iterator { width, width * height }; }
 };
 
-constexpr Size::iterator begin(Size const& s) noexcept
+constexpr size::iterator begin(size const& s) noexcept
 {
     return s.begin();
 }
-constexpr Size::iterator end(Size const& s) noexcept
+constexpr size::iterator end(size const& s) noexcept
 {
     return s.end();
 }
 
-constexpr int area(Size size) noexcept
+constexpr int area(size size) noexcept
 {
     return size.width * size.height;
 }
 
-constexpr bool operator<(Size a, Size b) noexcept
+constexpr bool operator<(size a, size b) noexcept
 {
     return a.width < b.width || (a.width == b.width && a.height < b.height);
 }
 
-constexpr bool operator==(Size const& a, Size const& b) noexcept
+constexpr bool operator==(size const& a, size const& b) noexcept
 {
     return a.width == b.width && a.height == b.height;
 }
 
-constexpr bool operator!=(Size const& a, Size const& b) noexcept
+constexpr bool operator!=(size const& a, size const& b) noexcept
 {
     return !(a == b);
 }
 
-constexpr Size operator+(Size a, Size b) noexcept
+constexpr size operator+(size a, size b) noexcept
 {
-    return Size { a.width + b.width, a.height + b.height };
+    return size { a.width + b.width, a.height + b.height };
 }
 
-constexpr Size operator-(Size a, Size b) noexcept
+constexpr size operator-(size a, size b) noexcept
 {
-    return Size { a.width - b.width, a.height - b.height };
+    return size { a.width - b.width, a.height - b.height };
 }
 
-constexpr Size operator*(Size a, Size b) noexcept
+constexpr size operator*(size a, size b) noexcept
 {
-    return Size { a.width * b.width, a.height * b.height };
+    return size { a.width * b.width, a.height * b.height };
 }
 
-inline Size operator*(Size a, double scalar) noexcept
+inline size operator*(size a, double scalar) noexcept
 {
-    return Size { int(ceil(double(a.width) * scalar)), int(ceil(double(a.height) * scalar)) };
+    return size { int(ceil(double(a.width) * scalar)), int(ceil(double(a.height) * scalar)) };
 }
 
-constexpr Size operator/(Size a, Size b) noexcept
+constexpr size operator/(size a, size b) noexcept
 {
-    return Size { a.width / b.width, a.height / b.height };
+    return size { a.width / b.width, a.height / b.height };
 }
 
 } // end namespace crispy
 
 template <>
-struct fmt::formatter<crispy::Size>
+struct fmt::formatter<crispy::size>
 {
     static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(const crispy::Size& value, format_context& ctx) -> format_context::iterator
+    static auto format(const crispy::size& value, format_context& ctx) -> format_context::iterator
     {
         return fmt::format_to(ctx.out(), "{}x{}", value.width, value.height);
     }

--- a/src/crispy/stdfs.h
+++ b/src/crispy/stdfs.h
@@ -17,7 +17,7 @@
     #include <filesystem>
     #include <system_error>
 namespace FileSystem = std::filesystem;
-using FileSystemError = std::error_code;
+using file_system_error = std::error_code;
 #elif defined(USING_BOOST_FILESYSTEM) && (USING_BOOST_FILESYSTEM)
     #include <boost/filesystem.hpp>
 namespace FileSystem = boost::filesystem;

--- a/src/crispy/times.h
+++ b/src/crispy/times.h
@@ -24,7 +24,7 @@ namespace crispy
 namespace detail
 {
     template <typename I, typename T>
-    struct TimesIterator
+    struct times_iterator
     {
         T start;
         I count;
@@ -34,47 +34,47 @@ namespace detail
         constexpr T operator*() noexcept { return current; }
         constexpr T const& operator*() const noexcept { return current; }
 
-        constexpr TimesIterator<I, T>& operator++() noexcept
+        constexpr times_iterator<I, T>& operator++() noexcept
         {
             current += step;
             --count;
             return *this;
         }
-        constexpr TimesIterator<I, T>& operator++(int) noexcept { return ++*this; }
+        constexpr times_iterator<I, T>& operator++(int) noexcept { return ++*this; }
 
-        constexpr TimesIterator<I, T>& operator--() noexcept
+        constexpr times_iterator<I, T>& operator--() noexcept
         {
             current -= step;
             ++count;
             return *this;
         }
-        constexpr TimesIterator<I, T>& operator--(int) noexcept { return ++*this; }
+        constexpr times_iterator<I, T>& operator--(int) noexcept { return ++*this; }
 
-        constexpr bool operator==(TimesIterator<I, T> const& other) const noexcept
+        constexpr bool operator==(times_iterator<I, T> const& other) const noexcept
         {
             return count == other.count;
         }
-        constexpr bool operator!=(TimesIterator<I, T> const& other) const noexcept
+        constexpr bool operator!=(times_iterator<I, T> const& other) const noexcept
         {
             return count != other.count;
         }
     };
 
     template <typename I, typename T>
-    struct Times
+    struct times
     {
         T start;
         I count;
         T step;
 
-        using iterator = TimesIterator<I, T>;
+        using iterator = times_iterator<I, T>;
 
         [[nodiscard]] constexpr std::size_t size() const noexcept { return count; }
         constexpr T operator[](size_t i) const noexcept { return start + i * step; }
 
         [[nodiscard]] constexpr iterator begin() const noexcept
         {
-            return TimesIterator<I, T> { start, count, step, start };
+            return times_iterator<I, T> { start, count, step, start };
         }
 
         [[nodiscard]] constexpr iterator end() const noexcept
@@ -84,42 +84,42 @@ namespace detail
     };
 
     template <typename I, typename T>
-    Times(T, I, T) -> Times<I, T>;
+    times(T, I, T) -> times<I, T>;
 
     template <typename I, typename T>
-    constexpr auto begin(Times<I, T> const& times) noexcept
+    constexpr auto begin(times<I, T> const& times) noexcept
     {
         return times.begin();
     }
     template <typename I, typename T>
-    constexpr auto end(Times<I, T> const& times) noexcept
+    constexpr auto end(times<I, T> const& times) noexcept
     {
         return times.end();
     }
 
     template <typename I, typename T>
-    constexpr auto begin(Times<I, T>& times) noexcept
+    constexpr auto begin(times<I, T>& times) noexcept
     {
         return times.begin();
     }
     template <typename I, typename T>
-    constexpr auto end(Times<I, T>& times) noexcept
+    constexpr auto end(times<I, T>& times) noexcept
     {
         return times.end();
     }
 
     template <typename I, typename T1, typename T2>
-    struct Times2DIterator
+    struct times_2d_iterator
     {
-        using Outer = Times<I, T1>;
-        using Inner = Times<I, T2>;
+        using outer = times<I, T1>;
+        using inner = times<I, T2>;
 
-        Outer first;
-        Inner second;
-        typename Outer::iterator outerIt;
-        typename Inner::iterator innerIt;
+        outer first;
+        inner second;
+        typename outer::iterator outerIt;
+        typename inner::iterator innerIt;
 
-        constexpr Times2DIterator(Outer outer, Inner inner, bool init) noexcept:
+        constexpr times_2d_iterator(outer outer, inner inner, bool init) noexcept:
             first { std::move(outer) },
             second { std::move(inner) },
             outerIt { init ? std::begin(first) : std::end(first) },
@@ -130,7 +130,7 @@ namespace detail
         using value_type = std::tuple<T1, T2>;
         constexpr value_type operator*() const noexcept { return { *outerIt, *innerIt }; }
 
-        constexpr Times2DIterator<I, T1, T2>& operator++() noexcept
+        constexpr times_2d_iterator<I, T1, T2>& operator++() noexcept
         {
             ++innerIt;
             if (innerIt == std::end(second))
@@ -142,27 +142,27 @@ namespace detail
             return *this;
         }
 
-        constexpr Times2DIterator<I, T1, T2>& operator++(int) noexcept { return *++this; }
+        constexpr times_2d_iterator<I, T1, T2>& operator++(int) noexcept { return *++this; }
 
-        constexpr bool operator==(Times2DIterator<I, T1, T2> const& other) const noexcept
+        constexpr bool operator==(times_2d_iterator<I, T1, T2> const& other) const noexcept
         {
             return innerIt == other.innerIt;
             // return outerIt == other.outerIt && innerIt == other.innerIt;
         }
 
-        constexpr bool operator!=(Times2DIterator<I, T1, T2> const& other) const noexcept
+        constexpr bool operator!=(times_2d_iterator<I, T1, T2> const& other) const noexcept
         {
             return !(*this == other);
         }
     };
 
     template <typename I, typename T1, typename T2>
-    struct Times2D
+    struct times_2d
     {
-        Times<I, T1> first;
-        Times<I, T2> second;
+        times<I, T1> first;
+        times<I, T2> second;
 
-        using iterator = Times2DIterator<I, T1, T2>;
+        using iterator = times_2d_iterator<I, T1, T2>;
 
         [[nodiscard]] constexpr std::size_t size() const noexcept { return first.size() * second.size(); }
         constexpr auto operator[](std::size_t i) const noexcept { return second[i % second.size()]; }
@@ -172,40 +172,40 @@ namespace detail
     };
 
     template <typename I, typename T1, typename T2>
-    constexpr auto begin(detail::Times2D<I, T1, T2> const& times) noexcept
+    constexpr auto begin(detail::times_2d<I, T1, T2> const& times) noexcept
     {
         return times.begin();
     }
 
     template <typename I, typename T1, typename T2>
-    constexpr auto end(detail::Times2D<I, T1, T2> const& times) noexcept
+    constexpr auto end(detail::times_2d<I, T1, T2> const& times) noexcept
     {
         return times.end();
     }
 
     template <typename I, typename T1, typename T2>
-    constexpr auto begin(detail::Times2D<I, T1, T2>& times) noexcept
+    constexpr auto begin(detail::times_2d<I, T1, T2>& times) noexcept
     {
         return times.begin();
     }
 
     template <typename I, typename T1, typename T2>
-    constexpr auto end(detail::Times2D<I, T1, T2>& times) noexcept
+    constexpr auto end(detail::times_2d<I, T1, T2>& times) noexcept
     {
         return times.end();
     }
 
     template <typename I, typename T1, typename T2>
-    constexpr inline detail::Times2D<I, T1, T2> operator*(detail::Times<I, T1> a, detail::Times<I, T2> b)
+    constexpr inline detail::times_2d<I, T1, T2> operator*(detail::times<I, T1> a, detail::times<I, T2> b)
     {
-        return detail::Times2D<I, T1, T2> { std::move(a), std::move(b) };
+        return detail::times_2d<I, T1, T2> { std::move(a), std::move(b) };
     }
 
     template <typename I,
               typename T,
               typename Callable,
               typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T>, int> = 0>
-    constexpr void operator|(detail::Times<I, T> times, Callable callable)
+    constexpr void operator|(detail::times<I, T> times, Callable callable)
     {
         for (auto&& i: times)
             callable(i);
@@ -215,7 +215,7 @@ namespace detail
               typename T,
               typename Callable,
               typename std::enable_if_t<std::is_invocable_r_v<void, Callable>, int> = 0>
-    constexpr void operator|(detail::Times<I, T> times, Callable callable)
+    constexpr void operator|(detail::times<I, T> times, Callable callable)
     {
         for ([[maybe_unused]] auto&& i: times)
             callable();
@@ -228,7 +228,7 @@ namespace detail
               typename T2,
               typename Callable,
               typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T1, T2>, int> = 0>
-    constexpr void operator|(detail::Times2D<I, T1, T2> times, Callable callable)
+    constexpr void operator|(detail::times_2d<I, T1, T2> times, Callable callable)
     {
         for (auto&& [i, j]: times)
             callable(i, j);
@@ -239,21 +239,21 @@ namespace detail
 // TODO: give random access hints to STL algorithms
 
 template <typename I, typename T>
-constexpr inline detail::Times<I, T> times(T start, I count, T step = T(1))
+constexpr inline detail::times<I, T> times(T start, I count, T step = T(1))
 {
-    return detail::Times<I, T> { start, count, step };
+    return detail::times<I, T> { start, count, step };
 }
 
 template <typename T>
-constexpr inline detail::Times<T, T> times(T count)
+constexpr inline detail::times<T, T> times(T count)
 {
-    return detail::Times<T, T> { T(0), count, T(1) };
+    return detail::times<T, T> { T(0), count, T(1) };
 }
 
 template <typename T>
-constexpr inline detail::Times2D<T, T, T> times2D(T a, T b)
+constexpr inline detail::times_2d<T, T, T> times2D(T a, T b)
 {
-    return detail::Times2D<T, T, T> { std::move(a), std::move(b) };
+    return detail::times_2d<T, T, T> { std::move(a), std::move(b) };
 }
 
 } // namespace crispy

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -387,7 +387,7 @@ inline std::string readFileAsString(FileSystem::path const& path)
 template <typename T>
 constexpr auto each_element() noexcept
 {
-    struct Container
+    struct container
     {
         struct iterator // NOLINT(readability-identifier-naming)
         {
@@ -408,7 +408,7 @@ constexpr auto each_element() noexcept
             return iterator { static_cast<T>(static_cast<int>(std::numeric_limits<T>::max()) + 1) };
         }
     };
-    return Container {};
+    return container {};
 }
 
 template <typename T>

--- a/src/crispy/utils_test.cpp
+++ b/src/crispy/utils_test.cpp
@@ -130,7 +130,7 @@ TEST_CASE("fromHexString")
     CHECK(crispy::fromHexString("4162"sv).value() == "Ab"sv);
 }
 
-struct VariableCollector
+struct variable_collector
 {
     auto operator()(string_view name) const { return fmt::format("({})", name); }
 };
@@ -138,12 +138,12 @@ struct VariableCollector
 TEST_CASE("replaceVariables")
 {
     // clang-format off
-    CHECK(""sv == crispy::replaceVariables("", VariableCollector()));
-    CHECK("()"sv == crispy::replaceVariables("${}", VariableCollector()));
-    CHECK("(Hello)"sv == crispy::replaceVariables("${Hello}", VariableCollector()));
-    CHECK("(Hello) World"sv == crispy::replaceVariables("${Hello} World", VariableCollector()));
-    CHECK("Hello, (World)!"sv == crispy::replaceVariables("Hello, ${World}!", VariableCollector()));
-    CHECK("(one), (two), (three)"sv == crispy::replaceVariables("${one}, ${two}, ${three}", VariableCollector()));
+    CHECK(""sv == crispy::replaceVariables("", variable_collector()));
+    CHECK("()"sv == crispy::replaceVariables("${}", variable_collector()));
+    CHECK("(Hello)"sv == crispy::replaceVariables("${Hello}", variable_collector()));
+    CHECK("(Hello) World"sv == crispy::replaceVariables("${Hello} World", variable_collector()));
+    CHECK("Hello, (World)!"sv == crispy::replaceVariables("Hello, ${World}!", variable_collector()));
+    CHECK("(one), (two), (three)"sv == crispy::replaceVariables("${one}, ${two}, ${three}", variable_collector()));
     // clang-format on
 }
 

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -509,8 +509,8 @@ std::optional<rasterized_glyph> directwrite_shaper::rasterize(glyph_key _glyph, 
     RECT textureBounds {};
     glyphAnalysis->GetAlphaTextureBounds(DWRITE_TEXTURE_CLEARTYPE_3x1, &textureBounds);
 
-    output.bitmapSize.width = crispy::Width(textureBounds.right - textureBounds.left);
-    output.bitmapSize.height = crispy::Height(textureBounds.bottom - textureBounds.top);
+    output.bitmapSize.width = crispy::width(textureBounds.right - textureBounds.left);
+    output.bitmapSize.height = crispy::height(textureBounds.bottom - textureBounds.top);
     output.position.x = textureBounds.left;
     output.position.y = -textureBounds.top;
 

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -39,7 +39,7 @@
 namespace text
 {
 
-auto const inline LocatorLog = logstore::Category("font.locator", "Logs about font loads.");
+auto const inline LocatorLog = logstore::category("font.locator", "Logs about font loads.");
 
 namespace detail
 {
@@ -329,7 +329,7 @@ struct hash<text::font_description>
 {
     std::size_t operator()(text::font_description const& fd) const noexcept
     {
-        auto fnv = crispy::FNV<char>();
+        auto fnv = crispy::fnv<char>();
         return size_t(
             fnv(fnv(fnv(fnv(fnv(fd.familyName), char(fd.weight)), char(fd.slant)), char(fd.spacing)),
                 char(fd.strict_spacing)));

--- a/src/text_shaper/shaper.cpp
+++ b/src/text_shaper/shaper.cpp
@@ -35,8 +35,8 @@ namespace
 {
     template <std::size_t NumComponents>
     constexpr void scaleDownExplicit(vector<uint8_t> const& inputBitmap,
-                                     crispy::ImageSize inputSize,
-                                     crispy::ImageSize outputSize,
+                                     crispy::image_size inputSize,
+                                     crispy::image_size outputSize,
                                      size_t factor,
                                      vector<uint8_t>& outputBitmap) noexcept
     {
@@ -70,7 +70,7 @@ namespace
 
 } // namespace
 
-tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, crispy::ImageSize boundingBox)
+tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, crispy::image_size boundingBox)
 {
     // NB: We're only supporting down-scaling.
     assert(bitmap.bitmapSize.width >= boundingBox.width);
@@ -83,8 +83,8 @@ tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, crispy::Ima
 
     // Adjust new image size to respect ratio.
     auto const newSize =
-        crispy::ImageSize { crispy::Width::cast_from(unbox<double>(bitmap.bitmapSize.width) / ratio),
-                            crispy::Height::cast_from(unbox<double>(bitmap.bitmapSize.height) / ratio) };
+        crispy::image_size { crispy::width::cast_from(unbox<double>(bitmap.bitmapSize.width) / ratio),
+                             crispy::height::cast_from(unbox<double>(bitmap.bitmapSize.height) / ratio) };
 
     RasterizerLog()("scaling {} from {} to {}, ratio {}x{} ({}), factor {}",
                     bitmap.format,

--- a/src/text_shaper/shaper.h
+++ b/src/text_shaper/shaper.h
@@ -40,8 +40,8 @@
 namespace text
 {
 
-auto const inline RasterizerLog = logstore::Category("font.render", "Logs details about rendering glyphs.");
-auto const inline TextShapingLog = logstore::Category("font.textshaping", "Logs details about text shaping.");
+auto const inline RasterizerLog = logstore::category("font.render", "Logs details about rendering glyphs.");
+auto const inline TextShapingLog = logstore::category("font.textshaping", "Logs details about text shaping.");
 
 // NOLINTBEGIN(readability-identifier-naming)
 enum class bitmap_format
@@ -66,8 +66,8 @@ constexpr size_t pixel_size(bitmap_format format) noexcept
 struct rasterized_glyph
 {
     glyph_index index;
-    crispy::ImageSize bitmapSize; // Glyph bitmap size in pixels.
-    crispy::Point position;       // top-left position of the bitmap, relative to the basline's origin.
+    crispy::image_size bitmapSize; // Glyph bitmap size in pixels.
+    crispy::point position;        // top-left position of the bitmap, relative to the basline's origin.
     bitmap_format format;
     std::vector<uint8_t> bitmap;
 
@@ -79,13 +79,13 @@ struct rasterized_glyph
     }
 };
 
-std::tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, crispy::ImageSize boundingBox);
+std::tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, crispy::image_size boundingBox);
 
 struct glyph_position
 {
     glyph_key glyph;
-    crispy::Point offset;
-    crispy::Point advance;
+    crispy::point offset;
+    crispy::point advance;
 
     unicode::PresentationStyle presentation {};
 };

--- a/src/vtbackend/Capabilities.cpp
+++ b/src/vtbackend/Capabilities.cpp
@@ -510,7 +510,7 @@ string StaticDatabase::terminfo() const
 
     for (auto const& cap: move(strings) | actions::sort)
         if (!cap.name.empty())
-            output << "    " << cap.name << "=" << crispy::escape(cap.value, crispy::NumericEscape::Octal)
+            output << "    " << cap.name << "=" << crispy::escape(cap.value, crispy::numeric_escape::Octal)
                    << ",\n";
 
     return output.str();

--- a/src/vtbackend/ColorPalette.cpp
+++ b/src/vtbackend/ColorPalette.cpp
@@ -91,8 +91,7 @@ ColorPalette::Palette const ColorPalette::defaultColorPalette = []() constexpr {
 void ImageData::updateHash() noexcept
 {
     // clang-format off
-    using crispy::StrongHash;
-    auto hashValue = StrongHash(0, 0, 0, size.width.value)
+    auto hashValue = crispy::strong_hash(0, 0, 0, size.width.value)
                    * static_cast<uint32_t>(size.height.value)
                    * static_cast<uint32_t>(rowAlignment)
                    * static_cast<uint32_t>(format);
@@ -101,7 +100,7 @@ void ImageData::updateHash() noexcept
     auto const pitch = roundUp(scanLineLength, static_cast<size_t>(rowAlignment));
     for (unsigned row = 0; row < size.height.value; ++row)
     {
-        hashValue = hashValue * StrongHash::compute(scanLine, scanLineLength);
+        hashValue = hashValue * crispy::strong_hash::compute(scanLine, scanLineLength);
         scanLine += pitch;
     }
     hash = hashValue;

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -42,7 +42,7 @@ struct ImageData
     ImageSize size;
     std::vector<uint8_t> pixels;
 
-    crispy::StrongHash hash;
+    crispy::strong_hash hash;
 
     void updateHash() noexcept;
 };
@@ -54,7 +54,7 @@ struct BackgroundImage
     using Location = std::variant<FileSystem::path, ImageDataPtr>;
 
     Location location;
-    crispy::StrongHash hash;
+    crispy::strong_hash hash;
 
     // image configuration
     float opacity = 1.0; // normalized value

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -31,8 +31,8 @@ using std::vector;
 namespace terminal
 {
 
-auto const inline GridLog = logstore::Category(
-    "vt.grid", "Grid related", logstore::Category::State::Disabled, logstore::Category::Visibility::Hidden);
+auto const inline GridLog = logstore::category(
+    "vt.grid", "Grid related", logstore::category::state::Disabled, logstore::category::visibility::Hidden);
 
 namespace detail
 {
@@ -967,20 +967,20 @@ CellLocation Grid<Cell>::resize(PageSize newSize, CellLocation currentCursorPos,
     CellLocation cursor = currentCursorPos;
 
     // grow/shrink columns
-    using crispy::Comparison;
+    using crispy::comparison;
     switch (crispy::strongCompare(newSize.columns, _pageSize.columns))
     {
-        case Comparison::Greater: cursor += growColumns(newSize.columns); break;
-        case Comparison::Less: cursor = shrinkColumns(newSize.columns, newSize.lines, cursor); break;
-        case Comparison::Equal: break;
+        case comparison::Greater: cursor += growColumns(newSize.columns); break;
+        case comparison::Less: cursor = shrinkColumns(newSize.columns, newSize.lines, cursor); break;
+        case comparison::Equal: break;
     }
 
     // grow/shrink lines
     switch (crispy::strongCompare(newSize.lines, _pageSize.lines))
     {
-        case Comparison::Greater: cursor += growLines(newSize.lines, cursor); break;
-        case Comparison::Less: cursor += shrinkLines(newSize.lines, cursor); break;
-        case Comparison::Equal: break;
+        case comparison::Greater: cursor += growLines(newSize.lines, cursor); break;
+        case comparison::Less: cursor += shrinkLines(newSize.lines, cursor); break;
+        case comparison::Equal: break;
     }
 
     Ensures(_pageSize == newSize);

--- a/src/vtbackend/Grid_test.cpp
+++ b/src/vtbackend/Grid_test.cpp
@@ -21,6 +21,8 @@
 
 #include <iostream>
 
+#include "crispy/BufferObject.h"
+
 using namespace terminal;
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -892,7 +894,7 @@ TEST_CASE("Grid resize", "[grid]")
     auto width = ColumnCount(6);
     auto grid = Grid<Cell>(PageSize { LineCount(2), width }, true, LineCount(0));
     auto text = "abcd"sv;
-    auto pool = crispy::BufferObjectPool<char>(32);
+    auto pool = crispy::buffer_object_pool<char>(32);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(text);
     auto const bufferFragment = bufferObject->ref(0, 4);

--- a/src/vtbackend/Hyperlink.h
+++ b/src/vtbackend/Hyperlink.h
@@ -83,7 +83,7 @@ using HyperlinkId = crispy::boxed<uint16_t, detail::HyperlinkTag>;
 
 bool is_local(HyperlinkInfo const& hyperlink);
 
-using HyperlinkCache = crispy::LRUCache<HyperlinkId, std::shared_ptr<HyperlinkInfo>>;
+using HyperlinkCache = crispy::lru_cache<HyperlinkId, std::shared_ptr<HyperlinkInfo>>;
 
 struct HyperlinkStorage
 {

--- a/src/vtbackend/Image.cpp
+++ b/src/vtbackend/Image.cpp
@@ -16,6 +16,8 @@
 #include <algorithm>
 #include <memory>
 
+#include "crispy/StrongLRUHashtable.h"
+
 using std::copy;
 using std::make_shared;
 using std::min;
@@ -23,9 +25,6 @@ using std::move;
 using std::ostream;
 using std::shared_ptr;
 using std::string;
-
-using crispy::LRUCapacity;
-using crispy::StrongHashtableSize;
 
 namespace terminal
 {
@@ -54,8 +53,8 @@ ImageFragment::~ImageFragment()
 
 ImagePool::ImagePool(OnImageRemove onImageRemove, ImageId nextImageId):
     _nextImageId { nextImageId },
-    _imageNameToImageCache { StrongHashtableSize { 1024 },
-                             LRUCapacity { 100 },
+    _imageNameToImageCache { crispy::strong_hashtable_size { 1024 },
+                             crispy::lru_capacity { 100 },
                              "ImagePool name-to-image mappings" },
     _onImageRemove { std::move(onImageRemove) }
 {

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -270,7 +270,7 @@ class ImagePool
   private:
     void removeRasterizedImage(RasterizedImage* image); //!< Removes a rasterized image from pool.
 
-    using NameToImageIdCache = crispy::StrongLRUCache<std::string, std::shared_ptr<Image const>>;
+    using NameToImageIdCache = crispy::strong_lru_cache<std::string, std::shared_ptr<Image const>>;
 
     // data members
     //

--- a/src/vtbackend/Line.cpp
+++ b/src/vtbackend/Line.cpp
@@ -29,23 +29,23 @@ namespace terminal
 template <typename Cell>
 typename Line<Cell>::InflatedBuffer Line<Cell>::reflow(ColumnCount newColumnCount)
 {
-    using crispy::Comparison;
+    using crispy::comparison;
     if (isTrivialBuffer())
     {
         switch (crispy::strongCompare(newColumnCount, ColumnCount::cast_from(trivialBuffer().text.size())))
         {
-            case Comparison::Greater: trivialBuffer().displayWidth = newColumnCount; return {};
-            case Comparison::Equal: return {};
-            case Comparison::Less:;
+            case comparison::Greater: trivialBuffer().displayWidth = newColumnCount; return {};
+            case comparison::Equal: return {};
+            case comparison::Less:;
         }
     }
     auto& buffer = inflatedBuffer();
     // TODO: Efficiently handle TrivialBuffer-case.
     switch (crispy::strongCompare(newColumnCount, size()))
     {
-        case Comparison::Equal: break;
-        case Comparison::Greater: buffer.resize(unbox<size_t>(newColumnCount)); break;
-        case Comparison::Less: {
+        case comparison::Equal: break;
+        case comparison::Greater: buffer.resize(unbox<size_t>(newColumnCount)); break;
+        case comparison::Less: {
             // TODO: properly handle wide character cells
             // - when cutting in the middle of a wide char, the wide char gets wrapped and an empty
             //   cell needs to be injected to match the expected column width.

--- a/src/vtbackend/Line_test.cpp
+++ b/src/vtbackend/Line_test.cpp
@@ -29,7 +29,7 @@ using Cell = PrimaryScreenCell;
 TEST_CASE("Line.BufferFragment", "[Line]")
 {
     auto constexpr testText = "0123456789ABCDEF"sv;
-    auto pool = BufferObjectPool<char>(16);
+    auto pool = buffer_object_pool<char>(16);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(testText);
     auto const bufferFragment = bufferObject->ref(0, 10);
@@ -43,7 +43,7 @@ TEST_CASE("Line.resize", "[Line]")
 {
     auto constexpr DisplayWidth = ColumnCount(4);
     auto text = "abcd"sv;
-    auto pool = BufferObjectPool<char>(32);
+    auto pool = buffer_object_pool<char>(32);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(text);
 
@@ -70,7 +70,7 @@ TEST_CASE("Line.reflow", "[Line]")
 {
     auto constexpr DisplayWidth = ColumnCount(4);
     auto text = "abcd"sv;
-    auto pool = BufferObjectPool<char>(32);
+    auto pool = buffer_object_pool<char>(32);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(text);
 
@@ -93,7 +93,7 @@ TEST_CASE("Line.reflow", "[Line]")
 TEST_CASE("Line.inflate", "[Line]")
 {
     auto constexpr testText = "0123456789ABCDEF"sv;
-    auto pool = BufferObjectPool<char>(16);
+    auto pool = buffer_object_pool<char>(16);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(testText);
     auto const bufferFragment = bufferObject->ref(0, 10);
@@ -127,7 +127,7 @@ TEST_CASE("Line.inflate.Unicode", "[Line]")
     auto constexpr testTextUtf32 = U"0\u2705123456789ABCDEF"sv;
     auto const testTextUtf8 = unicode::convert_to<char>(testTextUtf32);
 
-    auto pool = BufferObjectPool<char>(32);
+    auto pool = buffer_object_pool<char>(32);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(testTextUtf8);
 
@@ -178,7 +178,7 @@ TEST_CASE("Line.inflate.Unicode.FamilyEmoji", "[Line]")
     auto const testTextUtf8 = unicode::convert_to<char>(testTextUtf32);
     auto const familyEmojiUtf8 = unicode::convert_to<char>(U"\U0001F468\u200D\U0001F468\u200D\U0001F467"sv);
 
-    auto pool = BufferObjectPool<char>(32);
+    auto pool = buffer_object_pool<char>(32);
     auto bufferObject = pool.allocateBufferObject();
     bufferObject->writeAtEnd(testTextUtf8);
 

--- a/src/vtbackend/MockTerm.h
+++ b/src/vtbackend/MockTerm.h
@@ -106,7 +106,7 @@ inline MockTerm<PtyDevice>::MockTerm(PageSize pageSize,
     if (logFilterString)
     {
         logstore::configure(logFilterString);
-        crispy::App::customizeLogStoreOutput();
+        crispy::app::customizeLogStoreOutput();
     }
 }
 

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -88,10 +88,10 @@ namespace terminal
 
 auto constexpr inline TabWidth = ColumnCount(8);
 
-auto const inline VTCaptureBufferLog = logstore::Category("vt.ext.capturebuffer",
+auto const inline VTCaptureBufferLog = logstore::category("vt.ext.capturebuffer",
                                                           "Capture Buffer debug logging.",
-                                                          logstore::Category::State::Disabled,
-                                                          logstore::Category::Visibility::Hidden);
+                                                          logstore::category::state::Disabled,
+                                                          logstore::category::visibility::Hidden);
 
 namespace // {{{ helper
 {

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -30,7 +30,7 @@
 #include <libunicode/convert.h>
 
 using crispy::escape;
-using crispy::Size;
+using crispy::size;
 using namespace terminal;
 using namespace terminal::test;
 using namespace std;

--- a/src/vtbackend/Selector_test.cpp
+++ b/src/vtbackend/Selector_test.cpp
@@ -17,7 +17,7 @@
 
 #include <catch2/catch.hpp>
 
-using crispy::Size;
+using crispy::size;
 using namespace std;
 using namespace std::placeholders;
 using namespace terminal;

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -40,7 +40,7 @@
 
 #include <libunicode/convert.h>
 
-using crispy::Size;
+using crispy::size;
 using std::nullopt;
 using std::optional;
 using std::string;

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -44,6 +44,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -643,7 +645,7 @@ class Terminal
     void applyPageSizeToCurrentBuffer();
     void applyPageSizeToMainDisplay(ScreenType screenType);
 
-    [[nodiscard]] crispy::BufferObjectPtr<char> currentPtyBuffer() const noexcept
+    [[nodiscard]] crispy::buffer_object_ptr<char> currentPtyBuffer() const noexcept
     {
         return _currentPtyBuffer;
     }
@@ -769,8 +771,8 @@ class Terminal
     std::chrono::steady_clock::time_point _currentTime;
 
     // {{{ PTY and PTY read buffer management
-    crispy::BufferObjectPool<char> _ptyBufferPool;
-    crispy::BufferObjectPtr<char> _currentPtyBuffer;
+    crispy::buffer_object_pool<char> _ptyBufferPool;
+    crispy::buffer_object_ptr<char> _currentPtyBuffer;
     size_t _ptyReadBufferSize;
     std::unique_ptr<Pty> _pty;
     // }}}

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -19,6 +19,7 @@
 
 #include <variant>
 
+#include "crispy/TrieMap.h"
 #include <libunicode/convert.h>
 
 using std::nullopt;
@@ -268,16 +269,16 @@ bool ViInputHandler::handlePendingInput()
 
     CommandHandlerMap const& mapping = isVisualMode() ? _visualMode : _normalMode;
     auto const mappingResult = mapping.search(_pendingInput, TrieMapAllowWildcardDot);
-    if (std::holds_alternative<crispy::ExactMatch<CommandHandler>>(mappingResult))
+    if (std::holds_alternative<crispy::exact_match<CommandHandler>>(mappingResult))
     {
         InputLog()("Executing handler for: {}{}", _count ? fmt::format("{} ", _count) : "", _pendingInput);
         _lastChar =
             unicode::convert_to<char32_t>(std::string_view(_pendingInput.data(), _pendingInput.size()))
                 .back();
-        std::get<crispy::ExactMatch<CommandHandler>>(mappingResult).value();
+        std::get<crispy::exact_match<CommandHandler>>(mappingResult).value();
         clearPendingInput();
     }
-    else if (std::holds_alternative<crispy::NoMatch>(mappingResult))
+    else if (std::holds_alternative<crispy::no_match>(mappingResult))
     {
         InputLog()("Invalid command: {}", _pendingInput);
         clearPendingInput();

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -230,7 +230,7 @@ class ViInputHandler: public InputHandler
     };
 
     using CommandHandler = std::function<void()>;
-    using CommandHandlerMap = crispy::TrieMap<std::string, CommandHandler>;
+    using CommandHandlerMap = crispy::trie_map<std::string, CommandHandler>;
 
     void registerAllCommands();
     void registerCommand(ModeSelect modes, std::string_view command, CommandHandler handler);

--- a/src/vtbackend/Viewport.h
+++ b/src/vtbackend/Viewport.h
@@ -30,7 +30,7 @@ class Viewport
 {
   public:
 #if defined(CONTOUR_LOG_VIEWPORT)
-    static auto inline const ViewportLog = logstore::Category("vt.viewport", "Logs viewport details.");
+    static auto inline const ViewportLog = logstore::category("vt.viewport", "Logs viewport details.");
 #endif
 
     using ModifyEvent = std::function<void()>;

--- a/src/vtbackend/bench-headless.cpp
+++ b/src/vtbackend/bench-headless.cpp
@@ -30,6 +30,7 @@
 #include <random>
 #include <thread>
 
+#include "crispy/BufferObject.h"
 #include <libtermbench/termbench.h>
 
 using namespace std;
@@ -111,13 +112,13 @@ int baseBenchmark(Writer&& writer, BenchOptions options, string_view title)
 
 namespace CLI = crispy::cli;
 
-class ContourHeadlessBench: public crispy::App
+class ContourHeadlessBench: public crispy::app
 {
   public:
     ContourHeadlessBench():
-        App("bench-headless", "Contour Headless Benchmark", CONTOUR_VERSION_STRING, "Apache-2.0")
+        app("bench-headless", "Contour Headless Benchmark", CONTOUR_VERSION_STRING, "Apache-2.0")
     {
-        using Project = crispy::cli::about::Project;
+        using Project = crispy::cli::about::project;
         crispy::cli::about::registerProjects(
 #if defined(CONTOUR_BUILD_WITH_MIMALLOC)
             Project { "mimalloc", "", "" },
@@ -135,37 +136,37 @@ class ContourHeadlessBench: public crispy::App
         if (logFilterString)
         {
             logstore::configure(logFilterString);
-            crispy::App::customizeLogStoreOutput();
+            crispy::app::customizeLogStoreOutput();
         }
     }
 
-    [[nodiscard]] crispy::cli::Command parameterDefinition() const override
+    [[nodiscard]] crispy::cli::command parameterDefinition() const override
     {
-        auto const perfOptions = CLI::OptionList {
-            CLI::Option { "size", CLI::Value { 32u }, "Number of megabyte to process per test.", "MB" },
-            CLI::Option { "cat", CLI::Value { false }, "Enable cat-style short-line ASCII stream test." },
-            CLI::Option { "long", CLI::Value { false }, "Enable long-line ASCII stream test." },
-            CLI::Option { "sgr", CLI::Value { false }, "Enable SGR stream test." },
-            CLI::Option { "binary", CLI::Value { false }, "Enable binary stream test." },
+        auto const perfOptions = CLI::option_list {
+            CLI::option { "size", CLI::value { 32u }, "Number of megabyte to process per test.", "MB" },
+            CLI::option { "cat", CLI::value { false }, "Enable cat-style short-line ASCII stream test." },
+            CLI::option { "long", CLI::value { false }, "Enable long-line ASCII stream test." },
+            CLI::option { "sgr", CLI::value { false }, "Enable SGR stream test." },
+            CLI::option { "binary", CLI::value { false }, "Enable binary stream test." },
         };
 
-        return CLI::Command {
+        return CLI::command {
             "bench-headless",
             "Contour Terminal Emulator " CONTOUR_VERSION_STRING
             " - https://github.com/contour-terminal/contour/ ;-)",
-            CLI::OptionList {},
-            CLI::CommandList {
-                CLI::Command { "help", "Shows this help and exits." },
-                CLI::Command { "meta", "Shows some terminal backend meta information and exits." },
-                CLI::Command { "version", "Shows the version and exits." },
-                CLI::Command { "license",
+            CLI::option_list {},
+            CLI::command_list {
+                CLI::command { "help", "Shows this help and exits." },
+                CLI::command { "meta", "Shows some terminal backend meta information and exits." },
+                CLI::command { "version", "Shows the version and exits." },
+                CLI::command { "license",
                                "Shows the license, and project URL of the used projects and Contour." },
-                CLI::Command { "grid",
+                CLI::command { "grid",
                                "Performs performance tests utilizing the full grid including VT parser.",
                                perfOptions },
-                CLI::Command {
+                CLI::command {
                     "parser", "Performs performance tests utilizing the VT parser only.", perfOptions },
-                CLI::Command {
+                CLI::command {
                     "pty",
                     "Performs performance tests utilizing the underlying operating system's PTY only." },
             }
@@ -246,7 +247,7 @@ class ContourHeadlessBench: public crispy::App
         auto& ptySlave = pty.slave();
         (void) ptySlave.configure();
 
-        auto bufferObjectPool = crispy::BufferObjectPool<char>(4llu * 1024 * 1024);
+        auto bufferObjectPool = crispy::buffer_object_pool<char>(4llu * 1024 * 1024);
         auto bufferObject = bufferObjectPool.allocateBufferObject();
 
         auto bytesTransferred = uint64_t { 0 };

--- a/src/vtbackend/cell/CompactCell.h
+++ b/src/vtbackend/cell/CompactCell.h
@@ -151,7 +151,7 @@ class CRISPY_PACKED CompactCell
     char32_t _codepoint = 0; /// Primary Unicode codepoint to be displayed.
     Color _foregroundColor = DefaultColor();
     Color _backgroundColor = DefaultColor();
-    crispy::Owned<CellExtra> _extra = {};
+    crispy::owned<CellExtra> _extra = {};
     // TODO(perf) ^^ use CellExtraId = boxed<int24_t> into pre-alloc'ed vector<CellExtra>.
 };
 

--- a/src/vtbackend/logging.h
+++ b/src/vtbackend/logging.h
@@ -18,17 +18,17 @@
 namespace terminal
 {
 
-auto const inline TerminalLog = logstore::Category("vt.session", "Logs general terminal events.");
-auto const inline InputLog = logstore::Category("vt.input", "Logs terminal keyboard/mouse input events.");
-auto const inline VTParserLog = logstore::Category("vt.parser",
+auto const inline TerminalLog = logstore::category("vt.session", "Logs general terminal events.");
+auto const inline InputLog = logstore::category("vt.input", "Logs terminal keyboard/mouse input events.");
+auto const inline VTParserLog = logstore::category("vt.parser",
                                                    "Logs terminal parser errors.",
-                                                   logstore::Category::State::Enabled,
-                                                   logstore::Category::Visibility::Hidden);
+                                                   logstore::category::state::Enabled,
+                                                   logstore::category::visibility::Hidden);
 
 #if defined(LIBTERMINAL_LOG_TRACE)
-auto const inline VTTraceSequenceLog = logstore::Category("vt.trace.sequence", "Logs terminal screen trace.");
+auto const inline VTTraceSequenceLog = logstore::category("vt.trace.sequence", "Logs terminal screen trace.");
 #endif
 
-auto const inline RenderBufferLog = logstore::Category("vt.renderbuffer", "Render Buffer Objects");
+auto const inline RenderBufferLog = logstore::category("vt.renderbuffer", "Render Buffer Objects");
 
 } // namespace terminal

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -435,9 +435,9 @@ constexpr Length length(Range range) noexcept
 // }}}
 // {{{ ImageSize types
 
-using Width = crispy::Width;
-using Height = crispy::Height;
-using ImageSize = crispy::ImageSize;
+using Width = crispy::width;
+using Height = crispy::height;
+using ImageSize = crispy::image_size;
 
 // }}}
 // {{{ Mixed boxed types operator overloads

--- a/src/vtbackend/test_main.cpp
+++ b/src/vtbackend/test_main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char const* argv[])
     if (logFilterString)
     {
         logstore::configure(logFilterString);
-        crispy::App::customizeLogStoreOutput();
+        crispy::app::customizeLogStoreOutput();
     }
     int const result = Catch::Session().run(argc, argv);
 

--- a/src/vtparser/Parser-impl.h
+++ b/src/vtparser/Parser-impl.h
@@ -30,7 +30,7 @@ namespace terminal::parser
 {
 
 auto const inline VTTraceParserLog =
-    logstore::Category("vt.trace.parser", "Logs terminal parser instruction trace.");
+    logstore::category("vt.trace.parser", "Logs terminal parser instruction trace.");
 
 namespace
 {

--- a/src/vtparser/test_main.cpp
+++ b/src/vtparser/test_main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char const* argv[])
     if (logFilterString)
     {
         logstore::configure(logFilterString);
-        crispy::App::customizeLogStoreOutput();
+        crispy::app::customizeLogStoreOutput();
     }
     int const result = Catch::Session().run(argc, argv);
 

--- a/src/vtpty/ConPty.cpp
+++ b/src/vtpty/ConPty.cpp
@@ -17,6 +17,8 @@
 
 #include <Windows.h>
 
+#include "crispy/BufferObject.h"
+
 using namespace std;
 
 namespace
@@ -141,7 +143,7 @@ void ConPty::close()
     }
 }
 
-Pty::ReadResult ConPty::read(crispy::BufferObject<char>& buffer,
+Pty::ReadResult ConPty::read(crispy::buffer_object<char>& buffer,
                              std::chrono::milliseconds timeout,
                              size_t size)
 {
@@ -180,7 +182,7 @@ PageSize ConPty::pageSize() const noexcept
     return _size;
 }
 
-void ConPty::resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels)
+void ConPty::resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels)
 {
     if (!_slave)
         return;

--- a/src/vtpty/ConPty.h
+++ b/src/vtpty/ConPty.h
@@ -21,6 +21,8 @@
 
 #include <Windows.h>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -35,13 +37,13 @@ class ConPty: public Pty
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 
-    [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override;
 
     PtySlave& slave() noexcept override;
     HPCON master() const noexcept { return _master; }

--- a/src/vtpty/LinuxPty.cpp
+++ b/src/vtpty/LinuxPty.cpp
@@ -40,6 +40,8 @@
 #include <pwd.h>
 #include <unistd.h>
 
+#include "crispy/BufferObject.h"
+
 #if !defined(FLATPAK)
     #include <utempter.h>
 #endif
@@ -62,7 +64,7 @@ namespace terminal
 
 namespace
 {
-    LinuxPty::PtyHandles createLinuxPty(PageSize const& windowSize, optional<crispy::ImageSize> pixels)
+    LinuxPty::PtyHandles createLinuxPty(PageSize const& windowSize, optional<crispy::image_size> pixels)
     {
         // See https://code.woboq.org/userspace/glibc/login/forkpty.c.html
         assert(*windowSize.lines <= numeric_limits<unsigned short>::max());
@@ -70,8 +72,8 @@ namespace
 
         winsize const ws { unbox<unsigned short>(windowSize.lines),
                            unbox<unsigned short>(windowSize.columns),
-                           unbox<unsigned short>(pixels.value_or(crispy::ImageSize {}).width),
-                           unbox<unsigned short>(pixels.value_or(crispy::ImageSize {}).height) };
+                           unbox<unsigned short>(pixels.value_or(crispy::image_size {}).width),
+                           unbox<unsigned short>(pixels.value_or(crispy::image_size {}).height) };
 
 #if defined(__APPLE__)
         winsize* wsa = const_cast<winsize*>(&ws);
@@ -192,7 +194,7 @@ int LinuxPty::Slave::write(std::string_view text) noexcept
 }
 // }}}
 
-LinuxPty::LinuxPty(PageSize pageSize, optional<crispy::ImageSize> pixels):
+LinuxPty::LinuxPty(PageSize pageSize, optional<crispy::image_size> pixels):
     _pageSize { pageSize }, _pixels { pixels }
 {
 }
@@ -356,7 +358,7 @@ int LinuxPty::waitForReadable(std::chrono::milliseconds timeout) noexcept
     }
 }
 
-Pty::ReadResult LinuxPty::read(crispy::BufferObject<char>& storage,
+Pty::ReadResult LinuxPty::read(crispy::buffer_object<char>& storage,
                                std::chrono::milliseconds timeout,
                                size_t size)
 {
@@ -433,7 +435,7 @@ PageSize LinuxPty::pageSize() const noexcept
     return _pageSize;
 }
 
-void LinuxPty::resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels)
+void LinuxPty::resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels)
 {
     if (_masterFd < 0)
         return;

--- a/src/vtpty/LinuxPty.h
+++ b/src/vtpty/LinuxPty.h
@@ -23,6 +23,8 @@
 
 #include <pty.h>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -51,7 +53,7 @@ class LinuxPty final: public Pty
         PtySlaveHandle slave;
     };
 
-    LinuxPty(PageSize pageSize, std::optional<crispy::ImageSize> pixels);
+    LinuxPty(PageSize pageSize, std::optional<crispy::image_size> pixels);
     ~LinuxPty() override;
 
     PtySlave& slave() noexcept override;
@@ -61,12 +63,12 @@ class LinuxPty final: public Pty
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
-    [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override;
 
     UnixPipe& stdoutFastPipe() noexcept { return _stdoutFastPipe; }
 
@@ -79,7 +81,7 @@ class LinuxPty final: public Pty
     int _eventFd = -1;
     UnixPipe _stdoutFastPipe;
     PageSize _pageSize;
-    std::optional<crispy::ImageSize> _pixels;
+    std::optional<crispy::image_size> _pixels;
     std::unique_ptr<Slave> _slave;
 };
 

--- a/src/vtpty/LinuxPty.h
+++ b/src/vtpty/LinuxPty.h
@@ -16,14 +16,14 @@
 #include <vtpty/Pty.h>
 #include <vtpty/UnixPty.h> // UnixPipe (TODO: move somewhere else)
 
+#include <crispy/BufferObject.h>
+
 #include <array>
 #include <memory>
 #include <optional>
 #include <vector>
 
 #include <pty.h>
-
-#include "crispy/BufferObject.h"
 
 namespace terminal
 {

--- a/src/vtpty/MockPty.cpp
+++ b/src/vtpty/MockPty.cpp
@@ -1,6 +1,6 @@
 #include <vtpty/MockPty.h>
 
-#include "crispy/BufferObject.h"
+#include <crispy/BufferObject.h>
 
 using namespace std::chrono;
 using std::min;

--- a/src/vtpty/MockPty.cpp
+++ b/src/vtpty/MockPty.cpp
@@ -1,5 +1,7 @@
 #include <vtpty/MockPty.h>
 
+#include "crispy/BufferObject.h"
+
 using namespace std::chrono;
 using std::min;
 using std::nullopt;
@@ -19,7 +21,7 @@ PtySlave& MockPty::slave() noexcept
     return _slave;
 }
 
-Pty::ReadResult MockPty::read(crispy::BufferObject<char>& storage,
+Pty::ReadResult MockPty::read(crispy::buffer_object<char>& storage,
                               std::chrono::milliseconds /*timeout*/,
                               size_t size)
 {
@@ -47,7 +49,7 @@ PageSize MockPty::pageSize() const noexcept
     return _pageSize;
 }
 
-void MockPty::resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels)
+void MockPty::resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels)
 {
     _pageSize = cells;
     _pixelSize = pixels;

--- a/src/vtpty/MockPty.h
+++ b/src/vtpty/MockPty.h
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -28,13 +30,13 @@ class MockPty: public Pty
     ~MockPty() override = default;
 
     PtySlave& slave() noexcept override;
-    [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override;
 
     void start() override;
     void close() override;
@@ -63,7 +65,7 @@ class MockPty: public Pty
 
   private:
     PageSize _pageSize;
-    std::optional<crispy::ImageSize> _pixelSize;
+    std::optional<crispy::image_size> _pixelSize;
     std::string _inputBuffer;
     std::string _outputBuffer;
     std::size_t _outputReadOffset = 0;

--- a/src/vtpty/MockPty.h
+++ b/src/vtpty/MockPty.h
@@ -15,9 +15,9 @@
 
 #include <vtpty/Pty.h>
 
-#include <string>
+#include <crispy/BufferObject.h>
 
-#include "crispy/BufferObject.h"
+#include <string>
 
 namespace terminal
 {

--- a/src/vtpty/MockViewPty.cpp
+++ b/src/vtpty/MockViewPty.cpp
@@ -14,6 +14,8 @@
 
 #include <vtpty/MockViewPty.h>
 
+#include "crispy/BufferObject.h"
+
 using std::min;
 using std::optional;
 using std::string_view;
@@ -33,7 +35,7 @@ PtySlave& MockViewPty::slave() noexcept
     return _slave;
 }
 
-optional<tuple<string_view, bool>> MockViewPty::read(crispy::BufferObject<char>& storage,
+optional<tuple<string_view, bool>> MockViewPty::read(crispy::buffer_object<char>& storage,
                                                      std::chrono::milliseconds /*timeout*/,
                                                      size_t size)
 {
@@ -60,7 +62,7 @@ terminal::PageSize MockViewPty::pageSize() const noexcept
     return _pageSize;
 }
 
-void MockViewPty::resizeScreen(terminal::PageSize cells, std::optional<crispy::ImageSize> pixels)
+void MockViewPty::resizeScreen(terminal::PageSize cells, std::optional<crispy::image_size> pixels)
 {
     _pageSize = cells;
     _pixelSize = pixels;

--- a/src/vtpty/MockViewPty.cpp
+++ b/src/vtpty/MockViewPty.cpp
@@ -14,7 +14,7 @@
 
 #include <vtpty/MockViewPty.h>
 
-#include "crispy/BufferObject.h"
+#include <crispy/BufferObject.h>
 
 using std::min;
 using std::optional;

--- a/src/vtpty/MockViewPty.h
+++ b/src/vtpty/MockViewPty.h
@@ -16,6 +16,8 @@
 
 #include <vtpty/Pty.h>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -27,13 +29,13 @@ class MockViewPty: public Pty
     void setReadData(std::string_view data);
 
     PtySlave& slave() noexcept override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(crispy::buffer_object<char>& storage,
                                                                          std::chrono::milliseconds timeout,
                                                                          size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override;
 
     void start() override;
     void close() override;
@@ -44,7 +46,7 @@ class MockViewPty: public Pty
 
   private:
     PageSize _pageSize;
-    std::optional<crispy::ImageSize> _pixelSize;
+    std::optional<crispy::image_size> _pixelSize;
     std::string _inputBuffer;
     std::string_view _outputBuffer;
     bool _closed = false;

--- a/src/vtpty/MockViewPty.h
+++ b/src/vtpty/MockViewPty.h
@@ -16,7 +16,7 @@
 
 #include <vtpty/Pty.h>
 
-#include "crispy/BufferObject.h"
+#include <crispy/BufferObject.h>
 
 namespace terminal
 {

--- a/src/vtpty/PageSize.h
+++ b/src/vtpty/PageSize.h
@@ -50,15 +50,15 @@ constexpr bool operator!=(PageSize a, PageSize b) noexcept
     return !(a == b);
 }
 
-constexpr crispy::ImageSize operator*(crispy::ImageSize a, PageSize b) noexcept
+constexpr crispy::image_size operator*(crispy::image_size a, PageSize b) noexcept
 {
-    return crispy::ImageSize { a.width * boxed_cast<crispy::Width>(b.columns),
-                               a.height * boxed_cast<crispy::Height>(b.lines) };
+    return crispy::image_size { a.width * boxed_cast<crispy::width>(b.columns),
+                                a.height * boxed_cast<crispy::height>(b.lines) };
 }
 
-constexpr crispy::ImageSize operator/(crispy::ImageSize a, PageSize s) noexcept
+constexpr crispy::image_size operator/(crispy::image_size a, PageSize s) noexcept
 {
-    return { crispy::Width::cast_from(unbox<unsigned>(a.width) / unbox<unsigned>(s.columns)),
-             crispy::Height::cast_from(unbox<unsigned>(a.height) / unbox<unsigned>(s.lines)) };
+    return { crispy::width::cast_from(unbox<unsigned>(a.width) / unbox<unsigned>(s.columns)),
+             crispy::height::cast_from(unbox<unsigned>(a.height) / unbox<unsigned>(s.lines)) };
 }
 } // namespace terminal

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -27,6 +27,8 @@
 #include <variant>
 #include <vector>
 
+#include "crispy/BufferObject.h"
+
 namespace terminal
 {
 
@@ -104,11 +106,11 @@ class [[nodiscard]] Process: public Pty
     [[nodiscard]] PtySlave& slave() noexcept override { return pty().slave(); }
     void close() override { pty().close(); }
     [[nodiscard]] bool isClosed() const noexcept override { return pty().isClosed(); }
-    [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
+    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }
     [[nodiscard]] int write(std::string_view data, bool blocking) override { return pty().write(data, blocking); }
     [[nodiscard]] PageSize pageSize() const noexcept override { return pty().pageSize(); }
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override { pty().resizeScreen(cells, pixels); }
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override { pty().resizeScreen(cells, pixels); }
     // clang-format on
 
   private:

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -15,6 +15,7 @@
 
 #include <vtpty/Pty.h>
 
+#include <crispy/BufferObject.h>
 #include <crispy/overloaded.h>
 #include <crispy/stdfs.h>
 
@@ -26,8 +27,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-
-#include "crispy/BufferObject.h"
 
 namespace terminal
 {

--- a/src/vtpty/Pty.cpp
+++ b/src/vtpty/Pty.cpp
@@ -28,7 +28,7 @@ using std::unique_ptr;
 namespace terminal
 {
 
-unique_ptr<Pty> createPty(PageSize pageSize, optional<crispy::ImageSize> viewSize)
+unique_ptr<Pty> createPty(PageSize pageSize, optional<crispy::image_size> viewSize)
 {
 #if defined(__linux__)
     return make_unique<terminal::LinuxPty>(pageSize, viewSize);

--- a/src/vtpty/Pty.h
+++ b/src/vtpty/Pty.h
@@ -90,7 +90,7 @@ class Pty
     /// @returns A view to the consumed buffer. The boolean in the ReadResult
     ///          indicates whether or not this data was coming through
     ///          the stdout-fastpipe.
-    [[nodiscard]] virtual ReadResult read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] virtual ReadResult read(crispy::buffer_object<char>& storage,
                                           std::chrono::milliseconds timeout,
                                           size_t size) = 0;
 
@@ -114,13 +114,13 @@ class Pty
     [[nodiscard]] virtual PageSize pageSize() const noexcept = 0;
 
     /// Resizes underlying window buffer by given character width and height.
-    virtual void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) = 0;
+    virtual void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) = 0;
 };
 
-[[nodiscard]] std::unique_ptr<Pty> createPty(PageSize pageSize, std::optional<crispy::ImageSize> viewSize);
+[[nodiscard]] std::unique_ptr<Pty> createPty(PageSize pageSize, std::optional<crispy::image_size> viewSize);
 
-auto const inline PtyLog = logstore::Category("pty", "Logs general PTY informations.");
-auto const inline PtyInLog = logstore::Category("pty.input", "Logs PTY raw input.");
-auto const inline PtyOutLog = logstore::Category("pty.output", "Logs PTY raw output.");
+auto const inline PtyLog = logstore::category("pty", "Logs general PTY informations.");
+auto const inline PtyInLog = logstore::category("pty.input", "Logs PTY raw input.");
+auto const inline PtyOutLog = logstore::category("pty.output", "Logs PTY raw output.");
 
 } // namespace terminal

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -14,6 +14,7 @@
 #include <vtpty/UnixPty.h>
 #include <vtpty/UnixUtils.h>
 
+#include <crispy/BufferObject.h>
 #include <crispy/deferred.h>
 #include <crispy/escape.h>
 #include <crispy/logstore.h>
@@ -26,8 +27,6 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
-
-#include "crispy/BufferObject.h"
 
 #if defined(__APPLE__)
     #include <util.h>

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -27,6 +27,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "crispy/BufferObject.h"
+
 #if defined(__APPLE__)
     #include <util.h>
 #elif defined(__FreeBSD__)
@@ -144,7 +146,7 @@ namespace
         }
     }
 
-    UnixPty::PtyHandles createUnixPty(PageSize const& windowSize, optional<crispy::ImageSize> pixels)
+    UnixPty::PtyHandles createUnixPty(PageSize const& windowSize, optional<crispy::image_size> pixels)
     {
         // See https://code.woboq.org/userspace/glibc/login/forkpty.c.html
         assert(*windowSize.lines <= numeric_limits<unsigned short>::max());
@@ -152,8 +154,8 @@ namespace
 
         winsize const ws { unbox<unsigned short>(windowSize.lines),
                            unbox<unsigned short>(windowSize.columns),
-                           unbox<unsigned short>(pixels.value_or(crispy::ImageSize {}).width),
-                           unbox<unsigned short>(pixels.value_or(crispy::ImageSize {}).height) };
+                           unbox<unsigned short>(pixels.value_or(crispy::image_size {}).width),
+                           unbox<unsigned short>(pixels.value_or(crispy::image_size {}).height) };
 
 #if defined(__APPLE__)
         auto* wsa = const_cast<winsize*>(&ws);
@@ -293,7 +295,7 @@ int UnixPty::Slave::write(std::string_view text) noexcept
 }
 // }}}
 
-UnixPty::UnixPty(PageSize pageSize, optional<crispy::ImageSize> pixels):
+UnixPty::UnixPty(PageSize pageSize, optional<crispy::image_size> pixels):
     _pageSize { pageSize }, _pixels { pixels }
 {
 }
@@ -387,7 +389,7 @@ optional<string_view> UnixPty::readSome(int fd, char* target, size_t n) noexcept
     return string_view { target, static_cast<size_t>(rv) };
 }
 
-Pty::ReadResult UnixPty::read(crispy::BufferObject<char>& storage,
+Pty::ReadResult UnixPty::read(crispy::buffer_object<char>& storage,
                               std::chrono::milliseconds timeout,
                               size_t size)
 {
@@ -464,7 +466,7 @@ PageSize UnixPty::pageSize() const noexcept
     return _pageSize;
 }
 
-void UnixPty::resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels)
+void UnixPty::resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels)
 {
     if (_masterFd < 0)
         return;

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -15,12 +15,12 @@
 
 #include <vtpty/Pty.h>
 
+#include <crispy/BufferObject.h>
+
 #include <array>
 #include <memory>
 #include <optional>
 #include <vector>
-
-#include "crispy/BufferObject.h"
 
 #if defined(__APPLE__)
     #include <util.h>

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -20,6 +20,8 @@
 #include <optional>
 #include <vector>
 
+#include "crispy/BufferObject.h"
+
 #if defined(__APPLE__)
     #include <util.h>
 #elif defined(__linux__)
@@ -76,7 +78,7 @@ class UnixPty final: public Pty
         PtySlaveHandle slave;
     };
 
-    UnixPty(PageSize pageSize, std::optional<crispy::ImageSize> pixels);
+    UnixPty(PageSize pageSize, std::optional<crispy::image_size> pixels);
     ~UnixPty() override;
 
     PtySlave& slave() noexcept override;
@@ -86,12 +88,12 @@ class UnixPty final: public Pty
     void close() override;
     [[nodiscard]] bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
-    [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
+    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
-    void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
+    void resizeScreen(PageSize cells, std::optional<crispy::image_size> pixels = std::nullopt) override;
 
     UnixPipe& stdoutFastPipe() noexcept { return _stdoutFastPipe; }
 
@@ -104,7 +106,7 @@ class UnixPty final: public Pty
     std::array<int, 2> _pipe = { -1, -1 };
     UnixPipe _stdoutFastPipe;
     PageSize _pageSize;
-    std::optional<crispy::ImageSize> _pixels;
+    std::optional<crispy::image_size> _pixels;
     std::unique_ptr<Slave> _slave;
 };
 

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -38,7 +38,7 @@ using std::sort;
 using std::string_view;
 using std::tuple;
 
-using crispy::Point;
+using crispy::point;
 using ranges::views::filter;
 using ranges::views::iota;
 using ranges::views::zip;
@@ -48,10 +48,10 @@ namespace terminal::rasterizer
 
 namespace
 {
-    auto const inline BoxDrawingLog = logstore::Category("renderer.boxdrawing",
+    auto const inline BoxDrawingLog = logstore::category("renderer.boxdrawing",
                                                          "Logs box drawing debugging.",
-                                                         logstore::Category::State::Disabled,
-                                                         logstore::Category::Visibility::Hidden);
+                                                         logstore::category::state::Disabled,
+                                                         logstore::category::visibility::Hidden);
 
     // TODO: Do not depend on this function but rather construct the pixmaps using the correct Y-coordinates.
     atlas::Buffer invertY(atlas::Buffer const& image, ImageSize cellSize)
@@ -152,7 +152,7 @@ namespace detail
             // inner circle
             drawEllipseArc(putpixel,
                            imageSize,
-                           crispy::Point { // radius
+                           crispy::point { // radius
                                            unbox<int>(imageSize.width) / 2 - int(thickness) / 2,
                                            unbox<int>(imageSize.height) / 2 - int(thickness) / 2 },
                            arc);
@@ -160,7 +160,7 @@ namespace detail
             // outer circle
             drawEllipseArc(putpixel,
                            imageSize,
-                           crispy::Point { // radius
+                           crispy::point { // radius
                                            unbox<int>(imageSize.width) / 2 + int(thickness) / 2 - 1,
                                            unbox<int>(imageSize.height) / 2 + int(thickness) / 2 - 1 },
                            arc);
@@ -621,7 +621,7 @@ namespace detail
         auto getTriangleProps(ImageSize size)
         {
             auto const c =
-                Point { Direction == Dir::Left ? unbox<int>(size.width) / DivisorX
+                point { Direction == Dir::Left ? unbox<int>(size.width) / DivisorX
                                                : unbox<int>(size.width) - unbox<int>(size.width) / DivisorX,
                         unbox<int>(size.height) / 2 };
             auto const w = unbox<int>(size.width) - 1;
@@ -671,7 +671,7 @@ namespace detail
         template <int P>
         auto triChecker(ImageSize size)
         {
-            auto const c = Point { unbox<int>(size.width) / 2, unbox<int>(size.height) / 2 };
+            auto const c = point { unbox<int>(size.width) / 2, unbox<int>(size.height) / 2 };
             auto const w = unbox<int>(size.width) - 1;
 
             auto const f = linearEq({ 0, 0 }, c);
@@ -697,7 +697,7 @@ namespace detail
             auto constexpr set = Inv == Inverted::No ? 255 : 0;
             auto constexpr unset = 255 - set;
 
-            auto const c = Point { unbox<int>(size.width) / 2, unbox<int>(size.height) / 2 };
+            auto const c = point { unbox<int>(size.width) / 2, unbox<int>(size.height) / 2 };
             auto const w = unbox<int>(size.width) - 1;
 
             auto const f = linearEq({ 0, 0 }, c);
@@ -1011,7 +1011,7 @@ auto BoxDrawingRenderer::createTileData(char32_t codepoint, atlas::TileLocation 
 Renderable::AtlasTileAttributes const* BoxDrawingRenderer::getOrCreateCachedTileAttributes(char32_t codepoint)
 {
     return textureAtlas().get_or_try_emplace(
-        crispy::StrongHash { 31, 13, 8, static_cast<uint32_t>(codepoint) },
+        crispy::strong_hash { 31, 13, 8, static_cast<uint32_t>(codepoint) },
         [this, codepoint](atlas::TileLocation tileLocation) -> optional<TextureAtlas::TileCreateData> {
             return createTileData(codepoint, tileLocation);
         });

--- a/src/vtrasterizer/CursorRenderer.cpp
+++ b/src/vtrasterizer/CursorRenderer.cpp
@@ -175,7 +175,7 @@ auto CursorRenderer::createTileData(CursorShape cursorShape,
     return {};
 }
 
-void CursorRenderer::render(crispy::Point pos, int columnWidth, RGBColor color)
+void CursorRenderer::render(crispy::point pos, int columnWidth, RGBColor color)
 {
     for (uint32_t i = 0; i < uint32_t(columnWidth); ++i)
     {

--- a/src/vtrasterizer/CursorRenderer.h
+++ b/src/vtrasterizer/CursorRenderer.h
@@ -40,7 +40,7 @@ class CursorRenderer: public Renderable
     [[nodiscard]] CursorShape shape() const noexcept { return _shape; }
     void setShape(CursorShape shape);
 
-    void render(crispy::Point pos, int columnWidth, RGBColor color);
+    void render(crispy::point pos, int columnWidth, RGBColor color);
 
     void inspect(std::ostream& output) const override;
 

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 
 using crispy::each_element;
-using crispy::Size;
+using crispy::size;
 
 using std::array;
 using std::ceil;
@@ -302,7 +302,7 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
 }
 
 void DecorationRenderer::renderDecoration(Decorator decoration,
-                                          crispy::Point pos,
+                                          crispy::point pos,
                                           ColumnCount columnCount,
                                           RGBColor const& color)
 {

--- a/src/vtrasterizer/DecorationRenderer.h
+++ b/src/vtrasterizer/DecorationRenderer.h
@@ -51,7 +51,7 @@ class DecorationRenderer: public Renderable
     void renderLine(RenderLine const& line);
 
     void renderDecoration(Decorator decoration,
-                          crispy::Point pos,
+                          crispy::point pos,
                           ColumnCount columnCount,
                           RGBColor const& color);
 

--- a/src/vtrasterizer/GridMetrics.h
+++ b/src/vtrasterizer/GridMetrics.h
@@ -69,19 +69,19 @@ struct GridMetrics
     /// @param line screen coordinate's line (between 0 and number of screen lines minus 1)
     ///
     /// @return 2D point into the grid cell's top left in drawing system coordinates.
-    constexpr crispy::Point map(LineOffset line, ColumnOffset column) const noexcept
+    constexpr crispy::point map(LineOffset line, ColumnOffset column) const noexcept
     {
         return mapTopLeft(line, column);
     }
 
-    constexpr crispy::Point map(CellLocation pos) const noexcept { return map(pos.line, pos.column); }
+    constexpr crispy::point map(CellLocation pos) const noexcept { return map(pos.line, pos.column); }
 
-    constexpr crispy::Point mapTopLeft(CellLocation pos) const noexcept
+    constexpr crispy::point mapTopLeft(CellLocation pos) const noexcept
     {
         return mapTopLeft(pos.line, pos.column);
     }
 
-    constexpr crispy::Point mapTopLeft(LineOffset line, ColumnOffset column) const noexcept
+    constexpr crispy::point mapTopLeft(LineOffset line, ColumnOffset column) const noexcept
     {
         auto const x = pageMargin.left + *column * cellSize.width.as<int>();
         auto const y = pageMargin.top + *line * cellSize.height.as<int>();
@@ -89,11 +89,11 @@ struct GridMetrics
         return { x, y };
     }
 
-    constexpr crispy::Point mapBottomLeft(CellLocation pos) const noexcept
+    constexpr crispy::point mapBottomLeft(CellLocation pos) const noexcept
     {
         return mapBottomLeft(pos.line, pos.column);
     }
-    constexpr crispy::Point mapBottomLeft(LineOffset line, ColumnOffset column) const noexcept
+    constexpr crispy::point mapBottomLeft(LineOffset line, ColumnOffset column) const noexcept
     {
         return mapTopLeft(line + 1, column);
     }

--- a/src/vtrasterizer/ImageRenderer.cpp
+++ b/src/vtrasterizer/ImageRenderer.cpp
@@ -18,6 +18,8 @@
 
 #include <array>
 
+#include "crispy/StrongHash.h"
+
 using crispy::times;
 
 using std::array;
@@ -45,7 +47,7 @@ void ImageRenderer::setCellSize(ImageSize cellSize)
     // TODO: recompute rasterized images slices here?
 }
 
-void ImageRenderer::renderImage(crispy::Point pos, ImageFragment const& fragment)
+void ImageRenderer::renderImage(crispy::point pos, ImageFragment const& fragment)
 {
     // std::cout << fmt::format("ImageRenderer.renderImage: {}\n", fragment);
 
@@ -103,7 +105,7 @@ Renderable::AtlasTileAttributes const* ImageRenderer::getOrCreateCachedTileAttri
     auto const key = ImageFragmentKey { fragment.rasterizedImage().image().id(),
                                         fragment.offset(),
                                         fragment.rasterizedImage().cellSize() };
-    auto const hash = crispy::StrongHash::compute(key);
+    auto const hash = crispy::strong_hash::compute(key);
 
     return textureAtlas().get_or_try_emplace(
         hash, [&](atlas::TileLocation tileLocation) -> optional<TextureAtlas::TileCreateData> {

--- a/src/vtrasterizer/ImageRenderer.h
+++ b/src/vtrasterizer/ImageRenderer.h
@@ -63,7 +63,7 @@ class ImageRenderer: public Renderable, public TextRendererEvents
     /// Reconfigures the slicing properties of existing images.
     void setCellSize(ImageSize cellSize);
 
-    void renderImage(crispy::Point pos, ImageFragment const& fragment);
+    void renderImage(crispy::point pos, ImageFragment const& fragment);
 
     /// notify underlying cache that this fragment is not going to be rendered anymore, maybe freeing up some
     /// GPU caches.

--- a/src/vtrasterizer/Pixmap.cpp
+++ b/src/vtrasterizer/Pixmap.cpp
@@ -103,7 +103,7 @@ Pixmap& Pixmap::halfFilledCircleLeft()
     auto const putBelow = [&](int x, int y) {
         putpixel(x, y + h / 2);
     };
-    auto const radius = crispy::Point { w, h / 2 };
+    auto const radius = crispy::point { w, h / 2 };
     drawEllipseArc(putAbove, size, radius, Arc::BottomLeft);
     drawEllipseArc(putBelow, size, radius, Arc::TopLeft);
     return *this;
@@ -124,7 +124,7 @@ Pixmap& Pixmap::halfFilledCircleRight()
     auto const putBelow = [&](int x, int y) {
         putpixel(x, y + h / 2);
     };
-    auto const radius = crispy::Point { w, h / 2 };
+    auto const radius = crispy::point { w, h / 2 };
     drawEllipseArc(putAbove, size, radius, Arc::BottomRight);
     drawEllipseArc(putBelow, size, radius, Arc::TopRight);
     return *this;

--- a/src/vtrasterizer/Pixmap.h
+++ b/src/vtrasterizer/Pixmap.h
@@ -58,13 +58,13 @@ constexpr RatioBlock left(double r) noexcept  { return RatioBlock { { 0, 0 },   
 constexpr RatioBlock right(double r) noexcept { return RatioBlock { { 1.f - r, 0.f }, { 1.f, 1.f } }; }
 // clang-format on
 
-constexpr crispy::Point operator*(ImageSize a, Ratio b) noexcept
+constexpr crispy::point operator*(ImageSize a, Ratio b) noexcept
 {
-    return crispy::Point { static_cast<int>(a.width.as<double>() * b.x),
+    return crispy::point { static_cast<int>(a.width.as<double>() * b.x),
                            static_cast<int>(a.height.as<double>() * b.y) };
 }
 
-constexpr auto linearEq(crispy::Point p1, crispy::Point p2) noexcept
+constexpr auto linearEq(crispy::point p1, crispy::point p2) noexcept
 {
     // Require(p2.x != p1.x);
     auto const m = double(p2.y - p1.y) / double(p2.x - p1.x);
@@ -114,7 +114,7 @@ auto makeDraw4WaySymmetric(Arc arc, ImageSize size, F putpixel)
 }
 
 template <typename F>
-constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::Point radius)
+constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::point radius)
 {
     auto const rx = radius.x;
     auto const ry = radius.y;
@@ -178,7 +178,7 @@ constexpr void drawEllipse(F doDraw4WaySymmetric, crispy::Point radius)
 }
 
 template <typename PutPixel>
-constexpr void drawEllipseArc(PutPixel putpixel, ImageSize imageSize, crispy::Point radius, Arc arc)
+constexpr void drawEllipseArc(PutPixel putpixel, ImageSize imageSize, crispy::point radius, Arc arc)
 {
     drawEllipse(makeDraw4WaySymmetric(arc, imageSize, std::move(putpixel)), radius);
 }

--- a/src/vtrasterizer/RenderTarget.h
+++ b/src/vtrasterizer/RenderTarget.h
@@ -29,6 +29,8 @@
 #include <optional>
 #include <vector>
 
+#include "crispy/ImageSize.h"
+
 namespace terminal
 {
 struct BackgroundImage;
@@ -101,8 +103,8 @@ class RenderTarget
 {
   public:
     using RGBAColor = terminal::RGBAColor;
-    using Width = crispy::Width;
-    using Height = crispy::Height;
+    using Width = crispy::width;
+    using Height = crispy::height;
     using TextureAtlas = terminal::rasterizer::atlas::TextureAtlas<RenderTileAttributes>;
 
     virtual ~RenderTarget() = default;
@@ -160,7 +162,7 @@ class Renderable
     [[nodiscard]] TextureAtlas::TileCreateData createTileData(atlas::TileLocation tileLocation,
                                                               std::vector<uint8_t> bitmap,
                                                               atlas::Format bitmapFormat,
-                                                              ImageSize bitmapSize,
+                                                              crispy::image_size bitmapSize,
                                                               RenderTileAttributes::X x,
                                                               RenderTileAttributes::Y y,
                                                               uint32_t fragmentShaderSelector);
@@ -168,8 +170,8 @@ class Renderable
     [[nodiscard]] TextureAtlas::TileCreateData createTileData(atlas::TileLocation tileLocation,
                                                               std::vector<uint8_t> bitmap,
                                                               atlas::Format bitmapFormat,
-                                                              ImageSize bitmapSize,
-                                                              ImageSize renderBitmapSize,
+                                                              crispy::image_size bitmapSize,
+                                                              crispy::image_size renderBitmapSize,
                                                               RenderTileAttributes::X x,
                                                               RenderTileAttributes::Y y,
                                                               uint32_t fragmentShaderSelector);
@@ -219,7 +221,7 @@ class Renderable
 inline Renderable::TextureAtlas::TileCreateData Renderable::createTileData(atlas::TileLocation tileLocation,
                                                                            std::vector<uint8_t> bitmap,
                                                                            atlas::Format bitmapFormat,
-                                                                           ImageSize bitmapSize,
+                                                                           crispy::image_size bitmapSize,
                                                                            RenderTileAttributes::X x,
                                                                            RenderTileAttributes::Y y,
                                                                            uint32_t fragmentShaderSelector)

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -18,6 +18,8 @@
 #include <text_shaper/font_locator.h>
 #include <text_shaper/open_shaper.h>
 
+#include "crispy/StrongLRUHashtable.h"
+
 #if defined(_WIN32)
     #include <text_shaper/directwrite_shaper.h>
 #endif
@@ -122,8 +124,8 @@ namespace
 Renderer::Renderer(PageSize pageSize,
                    FontDescriptions fontDescriptions,
                    terminal::ColorPalette const& colorPalette,
-                   crispy::StrongHashtableSize atlasHashtableSlotCount,
-                   crispy::LRUCapacity atlasTileCount,
+                   crispy::strong_hashtable_size atlasHashtableSlotCount,
+                   crispy::lru_capacity atlasTileCount,
                    bool atlasDirectMapping,
                    Decorator hyperlinkNormal,
                    Decorator hyperlinkHover):

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -35,16 +35,18 @@
 #include <utility>
 #include <vector>
 
+#include "crispy/StrongLRUHashtable.h"
+
 namespace terminal::rasterizer
 {
 
 struct RenderCursor
 {
-    crispy::Point position;
+    crispy::point position;
     CursorShape shape;
     int width;
 
-    RenderCursor(crispy::Point position, CursorShape shape, int width):
+    RenderCursor(crispy::point position, CursorShape shape, int width):
         position(position), shape(shape), width(width)
     {
     }
@@ -67,8 +69,8 @@ class Renderer
     Renderer(PageSize pageSize,
              FontDescriptions fontDescriptions,
              ColorPalette const& colorPalette,
-             crispy::StrongHashtableSize atlasHashtableSlotCount,
-             crispy::LRUCapacity atlasTileCount,
+             crispy::strong_hashtable_size atlasHashtableSlotCount,
+             crispy::lru_capacity atlasTileCount,
              bool atlasDirectMapping,
              Decorator hyperlinkNormal,
              Decorator hyperlinkHover);
@@ -142,8 +144,8 @@ class Renderer
     void renderLines(std::vector<RenderLine> const& renderableLines);
     void executeImageDiscards();
 
-    crispy::StrongHashtableSize _atlasHashtableSlotCount;
-    crispy::LRUCapacity _atlasTileCount;
+    crispy::strong_hashtable_size _atlasHashtableSlotCount;
+    crispy::lru_capacity _atlasTileCount;
     bool _atlasDirectMapping;
 
     RenderTarget* _renderTarget = nullptr;

--- a/src/vtrasterizer/TextRenderer.h
+++ b/src/vtrasterizer/TextRenderer.h
@@ -38,6 +38,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "crispy/StrongHash.h"
+#include "crispy/StrongLRUHashtable.h"
 #include <libunicode/convert.h>
 #include <libunicode/run_segmenter.h>
 
@@ -109,12 +111,12 @@ class TextRenderer: public Renderable
     void appendCellTextToClusterGroup(std::u32string_view codepoints, TextStyle style, RGBColor color);
 
     /// Gets the text shaping result of the current text cluster group
-    text::shape_result const& getOrCreateCachedGlyphPositions(crispy::StrongHash hash);
+    text::shape_result const& getOrCreateCachedGlyphPositions(crispy::strong_hash hash);
     text::shape_result createTextShapedGlyphPositions();
     text::shape_result shapeTextRun(unicode::run_segmenter::range const& run);
     void flushTextClusterGroup();
 
-    AtlasTileAttributes const* getOrCreateRasterizedMetadata(crispy::StrongHash const& hash,
+    AtlasTileAttributes const* getOrCreateRasterizedMetadata(crispy::strong_hash const& hash,
                                                              text::glyph_key const& glyphKey,
                                                              unicode::PresentationStyle presentationStyle);
 
@@ -126,7 +128,7 @@ class TextRenderer: public Renderable
         atlas::TileLocation tileLocation,
         text::glyph_key const& glyphKey,
         unicode::PresentationStyle presentation,
-        crispy::StrongHash const& hash);
+        crispy::strong_hash const& hash);
 
     std::optional<TextureAtlas::TileCreateData> createRasterizedGlyph(
         atlas::TileLocation tileLocation,
@@ -135,11 +137,11 @@ class TextRenderer: public Renderable
 
     void restrictToTileSize(TextureAtlas::TileCreateData& tileCreateData);
 
-    crispy::Point applyGlyphPositionToPen(crispy::Point pen,
+    crispy::point applyGlyphPositionToPen(crispy::point pen,
                                           AtlasTileAttributes const& tileAttributes,
                                           text::glyph_position const& gpos) const noexcept;
 
-    void renderRasterizedGlyph(crispy::Point pen, RGBAColor color, AtlasTileAttributes const& attributes);
+    void renderRasterizedGlyph(crispy::point pen, RGBAColor color, AtlasTileAttributes const& attributes);
 
     // general properties
     //
@@ -151,8 +153,8 @@ class TextRenderer: public Renderable
     //
     bool _pressure = false;
 
-    using ShapingResultCache = crispy::StrongLRUHashtable<text::shape_result>;
-    using ShapingResultCachePtr = ShapingResultCache::Ptr;
+    using ShapingResultCache = crispy::strong_lru_hashtable<text::shape_result>;
+    using ShapingResultCachePtr = ShapingResultCache::ptr;
 
     ShapingResultCachePtr _textShapingCache;
     // TODO: make unique_ptr, get owned, export cref for other users in Renderer impl.
@@ -181,7 +183,7 @@ class TextRenderer: public Renderable
     struct TextClusterGroup
     {
         // pen-start position of this text group
-        crispy::Point initialPenPosition {};
+        crispy::point initialPenPosition {};
 
         // uniform text style for this text group
         TextStyle style = TextStyle::Invalid;

--- a/src/vtrasterizer/TextureAtlas.h
+++ b/src/vtrasterizer/TextureAtlas.h
@@ -116,10 +116,10 @@ struct AtlasProperties
     // Number of hashtable slots to map to the texture tiles.
     // Larger values may increase performance, but too large may also decrease.
     // This value is rounted up to a value equal to the power of two.
-    crispy::StrongHashtableSize hashCount {};
+    crispy::strong_hashtable_size hashCount {};
 
     // Number of tiles the texture atlas must be able to store at least.
-    crispy::LRUCapacity tileCount {};
+    crispy::lru_capacity tileCount {};
 
     // Number of direct-mapped tile slots.
     //
@@ -135,7 +135,7 @@ struct AtlasProperties
 struct ConfigureAtlas
 {
     // Texture atlas size in pixels.
-    crispy::ImageSize size {};
+    crispy::image_size size {};
 
     AtlasProperties properties {};
 };
@@ -252,7 +252,7 @@ class TextureAtlas
     [[nodiscard]] ImageSize tileSize() const noexcept { return _atlasProperties.tileSize; }
 
     // Tests in LRU-cache if the tile
-    [[nodiscard]] constexpr bool contains(crispy::StrongHash const& id) const noexcept;
+    [[nodiscard]] constexpr bool contains(crispy::strong_hash const& id) const noexcept;
 
     // Return type for in-place tile-construction callback.
     struct TileCreateData
@@ -276,20 +276,20 @@ class TextureAtlas
     /// Always returns either the existing item by the given key, if found,
     /// or a newly created one by invoking constructValue().
     template <typename CreateTileDataFn>
-    [[nodiscard]] TileAttributes<Metadata>& get_or_emplace(crispy::StrongHash const& key,
+    [[nodiscard]] TileAttributes<Metadata>& get_or_emplace(crispy::strong_hash const& key,
                                                            CreateTileDataFn constructValue);
 
-    [[nodiscard]] TileAttributes<Metadata> const* try_get(crispy::StrongHash const& key);
+    [[nodiscard]] TileAttributes<Metadata> const* try_get(crispy::strong_hash const& key);
 
     template <typename CreateTileDataFn>
-    [[nodiscard]] TileAttributes<Metadata> const* get_or_try_emplace(crispy::StrongHash const& key,
+    [[nodiscard]] TileAttributes<Metadata> const* get_or_try_emplace(crispy::strong_hash const& key,
                                                                      CreateTileDataFn constructValue);
 
     /// Explicitly create or overwrites a tile for the given hash key.
     template <typename CreateTileDataFn>
-    void emplace(crispy::StrongHash const& key, CreateTileDataFn constructValue);
+    void emplace(crispy::strong_hash const& key, CreateTileDataFn constructValue);
 
-    void remove(crispy::StrongHash key);
+    void remove(crispy::strong_hash key);
 
     // Uploads tile data to a direct-mapped slot in the texture atlas
     // bypassing the LRU cache.
@@ -315,8 +315,8 @@ class TextureAtlas
     [[nodiscard]] uint32_t tilesInY() const noexcept { return _tilesInY; }
 
   private:
-    using TileCache = crispy::StrongLRUHashtable<TileAttributes<Metadata>>;
-    using TileCachePtr = typename TileCache::Ptr;
+    using TileCache = crispy::strong_lru_hashtable<TileAttributes<Metadata>>;
+    using TileCachePtr = typename TileCache::ptr;
 
     template <typename CreateTileDataFn>
     std::optional<TileAttributes<Metadata>> constructTile(CreateTileDataFn createTileData,
@@ -501,11 +501,11 @@ TextureAtlas<Metadata>::TextureAtlas(AtlasBackend& backend, AtlasProperties atla
     }() },
     _tileCache { TileCache::create(
         atlasProperties.hashCount,
-        crispy::LRUCapacity { // The LRU entry capacity is the number of total tiles availabe,
-                              // minus the number of reserved tiles for direct-mapping, and
-                              // minus one for the LRU-sentinel entry (which is why entryIndex
-                              // is between 1 and capacity inclusive)
-                              _tilesInX * _tilesInY - _atlasProperties.directMappingCount - 1 },
+        crispy::lru_capacity { // The LRU entry capacity is the number of total tiles availabe,
+                               // minus the number of reserved tiles for direct-mapping, and
+                               // minus one for the LRU-sentinel entry (which is why entryIndex
+                               // is between 1 and capacity inclusive)
+                               _tilesInX * _tilesInY - _atlasProperties.directMappingCount - 1 },
         "LRU cache for texture atlas") },
     _tileLocations { static_cast<size_t>(_tilesInX * _tilesInY) }
 {
@@ -544,7 +544,7 @@ TextureAtlas<Metadata>::TextureAtlas(AtlasBackend& backend, AtlasProperties atla
 }
 
 template <typename Metadata>
-constexpr bool TextureAtlas<Metadata>::contains(crispy::StrongHash const& id) const noexcept
+constexpr bool TextureAtlas<Metadata>::contains(crispy::strong_hash const& id) const noexcept
 {
     return _tileCache->contains(id);
 }
@@ -583,7 +583,7 @@ auto TextureAtlas<Metadata>::constructTile(CreateTileDataFn createTileData, uint
 
 template <typename Metadata>
 template <typename CreateTileDataFn>
-TileAttributes<Metadata>& TextureAtlas<Metadata>::get_or_emplace(crispy::StrongHash const& key,
+TileAttributes<Metadata>& TextureAtlas<Metadata>::get_or_emplace(crispy::strong_hash const& key,
                                                                  CreateTileDataFn constructValue)
 {
     return _tileCache->get_or_emplace(key,
@@ -593,7 +593,7 @@ TileAttributes<Metadata>& TextureAtlas<Metadata>::get_or_emplace(crispy::StrongH
 }
 
 template <typename Metadata>
-TileAttributes<Metadata> const* TextureAtlas<Metadata>::try_get(crispy::StrongHash const& key)
+TileAttributes<Metadata> const* TextureAtlas<Metadata>::try_get(crispy::strong_hash const& key)
 {
     return _tileCache->try_get(key);
 }
@@ -601,7 +601,7 @@ TileAttributes<Metadata> const* TextureAtlas<Metadata>::try_get(crispy::StrongHa
 template <typename Metadata>
 template <typename CreateTileDataFn>
 [[nodiscard]] TileAttributes<Metadata> const* TextureAtlas<Metadata>::get_or_try_emplace(
-    crispy::StrongHash const& key, CreateTileDataFn constructValue)
+    crispy::strong_hash const& key, CreateTileDataFn constructValue)
 {
     return _tileCache->get_or_try_emplace(
         key, [&](uint32_t entryIndex) -> std::optional<TileAttributes<Metadata>> {
@@ -611,7 +611,7 @@ template <typename CreateTileDataFn>
 
 template <typename Metadata>
 template <typename CreateTileDataFn>
-void TextureAtlas<Metadata>::emplace(crispy::StrongHash const& key, CreateTileDataFn constructValue)
+void TextureAtlas<Metadata>::emplace(crispy::strong_hash const& key, CreateTileDataFn constructValue)
 {
     // clang-format off
     _tileCache->emplace(
@@ -632,7 +632,7 @@ void TextureAtlas<Metadata>::emplace(crispy::StrongHash const& key, CreateTileDa
 }
 
 template <typename Metadata>
-void TextureAtlas<Metadata>::remove(crispy::StrongHash key)
+void TextureAtlas<Metadata>::remove(crispy::strong_hash key)
 {
     _tileCache->remove(key);
 }

--- a/src/vtrasterizer/utils.h
+++ b/src/vtrasterizer/utils.h
@@ -23,8 +23,8 @@ namespace terminal::rasterizer
 {
 
 auto const inline RendererLog =
-    logstore::Category("vt.renderer", "Logs general information about VT renderer.");
-auto const inline RasterizerLog = logstore::Category("vt.rasterizer", "Logs details about text rendering.");
+    logstore::category("vt.renderer", "Logs general information about VT renderer.");
+auto const inline RasterizerLog = logstore::category("vt.rasterizer", "Logs details about text rendering.");
 
 std::vector<uint8_t> downsampleRGBA(std::vector<uint8_t> const& bitmap, ImageSize size, ImageSize newSize);
 


### PR DESCRIPTION
Partially closes #960 

 * Build actions will compile with clang-tidy when we are using clang as compiler
 * apply naming convention to crispy folder