### PR TITLE
[vtbackend] Improve code quality with help of clang-tidy

### DIFF
--- a/src/vtbackend/Capabilities.h
+++ b/src/vtbackend/Capabilities.h
@@ -3,7 +3,6 @@
 
 #include <fmt/format.h>
 
-#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/vtbackend/Color.cpp
+++ b/src/vtbackend/Color.cpp
@@ -3,8 +3,6 @@
 
 #include <crispy/overloaded.h>
 
-#include <cstdio>
-
 using namespace std;
 
 namespace vtbackend
@@ -28,8 +26,8 @@ string to_string(Color color)
                 case 6: return "bright-cyan";
                 case 7: return "bright-white";
                 case 8: return "bright-DEFAULT";
+                default: return "?";
             }
-            return "?";
         case Type::Default:
             switch (color.index())
             {
@@ -42,8 +40,8 @@ string to_string(Color color)
                 case 6: return "cyan";
                 case 7: return "white";
                 case 8: return "DEFAULT";
+                default: return "?";
             }
-            return "?";
         case Type::RGB:
             return fmt::format("#{:02X}{:02X}{:02X}", color.rgb().red, color.rgb().green, color.rgb().blue);
         case Type::Undefined: break;

--- a/src/vtbackend/Color.h
+++ b/src/vtbackend/Color.h
@@ -6,15 +6,11 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <array>
-#include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <initializer_list>
 #include <optional>
 #include <ostream>
 #include <string>
-#include <utility>
 #include <variant>
 
 namespace vtbackend

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -8,16 +8,10 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstdint>
 #include <filesystem>
-#include <initializer_list>
-#include <optional>
-#include <ostream>
-#include <string>
-#include <utility>
 #include <variant>
 
 namespace vtbackend

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -15,7 +15,6 @@
 #include <array>
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace vtbackend
 {
@@ -651,11 +650,6 @@ inline auto allFunctions() noexcept
         });
         return funcs;
     }();
