### PR TITLE
Adds config option `profile.*.option_as_meta` to allow remapping Option key to Alt on MacOS

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -126,6 +126,7 @@
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>
           <li>Adds config option `profile.*.bell` to adjust BEL behavior and fixes (#1162) and (#1163).</li>
           <li>Adds config option `profile.*.frozen_dec_modes` to permanently enable/disable certain DEC modes.</li>
+          <li>Adds config option `profile.*.option_as_meta` to allow remapping Option key to Alt on MacOS.</li>
           <li>Adds capital `A` and `I` keys to switch from normal mode back to insert mode, too.</li>
           <li>Adds size indicator window on resize (#1203).</li>
           <li>Adds config entry `profile.*.size_indicator_on_resize` to control size indicator on resize and makes resize indicator small.</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1653,6 +1653,8 @@ namespace
         else
             terminalProfile.maxHistoryLineCount = LineCount(0);
 
+        tryLoadChildRelative(usedKeys, profile, basePath, "option_as_alt", terminalProfile.optionKeyAsAlt, logger);
+
         strValue = fmt::format("{}", ScrollBarPosition::Right);
         if (tryLoadChildRelative(usedKeys, profile, basePath, "scrollbar.position", strValue, logger))
         {

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -154,6 +154,7 @@ struct TerminalProfile
     terminal::StatusDisplayPosition statusDisplayPosition = terminal::StatusDisplayPosition::Bottom;
     bool syncWindowTitleWithHostWritableStatusDisplay = false;
     bool hideScrollbarInAltScreen = true;
+    bool optionKeyAsAlt = false;
 
     bool autoScrollOnUpdate;
 

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -190,6 +190,12 @@ profiles:
         # Defines the class part of the WM_CLASS property of the window.
         wm_class: "contour"
 
+        # Tells Contour how to handle Option-Key events on MacOS.
+        # This value is ignored on other platforms.
+        #
+        # Default: false
+        option_as_alt: false
+
         # Environment variables to be passed to the shell.
         # environment:
         #     TERM: contour

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -222,7 +222,15 @@ bool sendKeyEvent(QKeyEvent* event, TerminalSession& session)
         return true;
     }
 
-    if (modifiers.control() && key >= 0x20 && key < 0x80)
+    auto const optionKeyAsAlt =
+#if !defined(__APPLE__)
+        true
+#else
+        session.profile().optionKeyAsAlt
+#endif
+        ;
+
+    if (0x20 <= key && key < 0x80 && (modifiers.control() || (modifiers.alt() && optionKeyAsAlt)))
     {
         session.sendCharPressEvent(static_cast<char32_t>(key), modifiers, now);
         return true;


### PR DESCRIPTION
On MacOS, using the Option key with another (e.g. A, B, ...), will result in other Unicode characters. It is typical to remap the Option key as if it would be an Alt key however.
This config option allows the remapping.