### PR TITLE
Fixes bad use of fmtlib to also satisfy MSVC build

### DIFF
--- a/src/crispy/ImageSize.h
+++ b/src/crispy/ImageSize.h
@@ -79,16 +79,10 @@ constexpr image_size operator/(image_size a, image_size b) noexcept
 } // namespace crispy
 
 template <>
-struct fmt::formatter<crispy::image_size>
+struct fmt::formatter<crispy::image_size>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
+    auto format(crispy::image_size value, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(crispy::image_size value, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(), "{}x{}", value.width, value.height);
+        return formatter<std::string>::format(fmt::format("{}x{}", value.width, value.height), ctx);
     }
 };

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -42,20 +42,21 @@ struct lru_hashtable_stats
 
 // {{{ fmt
 template <>
-struct fmt::formatter<crispy::lru_hashtable_stats>
+struct fmt::formatter<crispy::lru_hashtable_stats>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(crispy::lru_hashtable_stats stats, format_context& ctx) -> format_context::iterator
+    auto format(crispy::lru_hashtable_stats stats, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(
-            ctx.out(),
-            "{} hits, {} misses, {} evictions, {:.3}% hit rate",
-            stats.hits,
-            stats.misses,
-            stats.recycles,
-            stats.hits + stats.misses != 0
-                ? 100.0 * (static_cast<double>(stats.hits) / static_cast<double>(stats.hits + stats.misses))
-                : 0.0);
+        return formatter<std::string>::format(
+            fmt::format(
+                "{} hits, {} misses, {} evictions, {:.3}% hit rate",
+                stats.hits,
+                stats.misses,
+                stats.recycles,
+                stats.hits + stats.misses != 0
+                    ? 100.0
+                          * (static_cast<double>(stats.hits) / static_cast<double>(stats.hits + stats.misses))
+                    : 0.0),
+            ctx);
     }
 };
 // }}}

--- a/src/crispy/logstore.h
+++ b/src/crispy/logstore.h
@@ -104,7 +104,7 @@ class message_builder
         return *this;
     }
     template <typename... T>
-    message_builder& operator()(fmt::format_string<T...> fmt, T&&... args)
+    message_builder& operator()(std::string_view fmt, T&&... args)
     {
         _buffer += fmt::vformat(fmt, fmt::make_format_args(args...));
         return *this;

--- a/src/crispy/point.h
+++ b/src/crispy/point.h
@@ -87,11 +87,10 @@ constexpr inline bool operator!=(point const& a, point const& b) noexcept
 } // namespace crispy
 
 template <>
-struct fmt::formatter<crispy::point>
+struct fmt::formatter<crispy::point>: formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(crispy::point coord, format_context& ctx) -> format_context::iterator
+    auto format(crispy::point coord, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "({}, {})", coord.x, coord.y);
+        return formatter<std::string>::format(fmt::format("({}, {})", coord.x, coord.y), ctx);
     }
 };

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -278,7 +278,7 @@ directwrite_shaper::directwrite_shaper(DPI _dpi, font_locator& _locator):
 
 optional<font_key> directwrite_shaper::load_font(font_description const& _description, font_size _size)
 {
-    locatorLog()("Loading font chain for: {}", _description);
+    locatorLog().operator()("Loading font chain for: {}", _description);
     font_source_list sources = d->locator_->locate(_description);
     if (sources.empty())
         return nullopt;

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -328,19 +328,18 @@ struct hash<text::font_description>
 
 // {{{ fmt formatter
 template <>
-struct fmt::formatter<text::DPI>
+struct fmt::formatter<text::DPI>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::DPI dpi, format_context& ctx) -> format_context::iterator
+    auto format(text::DPI dpi, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "{}x{}", dpi.x, dpi.y);
+        return formatter<std::string>::format(fmt::format("{}x{}", dpi.x, dpi.y), ctx);
     }
 };
 
 template <>
 struct fmt::formatter<text::font_weight>: formatter<string_view>
 {
-    static auto format(text::font_weight value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_weight value, format_context& ctx) -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -358,14 +357,14 @@ struct fmt::formatter<text::font_weight>: formatter<string_view>
             case text::font_weight::black: name = "Black"; break;
             case text::font_weight::extra_black: name = "ExtraBlack"; break;
         }
