### PR TITLE
Fix crash on text selection

### DIFF
--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -1260,12 +1260,9 @@ void TerminalWidget::scheduleRedraw()
         _lastHistoryLineCount = currentHistoryLineCount;
     }
 
-    if (setScreenDirty())
-    {
-        // QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
-        if (window())
-            post([this]() { window()->update(); });
-    }
+    // QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
+    if (window())
+        post([this]() { window()->update(); });
 }
 
 void TerminalWidget::renderBufferUpdated()

--- a/src/vtbackend/Line.cpp
+++ b/src/vtbackend/Line.cpp
@@ -215,6 +215,7 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
     }
 
     assert(columns.size() == unbox<size_t>(input.usedColumns));
+    assert(unbox(input.displayWidth) > 0);
 
     while (columns.size() < unbox<size_t>(input.displayWidth))
         columns.emplace_back(Cell { input.fillAttributes });


### PR DESCRIPTION
After qml merge contour started to crash on text selection, this PR fix this crash. 
As for the reason why, @christianparpart  maybe you have idea ? 