### PR TITLE
Fix file link opening

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -120,6 +120,7 @@
           <li>Adds config option `profile.*.frozen_dec_modes` to permanently enable/disable certain DEC modes.</li>
           <li>Adds capital `A` and `I` keys to switch from normal mode back to insert mode, too.</li>
           <li>Adds size indicator window on resize (#1203).</li>
+          <li>Fixes uri re-encoding of local files in `OSC 8` (#1199)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1462,7 +1462,7 @@ void TerminalSession::followHyperlink(terminal::HyperlinkInfo const& hyperlink)
         QProcess::execute(QString::fromStdString(_app.programPath()), args);
     }
     else if (isLocal)
-        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromUtf8(string(hyperlink.path()).c_str())));
+        QDesktopServices::openUrl(QUrl(hyperlink.uri.c_str()));
     else
         QDesktopServices::openUrl(QString::fromUtf8(hyperlink.uri.c_str()));
 }


### PR DESCRIPTION
closes #1199, The hyperlink uri already had the correct url format so, reencoding it again with QUrl was messing up the actual filename.