### PR TITLE
Fixes GUI infinite loop on PTY closing faster than GUI initialization period

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -891,9 +891,76 @@ jobs:
         if-no-files-found: error
         retention-days: 1
   # }}}
-  # {{{ external test: notcurses
+  # {{{ GUI: test: contour quick shell exit
+  test_quick_exit:
+    name: "GUI: Quick Shell Exit"
+    runs-on: ubuntu-22.04
+    needs: [package_for_Ubuntu, build_fontconfig]
+    env:
+      LD_LIBRARY_PATH: /home/runner/opt/fontconfig/lib
+      # I'm giving up on eliminating all leaks for now.
+      # There are still some deep inside Qt I can't explain myself if it's because of me.
+      ASAN_OPTIONS: detect_leaks=0
+      # Can be used to execute contour within a certain environment, such as valgrind:
+      # Valgrind is much more precise, but 10x slower.
+      CONTOUR_PREFIX: "" # valgrind --leak-check=full --num-callers=64 --error-exitcode=112"
+    steps:
+    - uses: actions/checkout@v3
+    - name: "update APT database"
+      run: sudo apt -q update
+    - name: Installing xmllint for ci-set-vars
+      run: sudo apt -qy install libxml2-utils
+    - name: set environment variables
+      id: set_vars
+      run: ./scripts/ci-set-vars.sh
+      env:
+        REPOSITORY: ${{ github.event.repository.name }}
+    - uses: actions/download-artifact@v3
+      with:
+        name: "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu22.04-amd64.deb"
+    - uses: actions/download-artifact@v3
+      with:
+        name: "patched-fontconfig"
+        path: "/home/runner/opt/fontconfig"
+    - name: "install dependencies"
+      run: ./scripts/ci/notcurses-install-deps.sh
+    - name: "install contour"
+      run: sudo dpkg -i "contour-${{ steps.set_vars.outputs.VERSION_STRING }}-ubuntu22.04-amd64.deb"
+    - name: "contour executable test"
+      run: |
+        contour version
+        contour help
+    - name: "create and patch contour.yml config file"
+      run: |
+        set -ex
+        mkdir -p ~/.config/contour/
+        contour generate config to ~/.config/contour/contour.yml
+        sed -i -e 's/locator: native/locator: mock/' ~/.config/contour/contour.yml
+        sed -i -e 's/strict_spacing: true/strict_spacing: false/' ~/.config/contour/contour.yml
+        cat .github/mock-font-locator.yml >> ~/.config/contour/contour.yml
+        cat ~/.config/contour/contour.yml
+    - name: "Run Contour: quick exit"
+      timeout-minutes: 5
+      id: Xvfb-contour
+      run: |
+        # export LD_LIBRARY_PATH="/home/runner/opt/fontconfig/lib"
+        ./scripts/ci/Xvfb-contour-run.sh \
+              "quick-exit-dumps/${{ matrix.name }}" \
+              true
+    - name: "Save dump"
+      uses: actions/upload-artifact@v3
+      with:
+        name: quick-exit-contour-dump
+        path: quick-exit-dumps
+        if-no-files-found: ignore
+        retention-days: 3
+    - name: "Check result success"
+      run: |
+        exit ${{ steps.Xvfb-contour.outputs.exitCode }}
+  # }}}
+  # {{{ GUI: external test: notcurses
   test_notcurses:
-    name: "notcurses-demo ${{ matrix.name }}"
+    name: "GUI: notcurses-demo ${{ matrix.name }}"
     runs-on: ubuntu-22.04
     needs: [package_for_Ubuntu, build_notcurses, build_fontconfig]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1076,7 +1076,7 @@ jobs:
         cat .github/mock-font-locator.yml >> ~/.config/contour/contour.yml
         cat ~/.config/contour/contour.yml
     - name: "Run Contour: notcurses-demo ${{ matrix.name }}"
-      timeout-minutes: 20
+      timeout-minutes: 5
       id: Xvfb-contour-notcurses
       run: |
         # export LD_LIBRARY_PATH="/home/runner/opt/notcurses/lib:/home/runner/opt/fontconfig/lib"

--- a/scripts/ci/Xvfb-contour-run.sh
+++ b/scripts/ci/Xvfb-contour-run.sh
@@ -28,6 +28,8 @@ sleep 3
 
 ldd `which $CONTOUR_BIN`
 
+export CONTOUR_SYNC_PTY_OUTPUT=1
+
 $CONTOUR_PREFIX \
     $CONTOUR_BIN terminal \
         debug "$LOG" \

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -527,7 +527,15 @@ void TerminalWidget::onBeforeSynchronize()
         return;
 
     if (!renderTarget_)
