### PR TITLE
Better check inside install-deps.sh script

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -42,11 +42,11 @@ fetch_and_unpack()
     FULL_DISTFILE="$SYSDEPS_DIST_DIR/$DISTFILE"
 
     if ! test -f "$FULL_DISTFILE"; then
-        if which wget &>/dev/null; then
+        if command -v wget &>/dev/null; then
             wget -O "$FULL_DISTFILE" "$URL"
-        elif which curl &>/dev/null; then
+        elif command -v curl &>/dev/null; then
             curl -L -o "$FULL_DISTFILE" "$URL"
-        elif which fetch &>/dev/null; then
+        elif command -v fetch &>/dev/null; then
             # FreeBSD
             fetch -o "$FULL_DISTFILE" "$URL"
         else


### PR DESCRIPTION
`which` does not always return proper exit status 
See https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script