### PR TITLE
Prefixes file path with `file:` to fix bell in release build

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1779,7 +1779,14 @@ namespace
 
         strValue = "default";
         if (tryLoadChildRelative(_usedKeys, _profile, basePath, "bell", strValue, _logger))
-            profile.bell = strValue;
+        {
+            if (!strValue.empty())
+            {
+                if (strValue != "off" && strValue != "default")
+                    strValue = "file:" + strValue;
+                profile.bell = strValue;
+            }
+        }
     }
 
     TerminalProfile loadTerminalProfile(UsedKeys& _usedKeys,


### PR DESCRIPTION
For me in release build QUrl can only deduce that the given path is a filesystem path if it prefixed with `file:`. 