### PR TITLE
Fixes VT sequence ED (CSI J) when performed at the bottom line in alt screen

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -116,6 +116,7 @@
           <li>Fixes VT sequence DECFRA (#1189).</li>
           <li>Fixes VT sequence DECSCPP and DECCOLM (#1205).</li>
           <li>Fixes VT sequence DECALN to properly reset margins when statusline is shown</li>
+          <li>Fixes VT sequence ED (CSI J) when statusline is shown.</li>
           <li>Fixes VT sequence SM ?1003 (Any Event mouse tracking) not reporting mouse move events.</li>
           <li>Fixes VT sequences CUU/CUD/CUF/CUB to better respect margins (#1201)</li>
           <li>Fixes URI re-encoding of local files in `OSC 8` (#1199)</li>

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -962,7 +962,7 @@ void Screen<Cell>::clearToEndOfScreen()
     clearToEndOfLine();
 
     for (auto const lineOffset:
-         ::ranges::views::iota(unbox(_cursor.position.line) + 1, unbox(_settings.pageSize.lines)))
+         ::ranges::views::iota(unbox(_cursor.position.line) + 1, unbox(pageSize().lines)))
     {
         Line<Cell>& line = _grid.lineAt(LineOffset::cast_from(lineOffset));
         line.reset(_grid.defaultLineFlags(), _cursor.graphicsRendition);

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -397,9 +397,9 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     // Tests if given coordinate is within the visible screen area.
     [[nodiscard]] bool contains(CellLocation coord) const noexcept override
     {
-        return LineOffset(0) <= coord.line && coord.line < boxed_cast<LineOffset>(_settings.pageSize.lines)
+        return LineOffset(0) <= coord.line && coord.line < boxed_cast<LineOffset>(pageSize().lines)
                && ColumnOffset(0) <= coord.column
-               && coord.column <= boxed_cast<ColumnOffset>(_settings.pageSize.columns);
+               && coord.column <= boxed_cast<ColumnOffset>(pageSize().columns);
     }
 
     [[nodiscard]] std::optional<CellLocation> search(std::u32string_view searchText,

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -767,8 +767,8 @@ TEST_CASE("ClearToEndOfScreen", "[screen]")
     REQUIRE(screen.logicalCursorPosition() == CellLocation { LineOffset(2), ColumnOffset(2) });
 
     logScreenText(screen);
-    screen.moveCursorTo(LineOffset { 1 }, ColumnOffset { 1 });
-    screen.clearToEndOfScreen();
+    mock.writeToScreen(CUP(2, 2));
+    mock.writeToScreen(ED());
     logScreenText(screen);
 
     CHECK("ABC" == screen.grid().lineText(LineOffset(0)));


### PR DESCRIPTION
I found out about this problem simply because I moved to bufferline.nvim and was wondering why it didn't look so pleasing on the right side of the buffer tabs.

What was happening is, that vim was executing `CSI J` (ED) at the bottom of the alt screen and the for-loop for every subsequent line below the current line should be fully cleared. however , there is none, but the for-loop was overshooting, which was working, because it's a ring buffer. It was clearing the top-most line in the full grid buffer.