-        return fmt::formatter<string_view> {}.format(name, ctx);
+        return formatter<string_view>::format(name, ctx);
     }
 };
 
 template <>
 struct fmt::formatter<text::font_slant>: formatter<string_view>
 {
-    static auto format(text::font_slant value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_slant value, format_context& ctx) -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -374,14 +373,14 @@ struct fmt::formatter<text::font_slant>: formatter<string_view>
             case text::font_slant::italic: name = "Italic"; break;
             case text::font_slant::oblique: name = "Oblique"; break;
         }
-        return fmt::formatter<string_view> {}.format(name, ctx);
+        return formatter<string_view>::format(name, ctx);
     }
 };
 
 template <>
 struct fmt::formatter<text::font_spacing>: formatter<string_view>
 {
-    static auto format(text::font_spacing value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_spacing value, format_context& ctx) -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -389,149 +388,108 @@ struct fmt::formatter<text::font_spacing>: formatter<string_view>
             case text::font_spacing::proportional: name = "Proportional"; break;
             case text::font_spacing::mono: name = "Monospace"; break;
         }
-        return fmt::formatter<string_view> {}.format(name, ctx);
+        return formatter<string_view>::format(name, ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_description>
+struct fmt::formatter<text::font_description>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::font_description const& desc, format_context& ctx) -> format_context::iterator
+    auto format(text::font_description const& desc, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(),
-                              "(family={} weight={} slant={} spacing={}, strict_spacing={})",
-                              desc.familyName,
-                              desc.weight,
-                              desc.slant,
-                              desc.spacing,
-                              desc.strict_spacing ? "yes" : "no");
+        return formatter<std::string>::format(
+            fmt::format("(family={} weight={} slant={} spacing={}, strict_spacing={})",
+                        desc.familyName,
+                        desc.weight,
+                        desc.slant,
+                        desc.spacing,
+                        desc.strict_spacing ? "yes" : "no"),
+            ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_metrics>
+struct fmt::formatter<text::font_metrics>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
+    auto format(text::font_metrics const& metrics, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::font_metrics const& metrics, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(),
-                              "({}, {}, {}, {}, {}, {})",
-                              metrics.line_height,
-                              metrics.advance,
-                              metrics.ascender,
-                              metrics.descender,
-                              metrics.underline_position,
-                              metrics.underline_thickness);
+        return formatter<std::string>::format(fmt::format("({}, {}, {}, {}, {}, {})",
+                                                          metrics.line_height,
+                                                          metrics.advance,
+                                                          metrics.ascender,
+                                                          metrics.descender,
+                                                          metrics.underline_position,
+                                                          metrics.underline_thickness),
+                                              ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_size>
+struct fmt::formatter<text::font_size>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
+    auto format(text::font_size size, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::font_size size, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(), "{}pt", size.pt);
+        return formatter<std::string>::format(fmt::format("{}pt", size.pt), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_key>
+struct fmt::formatter<text::font_key>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
+    auto format(text::font_key key, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::font_key key, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(), "{}", key.value);
+        return formatter<std::string>::format(fmt::format("{}", key.value), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::glyph_index>
+struct fmt::formatter<text::glyph_index>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
+    auto format(text::glyph_index value, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::glyph_index value, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(), "{}", value.value);
+        return formatter<std::string>::format(fmt::format("{}", value.value), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::glyph_key>
+struct fmt::formatter<text::glyph_key>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::glyph_key const& key, FormatContext& ctx)
+    auto format(text::glyph_key const& key, format_context& ctx) -> format_context::iterator
     {
 #if defined(GLYPH_KEY_DEBUG)
-        return fmt::format_to(
-            ctx.out(),
-            "({}, {}:{}, \"{}\")",
-            key.size,
-            key.font,
-            key.index,
-            unicode::convert_to<char>(std::u32string_view(key.text.data(), key.text.size())));
+        return formatter<std::string>::format(
+            fmt::format("({}, {}:{}, \"{}\")",
+                        key.size,
+                        key.font,
+                        key.index,
+                        unicode::convert_to<char>(std::u32string_view(key.text.data(), key.text.size()))),
+            ctx);
 #else
-        return fmt::format_to(ctx.out(), "({}, {}, {})", key.font, key.size, key.index);
+        return formatter<std::string>::format(fmt::format("({}, {}, {})", key.font, key.size, key.index),
+                                              ctx);
 #endif
     }
 };
 
 template <>
-struct fmt::formatter<text::font_feature>
+struct fmt::formatter<text::font_feature>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
+    auto format(text::font_feature value, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::font_feature value, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(),
-                              "{}{}{}{}{}",
-                              value.enabled ? '+' : '-',
-                              value.name[0],
-                              value.name[1],
-                              value.name[2],
-                              value.name[3]);
+        return formatter<std::string>::format(fmt::format("{}{}{}{}{}",
+                                                          value.enabled ? '+' : '-',
+                                                          value.name[0],
+                                                          value.name[1],
+                                                          value.name[2],
+                                                          value.name[3]),
+                                              ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::render_mode>
+struct fmt::formatter<text::render_mode>: fmt::formatter<std::string_view>
 {
-    template <typename ParseContext>
-    auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::render_mode value, FormatContext& ctx)
+    auto format(text::render_mode value, format_context& ctx) -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -542,7 +500,7 @@ struct fmt::formatter<text::render_mode>
             case text::render_mode::lcd: name = "LCD"; break;
             case text::render_mode::color: name = "Color"; break;
         }
-        return fmt::formatter<string_view> {}.format(name, ctx);
+        return fmt::formatter<string_view>::format(name, ctx);
     }
 };
 // }}}

--- a/src/text_shaper/font_locator.h
+++ b/src/text_shaper/font_locator.h
@@ -74,37 +74,36 @@ class font_locator
 } // namespace text
 
 template <>
