### PR TITLE
Fix formatting 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.9.0
+      uses: jidicula/clang-format-action@v4.11.0
       with:
         clang-format-version: '15'
         check-path: 'src'

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1653,7 +1653,8 @@ namespace
         else
             terminalProfile.maxHistoryLineCount = LineCount(0);
 
-        tryLoadChildRelative(usedKeys, profile, basePath, "option_as_alt", terminalProfile.optionKeyAsAlt, logger);
+        tryLoadChildRelative(
+            usedKeys, profile, basePath, "option_as_alt", terminalProfile.optionKeyAsAlt, logger);
 
         strValue = fmt::format("{}", ScrollBarPosition::Right);
         if (tryLoadChildRelative(usedKeys, profile, basePath, "scrollbar.position", strValue, logger))


### PR DESCRIPTION
Somehow clang-format 15 started to giving errors while they dont exist 