### PR TITLE
Add missing dependency for ArchLinux builds

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -373,6 +373,7 @@ install_deps_arch()
             qt6-base \
             qt6-declarative \
             qt6-multimedia \
+            qt6-shadertools \
             qt6-wayland \
         "
     else


### PR DESCRIPTION
## Description

Updating to latest main on ArchLinux builds but the resulting binary can't open a window due to:

```
Warning: QQmlApplicationEngine failed to load component ((null):0, (null))
Warning: qrc:/contour/ui/main.qml:30:5: Type Terminal unavailable (qrc:/contour/ui/main.qml:30, (null))
Warning: qrc:/contour/ui/Terminal.qml:41:5: Type FastBlur unavailable (qrc:/contour/ui/Terminal.qml:41, (null))
Warning: qrc:/qt-project.org/imports/Qt5Compat/GraphicalEffects/FastBlur.qml:5:1: Cannot load library /usr/lib/qt6/qml/Qt5Compat/GraphicalEffects/private/libqtgraphicaleffectsprivateplugin.so: (libQt6ShaderTools.so.6: cannot open shared object file: No such file or directory) (qrc:/qt-project.org/imports/Qt5Compat/GraphicalEffects/FastBlur.qml:5, (null))
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Allows QT6 builds to work on Arch Linux. Packages might need the same change.
```

## How Has This Been Tested?

I ran it locally without the package and saw that there was nothing to see. I installed the package and now contour seems to work again.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