-struct fmt::formatter<text::font_path>
+struct fmt::formatter<text::font_path>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::font_path spec, format_context& ctx) -> format_context::iterator
+    auto format(text::font_path spec, format_context& ctx) -> format_context::iterator
     {
         auto weightMod = spec.weight ? fmt::format(" {}", spec.weight.value()) : "";
         auto slantMod = spec.slant ? fmt::format(" {}", spec.slant.value()) : "";
-        return fmt::format_to(ctx.out(), "path {}{}{}", spec.value, weightMod, slantMod);
+        return formatter<std::string>::format(fmt::format("path {}{}{}", spec.value, weightMod, slantMod),
+                                              ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_memory_ref>
+struct fmt::formatter<text::font_memory_ref>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::font_memory_ref ref, format_context& ctx) -> format_context::iterator
+    auto format(text::font_memory_ref ref, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "in-memory: {}", ref.identifier);
+        return formatter<std::string>::format(fmt::format("in-memory: {}", ref.identifier), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::font_source>
+struct fmt::formatter<text::font_source>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::font_source source, format_context& ctx) -> format_context::iterator
+    auto format(text::font_source source, format_context& ctx) -> format_context::iterator
     {
+        std::string text;
         if (std::holds_alternative<text::font_path>(source))
-            return fmt::format_to(ctx.out(), "{}", std::get<text::font_path>(source));
-        if (std::holds_alternative<text::font_memory_ref>(source))
-            return fmt::format_to(ctx.out(), "{}", std::get<text::font_memory_ref>(source));
-        return fmt::format_to(ctx.out(), "UNKNOWN SOURCE");
+            text = fmt::format("{}", std::get<text::font_path>(source));
+        else if (std::holds_alternative<text::font_memory_ref>(source))
+            text = fmt::format("{}", std::get<text::font_memory_ref>(source));
+        return formatter<std::string>::format(text, ctx);
     }
 };

