### PR TITLE
Add config option `profile.*.frozen_dec_modes`

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -115,6 +115,7 @@
           <li>Delete dpi_scale entry in configuration (#1137)</li>
           <li>Fixes `show_title_bar` config option (#1153)</li>
           <li>Adds config option `profile.*.bell` to adjust BEL behavior and fixes (#1162) and (#1163).</li>
+          <li>Adds config option `profile.*.frozen_dec_modes` to permanently enable/disable certain DEC modes.</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -193,6 +193,9 @@ struct TerminalProfile
     } hyperlinkDecoration;
 
     std::string bell = "default";
+
+    // Set of DEC modes that are frozen and cannot be changed by the application.
+    std::map<terminal::DECMode, bool> frozenModes;
 };
 
 enum class RenderingBackend

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -122,6 +122,7 @@ namespace
         settings.primaryScreen.allowReflowOnResize = config.reflowOnResize;
         settings.highlightDoubleClickedWord = profile.highlightDoubleClickedWord;
         settings.highlightTimeout = profile.highlightTimeout;
+        settings.frozenModes = profile.frozenModes;
 
         return settings;
     }
@@ -327,7 +328,7 @@ void TerminalSession::requestPermission(config::Permission allowedByConfig, Guar
                 sessionLog()("Permission for {} requires asking user.", role);
                 switch (role)
                 {
-                    // clang-format off
+                        // clang-format off
                     case GuardedRole::ChangeFont: emit requestPermissionForFontChange(); break;
                     case GuardedRole::CaptureBuffer: emit requestPermissionForBufferCapture(); break;
                     case GuardedRole::ShowHostWritableStatusLine: emit requestPermissionForShowHostWritableStatusLine(); break;

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -205,6 +205,25 @@ profiles:
         # Default: VT525
         terminal_id: VT525
 
+        # Defines a list of DEC modes to explicitly and permanently disable/enable support for.
+        #
+        # This is a developer-users-only option that may possibly help investigating problems.
+        # This option may also be used by regular users if they're asked to in order to disable
+        # a broken functionality. This is something we hardly try to avoid, of course.
+        #
+        # This can be an object with each key being the DEC mode number and its value a boolean,
+        # indicating whether this DEC mode is permanently set (enabled) or unset (disabled).
+        #
+        # Example:
+        #
+        #     frozen_dec_modes:
+        #         2026: false
+        #         2027: true
+        #
+        # Default: (empty object)
+        frozen_dec_modes:
+            2026: false
+
         # Determines the initial terminal size in characters.
         terminal_size:
             columns: 80

--- a/src/vtbackend/Settings.h
+++ b/src/vtbackend/Settings.h
@@ -6,6 +6,7 @@
 #include <vtbackend/primitives.h>
 
 #include <chrono>
+#include <map>
 
 namespace terminal
 {
@@ -27,6 +28,9 @@ struct Settings
 {
     VTType terminalId = VTType::VT525;
     ColorPalette colorPalette; // NB: The default color palette can be taken from the factory settings.
+
+    // Set of DEC modes that are frozen and cannot be changed by the application.
+    std::map<terminal::DECMode, bool> frozenModes;
 
     // total page size available to this terminal.
     // This page size may differ from the main displays (primary/alternate screen) page size If

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -157,10 +157,10 @@ Terminal::Terminal(Events& eventListener,
     hardReset();
 #else
     setMode(DECMode::AutoWrap, true);
-    setMode(DECMode::VisibleCursor, true);
-    setMode(DECMode::Unicode, true);
-    setMode(DECMode::TextReflow, true);
     setMode(DECMode::SixelCursorNextToGraphic, true);
+    setMode(DECMode::TextReflow, _settings.primaryScreen.allowReflowOnResize);
+    setMode(DECMode::Unicode, true);
+    setMode(DECMode::VisibleCursor, true);
 #endif
     setMode(DECMode::LeftRightMargin, false);
 }
@@ -1757,9 +1757,9 @@ void Terminal::hardReset()
 
     _state.modes = Modes {};
     setMode(DECMode::AutoWrap, true);
-    setMode(DECMode::Unicode, true);
-    setMode(DECMode::TextReflow, _settings.primaryScreen.allowReflowOnResize);
     setMode(DECMode::SixelCursorNextToGraphic, true);
+    setMode(DECMode::TextReflow, _settings.primaryScreen.allowReflowOnResize);
+    setMode(DECMode::Unicode, true);
     setMode(DECMode::VisibleCursor, true);
 
     _primaryScreen.hardReset();

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -163,6 +163,9 @@ Terminal::Terminal(Events& eventListener,
     setMode(DECMode::VisibleCursor, true);
 #endif
     setMode(DECMode::LeftRightMargin, false);
+
+    for (auto const& [mode, frozen] : _settings.frozenModes)
+        freezeMode(mode, frozen);
 }
 
 void Terminal::setRefreshRate(RefreshRate refreshRate)
@@ -1761,6 +1764,9 @@ void Terminal::hardReset()
     setMode(DECMode::TextReflow, _settings.primaryScreen.allowReflowOnResize);
     setMode(DECMode::Unicode, true);
     setMode(DECMode::VisibleCursor, true);
+
+    for (auto const& [mode, frozen] : _settings.frozenModes)
+        freezeMode(mode, frozen);
 
     _primaryScreen.hardReset();
     _alternateScreen.hardReset();

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -20,9 +20,7 @@
 #include <sys/types.h>
 
 #include <chrono>
-#include <csignal>
 #include <cstdlib>
-#include <iostream>
 #include <utility>
 #include <variant>
 
@@ -1498,6 +1496,20 @@ void Terminal::setMode(DECMode mode, bool enable)
 {
     if (!isValidDECMode(static_cast<unsigned int>(mode)))
         return;
+
+    auto const currentModeValue = _state.modes.get(mode);
+
+    if (currentModeValue == ModeValue::PermanentlyReset || currentModeValue == ModeValue::PermanentlySet)
+    {
+        if (isEnabled(currentModeValue) != enable)
+        {
+            terminalLog()("Attempt to change permanently {} mode {} to {}.",
+                          currentModeValue == ModeValue::PermanentlySet ? "set" : "reset",
+                          mode,
+                          enable ? ModeValue::Set : ModeValue::Reset);
+        }
+        return;
+    }
 
     switch (mode)
     {

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -207,7 +207,7 @@ void Terminal::setExecutionMode(ExecutionMode mode)
 bool Terminal::processInputOnce()
 {
     // clang-format off
-    switch (_state.executionMode)
+    switch (_state.executionMode.load())
     {
         case ExecutionMode::BreakAtEmptyQueue:
             _state.executionMode = ExecutionMode::Waiting;
@@ -305,7 +305,7 @@ bool Terminal::ensureFreshRenderBuffer(bool locked)
     auto const elapsed = _currentTime - _renderBuffer.lastUpdate;
     auto const avoidRefresh = elapsed < _refreshInterval.value;
 
-    switch (_renderBuffer.state)
+    switch (_renderBuffer.state.load())
     {
         case RenderBufferState::WaitingForRefresh:
             if (avoidRefresh)

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -155,6 +155,12 @@ class Terminal
     bool isModeEnabled(DECMode m) const noexcept { return _state.modes.enabled(m); }
     void setMode(AnsiMode mode, bool enable);
     void setMode(DECMode mode, bool enable);
+    void freezeMode(DECMode mode, bool enable)
+    {
+        setMode(mode, enable);
+        _state.modes.freezeMode(mode, enable);
+    }
+    void unfreezeMode(DECMode mode) { _state.modes.unfreezeMode(mode); }
 
     void setTopBottomMargin(std::optional<LineOffset> top, std::optional<LineOffset> bottom);
     void setLeftRightMargin(std::optional<ColumnOffset> left, std::optional<ColumnOffset> right);


### PR DESCRIPTION
Adding this feature solely for the Chuck Norris TE users or TE devs, that sometimes need to have a specific DEC mode permanently set or unset. Luckily this was apparently(?) also possible on original VTs as well (except that they didn't use YAML configurations for that).

At least [DECRQM](https://vt100.net/docs/vt510-rm/DECRQM.html) makes me think like that. 