-
-#if 0
-    for (auto [a, b] : crispy::indexed(funcs))
-        std::cout << fmt::format("{:>2}: {}\n", a, b);
-#endif
 
     return funcs;
 }

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -24,15 +24,6 @@ auto const inline gridLog = logstore::category(
 
 namespace detail
 {
-    template <typename... Args>
-    void logf([[maybe_unused]] Args&&... args)
-    {
-#if 1 // !defined(NDEBUG)
-        fmt::print(std::forward<Args>(args)...);
-        fmt::print("\n");
-#endif
-    }
-
     template <typename Cell>
     gsl::span<Cell> trimRight(gsl::span<Cell> cells)
     {

--- a/src/vtbackend/Grid.h
+++ b/src/vtbackend/Grid.h
@@ -19,11 +19,8 @@
 #include <gsl/span_ext>
 
 #include <algorithm>
-#include <array>
-#include <sstream>
 #include <string>
 #include <string_view>
-#include <utility>
 
 #include <libunicode/convert.h>
 
@@ -866,9 +863,10 @@ bool Grid<Cell>::isLineWrapped(LineOffset line) const noexcept
 template <typename Cell>
 CRISPY_REQUIRES(CellConcept<Cell>)
 template <typename RendererT>
-[[nodiscard]] RenderPassHints Grid<Cell>::render(RendererT&& render,
-                                                 ScrollOffset scrollOffset,
-                                                 HighlightSearchMatches highlightSearchMatches) const
+[[nodiscard]] RenderPassHints Grid<Cell>::render(
+    RendererT&& render, // NOLINT(cppcoreguidelines-missing-std-forward)
+    ScrollOffset scrollOffset,
+    HighlightSearchMatches highlightSearchMatches) const
 {
     assert(!scrollOffset || unbox<LineCount>(scrollOffset) <= historyLineCount());
 

--- a/src/vtbackend/Grid_test.cpp
+++ b/src/vtbackend/Grid_test.cpp
@@ -3,13 +3,11 @@
 #include <vtbackend/cell/CellConfig.h>
 #include <vtbackend/primitives.h>
 
+#include <crispy/BufferObject.h>
+
 #include <fmt/format.h>
 
 #include <catch2/catch.hpp>
-
-#include <iostream>
-
-#include "crispy/BufferObject.h"
 
 using namespace vtbackend;
 using namespace std::string_literals;

--- a/src/vtbackend/Hyperlink.h
+++ b/src/vtbackend/Hyperlink.h
@@ -3,10 +3,8 @@
 
 #include <crispy/LRUCache.h>
 
-#include <list>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include <boxed-cpp/boxed.hpp>
 

--- a/src/vtbackend/Image.cpp
+++ b/src/vtbackend/Image.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <vtbackend/Image.h>
 
+#include <crispy/StrongLRUHashtable.h>
+
 #include <algorithm>
 #include <memory>
-
-#include "crispy/StrongLRUHashtable.h"
 
 using std::copy;
 using std::make_shared;

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -11,8 +11,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <list>
-#include <map>
 #include <memory>
 #include <vector>
 

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -7,13 +7,10 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <array>
 #include <iterator>
-#include <mutex>
 #include <string_view>
 #include <unordered_map>
-#include <utility>
 
 #include <libunicode/convert.h>
 
@@ -127,8 +124,7 @@ namespace mappings
         // clang-format on
     };
 
-    array<KeyMapping, 21> const applicationKeypad
-    {
+    array<KeyMapping, 21> const applicationKeypad {
         // clang-format off
         KeyMapping { Key::Numpad_NumLock, SS3 "P" },
         KeyMapping { Key::Numpad_Divide, SS3 "Q" },
@@ -151,11 +147,9 @@ namespace mappings
         KeyMapping { Key::Numpad_9, SS3 "y" },
         KeyMapping { Key::PageUp, CSI "5~" },
         KeyMapping { Key::PageDown, CSI "6~" },
-#if 0 // TODO
-        KeyMapping{Key::Space,    SS3 " "}, // TODO
-        KeyMapping{Key::Tab,      SS3 "I"},
-        KeyMapping{Key::Enter,    SS3 "M"},
-#endif
+        // KeyMapping{Key::Space,    SS3 " "}, // TODO
+        // KeyMapping{Key::Tab,      SS3 "I"}, // TODO
+        // KeyMapping{Key::Enter,    SS3 "M"}, // TODO
         // clang-format on
     };
 

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -6,13 +6,10 @@
 #include <crispy/escape.h>
 #include <crispy/overloaded.h>
 
-#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
 #include <string_view>
-#include <utility>
-#include <variant>
 #include <vector>
 
 #include <libunicode/convert.h>

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -5,11 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <algorithm>
-#include <iostream>
-#include <iterator>
 #include <string>
-#include <vector>
 
 #include <libunicode/convert.h>
 

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -13,8 +13,6 @@
 #include <gsl/span>
 #include <gsl/span_ext>
 
-#include <iterator>
-#include <sstream>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/vtbackend/Metrics.h
+++ b/src/vtbackend/Metrics.h
@@ -22,6 +22,7 @@ struct Metrics
     [[nodiscard]] std::vector<std::pair<std::string, uint64_t>> ordered() const
     {
         std::vector<std::pair<std::string, uint64_t>> vec;
+        vec.reserve(sequences.size());
         for (auto const& [name, freq]: sequences)
             vec.emplace_back(name, freq);
 

--- a/src/vtbackend/MockTerm.cpp
+++ b/src/vtbackend/MockTerm.cpp
@@ -6,8 +6,6 @@
 
 #include <crispy/App.h>
 
-#include <cstdlib>
-
 namespace vtbackend
 {
 

--- a/src/vtbackend/RenderBuffer.h
+++ b/src/vtbackend/RenderBuffer.h
@@ -9,6 +9,8 @@
 
 #include <vtrasterizer/RenderTarget.h>
 
+#include <gsl/pointers>
+
 #include <atomic>
 #include <chrono>
 #include <mutex>
@@ -82,17 +84,17 @@ struct RenderBuffer
 /// @see RenderBuffer
 struct RenderBufferRef
 {
-    RenderBuffer const& buffer;
-    std::mutex& guard;
+    gsl::not_null<RenderBuffer const*> buffer;
+    gsl::not_null<std::mutex*> guard;
 
-    [[nodiscard]] RenderBuffer const& get() const noexcept { return buffer; }
+    [[nodiscard]] RenderBuffer const& get() const noexcept { return *buffer; }
 
-    RenderBufferRef(RenderBuffer const& buf, std::mutex& lock): buffer { buf }, guard { lock }
+    RenderBufferRef(RenderBuffer const& buf, std::mutex& lock): buffer { &buf }, guard { &lock }
     {
-        guard.lock();
+        guard->lock();
     }
 
-    ~RenderBufferRef() { guard.unlock(); }
+    ~RenderBufferRef() { guard->unlock(); }
 };
 
 /// Reflects the current state of a RenderDoubleBuffer object.

--- a/src/vtbackend/RenderBufferBuilder.h
+++ b/src/vtbackend/RenderBufferBuilder.h
@@ -1,8 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <vtbackend/RenderBuffer.h>
 #include <vtbackend/Terminal.h>
 #include <vtbackend/primitives.h>
+
+#include <gsl/pointers>
 
 #include <optional>
 
@@ -115,8 +119,8 @@ class RenderBufferBuilder
     enum class State { Gap, Sequence };
     // clang-format on
 
-    RenderBuffer& _output;
-    Terminal const& _terminal;
+    gsl::not_null<RenderBuffer*> _output;
+    gsl::not_null<Terminal const*> _terminal;
     std::optional<CellLocation> _cursorPosition;
     LineOffset _baseLine;
     bool _reverseVideo;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -22,6 +22,8 @@
 
 #include <fmt/format.h>
 
+#include <gsl/pointers>
+
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -286,7 +288,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void requestDECMode(unsigned int mode);
 
     [[nodiscard]] PageSize pageSize() const noexcept { return _grid.pageSize(); }
-    [[nodiscard]] ImageSize pixelSize() const noexcept { return _state.cellPixelSize * _settings.pageSize; }
+    [[nodiscard]] ImageSize pixelSize() const noexcept { return _state->cellPixelSize * _settings->pageSize; }
 
     [[nodiscard]] Margin margin() const noexcept override { return _grid.margin(); }
     [[nodiscard]] Margin& margin() noexcept override { return _grid.margin(); }
@@ -459,7 +461,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] Cell& useCellAt(CellLocation p) noexcept { return useCellAt(p.line, p.column); }
     [[nodiscard]] Cell const& at(CellLocation p) const noexcept { return _grid.at(p.line, p.column); }
 
-    [[nodiscard]] std::string const& windowTitle() const noexcept { return _state.windowTitle; }
+    [[nodiscard]] std::string const& windowTitle() const noexcept { return _state->windowTitle; }
 
     /// Finds the next marker right after the given line position.
     ///
@@ -478,7 +480,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] std::optional<LineOffset> findMarkerUpwards(LineOffset startLine) const;
 
     /// ScreenBuffer's type, such as main screen or alternate screen.
-    [[nodiscard]] ScreenType bufferType() const noexcept { return _state.screenType; }
+    [[nodiscard]] ScreenType bufferType() const noexcept { return _state->screenType; }
 
     void scrollUp(LineCount n) { scrollUp(n, margin()); }
     void scrollDown(LineCount n) { scrollDown(n, margin()); }
@@ -494,13 +496,13 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
         return _grid.isLineWrapped(lineNumber);
     }
 
-    [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
-    [[nodiscard]] ColorPalette const& colorPalette() const noexcept { return _state.colorPalette; }
+    [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state->colorPalette; }
+    [[nodiscard]] ColorPalette const& colorPalette() const noexcept { return _state->colorPalette; }
 
-    [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
+    [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state->defaultColorPalette; }
     [[nodiscard]] ColorPalette const& defaultColorPalette() const noexcept
     {
-        return _state.defaultColorPalette;
+        return _state->defaultColorPalette;
     }
 
     [[nodiscard]] bool isCellEmpty(CellLocation position) const noexcept override
@@ -567,16 +569,16 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
 
     [[nodiscard]] std::shared_ptr<HyperlinkInfo const> hyperlinkAt(CellLocation pos) const noexcept override
     {
-        return _state.hyperlinks.hyperlinkById(hyperlinkIdAt(pos));
+        return _state->hyperlinks.hyperlinkById(hyperlinkIdAt(pos));
     }
 
-    [[nodiscard]] HyperlinkStorage const& hyperlinks() const noexcept { return _state.hyperlinks; }
+    [[nodiscard]] HyperlinkStorage const& hyperlinks() const noexcept { return _state->hyperlinks; }
 
-    void resetInstructionCounter() noexcept { _state.instructionCounter = 0; }
-    [[nodiscard]] uint64_t instructionCounter() const noexcept { return _state.instructionCounter; }
+    void resetInstructionCounter() noexcept { _state->instructionCounter = 0; }
+    [[nodiscard]] uint64_t instructionCounter() const noexcept { return _state->instructionCounter; }
     [[nodiscard]] char32_t precedingGraphicCharacter() const noexcept
     {
-        return _state.parser.precedingGraphicCharacter();
+        return _state->parser.precedingGraphicCharacter();
     }
 
     void applyAndLog(FunctionDefinition const& function, Sequence const& seq);
@@ -627,9 +629,9 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] std::unique_ptr<ParserExtension> hookDECRQSS(Sequence const& seq);
     [[nodiscard]] std::unique_ptr<ParserExtension> hookXTGETTCAP(Sequence const& seq);
 
-    Terminal& _terminal;
-    Settings& _settings;
-    TerminalState& _state;
+    gsl::not_null<Terminal*> _terminal;
+    gsl::not_null<Settings*> _settings;
+    gsl::not_null<TerminalState*> _state;
     Grid<Cell> _grid;
 
     CellLocation _lastCursorPosition {};

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -11,9 +11,6 @@
 
 #include <catch2/catch.hpp>
 
-#include <algorithm>
-#include <iostream>
-#include <iterator>
 #include <string>
 #include <vector>
 

--- a/src/vtbackend/VTWriter.h
+++ b/src/vtbackend/VTWriter.h
@@ -74,7 +74,11 @@ class VTWriter
 template <typename... T>
 inline void VTWriter::write(fmt::format_string<T...> fmt, T&&... args)
 {
+#if defined(__APPLE__)
     write(fmt::vformat(fmt, fmt::make_format_args(args...)));
+#else
+    write(fmt::vformat(fmt, fmt::make_format_args(std::forward<T>(args)...)));
+#endif
 }
 
 inline void VTWriter::crlf()

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -164,32 +164,32 @@ namespace
 
 using namespace std;
 
-ViCommands::ViCommands(Terminal& theTerminal): _terminal { theTerminal }
+ViCommands::ViCommands(Terminal& theTerminal): _terminal { &theTerminal }
 {
 }
 
 void ViCommands::scrollViewport(ScrollOffset delta)
 {
     if (delta.value < 0)
-        _terminal.viewport().scrollDown(boxed_cast<LineCount>(-delta));
+        _terminal->viewport().scrollDown(boxed_cast<LineCount>(-delta));
     else
-        _terminal.viewport().scrollUp(boxed_cast<LineCount>(delta));
+        _terminal->viewport().scrollUp(boxed_cast<LineCount>(delta));
 }
 
 void ViCommands::searchStart()
 {
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 void ViCommands::searchDone()
 {
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 void ViCommands::searchCancel()
 {
-    _terminal.state().searchMode.pattern.clear();
-    _terminal.screenUpdated();
+    _terminal->state().searchMode.pattern.clear();
+    _terminal->screenUpdated();
 }
 
 bool ViCommands::jumpToNextMatch(unsigned count)
@@ -197,15 +197,15 @@ bool ViCommands::jumpToNextMatch(unsigned count)
     for (unsigned i = 0; i < count; ++i)
     {
         auto startPosition = cursorPosition;
-        if (startPosition.column < boxed_cast<ColumnOffset>(_terminal.pageSize().columns))
+        if (startPosition.column < boxed_cast<ColumnOffset>(_terminal->pageSize().columns))
             startPosition.column++;
-        else if (cursorPosition.line < boxed_cast<LineOffset>(_terminal.pageSize().lines) - 1)
+        else if (cursorPosition.line < boxed_cast<LineOffset>(_terminal->pageSize().lines) - 1)
         {
             startPosition.line++;
             startPosition.column = ColumnOffset(0);
         }
 
-        auto const nextPosition = _terminal.search(startPosition);
+        auto const nextPosition = _terminal->search(startPosition);
         if (!nextPosition)
             return false;
 
@@ -221,13 +221,13 @@ bool ViCommands::jumpToPreviousMatch(unsigned count)
         auto startPosition = cursorPosition;
         if (startPosition.column != ColumnOffset(0))
             startPosition.column--;
-        else if (cursorPosition.line > -boxed_cast<LineOffset>(_terminal.currentScreen().historyLineCount()))
+        else if (cursorPosition.line > -boxed_cast<LineOffset>(_terminal->currentScreen().historyLineCount()))
         {
             startPosition.line--;
-            startPosition.column = boxed_cast<ColumnOffset>(_terminal.pageSize().columns) - 1;
+            startPosition.column = boxed_cast<ColumnOffset>(_terminal->pageSize().columns) - 1;
         }
 
-        auto const nextPosition = _terminal.searchReverse(startPosition);
+        auto const nextPosition = _terminal->searchReverse(startPosition);
         if (!nextPosition)
             return false;
 
@@ -238,7 +238,7 @@ bool ViCommands::jumpToPreviousMatch(unsigned count)
 
 void ViCommands::updateSearchTerm(std::u32string const& text)
 {
-    if (auto const newLocation = _terminal.searchReverse(text, cursorPosition))
+    if (auto const newLocation = _terminal->searchReverse(text, cursorPosition))
         moveCursorTo(newLocation.value());
 }
 
@@ -250,60 +250,60 @@ void ViCommands::modeChanged(ViMode mode)
 
     inputLog()("mode changed to {}\n", mode);
 
-    auto const selectFrom = _terminal.selector() ? _terminal.selector()->from() : cursorPosition;
+    auto const selectFrom = _terminal->selector() ? _terminal->selector()->from() : cursorPosition;
 
     switch (mode)
     {
         case ViMode::Insert:
             // Force re-render as viewport & cursor might have changed.
-            _terminal.setMode(DECMode::VisibleCursor, _lastCursorVisible);
-            _terminal.setCursorShape(_lastCursorShape);
-            _terminal.viewport().forceScrollToBottom();
-            _terminal.clearSearch();
-            _terminal.popStatusDisplay();
-            _terminal.screenUpdated();
+            _terminal->setMode(DECMode::VisibleCursor, _lastCursorVisible);
+            _terminal->setCursorShape(_lastCursorShape);
+            _terminal->viewport().forceScrollToBottom();
+            _terminal->clearSearch();
+            _terminal->popStatusDisplay();
+            _terminal->screenUpdated();
             break;
         case ViMode::Normal:
-            _lastCursorShape = _terminal.cursorShape();
-            _lastCursorVisible = _terminal.isModeEnabled(DECMode::VisibleCursor);
-            _terminal.setMode(DECMode::VisibleCursor, true);
+            _lastCursorShape = _terminal->cursorShape();
+            _lastCursorVisible = _terminal->isModeEnabled(DECMode::VisibleCursor);
+            _terminal->setMode(DECMode::VisibleCursor, true);
 
             if (_lastMode == ViMode::Insert)
-                cursorPosition = _terminal.currentScreen().cursor().position;
-            if (_terminal.selectionAvailable())
-                _terminal.clearSelection();
-            _terminal.pushStatusDisplay(StatusDisplayType::Indicator);
-            _terminal.screenUpdated();
+                cursorPosition = _terminal->currentScreen().cursor().position;
+            if (_terminal->selectionAvailable())
+                _terminal->clearSelection();
+            _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
+            _terminal->screenUpdated();
             break;
         case ViMode::Visual:
-            _terminal.setSelector(make_unique<LinearSelection>(
-                _terminal.selectionHelper(), selectFrom, _terminal.selectionUpdatedHelper()));
-            (void) _terminal.selector()->extend(cursorPosition);
-            _terminal.pushStatusDisplay(StatusDisplayType::Indicator);
+            _terminal->setSelector(make_unique<LinearSelection>(
+                _terminal->selectionHelper(), selectFrom, _terminal->selectionUpdatedHelper()));
+            (void) _terminal->selector()->extend(cursorPosition);
+            _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
             break;
         case ViMode::VisualLine:
-            _terminal.setSelector(make_unique<FullLineSelection>(
-                _terminal.selectionHelper(), selectFrom, _terminal.selectionUpdatedHelper()));
-            (void) _terminal.selector()->extend(cursorPosition);
-            _terminal.pushStatusDisplay(StatusDisplayType::Indicator);
-            _terminal.screenUpdated();
+            _terminal->setSelector(make_unique<FullLineSelection>(
+                _terminal->selectionHelper(), selectFrom, _terminal->selectionUpdatedHelper()));
+            (void) _terminal->selector()->extend(cursorPosition);
+            _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
+            _terminal->screenUpdated();
             break;
         case ViMode::VisualBlock:
-            _terminal.setSelector(make_unique<RectangularSelection>(
-                _terminal.selectionHelper(), selectFrom, _terminal.selectionUpdatedHelper()));
-            (void) _terminal.selector()->extend(cursorPosition);
-            _terminal.pushStatusDisplay(StatusDisplayType::Indicator);
-            _terminal.screenUpdated();
+            _terminal->setSelector(make_unique<RectangularSelection>(
+                _terminal->selectionHelper(), selectFrom, _terminal->selectionUpdatedHelper()));
+            (void) _terminal->selector()->extend(cursorPosition);
+            _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
+            _terminal->screenUpdated();
             break;
     }
 
-    _terminal.inputModeChanged(mode);
+    _terminal->inputModeChanged(mode);
 }
 
 void ViCommands::reverseSearchCurrentWord()
 {
     // auto const oldPos = cursorPosition;
-    auto const [wordUnderCursor, range] = _terminal.extractWordUnderCursor(cursorPosition);
+    auto const [wordUnderCursor, range] = _terminal->extractWordUnderCursor(cursorPosition);
     assert(range.contains(cursorPosition));
     cursorPosition = range.first;
 
@@ -313,14 +313,14 @@ void ViCommands::reverseSearchCurrentWord()
 
 void ViCommands::toggleLineMark()
 {
-    auto const currentLineFlags = _terminal.currentScreen().lineFlagsAt(cursorPosition.line);
-    _terminal.currentScreen().enableLineFlags(
+    auto const currentLineFlags = _terminal->currentScreen().lineFlagsAt(cursorPosition.line);
+    _terminal->currentScreen().enableLineFlags(
         cursorPosition.line, LineFlags::Marked, !unsigned(currentLineFlags & LineFlags::Marked));
 }
 
 void ViCommands::searchCurrentWord()
 {
-    auto const [wordUnderCursor, range] = _terminal.extractWordUnderCursor(cursorPosition);
+    auto const [wordUnderCursor, range] = _terminal->extractWordUnderCursor(cursorPosition);
     assert(range.contains(cursorPosition));
     cursorPosition = range.second;
     updateSearchTerm(wordUnderCursor);
@@ -332,15 +332,15 @@ void ViCommands::executeYank(ViMotion motion, unsigned count)
     switch (motion)
     {
         case ViMotion::Selection: {
-            assert(_terminal.selector());
+            assert(_terminal->selector());
             if (_lastMode == ViMode::VisualBlock)
-                _terminal.setHighlightRange(
-                    RectangularHighlight { _terminal.selector()->from(), _terminal.selector()->to() });
+                _terminal->setHighlightRange(
+                    RectangularHighlight { _terminal->selector()->from(), _terminal->selector()->to() });
             else
-                _terminal.setHighlightRange(
-                    LinearHighlight { _terminal.selector()->from(), _terminal.selector()->to() });
-            _terminal.copyToClipboard(_terminal.extractSelectionText());
-            _terminal.inputHandler().setMode(ViMode::Normal);
+                _terminal->setHighlightRange(
+                    LinearHighlight { _terminal->selector()->from(), _terminal->selector()->to() });
+            _terminal->copyToClipboard(_terminal->extractSelectionText());
+            _terminal->inputHandler().setMode(ViMode::Normal);
             break;
         }
         default: {
@@ -353,8 +353,8 @@ void ViCommands::executeYank(ViMotion motion, unsigned count)
 
 void ViCommands::executeYank(CellLocation from, CellLocation to)
 {
-    assert(_terminal.inputHandler().mode() == ViMode::Normal);
-    assert(!_terminal.selector());
+    assert(_terminal->inputHandler().mode() == ViMode::Normal);
+    assert(!_terminal->selector());
 
     // TODO: ideally keep that selection for about N msecs,
     // such that it'll be visually rendered and the user has a feedback of what's
@@ -362,20 +362,20 @@ void ViCommands::executeYank(CellLocation from, CellLocation to)
     // Maybe via a event API to inform that a non-visual selection
     // has happened and that it can now either be instantly destroyed
     // or delayed (N msecs, configurable),
-    _terminal.setSelector(
-        make_unique<LinearSelection>(_terminal.selectionHelper(), from, _terminal.selectionUpdatedHelper()));
-    (void) _terminal.selector()->extend(to);
-    auto const text = _terminal.extractSelectionText();
-    _terminal.copyToClipboard(text);
-    _terminal.clearSelection();
-    _terminal.setHighlightRange(LinearHighlight { from, to });
-    _terminal.inputHandler().setMode(ViMode::Normal);
-    _terminal.screenUpdated();
+    _terminal->setSelector(make_unique<LinearSelection>(
+        _terminal->selectionHelper(), from, _terminal->selectionUpdatedHelper()));
+    (void) _terminal->selector()->extend(to);
+    auto const text = _terminal->extractSelectionText();
+    _terminal->copyToClipboard(text);
+    _terminal->clearSelection();
+    _terminal->setHighlightRange(LinearHighlight { from, to });
+    _terminal->inputHandler().setMode(ViMode::Normal);
+    _terminal->screenUpdated();
 }
 
 void ViCommands::execute(ViOperator op, ViMotion motion, unsigned count, char32_t lastChar)
 {
-    inputLog()("{}: Executing: {} {} {}\n", _terminal.inputHandler().mode(), count, op, motion);
+    inputLog()("{}: Executing: {} {} {}\n", _terminal->inputHandler().mode(), count, op, motion);
     switch (op)
     {
         case ViOperator::MoveCursor:
@@ -393,16 +393,16 @@ void ViCommands::execute(ViOperator op, ViMotion motion, unsigned count, char32_
             break;
         case ViOperator::Paste:
             //.
-            _terminal.sendPasteFromClipboard(count, false);
+            _terminal->sendPasteFromClipboard(count, false);
             break;
         case ViOperator::PasteStripped:
             //.
-            _terminal.sendPasteFromClipboard(count, true);
+            _terminal->sendPasteFromClipboard(count, true);
             break;
         case ViOperator::ReverseSearchCurrentWord: // TODO: Does this even make sense to have?
             break;
     }
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 void ViCommands::select(TextObjectScope scope, TextObject textObject)
@@ -410,38 +410,38 @@ void ViCommands::select(TextObjectScope scope, TextObject textObject)
     auto const [from, to] = translateToCellRange(scope, textObject);
     cursorPosition = to;
     inputLog()("{}: Executing: select {} {} [{} .. {}]\n",
-               _terminal.inputHandler().mode(),
+               _terminal->inputHandler().mode(),
                scope,
                textObject,
                from,
                to);
-    _terminal.setSelector(
-        make_unique<LinearSelection>(_terminal.selectionHelper(), from, _terminal.selectionUpdatedHelper()));
-    (void) _terminal.selector()->extend(to);
-    _terminal.screenUpdated();
+    _terminal->setSelector(make_unique<LinearSelection>(
+        _terminal->selectionHelper(), from, _terminal->selectionUpdatedHelper()));
+    (void) _terminal->selector()->extend(to);
+    _terminal->screenUpdated();
 }
 
 void ViCommands::yank(TextObjectScope scope, TextObject textObject)
 {
     auto const [from, to] = translateToCellRange(scope, textObject);
     cursorPosition = from;
-    inputLog()("{}: Executing: yank {} {}\n", _terminal.inputHandler().mode(), scope, textObject);
+    inputLog()("{}: Executing: yank {} {}\n", _terminal->inputHandler().mode(), scope, textObject);
     executeYank(from, to);
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 void ViCommands::yank(ViMotion motion)
 {
     auto const [from, to] = translateToCellRange(motion, 1);
     cursorPosition = from;
-    inputLog()("{}: Executing: motion-yank {}\n", _terminal.inputHandler().mode(), motion);
+    inputLog()("{}: Executing: motion-yank {}\n", _terminal->inputHandler().mode(), motion);
     executeYank(from, to);
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 void ViCommands::paste(unsigned count, bool stripped)
 {
-    _terminal.sendPasteFromClipboard(count, stripped);
+    _terminal->sendPasteFromClipboard(count, stripped);
 }
 
 CellLocation ViCommands::prev(CellLocation location) const noexcept
@@ -449,13 +449,13 @@ CellLocation ViCommands::prev(CellLocation location) const noexcept
     if (location.column.value > 0)
         return { location.line, location.column - 1 };
 
-    auto const topLineOffset = _terminal.isPrimaryScreen()
-                                   ? -boxed_cast<LineOffset>(_terminal.primaryScreen().historyLineCount())
+    auto const topLineOffset = _terminal->isPrimaryScreen()
+                                   ? -boxed_cast<LineOffset>(_terminal->primaryScreen().historyLineCount())
                                    : LineOffset(0);
     if (location.line > topLineOffset)
     {
-        location = getRightMostNonEmptyCellLocation(_terminal, location.line - 1);
-        if (location.column + 1 < boxed_cast<ColumnOffset>(_terminal.pageSize().columns))
+        location = getRightMostNonEmptyCellLocation(*_terminal, location.line - 1);
+        if (location.column + 1 < boxed_cast<ColumnOffset>(_terminal->pageSize().columns))
             ++location.column;
     }
 
@@ -464,14 +464,14 @@ CellLocation ViCommands::prev(CellLocation location) const noexcept
 
 CellLocation ViCommands::next(CellLocation location) const noexcept
 {
-    auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>() - 1;
+    auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>() - 1;
     if (location.column < rightMargin)
     {
-        auto const width = max(uint8_t { 1 }, _terminal.currentScreen().cellWidthAt(location));
+        auto const width = max(uint8_t { 1 }, _terminal->currentScreen().cellWidthAt(location));
         return { location.line, location.column + ColumnOffset::cast_from(width) };
     }
 
-    if (location.line < boxed_cast<LineOffset>(_terminal.pageSize().lines - 1))
+    if (location.line < boxed_cast<LineOffset>(_terminal->pageSize().lines - 1))
     {
         location.line++;
         location.column = ColumnOffset(0);
@@ -482,7 +482,7 @@ CellLocation ViCommands::next(CellLocation location) const noexcept
 
 CellLocation ViCommands::findMatchingPairFrom(CellLocation location) const noexcept
 {
-    auto const& cell = _terminal.primaryScreen().at(cursorPosition);
+    auto const& cell = _terminal->primaryScreen().at(cursorPosition);
     if (cell.codepointCount() != 1)
         return location;
 
@@ -574,9 +574,9 @@ CellLocationRange ViCommands::expandMatchingPair(TextObjectScope scope, char lef
 CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
                                                    TextObject textObject) const noexcept
 {
-    auto const gridTop = -_terminal.currentScreen().historyLineCount().as<LineOffset>();
-    auto const gridBottom = _terminal.pageSize().lines.as<LineOffset>() - 1;
-    auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>() - 1;
+    auto const gridTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
+    auto const gridBottom = _terminal->pageSize().lines.as<LineOffset>() - 1;
+    auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>() - 1;
     auto a = cursorPosition;
     auto b = cursorPosition;
     switch (textObject)
@@ -589,14 +589,14 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
             // Walk the line upwards until we find a marked line.
             while (
                 a.line > gridTop
-                && !(unsigned(_terminal.currentScreen().lineFlagsAt(a.line)) & unsigned(LineFlags::Marked)))
+                && !(unsigned(_terminal->currentScreen().lineFlagsAt(a.line)) & unsigned(LineFlags::Marked)))
                 --a.line;
             if (scope == TextObjectScope::Inner && a != cursorPosition)
                 ++a.line;
             // Walk the line downwards until we find a marked line.
             while (
                 b.line < gridBottom
-                && !(unsigned(_terminal.currentScreen().lineFlagsAt(b.line)) & unsigned(LineFlags::Marked)))
+                && !(unsigned(_terminal->currentScreen().lineFlagsAt(b.line)) & unsigned(LineFlags::Marked)))
                 ++b.line;
             if (scope == TextObjectScope::Inner && b != cursorPosition)
                 --b.line;
@@ -605,9 +605,9 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
             b.column = rightMargin;
             break;
         case TextObject::Paragraph:
-            while (a.line > gridTop && !_terminal.currentScreen().isLineEmpty(a.line - 1))
+            while (a.line > gridTop && !_terminal->currentScreen().isLineEmpty(a.line - 1))
                 --a.line;
-            while (b.line < gridBottom && !_terminal.currentScreen().isLineEmpty(b.line))
+            while (b.line < gridBottom && !_terminal->currentScreen().isLineEmpty(b.line))
                 ++b.line;
             break;
         case TextObject::RoundBrackets: return expandMatchingPair(scope, '(', ')');
@@ -619,9 +619,9 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
             break;
         }
         case TextObject::BigWord: {
-            while (a.column.value > 0 && !_terminal.currentScreen().isCellEmpty(prev(a)))
+            while (a.column.value > 0 && !_terminal->currentScreen().isCellEmpty(prev(a)))
                 a = prev(a);
-            while (b.column < rightMargin && !_terminal.currentScreen().isCellEmpty(next(b)))
+            while (b.column < rightMargin && !_terminal->currentScreen().isCellEmpty(next(b)))
                 b = next(b);
             break;
         }
@@ -635,7 +635,7 @@ CellLocationRange ViCommands::translateToCellRange(ViMotion motion, unsigned cou
     {
         case ViMotion::FullLine:
             return { cursorPosition - cursorPosition.column,
-                     { cursorPosition.line, _terminal.pageSize().columns.as<ColumnOffset>() - 1 } };
+                     { cursorPosition.line, _terminal->pageSize().columns.as<ColumnOffset>() - 1 } };
         default:
             //.
             return { cursorPosition, translateToCellLocation(motion, count) };
@@ -645,20 +645,20 @@ CellLocationRange ViCommands::translateToCellRange(ViMotion motion, unsigned cou
 CellLocation ViCommands::findBeginOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept
 {
     auto const firstAddressableLocation =
-        CellLocation { -LineOffset::cast_from(_terminal.currentScreen().historyLineCount()),
+        CellLocation { -LineOffset::cast_from(_terminal->currentScreen().historyLineCount()),
                        ColumnOffset(0) };
 
     auto current = location;
     auto leftLocation = prev(current);
-    auto leftClass = wordSkipClass(_terminal.currentScreen().cellTextAt(leftLocation));
+    auto leftClass = wordSkipClass(_terminal->currentScreen().cellTextAt(leftLocation));
     auto continuationClass =
-        jumpOver == JumpOver::Yes ? leftClass : wordSkipClass(_terminal.currentScreen().cellTextAt(current));
+        jumpOver == JumpOver::Yes ? leftClass : wordSkipClass(_terminal->currentScreen().cellTextAt(current));
 
     while (current != firstAddressableLocation && leftClass == continuationClass)
     {
         current = leftLocation;
         leftLocation = prev(current);
-        leftClass = wordSkipClass(_terminal.currentScreen().cellTextAt(leftLocation));
+        leftClass = wordSkipClass(_terminal->currentScreen().cellTextAt(leftLocation));
         if (continuationClass == WordSkipClass::Whitespace && leftClass != WordSkipClass::Whitespace)
             continuationClass = leftClass;
     }
@@ -668,13 +668,13 @@ CellLocation ViCommands::findBeginOfWordAt(CellLocation location, JumpOver jumpO
 
 CellLocation ViCommands::findEndOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept
 {
-    auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>();
+    auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>();
     auto leftOfCurrent = location;
     if (leftOfCurrent.column + 1 < rightMargin && jumpOver == JumpOver::Yes)
         leftOfCurrent.column++;
     auto current = leftOfCurrent;
     while (current.column + 1 < rightMargin
-           && !(!_terminal.wordDelimited(leftOfCurrent) && _terminal.wordDelimited(current)))
+           && !(!_terminal->wordDelimited(leftOfCurrent) && _terminal->wordDelimited(current)))
     {
         leftOfCurrent.column = current.column;
         current.column++;
@@ -692,7 +692,7 @@ CellLocation ViCommands::snapToCell(CellLocation location) const noexcept
 
 CellLocation ViCommands::snapToCellRight(CellLocation location) const noexcept
 {
-    auto const rightMargin = ColumnOffset::cast_from(_terminal.pageSize().columns - 1);
+    auto const rightMargin = ColumnOffset::cast_from(_terminal->pageSize().columns - 1);
     while (location.column < rightMargin && compareCellTextAt(location, '\0'))
         ++location.column;
     return location;
@@ -700,12 +700,12 @@ CellLocation ViCommands::snapToCellRight(CellLocation location) const noexcept
 
 bool ViCommands::compareCellTextAt(CellLocation position, char codepoint) const noexcept
 {
-    return _terminal.currentScreen().compareCellTextAt(position, codepoint);
+    return _terminal->currentScreen().compareCellTextAt(position, codepoint);
 }
 
 CellLocation ViCommands::globalCharUp(CellLocation location, char ch, unsigned count) const noexcept
 {
-    auto const pageTop = -_terminal.currentScreen().historyLineCount().as<LineOffset>();
+    auto const pageTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
     auto result = CellLocation { location.line, ColumnOffset(0) };
     while (count > 0)
     {
@@ -713,7 +713,7 @@ CellLocation ViCommands::globalCharUp(CellLocation location, char ch, unsigned c
             --result.line;
         while (result.line > pageTop)
         {
-            auto const& line = _terminal.currentScreen().lineTextAt(result.line, false, true);
+            auto const& line = _terminal->currentScreen().lineTextAt(result.line, false, true);
             if (line.size() == 1 && line[0] == ch)
                 break;
             --result.line;
@@ -725,7 +725,7 @@ CellLocation ViCommands::globalCharUp(CellLocation location, char ch, unsigned c
 
 CellLocation ViCommands::globalCharDown(CellLocation location, char ch, unsigned count) const noexcept
 {
-    auto const pageBottom = _terminal.pageSize().lines.as<LineOffset>() - 1;
+    auto const pageBottom = _terminal->pageSize().lines.as<LineOffset>() - 1;
     auto result = CellLocation { location.line, ColumnOffset(0) };
     while (count > 0)
     {
@@ -733,7 +733,7 @@ CellLocation ViCommands::globalCharDown(CellLocation location, char ch, unsigned
             ++result.line;
         while (result.line < pageBottom)
         {
-            auto const& line = _terminal.currentScreen().lineTextAt(result.line, false, true);
+            auto const& line = _terminal->currentScreen().lineTextAt(result.line, false, true);
             if (line.size() == 1 && line[0] == ch)
                 break;
             ++result.line;
@@ -770,66 +770,66 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         case ViMotion::ScreenColumn: // |
             return snapToCell({ cursorPosition.line,
                                 min(ColumnOffset::cast_from(count - 1),
-                                    _terminal.pageSize().columns.as<ColumnOffset>() - 1) });
+                                    _terminal->pageSize().columns.as<ColumnOffset>() - 1) });
         case ViMotion::FileBegin: // gg
             return snapToCell(
-                { LineOffset::cast_from(-_terminal.currentScreen().historyLineCount().as<int>()),
+                { LineOffset::cast_from(-_terminal->currentScreen().historyLineCount().as<int>()),
                   ColumnOffset(0) });
         case ViMotion::FileEnd: // G
-            return snapToCell({ _terminal.pageSize().lines.as<LineOffset>() - 1, ColumnOffset(0) });
+            return snapToCell({ _terminal->pageSize().lines.as<LineOffset>() - 1, ColumnOffset(0) });
         case ViMotion::PageTop: // <S-H>
-            return snapToCell({ boxed_cast<LineOffset>(-_terminal.viewport().scrollOffset())
-                                    + *_terminal.viewport().scrollOff(),
+            return snapToCell({ boxed_cast<LineOffset>(-_terminal->viewport().scrollOffset())
+                                    + *_terminal->viewport().scrollOff(),
                                 ColumnOffset(0) });
         case ViMotion::PageBottom: // <S-L>
-            return snapToCell({ boxed_cast<LineOffset>(-_terminal.viewport().scrollOffset())
-                                    + boxed_cast<LineOffset>(_terminal.pageSize().lines
-                                                             - *_terminal.viewport().scrollOff() - 1),
+            return snapToCell({ boxed_cast<LineOffset>(-_terminal->viewport().scrollOffset())
+                                    + boxed_cast<LineOffset>(_terminal->pageSize().lines
+                                                             - *_terminal->viewport().scrollOff() - 1),
                                 ColumnOffset(0) });
         case ViMotion::LineBegin: // 0
             return { cursorPosition.line, ColumnOffset(0) };
         case ViMotion::LineTextBegin: // ^
         {
             auto result = CellLocation { cursorPosition.line, ColumnOffset(0) };
-            while (result.column < _terminal.pageSize().columns.as<ColumnOffset>() - 1
-                   && _terminal.currentScreen().isCellEmpty(result))
+            while (result.column < _terminal->pageSize().columns.as<ColumnOffset>() - 1
+                   && _terminal->currentScreen().isCellEmpty(result))
                 ++result.column;
             return result;
         }
         case ViMotion::LineDown: // j
             return { min(cursorPosition.line + LineOffset::cast_from(count),
-                         _terminal.pageSize().lines.as<LineOffset>() - 1),
+                         _terminal->pageSize().lines.as<LineOffset>() - 1),
                      cursorPosition.column };
         case ViMotion::LineEnd: // $
-            return getRightMostNonEmptyCellLocation(_terminal, cursorPosition.line);
+            return getRightMostNonEmptyCellLocation(*_terminal, cursorPosition.line);
         case ViMotion::LineUp: // k
             return { max(cursorPosition.line - LineOffset::cast_from(count),
-                         -_terminal.currentScreen().historyLineCount().as<LineOffset>()),
+                         -_terminal->currentScreen().historyLineCount().as<LineOffset>()),
                      cursorPosition.column };
         case ViMotion::LinesCenter: // M
-            return { LineOffset::cast_from(_terminal.pageSize().lines / 2 - 1)
-                         - boxed_cast<LineOffset>(_terminal.viewport().scrollOffset()),
+            return { LineOffset::cast_from(_terminal->pageSize().lines / 2 - 1)
+                         - boxed_cast<LineOffset>(_terminal->viewport().scrollOffset()),
                      cursorPosition.column };
         case ViMotion::PageDown:
-            return { min(cursorPosition.line + LineOffset::cast_from(_terminal.pageSize().lines / 2),
-                         _terminal.pageSize().lines.as<LineOffset>() - 1),
+            return { min(cursorPosition.line + LineOffset::cast_from(_terminal->pageSize().lines / 2),
+                         _terminal->pageSize().lines.as<LineOffset>() - 1),
                      cursorPosition.column };
         case ViMotion::PageUp:
-            return { max(cursorPosition.line - LineOffset::cast_from(_terminal.pageSize().lines / 2),
-                         -_terminal.currentScreen().historyLineCount().as<LineOffset>()),
+            return { max(cursorPosition.line - LineOffset::cast_from(_terminal->pageSize().lines / 2),
+                         -_terminal->currentScreen().historyLineCount().as<LineOffset>()),
                      cursorPosition.column };
             return cursorPosition
-                   - min(cursorPosition.line, LineOffset::cast_from(_terminal.pageSize().lines) / 2);
+                   - min(cursorPosition.line, LineOffset::cast_from(_terminal->pageSize().lines) / 2);
         case ViMotion::ParagraphBackward: // {
         {
-            auto const pageTop = -_terminal.currentScreen().historyLineCount().as<LineOffset>();
+            auto const pageTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
             auto prev = CellLocation { cursorPosition.line, ColumnOffset(0) };
             if (prev.line.value > 0)
                 prev.line--;
             auto current = prev;
             while (current.line > pageTop
-                   && (!_terminal.currentScreen().isLineEmpty(current.line)
-                       || _terminal.currentScreen().isLineEmpty(prev.line)))
+                   && (!_terminal->currentScreen().isLineEmpty(current.line)
+                       || _terminal->currentScreen().isLineEmpty(prev.line)))
             {
                 prev.line = current.line;
                 current.line--;
@@ -846,15 +846,15 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             return globalCharDown(cursorPosition, '}', count);
         case ViMotion::LineMarkUp: // [m
         {
-            auto const gridTop = -_terminal.currentScreen().historyLineCount().as<LineOffset>();
+            auto const gridTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
             auto result = CellLocation { cursorPosition.line, ColumnOffset(0) };
             while (count > 0)
             {
                 if (result.line > gridTop
-                    && _terminal.currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
+                    && _terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
                     --result.line;
                 while (result.line > gridTop
-                       && !_terminal.currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
+                       && !_terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
                     --result.line;
                 --count;
             }
@@ -862,7 +862,7 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         }
         case ViMotion::LineMarkDown: // ]m
         {
-            auto const pageBottom = _terminal.pageSize().lines.as<LineOffset>() - 1;
+            auto const pageBottom = _terminal->pageSize().lines.as<LineOffset>() - 1;
             auto result = CellLocation { cursorPosition.line, ColumnOffset(0) };
             while (count > 0)
             {
@@ -870,7 +870,7 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
                     ++result.line;
                 while (result.line < pageBottom)
                 {
-                    if (unsigned(_terminal.currentScreen().lineFlagsAt(result.line))
+                    if (unsigned(_terminal->currentScreen().lineFlagsAt(result.line))
                         & unsigned(LineFlags::Marked))
                         break;
                     ++result.line;
@@ -881,14 +881,14 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         }
         case ViMotion::ParagraphForward: // }
         {
-            auto const pageBottom = _terminal.pageSize().lines.as<LineOffset>() - 1;
+            auto const pageBottom = _terminal->pageSize().lines.as<LineOffset>() - 1;
             auto prev = CellLocation { cursorPosition.line, ColumnOffset(0) };
             if (prev.line < pageBottom)
                 prev.line++;
             auto current = prev;
             while (current.line < pageBottom
-                   && (!_terminal.currentScreen().isLineEmpty(current.line)
-                       || _terminal.currentScreen().isLineEmpty(prev.line)))
+                   && (!_terminal->currentScreen().isLineEmpty(current.line)
+                       || _terminal->currentScreen().isLineEmpty(prev.line)))
             {
                 prev.line = current.line;
                 current.line++;
@@ -903,7 +903,7 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             for (unsigned i = 0; i < count; ++i)
             {
                 startPosition = prev(startPosition);
-                auto const nextPosition = _terminal.searchReverse(startPosition);
+                auto const nextPosition = _terminal->searchReverse(startPosition);
                 if (!nextPosition)
                     return cursorPosition;
 
@@ -917,7 +917,7 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             for (unsigned i = 0; i < count; ++i)
             {
                 startPosition = next(startPosition);
-                auto const nextPosition = _terminal.search(startPosition);
+                auto const nextPosition = _terminal->search(startPosition);
                 if (!nextPosition)
                     return cursorPosition;
                 startPosition = *nextPosition;
@@ -941,14 +941,14 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         }
         case ViMotion::BigWordForward: // W
         {
-            auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>();
+            auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>();
             auto prev = cursorPosition;
             if (prev.column + 1 < rightMargin)
                 prev.column++;
             auto current = prev;
             while (current.column + 1 < rightMargin
-                   && (_terminal.currentScreen().isCellEmpty(current)
-                       || !_terminal.currentScreen().isCellEmpty(prev)))
+                   && (_terminal->currentScreen().isCellEmpty(current)
+                       || !_terminal->currentScreen().isCellEmpty(prev)))
             {
                 prev = current;
                 current.column++;
@@ -957,14 +957,14 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         }
         case ViMotion::BigWordEndForward: // E
         {
-            auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>();
+            auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>();
             auto prev = cursorPosition;
             if (prev.column + 1 < rightMargin)
                 prev.column++;
             auto current = prev;
             while (current.column + 1 < rightMargin
-                   && (!_terminal.currentScreen().isCellEmpty(current)
-                       || _terminal.currentScreen().isCellEmpty(prev)))
+                   && (!_terminal->currentScreen().isCellEmpty(current)
+                       || _terminal->currentScreen().isCellEmpty(prev)))
             {
                 prev.column = current.column;
                 current.column++;
@@ -979,8 +979,8 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             auto current = prev;
 
             while (current.column.value > 0
-                   && (!_terminal.currentScreen().isCellEmpty(current)
-                       || _terminal.currentScreen().isCellEmpty(prev)))
+                   && (!_terminal->currentScreen().isCellEmpty(current)
+                       || _terminal->currentScreen().isCellEmpty(prev)))
             {
                 prev.column = current.column;
                 current.column--;
@@ -993,16 +993,16 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
         case ViMotion::WordForward: // w
         {
             auto const lastAddressableLocation =
-                CellLocation { LineOffset::cast_from(_terminal.pageSize().lines - 1),
-                               ColumnOffset::cast_from(_terminal.pageSize().columns - 1) };
+                CellLocation { LineOffset::cast_from(_terminal->pageSize().lines - 1),
+                               ColumnOffset::cast_from(_terminal->pageSize().columns - 1) };
             auto result = cursorPosition;
             while (count > 0)
             {
-                auto initialClass = wordSkipClass(_terminal.currentScreen().cellTextAt(result));
+                auto initialClass = wordSkipClass(_terminal->currentScreen().cellTextAt(result));
                 result = next(result);
                 while (result != lastAddressableLocation
                        && shouldSkipForUntilWordBegin(
-                           wordSkipClass(_terminal.currentScreen().cellTextAt(result)), initialClass))
+                           wordSkipClass(_terminal->currentScreen().cellTextAt(result)), initialClass))
                     result = next(result);
                 --count;
             }
@@ -1042,13 +1042,13 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
 optional<CellLocation> ViCommands::toCharRight(CellLocation startPosition) const noexcept
 {
     auto result = next(startPosition);
-    auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>() - 1;
+    auto const rightMargin = _terminal->pageSize().columns.as<ColumnOffset>() - 1;
     while (true)
     {
         // if on wrong line
         if (result.line != startPosition.line)
             return std::nullopt;
-        if (_terminal.currentScreen().compareCellTextAt(result, _lastChar))
+        if (_terminal->currentScreen().compareCellTextAt(result, _lastChar))
             return result;
         // if reached end of the line
         if (result.column == rightMargin)
@@ -1065,7 +1065,7 @@ optional<CellLocation> ViCommands::toCharLeft(CellLocation startPosition) const 
     {
         if (result.line != startPosition.line)
             return std::nullopt;
-        if (_terminal.currentScreen().compareCellTextAt(result, _lastChar))
+        if (_terminal->currentScreen().compareCellTextAt(result, _lastChar))
             return result;
         result = prev(result);
     }
@@ -1095,7 +1095,7 @@ optional<CellLocation> ViCommands::toCharLeft(unsigned count) const noexcept
 
 void ViCommands::moveCursor(ViMotion motion, unsigned count, char32_t lastChar)
 {
-    Require(_terminal.inputHandler().mode() != ViMode::Insert);
+    Require(_terminal->inputHandler().mode() != ViMode::Insert);
 
     if (isValidCharMove(motion))
     {
@@ -1112,21 +1112,21 @@ void ViCommands::moveCursorTo(CellLocation position)
 {
     cursorPosition = position;
 
-    _terminal.viewport().makeVisibleWithinSafeArea(cursorPosition.line);
+    _terminal->viewport().makeVisibleWithinSafeArea(cursorPosition.line);
 
-    switch (_terminal.inputHandler().mode())
+    switch (_terminal->inputHandler().mode())
     {
         case ViMode::Normal:
         case ViMode::Insert: break;
         case ViMode::Visual:
         case ViMode::VisualLine:
         case ViMode::VisualBlock:
-            if (_terminal.selector())
-                (void) _terminal.selector()->extend(cursorPosition);
+            if (_terminal->selector())
+                (void) _terminal->selector()->extend(cursorPosition);
             break;
     }
 
-    _terminal.screenUpdated();
+    _terminal->screenUpdated();
 }
 
 } // namespace vtbackend

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -3,8 +3,9 @@
 
 #include <vtbackend/ViInputHandler.h>
 
+#include <gsl/pointers>
+
 #include <optional>
-#include <utility>
 
 namespace vtbackend
 {
@@ -83,7 +84,7 @@ class ViCommands: public ViInputHandler::Executor
     CellLocation cursorPosition {};
 
   private:
-    Terminal& _terminal;
+    gsl::not_null<Terminal*> _terminal;
     ViMode _lastMode = ViMode::Insert;
     CursorShape _lastCursorShape = CursorShape::Block;
     mutable char32_t _lastChar = U'\0';

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -60,7 +60,7 @@ namespace
 } // namespace
 
 ViInputHandler::ViInputHandler(Executor& theExecutor, ViMode initialMode):
-    _viMode { initialMode }, _executor { theExecutor }
+    _viMode { initialMode }, _executor { &theExecutor }
 {
     registerAllCommands();
 }
@@ -143,17 +143,17 @@ void ViInputHandler::registerAllCommands()
     {
         for (auto const& [motionChar, motion]: MotionMappings)
             registerCommand(
-                modeSelect, motionChar, [this, motion = motion]() { _executor.moveCursor(motion, count()); });
+                modeSelect, motionChar, [this, motion = motion]() { _executor->moveCursor(motion, count()); });
 
-        registerCommand(modeSelect, "J", [this]() { _executor.scrollViewport(ScrollOffset(-1)); _executor.moveCursor(ViMotion::LineDown, 1);});
-        registerCommand(modeSelect, "K", [this]() { _executor.scrollViewport(ScrollOffset(+1)); _executor.moveCursor(ViMotion::LineUp, 1);});
+        registerCommand(modeSelect, "J", [this]() { _executor->scrollViewport(ScrollOffset(-1)); _executor->moveCursor(ViMotion::LineDown, 1);});
+        registerCommand(modeSelect, "K", [this]() { _executor->scrollViewport(ScrollOffset(+1)); _executor->moveCursor(ViMotion::LineUp, 1);});
 
-        registerCommand(modeSelect, "t.", [this]() { _executor.moveCursor(ViMotion::TillBeforeCharRight, count(), _lastChar); });
-        registerCommand(modeSelect, "T.", [this]() { _executor.moveCursor(ViMotion::TillAfterCharLeft, count(), _lastChar); });
-        registerCommand(modeSelect, "f.", [this]() { _executor.moveCursor(ViMotion::ToCharRight, count(), _lastChar); });
-        registerCommand(modeSelect, "F.", [this]() { _executor.moveCursor(ViMotion::ToCharLeft, count(), _lastChar); });
-        registerCommand(modeSelect, ";", [this]() { _executor.moveCursor(ViMotion::RepeatCharMove, count()); });
-        registerCommand(modeSelect, ",", [this]() { _executor.moveCursor(ViMotion::RepeatCharMoveReverse, count()); });
+        registerCommand(modeSelect, "t.", [this]() { _executor->moveCursor(ViMotion::TillBeforeCharRight, count(), _lastChar); });
+        registerCommand(modeSelect, "T.", [this]() { _executor->moveCursor(ViMotion::TillAfterCharLeft, count(), _lastChar); });
+        registerCommand(modeSelect, "f.", [this]() { _executor->moveCursor(ViMotion::ToCharRight, count(), _lastChar); });
+        registerCommand(modeSelect, "F.", [this]() { _executor->moveCursor(ViMotion::ToCharLeft, count(), _lastChar); });
+        registerCommand(modeSelect, ";", [this]() { _executor->moveCursor(ViMotion::RepeatCharMove, count()); });
+        registerCommand(modeSelect, ",", [this]() { _executor->moveCursor(ViMotion::RepeatCharMoveReverse, count()); });
     }
 
     registerCommand(ModeSelect::Normal, "A", [this]() { setMode(ViMode::Insert); });
@@ -165,36 +165,36 @@ void ViInputHandler::registerAllCommands()
     registerCommand(ModeSelect::Normal, "V", [this]() { toggleMode(ViMode::VisualLine); });
     registerCommand(ModeSelect::Normal, "C-V", [this]() { toggleMode(ViMode::VisualBlock); });
     registerCommand(ModeSelect::Normal, "/", [this]() { startSearch(); });
-    registerCommand(ModeSelect::Normal, "#", [this]() { _executor.reverseSearchCurrentWord(); });
-    registerCommand(ModeSelect::Normal, "mm", [this]() { _executor.toggleLineMark(); });
-    registerCommand(ModeSelect::Normal, "*", [this]() { _executor.searchCurrentWord(); });
-    registerCommand(ModeSelect::Normal, "p", [this]() { _executor.paste(count(), false); });
-    registerCommand(ModeSelect::Normal, "P", [this]() { _executor.paste(count(), true); });
+    registerCommand(ModeSelect::Normal, "#", [this]() { _executor->reverseSearchCurrentWord(); });
+    registerCommand(ModeSelect::Normal, "mm", [this]() { _executor->toggleLineMark(); });
+    registerCommand(ModeSelect::Normal, "*", [this]() { _executor->searchCurrentWord(); });
+    registerCommand(ModeSelect::Normal, "p", [this]() { _executor->paste(count(), false); });
+    registerCommand(ModeSelect::Normal, "P", [this]() { _executor->paste(count(), true); });
 
-    registerCommand(ModeSelect::Normal, "Y", [this]() { _executor.execute(ViOperator::Yank, ViMotion::FullLine, count()); });
-    registerCommand(ModeSelect::Normal, "yy", [this]() { _executor.execute(ViOperator::Yank, ViMotion::FullLine, count()); });
-    registerCommand(ModeSelect::Normal, "yb", [this]() { _executor.execute(ViOperator::Yank, ViMotion::WordBackward, count()); });
-    registerCommand(ModeSelect::Normal, "ye", [this]() { _executor.execute(ViOperator::Yank, ViMotion::WordEndForward, count()); });
-    registerCommand(ModeSelect::Normal, "yw", [this]() { _executor.execute(ViOperator::Yank, ViMotion::WordForward, count()); });
-    registerCommand(ModeSelect::Normal, "yB", [this]() { _executor.execute(ViOperator::Yank, ViMotion::BigWordBackward, count()); });
-    registerCommand(ModeSelect::Normal, "yE", [this]() { _executor.execute(ViOperator::Yank, ViMotion::BigWordEndForward, count()); });
-    registerCommand(ModeSelect::Normal, "yW", [this]() { _executor.execute(ViOperator::Yank, ViMotion::BigWordForward, count()); });
-    registerCommand(ModeSelect::Normal, "yt.", [this]() { _executor.execute(ViOperator::Yank, ViMotion::TillBeforeCharRight, count(), _lastChar); });
-    registerCommand(ModeSelect::Normal, "yT.", [this]() { _executor.execute(ViOperator::Yank, ViMotion::TillAfterCharLeft, count(), _lastChar); });
-    registerCommand(ModeSelect::Normal, "yf.", [this]() { _executor.execute(ViOperator::Yank, ViMotion::ToCharRight, count(), _lastChar); });
-    registerCommand(ModeSelect::Normal, "yF.", [this]() { _executor.execute(ViOperator::Yank, ViMotion::ToCharLeft, count(), _lastChar); });
+    registerCommand(ModeSelect::Normal, "Y", [this]() { _executor->execute(ViOperator::Yank, ViMotion::FullLine, count()); });
+    registerCommand(ModeSelect::Normal, "yy", [this]() { _executor->execute(ViOperator::Yank, ViMotion::FullLine, count()); });
+    registerCommand(ModeSelect::Normal, "yb", [this]() { _executor->execute(ViOperator::Yank, ViMotion::WordBackward, count()); });
+    registerCommand(ModeSelect::Normal, "ye", [this]() { _executor->execute(ViOperator::Yank, ViMotion::WordEndForward, count()); });
+    registerCommand(ModeSelect::Normal, "yw", [this]() { _executor->execute(ViOperator::Yank, ViMotion::WordForward, count()); });
+    registerCommand(ModeSelect::Normal, "yB", [this]() { _executor->execute(ViOperator::Yank, ViMotion::BigWordBackward, count()); });
+    registerCommand(ModeSelect::Normal, "yE", [this]() { _executor->execute(ViOperator::Yank, ViMotion::BigWordEndForward, count()); });
+    registerCommand(ModeSelect::Normal, "yW", [this]() { _executor->execute(ViOperator::Yank, ViMotion::BigWordForward, count()); });
+    registerCommand(ModeSelect::Normal, "yt.", [this]() { _executor->execute(ViOperator::Yank, ViMotion::TillBeforeCharRight, count(), _lastChar); });
+    registerCommand(ModeSelect::Normal, "yT.", [this]() { _executor->execute(ViOperator::Yank, ViMotion::TillAfterCharLeft, count(), _lastChar); });
+    registerCommand(ModeSelect::Normal, "yf.", [this]() { _executor->execute(ViOperator::Yank, ViMotion::ToCharRight, count(), _lastChar); });
+    registerCommand(ModeSelect::Normal, "yF.", [this]() { _executor->execute(ViOperator::Yank, ViMotion::ToCharLeft, count(), _lastChar); });
     // clang-format on
 
     for (auto const& [scopeChar, scope]: ScopeMappings)
         for (auto const& [objectChar, obj]: TextObjectMappings)
             registerCommand(ModeSelect::Normal,
                             fmt::format("y{}{}", scopeChar, objectChar),
-                            [this, scope = scope, obj = obj]() { _executor.yank(scope, obj); });
+                            [this, scope = scope, obj = obj]() { _executor->yank(scope, obj); });
 
     // visual mode
     registerCommand(ModeSelect::Visual, "/", [this]() { startSearch(); });
     registerCommand(ModeSelect::Visual, "y", [this]() {
-        _executor.execute(ViOperator::Yank, ViMotion::Selection, count());
+        _executor->execute(ViOperator::Yank, ViMotion::Selection, count());
     });
     registerCommand(ModeSelect::Visual, "v", [this]() { toggleMode(ViMode::Normal); });
     registerCommand(ModeSelect::Visual, "V", [this]() { toggleMode(ViMode::VisualLine); });
@@ -204,7 +204,7 @@ void ViInputHandler::registerAllCommands()
         for (auto const& [objectChar, obj]: TextObjectMappings)
             registerCommand(ModeSelect::Visual,
                             fmt::format("{}{}", scopeChar, objectChar),
-                            [this, scope = scope, obj = obj]() { _executor.select(scope, obj); });
+                            [this, scope = scope, obj = obj]() { _executor->select(scope, obj); });
 }
 
 void ViInputHandler::registerCommand(ModeSelect modes,
@@ -296,7 +296,7 @@ void ViInputHandler::setMode(ViMode theMode)
     _viMode = theMode;
     clearPendingInput();
 
-    _executor.modeChanged(theMode);
+    _executor->modeChanged(theMode);
 }
 
 bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
@@ -351,7 +351,7 @@ bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
 void ViInputHandler::startSearchExternally()
 {
     _searchTerm.clear();
-    _executor.searchStart();
+    _executor->searchStart();
 
     if (_viMode != ViMode::Insert)
         _searchEditMode = SearchEditMode::Enabled;
@@ -375,24 +375,24 @@ bool ViInputHandler::handleSearchEditor(char32_t ch, Modifier modifier)
             if (_searchEditMode == SearchEditMode::ExternallyEnabled)
                 setMode(ViMode::Insert);
             _searchEditMode = SearchEditMode::Disabled;
-            _executor.searchCancel();
+            _executor->searchCancel();
             break;
         case '\x0D'_key:
             if (_searchEditMode == SearchEditMode::ExternallyEnabled)
                 setMode(ViMode::Insert);
             _searchEditMode = SearchEditMode::Disabled;
-            _executor.searchDone();
+            _executor->searchDone();
             break;
         case '\x08'_key:
         case '\x7F'_key:
             if (!_searchTerm.empty())
                 _searchTerm.resize(_searchTerm.size() - 1);
-            _executor.updateSearchTerm(_searchTerm);
+            _executor->updateSearchTerm(_searchTerm);
             break;
         case Modifier::Control | 'L':
         case Modifier::Control | 'U':
             _searchTerm.clear();
-            _executor.updateSearchTerm(_searchTerm);
+            _executor->updateSearchTerm(_searchTerm);
             break;
         case Modifier::Control | 'A': // TODO: move cursor to BOL
         case Modifier::Control | 'E': // TODO: move cursor to EOL
@@ -400,7 +400,7 @@ bool ViInputHandler::handleSearchEditor(char32_t ch, Modifier modifier)
             if (ch >= 0x20 && modifier.without(Modifier::Shift).none())
             {
                 _searchTerm += ch;
-                _executor.updateSearchTerm(_searchTerm);
+                _executor->updateSearchTerm(_searchTerm);
             }
             else
                 errorLog()("ViInputHandler: Receiving control code {}+0x{:02X} in search mode. Ignoring.",
@@ -455,7 +455,7 @@ bool ViInputHandler::parseCount(char32_t ch, Modifier modifier)
     {
         case '0':
             if (!_count)
-                break;
+                return false;
             [[fallthrough]];
         case '1':
         case '2':
@@ -469,14 +469,16 @@ bool ViInputHandler::parseCount(char32_t ch, Modifier modifier)
             //.
             _count = _count * 10 + (ch - '0');
             return true;
+        default:
+            //.
+            return false;
     }
-    return false;
 }
 
 void ViInputHandler::startSearch()
 {
     _searchEditMode = SearchEditMode::Enabled;
-    _executor.searchStart();
+    _executor->searchStart();
 }
 
 void ViInputHandler::toggleMode(ViMode newMode)

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -9,6 +9,8 @@
 #include <crispy/assert.h>
 #include <crispy/logstore.h>
 
+#include <gsl/pointers>
+
 namespace vtbackend
 {
 
@@ -247,7 +249,7 @@ class ViInputHandler: public InputHandler
     CommandHandlerMap _visualMode;
     unsigned _count = 0;
     char32_t _lastChar = 0;
-    Executor& _executor;
+    gsl::not_null<Executor*> _executor;
 };
 
 } // namespace vtbackend

--- a/src/vtbackend/Viewport.cpp
+++ b/src/vtbackend/Viewport.cpp
@@ -96,7 +96,7 @@ bool Viewport::scrollMarkUp()
         return false;
 
     auto const newScrollOffset =
-        _terminal.primaryScreen().findMarkerUpwards(-boxed_cast<LineOffset>(_scrollOffset));
+        _terminal->primaryScreen().findMarkerUpwards(-boxed_cast<LineOffset>(_scrollOffset));
     if (newScrollOffset.has_value())
         return scrollTo(boxed_cast<ScrollOffset>(-*newScrollOffset));
 
@@ -109,7 +109,7 @@ bool Viewport::scrollMarkDown()
         return false;
 
     auto const newScrollOffset =
-        _terminal.primaryScreen().findMarkerDownwards(-boxed_cast<LineOffset>(_scrollOffset));
+        _terminal->primaryScreen().findMarkerDownwards(-boxed_cast<LineOffset>(_scrollOffset));
     if (newScrollOffset)
         return scrollTo(boxed_cast<ScrollOffset>(-*newScrollOffset));
     else
@@ -120,18 +120,18 @@ bool Viewport::scrollMarkDown()
 
 LineCount Viewport::historyLineCount() const noexcept
 {
-    return _terminal.currentScreen().historyLineCount();
+    return _terminal->currentScreen().historyLineCount();
 }
 
 LineCount Viewport::screenLineCount() const noexcept
 {
-    return _terminal.pageSize().lines;
+    return _terminal->pageSize().lines;
 }
 
 bool Viewport::scrollingDisabled() const noexcept
 {
     // TODO: make configurable
-    return _terminal.isAlternateScreen();
+    return _terminal->isAlternateScreen();
 }
 
 } // namespace vtbackend

--- a/src/vtbackend/Viewport.h
+++ b/src/vtbackend/Viewport.h
@@ -6,8 +6,7 @@
 
 #include <crispy/logstore.h>
 
-#include <algorithm>
-#include <optional>
+#include <gsl/pointers>
 
 namespace vtbackend
 {
@@ -24,7 +23,7 @@ class Viewport
     using ModifyEvent = std::function<void()>;
 
     explicit Viewport(Terminal& term, ModifyEvent onModify = {}):
-        _terminal { term }, _modified { onModify ? std::move(onModify) : []() {
+        _terminal { &term }, _modified { onModify ? std::move(onModify) : []() {
         } }
     {
     }
@@ -98,7 +97,7 @@ class Viewport
 
     // private fields
     //
-    Terminal& _terminal;
+    gsl::not_null<Terminal*> _terminal;
     ModifyEvent _modified;
     //!< scroll offset relative to scroll top (0) or nullopt if not scrolled into history
     ScrollOffset _scrollOffset;

--- a/src/vtbackend/test_helpers.h
+++ b/src/vtbackend/test_helpers.h
@@ -47,7 +47,7 @@ template <typename S>
 
     vtbackend::CellLocation lastPos = {};
     size_t lastCount = 0;
-    for (vtbackend::RenderCell const& cell: renderBuffer.buffer.cells)
+    for (vtbackend::RenderCell const& cell: renderBuffer.buffer->cells)
     {
         auto const gap = (cell.position.column + static_cast<int>(lastCount) - 1) - lastPos.column;
         auto& currentLine = lines.at(unbox<size_t>(cell.position.line));
@@ -58,7 +58,7 @@ template <typename S>
         lastPos = cell.position;
         lastCount = 1;
     }
-    for (vtbackend::RenderLine const& line: renderBuffer.buffer.lines)
+    for (vtbackend::RenderLine const& line: renderBuffer.buffer->lines)
     {
         auto& currentLine = lines.at(unbox<size_t>(line.lineOffset));
         currentLine = line.text;


### PR DESCRIPTION
Improve overall code quality by listening to what clang-tidy had to say.

- drop dead code (if not needed anymore)
- drop unnecessary includes
- use `gsl::not_null<T*>` instead of bare references