--- a/src/text_shaper/shaper.h
+++ b/src/text_shaper/shaper.h
@@ -156,54 +156,47 @@ class shaper
 
 // {{{ fmtlib support
 template <>
-struct fmt::formatter<text::bitmap_format>
+struct fmt::formatter<text::bitmap_format>: fmt::formatter<std::string_view>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::bitmap_format value, format_context& ctx) -> format_context::iterator
+    auto format(text::bitmap_format value, format_context& ctx) -> format_context::iterator
     {
+        string_view name;
         switch (value)
         {
-            case text::bitmap_format::alpha_mask: return fmt::format_to(ctx.out(), "alpha_mask");
-            case text::bitmap_format::rgb: return fmt::format_to(ctx.out(), "rgb");
-            case text::bitmap_format::rgba: return fmt::format_to(ctx.out(), "rgba");
-            default: return fmt::format_to(ctx.out(), "{}", static_cast<unsigned>(value));
+            case text::bitmap_format::alpha_mask: name = "alpha_mask"; break;
+            case text::bitmap_format::rgb: name = "rgb"; break;
+            case text::bitmap_format::rgba: name = "rgba"; break;
         }
+        return formatter<string_view>::format(name, ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::glyph_position>
+struct fmt::formatter<text::glyph_position>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(text::glyph_position const& gpos, format_context& ctx) -> format_context::iterator
+    auto format(text::glyph_position const& gpos, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(),
-                              "({}+{}+{}|{}+{})",
-                              gpos.glyph.index.value,
-                              gpos.offset.x,
-                              gpos.offset.y,
-                              gpos.advance.x,
-                              gpos.advance.y);
+        return formatter<std::string>::format(fmt::format("({}+{}+{}|{}+{})",
+                                                          gpos.glyph.index.value,
+                                                          gpos.offset.x,
+                                                          gpos.offset.y,
+                                                          gpos.advance.x,
+                                                          gpos.advance.y),
+                                              ctx);
     }
 };
 
 template <>
-struct fmt::formatter<text::rasterized_glyph>
+struct fmt::formatter<text::rasterized_glyph>: fmt::formatter<std::string>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
+    auto format(text::rasterized_glyph const& glyph, format_context& ctx) -> format_context::iterator
     {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(text::rasterized_glyph const& glyph, FormatContext& ctx)
-    {
-        return fmt::format_to(ctx.out(),
-                              "rasterized_glyph({}, {}+{}, {})",
-                              glyph.index.value,
-                              glyph.bitmapSize,
-                              glyph.position,
-                              glyph.format);
+        return formatter<std::string>::format(fmt::format("rasterized_glyph({}, {}+{}, {})",
+                                                          glyph.index.value,
+                                                          glyph.bitmapSize,
+                                                          glyph.position,
+                                                          glyph.format),
+                                              ctx);
     }
 };
 // }}}

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -802,74 +802,69 @@ struct fmt::formatter<terminal::FunctionCategory>: fmt::formatter<std::string_vi
 };
 
 template <>