+    {
+        // This is the first call, so create the renderer (on demand) now.
         createRenderer();
+
+        // Also check if the terminal terminated faster than the frontend needed to render the first frame.
+        if (terminal().device().isClosed())
+            // Then we inform the session about it.
+            session_->onClosed();
+    }
 
     auto const dpr = contentScale();
     auto const windowSize = window()->size() * dpr;

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -356,7 +356,7 @@ void TerminalWidget::handleWindowChanged(QQuickWindow* newWindow)
         connect(newWindow,
                 &QQuickWindow::beforeSynchronizing,
                 this,
-                &TerminalWidget::synchronize,
+                &TerminalWidget::onBeforeSynchronize,
                 Qt::DirectConnection);
 
         connect(newWindow,
@@ -521,7 +521,7 @@ void TerminalWidget::onSceneGrapheInitialized()
 #endif
 }
 
-void TerminalWidget::synchronize()
+void TerminalWidget::onBeforeSynchronize()
 {
     if (!session_)
         return;

--- a/src/contour/display/TerminalWidget.h
+++ b/src/contour/display/TerminalWidget.h
@@ -174,7 +174,7 @@ class TerminalWidget: public QQuickItem
 
   public Q_SLOTS:
     void onSceneGrapheInitialized();
-    void synchronize();
+    void onBeforeSynchronize();
     void onBeforeRendering();
     void paint();
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -287,7 +287,7 @@ class Terminal
     bool applicationKeypad() const noexcept { return _state.inputGenerator.applicationKeypad(); }
 
     bool hasInput() const noexcept;
-    void flushInput();
+    void flushInput(bool blocking = false);
 
     std::string_view peekInput() const noexcept { return _state.inputGenerator.peek(); }
     // }}}

--- a/src/vtpty/ConPty.cpp
+++ b/src/vtpty/ConPty.cpp
@@ -163,8 +163,11 @@ void ConPty::wakeupReader()
     // How can we make ReadFile() return early? We could maybe WriteFile() to it?
 }
 
