### PR TITLE
Avoid rendering empty space when cutting off overly wide LCD subpixel AA glyphs

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -118,6 +118,7 @@
           <li>Fixes VT sequence SM ?1003 (Any Event mouse tracking) not reporting mouse move events.</li>
           <li>Fixes VT sequences CUU/CUD/CUF/CUB to better respect margins (#1201)</li>
           <li>Fixes URI re-encoding of local files in `OSC 8` (#1199)</li>
+          <li>Fixes LCD subpixel rendering for overly wide US-ASCII glyphs (#1022)</li>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -789,7 +789,7 @@ optional<rasterized_glyph> open_shaper::rasterize(glyph_key glyph, render_mode m
             // rasterizerLog()("Rasterizing using pixel mode: {}, rows={}, width={}, pitch={}, mode={}",
             //                 "lcd",
             //                 ftBitmap.rows,
-            //                 ftBitmap.width,
+            //                 ftBitmap.width / 3,
             //                 ftBitmap.pitch,
             //                 ftBitmap.pixel_mode);
 

--- a/src/vtrasterizer/RenderTarget.cpp
+++ b/src/vtrasterizer/RenderTarget.cpp
@@ -66,7 +66,7 @@ auto Renderable::sliceTileData(Renderable::TextureAtlas::TileCreateData const& c
         uint8_t const* sourceRow =
             createData.bitmap.data() + rowIndex * pitch + uintptr_t(sliceIndex.beginX) * colorComponentCount;
         Require(sourceRow + subPitch <= createData.bitmap.data() + createData.bitmap.size());
-        std::memcpy(targetRow, sourceRow, subPitch);
+        std::copy_n(sourceRow, subPitch, targetRow);
     }
 
     return createTileData(tileLocation,

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -385,6 +385,10 @@ void TextRenderer::restrictToTileSize(TextureAtlas::TileCreateData& tileCreateDa
     tileCreateData.metadata.targetSize = {};
     tileCreateData.bitmapSize = targetSize;
     tileCreateData.bitmap = std::move(slicedBitmap);
+
+    // NB: Also adjust the normalized width to not render the empty space.
+    auto const atlasSize = _textureScheduler->atlasSize();
+    tileCreateData.metadata.normalizedLocation.width = unbox<float>(tileCreateData.bitmapSize.width) / unbox<float>(atlasSize.width);
 }
 
 void TextRenderer::initializeDirectMapping()

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -350,7 +350,6 @@ void TextRenderer::restrictToTileSize(TextureAtlas::TileCreateData& tileCreateDa
 {
     if (tileCreateData.bitmapSize.width <= _textureAtlas->tileSize().width)
         return;
-
     // Shrink the image's width by recreating it.
     // TODO: In the longer term it would be nice to simply touch the pitch value in order to shrink.
     //       But this requires extending the data structure to also provide a pitch value.

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -120,9 +120,11 @@ Making use of reserved glyph slots
 #include <text_shaper/fontconfig_locator.h>
 #include <text_shaper/mock_font_locator.h>
 
-#include "crispy/StrongHash.h"
-#include "crispy/StrongLRUHashtable.h"
-#include "crispy/point.h"
+#include <crispy/StrongHash.h>
+#include <crispy/StrongLRUHashtable.h>
+#include <crispy/point.h>
+
+#include <range/v3/view/iota.hpp>
 
 #if defined(_WIN32)
     #include <text_shaper/directwrite_locator.h>
@@ -354,33 +356,34 @@ void TextRenderer::restrictToTileSize(TextureAtlas::TileCreateData& tileCreateDa
     // TODO: In the longer term it would be nice to simply touch the pitch value in order to shrink.
     //       But this requires extending the data structure to also provide a pitch value.
 
-    auto const bitmapFormat = tileCreateData.bitmapFormat;
-    auto const colorComponentCount = atlas::element_count(bitmapFormat);
+    auto const colorComponentCount = atlas::element_count(tileCreateData.bitmapFormat);
 
-    auto const subWidth = _textureAtlas->tileSize().width;
-    auto const subSize = ImageSize { subWidth, tileCreateData.bitmapSize.height };
-    auto const subPitch = unbox<uintptr_t>(subSize.width) * colorComponentCount;
-    auto const xOffset = 0;
+    auto const targetSize = ImageSize { _textureAtlas->tileSize().width, tileCreateData.bitmapSize.height };
+    auto const targetPitch = unbox<uintptr_t>(targetSize.width) * colorComponentCount;
     auto const sourcePitch = unbox<uintptr_t>(tileCreateData.bitmapSize.width) * colorComponentCount;
 
-    auto slicedBitmap = vector<uint8_t>(subSize.area() * colorComponentCount);
+    Require(targetPitch < sourcePitch);
+
+    auto slicedBitmap = vector<uint8_t>(targetSize.area() * colorComponentCount);
 
     if (rasterizerLog)
-        rasterizerLog()("Cutting off oversized {} tile from {} down to {}.",
+        rasterizerLog()("Cutting off oversized {} ({}) tile from {} ({}) down to {}.",
                         tileCreateData.bitmapFormat,
+                        colorComponentCount,
                         tileCreateData.bitmapSize,
-                        _textureAtlas->tileSize());
+                        tileCreateData.metadata.targetSize,
+                        targetSize);
 
-    for (uintptr_t rowIndex = 0; rowIndex < unbox<uintptr_t>(subSize.height); ++rowIndex)
+    for (auto const rowIndex: ranges::views::iota(uintptr_t { 0 }, unbox<uintptr_t>(targetSize.height)))
     {
-        uint8_t* targetRow = slicedBitmap.data() + rowIndex * subPitch;
-        uint8_t const* sourceRow =
-            tileCreateData.bitmap.data() + rowIndex * sourcePitch + uintptr_t(xOffset) * colorComponentCount;
-        Require(sourceRow + subPitch <= tileCreateData.bitmap.data() + tileCreateData.bitmap.size());
-        std::memcpy(targetRow, sourceRow, subPitch);
+        uint8_t* targetRow = slicedBitmap.data() + rowIndex * targetPitch;
+        uint8_t const* sourceRow = tileCreateData.bitmap.data() + rowIndex * sourcePitch;
+        Require(sourceRow + targetPitch <= tileCreateData.bitmap.data() + tileCreateData.bitmap.size());
+        std::copy_n(sourceRow, targetPitch, targetRow);
     }
 
-    tileCreateData.bitmapSize = subSize;
+    tileCreateData.metadata.targetSize = {};
+    tileCreateData.bitmapSize = targetSize;
     tileCreateData.bitmap = std::move(slicedBitmap);
 }
 
@@ -424,8 +427,8 @@ Renderable::AtlasTileAttributes const* TextRenderer::ensureRasterizedIfDirectMap
     if (!tileCreateData)
         return nullptr;
 
-    // Require(tileCreateData->bitmapSize.width <= textureAtlas().tileSize().width);
     restrictToTileSize(*tileCreateData);
+    Require(tileCreateData->bitmapSize.width <= textureAtlas().tileSize().width);
 
     // fmt::print("Initialize direct mapping {} ({}) for {}; {}; {}\n",
     //            tileIndex,


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1022
Issue is that we were calling restrict
 ` void TextRenderer::restrictToTileSize(TextureAtlas::TileCreateData& tileCreateData) `
it can happen that tile is only partially larger and then we end up in such situation : 
 ```
 [2023-09-23 07:17:58.886218542.886218] [vt.rasterizer] Inserting rasterized_glyph(0, 12x13+(-1, 13), rgb) (bbox 10x17, numCells 1) id 7034 render mode LCD Text yOverflow 0 yMin 4.
[2023-09-23 07:17:58.886221347.886221] [vt.rasterizer] Cutting off oversized RGB tile from 12x13 down to 10x21.
```
This cutting was copying empty rows 