-struct fmt::formatter<terminal::FunctionDefinition>
+struct fmt::formatter<terminal::FunctionDefinition>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(const terminal::FunctionDefinition f, format_context& ctx) -> format_context::iterator
+    auto format(const terminal::FunctionDefinition f, format_context& ctx) -> format_context::iterator
     {
+        std::string value;
         switch (f.category)
         {
             case terminal::FunctionCategory::C0:
-                return fmt::format_to(ctx.out(), "{}", crispy::escape(static_cast<uint8_t>(f.finalSymbol)));
+                value = fmt::format("{}", crispy::escape(static_cast<uint8_t>(f.finalSymbol)));
             case terminal::FunctionCategory::ESC:
-                return fmt::format_to(ctx.out(),
-                                      "{} {} {}",
-                                      f.category,
-                                      f.intermediate ? f.intermediate : ' ',
-                                      f.finalSymbol ? f.finalSymbol : ' ');
+                value = fmt::format("{} {} {}",
+                                    f.category,
+                                    f.intermediate ? f.intermediate : ' ',
+                                    f.finalSymbol ? f.finalSymbol : ' ');
             case terminal::FunctionCategory::OSC:
-                return fmt::format_to(ctx.out(), "{} {}", f.category, f.maximumParameters);
+                value = fmt::format("{} {}", f.category, f.maximumParameters);
             case terminal::FunctionCategory::DCS:
             case terminal::FunctionCategory::CSI:
                 if (f.minimumParameters == f.maximumParameters)
-                    return fmt::format_to(ctx.out(),
-                                          "{} {} {}    {} {}",
-                                          f.category,
-                                          f.leader ? f.leader : ' ',
-                                          f.minimumParameters,
-                                          f.intermediate ? f.intermediate : ' ',
-                                          f.finalSymbol);
+                    value = fmt::format("{} {} {}    {} {}",
+                                        f.category,
+                                        f.leader ? f.leader : ' ',
+                                        f.minimumParameters,
+                                        f.intermediate ? f.intermediate : ' ',
+                                        f.finalSymbol);
                 else if (f.maximumParameters == terminal::ArgsMax)
-                    return fmt::format_to(ctx.out(),
-                                          "{} {} {}..  {} {}",
-                                          f.category,
-                                          f.leader ? f.leader : ' ',
-                                          f.minimumParameters,
-                                          f.intermediate ? f.intermediate : ' ',
-                                          f.finalSymbol);
+                    value = fmt::format("{} {} {}..  {} {}",
+                                        f.category,
+                                        f.leader ? f.leader : ' ',
+                                        f.minimumParameters,
+                                        f.intermediate ? f.intermediate : ' ',
+                                        f.finalSymbol);
                 else
-                    return fmt::format_to(ctx.out(),
-                                          "{} {} {}..{} {} {}",
-                                          f.category,
-                                          f.leader ? f.leader : ' ',
-                                          f.minimumParameters,
-                                          f.maximumParameters,
-                                          f.intermediate ? f.intermediate : ' ',
-                                          f.finalSymbol);
+                    value = fmt::format("{} {} {}..{} {} {}",
+                                        f.category,
+                                        f.leader ? f.leader : ' ',
+                                        f.minimumParameters,
+                                        f.maximumParameters,
+                                        f.intermediate ? f.intermediate : ' ',
+                                        f.finalSymbol);
         }
-        return fmt::format_to(ctx.out(), "?");
+        return formatter<std::string>::format(value, ctx);
     }
 };
 
 template <>
-struct fmt::formatter<terminal::FunctionSelector>
+struct fmt::formatter<terminal::FunctionSelector>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(const terminal::FunctionSelector f, format_context& ctx) -> format_context::iterator
+    auto format(const terminal::FunctionSelector f, format_context& ctx) -> format_context::iterator
     {
+        std::string value;
         switch (f.category)
         {
-            case terminal::FunctionCategory::OSC:
-                return fmt::format_to(ctx.out(), "{} {}", f.category, f.argc);
+            case terminal::FunctionCategory::OSC: value = fmt::format("{} {}", f.category, f.argc);
             default:
-                return fmt::format_to(ctx.out(),
-                                      "{} {} {} {} {}",
-                                      f.category,
-                                      f.leader ? f.leader : ' ',
-                                      f.argc,
-                                      f.intermediate ? f.intermediate : ' ',
-                                      f.finalSymbol ? f.finalSymbol : ' ');
+                value = fmt::format("{} {} {} {} {}",
+                                    f.category,
+                                    f.leader ? f.leader : ' ',
+                                    f.argc,
+                                    f.intermediate ? f.intermediate : ' ',
+                                    f.finalSymbol ? f.finalSymbol : ' ');
         }
+        return formatter<std::string>::format(value, ctx);
     }
 };
 // }}}

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -298,20 +298,23 @@ struct fmt::formatter<terminal::ImageStats>: formatter<std::string>
 };
 
 template <>
