### PR TITLE
Fixes bold_italic front not inheriting from regular

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1596,6 +1596,7 @@ namespace
                      "italic",
                      terminalProfile.fonts.italic);
 
+        terminalProfile.fonts.boldItalic = terminalProfile.fonts.regular;
         terminalProfile.fonts.boldItalic.weight = text::font_weight::bold;
         terminalProfile.fonts.boldItalic.slant = text::font_slant::italic;
         softLoadFont(terminalProfile.fonts.textShapingEngine,


### PR DESCRIPTION
@Yaraslaut if you look a few lines above, we'll already inherit bold from regular and italic from regular (as used to be), but somehow missed that line for bold+italic.

I'm adding this line back. Would you mind having a look over it?