### PR TITLE
Upgrade Catch2 from 2.13.7 to 2.13.10 (latest v2 release)

### DIFF
--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -20,9 +20,9 @@ $ThirdParties =
         Macro   = ""
     };
     [ThirdParty]@{
-        Folder  = "Catch2-2.13.7";
-        Archive = "Catch2-2.13.7.zip";
-        URI     = "https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.zip";
+        Folder  = "Catch2-2.13.10";
+        Archive = "Catch2-2.13.10.zip";
+        URI     = "https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.10.zip";
         Macro   = ""
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -76,9 +76,9 @@ fetch_and_unpack()
 fetch_and_unpack_Catch2()
 {
     fetch_and_unpack \
-        Catch2-2.13.7 \
-        Catch2-2.13.7.tar.gz \
-        https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.tar.gz
+        Catch2-2.13.10 \
+        Catch2-2.13.10.tar.gz \
+        https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.10.tar.gz
 }
 
 fetch_and_unpack_fmtlib()


### PR DESCRIPTION
Upgrading Catch2 to the latest available v2 release.

I highly doubt there will be any other v2 release ever, since v3 is out since quite some time already.

We can move to v3 as soon as it's available on all platforms (as in: we can make sure we can use v3 trivially on CI for all platforms we support so far).