-struct fmt::formatter<std::shared_ptr<terminal::Image const>>
+struct fmt::formatter<std::shared_ptr<terminal::Image const>>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(std::shared_ptr<terminal::Image const> const& image, format_context& ctx)
+    auto format(std::shared_ptr<terminal::Image const> const& image, format_context& ctx)
         -> format_context::iterator
     {
+        std::string text;
         if (!image)
-            return fmt::format_to(ctx.out(), "nullptr");
-        terminal::Image const& imageRef = *image;
-        return fmt::format_to(ctx.out(),
-                              "Image<#{}, {}, size={}>",
-                              imageRef.weak_from_this().use_count(),
-                              imageRef.id(),
-                              imageRef.size());
+            text = "nullptr";
+        else
+        {
+            terminal::Image const& imageRef = *image;
+            text = fmt::format("Image<#{}, {}, size={}>",
+                               imageRef.weak_from_this().use_count(),
+                               imageRef.id(),
+                               imageRef.size());
+        }
+        return formatter<std::string>::format(text, ctx);
     }
 };
 
@@ -370,14 +373,12 @@ struct fmt::formatter<terminal::RasterizedImage>: formatter<std::string>
 };
 
 template <>
-struct fmt::formatter<terminal::ImageFragment>
+struct fmt::formatter<terminal::ImageFragment>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(const terminal::ImageFragment& fragment, format_context& ctx)
-        -> format_context::iterator
+    auto format(const terminal::ImageFragment& fragment, format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(
-            ctx.out(), "ImageFragment<offset={}, {}>", fragment.offset(), fragment.rasterizedImage());
+        return formatter<std::string>::format(
+            fmt::format("ImageFragment<offset={}, {}>", fragment.offset(), fragment.rasterizedImage()), ctx);
     }
 };
 // }}}

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -840,19 +840,21 @@ class Terminal
 } // namespace terminal
 
 template <>
-struct fmt::formatter<terminal::TraceHandler::PendingSequence>
+struct fmt::formatter<terminal::TraceHandler::PendingSequence>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(terminal::TraceHandler::PendingSequence const& pendingSequence, format_context& ctx)
+    auto format(terminal::TraceHandler::PendingSequence const& pendingSequence, format_context& ctx)
         -> format_context::iterator
     {
+        std::string value;
         if (auto const* p = std::get_if<terminal::Sequence>(&pendingSequence))
-            return fmt::format_to(ctx.out(), "{}", p->text());
+            value = fmt::format("{}", p->text());
         else if (auto const* p = std::get_if<terminal::TraceHandler::CodepointSequence>(&pendingSequence))
-            return fmt::format_to(ctx.out(), "\"{}\"", crispy::escape(p->text));
+            value = fmt::format("\"{}\"", crispy::escape(p->text));
         else if (auto const* p = std::get_if<char32_t>(&pendingSequence))
-            return fmt::format_to(ctx.out(), "'{}'", unicode::convert_to<char>(*p));
+            value = fmt::format("'{}'", unicode::convert_to<char>(*p));
         else
             crispy::unreachable();
+
+        return formatter<std::string>::format(value, ctx);
     }
 };

