### PR TITLE
Add cmake target for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ else()
     message(STATUS "No sanitizer enabled.")
 endif()
 
+if(CONTOUR_TESTING)
+    enable_testing()
+endif()
 # ----------------------------------------------------------------------------
 
 include(ContourThirdParties)

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 # --------------------------------------------------------------------------------------------------------
 # crispy_test
 
-option(CRISPY_TESTING "Enables building of unittests for crispy library [default: ON]" ON)
+option(CRISPY_TESTING "Enables building of unittests for crispy library [default: ON]" ${CONTOUR_TESTING})
 if(CRISPY_TESTING)
     enable_testing()
     add_executable(crispy_test

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
-#project(libterminal VERSION "0.0.0" LANGUAGES CXX)
-
 find_package(Threads)
 
-option(LIBTERMINAL_TESTING "Enables building of unittests for libterminal [default: ON]" ON)
+option(LIBTERMINAL_TESTING "Enables building of unittests for libterminal [default: ON]" ${CONTOUR_TESTING})
 option(LIBTERMINAL_LOG_TRACE "Enables VT sequence tracing. [default: ON]" ON)
 option(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER "Enables caching the pointer to the current line, which should improve performance. [default: OFF]" OFF)
 
@@ -129,7 +127,7 @@ if(LIBTERMINAL_TESTING)
         Capabilities_test.cpp
         Color_test.cpp
         InputGenerator_test.cpp
-		Selector_test.cpp
+        Selector_test.cpp
         Functions_test.cpp
         Grid_test.cpp
         Line_test.cpp

--- a/src/vtparser/CMakeLists.txt
+++ b/src/vtparser/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(vtparser PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
 )
 
-option(VTPARSER_TESTING "Enables building of unittests for vtparser [default: ON]" ON)
+option(VTPARSER_TESTING "Enables building of unittests for vtparser [default: ON]" ${CONTOUR_TESTING})
 if(VTPARSER_TESTING)
     enable_testing()
     add_executable(vtparser_test


### PR DESCRIPTION
This PR adds cmake target to run unit tests with `cmake --build build --target test`

Also, option for unit tests inherit value of `CONTOUR_TESTING`