-int ConPty::write(char const* buf, size_t size)
+int ConPty::write(std::string_view data, bool /*blocking*/)
 {
+    auto const* buf = data.data();
+    auto const size = data.size();
+
     DWORD nwritten {};
     if (WriteFile(_output, buf, static_cast<DWORD>(size), &nwritten, nullptr))
         return static_cast<int>(nwritten);

--- a/src/vtpty/ConPty.h
+++ b/src/vtpty/ConPty.h
@@ -39,7 +39,7 @@ class ConPty: public Pty
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     void wakeupReader() override;
-    int write(char const* buf, size_t size) override;
+    int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
 

--- a/src/vtpty/LinuxPty.cpp
+++ b/src/vtpty/LinuxPty.cpp
@@ -281,7 +281,11 @@ optional<string_view> LinuxPty::readSome(int fd, char* target, size_t n) noexcep
 {
     auto const rv = static_cast<int>(::read(fd, target, n));
     if (rv < 0)
+    {
+        if (errno != EAGAIN && errno != EINTR)
+            errorlog()("{} read failed: {}", fd == _masterFd ? "master" : "stdout-fastpipe", strerror(errno));
         return nullopt;
+    }
 
     if (PtyInLog)
         PtyInLog()("{} received: \"{}\"",

--- a/src/vtpty/LinuxPty.cpp
+++ b/src/vtpty/LinuxPty.cpp
@@ -370,8 +370,21 @@ Pty::ReadResult LinuxPty::read(crispy::BufferObject<char>& storage,
     return nullopt;
 }
 
-int LinuxPty::write(char const* buf, size_t size)
+int LinuxPty::write(string_view data, bool blocking)
 {
+    auto const* buf = data.data();
+    auto const size = data.size();
+
+    if (blocking)
+    {
+        detail::setFileBlocking(_masterFd, true);
+        auto const rv = ::write(_masterFd, buf, size);
+        detail::setFileBlocking(_masterFd, false);
+        if (PtyOutLog)
+            PtyOutLog()("Sending bytes: \"{}\"", crispy::escape(buf, buf + rv));
+        return static_cast<int>(rv);
+    }
+
     timeval tv {};
     tv.tv_sec = 1;
     tv.tv_usec = 0;

--- a/src/vtpty/LinuxPty.h
+++ b/src/vtpty/LinuxPty.h
@@ -64,7 +64,7 @@ class LinuxPty final: public Pty
     [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
-    int write(char const* buf, size_t size) override;
+    int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
 

--- a/src/vtpty/MockPty.cpp
+++ b/src/vtpty/MockPty.cpp
@@ -35,11 +35,11 @@ void MockPty::wakeupReader()
     // No-op. as we're a mock-pty.
 }
 
-int MockPty::write(char const* buf, size_t size)
+int MockPty::write(std::string_view data, bool /*blocking*/)
 {
     // Writing into stdin.
-    _inputBuffer += std::string_view(buf, size);
-    return static_cast<int>(size);
+    _inputBuffer += std::string_view(data.data(), data.size());
+    return static_cast<int>(data.size());
 }
 
 PageSize MockPty::pageSize() const noexcept

--- a/src/vtpty/MockPty.h
+++ b/src/vtpty/MockPty.h
@@ -32,7 +32,7 @@ class MockPty: public Pty
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
     void wakeupReader() override;
-    int write(char const* buf, size_t size) override;
+    int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
 

--- a/src/vtpty/MockViewPty.cpp
+++ b/src/vtpty/MockViewPty.cpp
@@ -48,11 +48,11 @@ void MockViewPty::wakeupReader()
     // No-op. as we're a mock-pty.
 }
 
-int MockViewPty::write(char const* buf, size_t size)
+int MockViewPty::write(std::string_view data, bool /*blocking*/)
 {
     // Writing into stdin.
-    _inputBuffer += std::string_view(buf, size);
-    return static_cast<int>(size);
+    _inputBuffer += std::string_view(data.data(), data.size());
+    return static_cast<int>(data.size());
 }
 
 terminal::PageSize MockViewPty::pageSize() const noexcept

--- a/src/vtpty/MockViewPty.h
+++ b/src/vtpty/MockViewPty.h
@@ -31,7 +31,7 @@ class MockViewPty: public Pty
                                                                          std::chrono::milliseconds timeout,
                                                                          size_t size) override;
     void wakeupReader() override;
-    int write(char const* buf, size_t size) override;
+    int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
 

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -106,7 +106,7 @@ class [[nodiscard]] Process: public Pty
     [[nodiscard]] bool isClosed() const noexcept override { return pty().isClosed(); }
     [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage, std::chrono::milliseconds timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }
-    [[nodiscard]] int write(char const* buf, size_t size) override { return pty().write(buf, size); }
+    [[nodiscard]] int write(std::string_view data, bool blocking) override { return pty().write(data, blocking); }
     [[nodiscard]] PageSize pageSize() const noexcept override { return pty().pageSize(); }
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override { pty().resizeScreen(cells, pixels); }
     // clang-format on

--- a/src/vtpty/Pty.h
+++ b/src/vtpty/Pty.h
@@ -104,11 +104,11 @@ class Pty
 
     /// Writes to the PTY device, so the other end can read from it.
     ///
-    /// @param buf    Buffer of data to be written.
-    /// @param size   Number of bytes in @p buf to write.
+    /// @param buf      Buffer of data to be written.
+    /// @param blocking If false, the data will be sent in non-blocking mode, blocking otherwise.
     ///
     /// @returns Number of bytes written or -1 on error.
-    [[nodiscard]] virtual int write(char const* buf, size_t size) = 0;
+    [[nodiscard]] virtual int write(std::string_view buf, bool blocking) = 0;
 
     /// @returns current underlying window size in characters width and height.
     [[nodiscard]] virtual PageSize pageSize() const noexcept = 0;

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -365,7 +365,11 @@ optional<string_view> UnixPty::readSome(int fd, char* target, size_t n) noexcept
 {
     auto const rv = static_cast<int>(::read(fd, target, n));
     if (rv < 0)
+    {
+        if (errno != EAGAIN && errno != EINTR)
+            errorlog()("{} read failed: {}", fd == _masterFd ? "master" : "stdout-fastpipe", strerror(errno));
         return nullopt;
+    }
 
     if (PtyInLog)
         PtyInLog()("{} received: \"{}\"",

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -401,8 +401,21 @@ Pty::ReadResult UnixPty::read(crispy::BufferObject<char>& storage,
     return nullopt;
 }
 
-int UnixPty::write(char const* buf, size_t size)
+int UnixPty::write(std::string_view data, bool blocking)
 {
+    auto const* buf = data.data();
+    auto const size = data.size();
+
+    if (blocking)
+    {
+        detail::setFileBlocking(_masterFd, true);
+        auto const rv = ::write(_masterFd, buf, size);
+        detail::setFileBlocking(_masterFd, false);
+        if (PtyOutLog)
+            PtyOutLog()("Sending bytes: \"{}\"", crispy::escape(buf, buf + rv));
+        return static_cast<int>(rv);
+    }
+
     timeval tv {};
     tv.tv_sec = 1;
     tv.tv_usec = 0;

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -89,7 +89,7 @@ class UnixPty final: public Pty
     [[nodiscard]] ReadResult read(crispy::BufferObject<char>& storage,
                                   std::chrono::milliseconds timeout,
                                   size_t size) override;
-    int write(char const* buf, size_t size) override;
+    int write(std::string_view data, bool blocking) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<crispy::ImageSize> pixels = std::nullopt) override;
 

--- a/src/vtpty/UnixUtils.h
+++ b/src/vtpty/UnixUtils.h
@@ -81,6 +81,11 @@ inline bool setFileFlags(int fd, int flags) noexcept
     return true;
 }
 
+inline void setFileBlocking(int fd, bool blocking) noexcept
+{
+    setFileFlags(fd, blocking ? 0 : O_NONBLOCK);
+}
+
 inline void saveClose(int* fd) noexcept
 {
     if (fd && *fd != -1)


### PR DESCRIPTION
this is a general alternative approach to #1150.

I tried to repro that be simply running `contour early-exit-threshold 0 true` where `true` is the command to execute within the contour TE instance, which exits instantly, thus, faster than the GUI needs time to fully initialize and have its first frame rendered.

This will not necessarily fix why notcurses-demo exits instantly **sometimes** on CI, but it helps avoiding the infinite wait loop.