--- a/src/vtrasterizer/RenderTarget.h
+++ b/src/vtrasterizer/RenderTarget.h
@@ -221,26 +221,28 @@ inline Renderable::TextureAtlas::TileCreateData Renderable::createTileData(atlas
 
 // {{{ fmt
 template <>
-struct fmt::formatter<terminal::rasterizer::RenderTileAttributes>
+struct fmt::formatter<terminal::rasterizer::RenderTileAttributes>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(terminal::rasterizer::RenderTileAttributes value, format_context& ctx)
+    auto format(terminal::rasterizer::RenderTileAttributes value, format_context& ctx)
         -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "tile +{}x +{}y", value.x.value, value.y.value);
+        return fmt::formatter<std::string>::format(
+            fmt::format("tile +{}x +{}y", value.x.value, value.y.value), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<terminal::rasterizer::atlas::TileAttributes<terminal::rasterizer::RenderTileAttributes>>
+struct fmt::formatter<
+    terminal::rasterizer::atlas::TileAttributes<terminal::rasterizer::RenderTileAttributes>>:
+    fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(
+    auto format(
         terminal::rasterizer::atlas::TileAttributes<terminal::rasterizer::RenderTileAttributes> const& value,
         format_context& ctx) -> format_context::iterator
     {
-        return fmt::format_to(
-            ctx.out(), "(location {}; bitmap {}; {})", value.location, value.bitmapSize, value.metadata);
+        return formatter<std::string>::format(
+            fmt::format("(location {}; bitmap {}; {})", value.location, value.bitmapSize, value.metadata),
+            ctx);
     }
 };
 // }}}

--- a/src/vtrasterizer/TextureAtlas.h
+++ b/src/vtrasterizer/TextureAtlas.h
@@ -694,40 +694,37 @@ struct fmt::formatter<terminal::rasterizer::atlas::Format>: formatter<std::strin
 };
 
 template <>
-struct fmt::formatter<terminal::rasterizer::atlas::TileLocation>
+struct fmt::formatter<terminal::rasterizer::atlas::TileLocation>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(terminal::rasterizer::atlas::TileLocation value, format_context& ctx)
+    auto format(terminal::rasterizer::atlas::TileLocation value, format_context& ctx)
         -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "Tile {}x+{}y", value.x.value, value.y.value);
+        return formatter<std::string>::format(fmt::format("Tile {}x+{}y", value.x.value, value.y.value), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<terminal::rasterizer::atlas::RenderTile>
+struct fmt::formatter<terminal::rasterizer::atlas::RenderTile>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(terminal::rasterizer::atlas::RenderTile const& value, format_context& ctx)
+    auto format(terminal::rasterizer::atlas::RenderTile const& value, format_context& ctx)
         -> format_context::iterator
     {
-        return fmt::format_to(
-            ctx.out(), "RenderTile({}x + {}y, {})", value.x.value, value.y.value, value.tileLocation);
+        return formatter<std::string>::format(
+            fmt::format("RenderTile({}x + {}y, {})", value.x.value, value.y.value, value.tileLocation), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<terminal::rasterizer::atlas::AtlasProperties>
+struct fmt::formatter<terminal::rasterizer::atlas::AtlasProperties>: fmt::formatter<std::string>
 {
-    static auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.begin(); }
-    static auto format(terminal::rasterizer::atlas::AtlasProperties const& value, format_context& ctx)
+    auto format(terminal::rasterizer::atlas::AtlasProperties const& value, format_context& ctx)
         -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(),
-                              "tile size {}, format {}, direct-mapped {}",
-                              value.tileSize,
-                              value.format,
-                              value.directMappingCount);
+        return formatter<std::string>::format(fmt::format("tile size {}, format {}, direct-mapped {}",
+                                                          value.tileSize,
+                                                          value.format,
+                                                          value.directMappingCount),
+                                              ctx);
     }
 };
 // }}}


### PR DESCRIPTION
At least my local dev box's MSVC + fmtlib version does not like the old way, which was not good anyways. But why was Github CI passing through?
