### PR TITLE
Use color scheme based on OS system dark/light mode preferences

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -95,7 +95,7 @@ IncludeCategories:
     Priority:  52
   - Regex:     '^<harfbuzz/'
     Priority:  53
-  - Regex:     '^<(QtCore|QtGui|QtWidgets|QtQml|QtQuick|QtNetwork|QtMultimedia)/'
+  - Regex:     '^<(QtCore|QtGui|QtDBus|QtWidgets|QtQml|QtQuick|QtNetwork|QtMultimedia)/'
     Priority:  64
   - Regex:     '^<catch2/'
     Priority:  70

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _deps/**
 out
 out/**
 CMakeSettings.json
+vcpkg_installed/**
 
 # VIM: code completion / IntelliSense
 .clangd

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -363,12 +363,26 @@ profiles:
 
 
 ### `colors`
-section in the configuration file allows you to specify the colorscheme to use for the terminal. Alternatively, you can inline the color definitions within this section.
+section in the configuration file allows you to specify the colorscheme to use for the terminal.
 ``` yaml
 profiles:
   profile_name:
     colors: "default"
 ```
+
+To make the terminal's color scheme dependant on OS appearance (dark and light mode) settings,
+you need to specify two color schemes:
+
+```yaml
+profiles:
+  profile_name:
+    colors:
+      dark: "some_dark_scheme_name"
+      light: "some_light_scheme_name"
+```
+
+With this, the terminal will use the color scheme as specified in `dark` when OS dark mode is on,
+and `light`'s color scheme otherwise.
 
 ### `hyperlink_decoration:`
 section in the configuration file allows you to configure the styling and colorization of hyperlinks when they are displayed in the terminal and when they are hovered over by the cursor.

--- a/docs/vt-extensions/color-palette-update-notifications.md
+++ b/docs/vt-extensions/color-palette-update-notifications.md
@@ -1,0 +1,40 @@
+# Dark and Light Mode detection
+
+Most modern operating systems and desktop environments do support Dark and Light themes,
+this includes at least MacOS, Windows, KDE Plasma, Gnome, and probably others.
+
+Some even support switching from dark to light and light to dark mode based on sun rise / sun set.
+
+In order to not make the terminal emulator look bad after such switch, we must
+enable the applications inside the terminal to detect when the terminal has
+updated the color palette. This may happen either due to the operaging system having
+changed the current theme or simply because the user has explicitly requested to
+reconfigure the currently used theme.
+
+Ideally we are getting CLI tools like [delta]() to query the theme mode before sending out RGB values
+to the terminal to make the output look more in line with the rest of the desktop.
+
+But also TUIs like vim should be able to reflect dark/light mode changes as soon as the
+desktop has charnged from light to dark and vice versa, e.g. to make it more pleasing to the eyes.
+
+## Query the current theme mode?
+
+Send `CSI ? 996 n` to the terminal to explicitly request the current
+color preference (dark mode or light mode) by the operating system.
+
+The terminal will reply back in either of the two ways:
+
+VT sequence       | description
+------------------|---------------------------------
+`CSI ? 997 ; 1 n` | DSR reply to indicate dark mode
+`CSI ? 997 ; 2 n` | DSR reply to indicate light mode
+
+## Request unsolicited DSR on color palette updates
+
+Send `CSI ? 2031 h` to the terminal to enable unsolicited DSR (device status report) messages
+for color palette updates and `CSI ? 2031 l` respectively to disable it again.
+
+The sent out DSR looks equivalent to the already above mentioned.
+This notification is not just sent when dark/light mode has been changed
+by the operating system / desktop, but also if the user explicitly changed color scheme,
+e.g. by configuration.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -129,6 +129,8 @@
           <li>Removes the ability to inline colorschemes within a configuration profile. Colorschemes must now always be referenced by their name.</li>
           <li>Adds the ability to chose a color scheme based on the operating systems's dark/light mode setting. This will change live whenever the OS's dark/light mode setting changes as well (#604).</li>
           <li>Adds VT sequence DECSSCLS (change scroll speed) and properly handle DECSCLM (enable slow scrolling mode) (#1204)</li>
+          <li>Adds VT sequence parameter ?996 to DSR to request a report of current color scheme dark/light mode hint.</li>
+          <li>Adds VT sequence `SM ?2031` and `RM ?2031` to enable/disable unsolicited DSR for color scheme updates by the user or OS.</li>
           <li>Adds percentage value to Indicator Statusline to indicate scroll offset in scrollback buffer.</li>
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>
           <li>Adds config option `profile.*.bell` to adjust BEL behavior and fixes (#1162) and (#1163).</li>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -126,6 +126,8 @@
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>
+          <li>Removes the ability to inline colorschemes within a configuration profile. Colorschemes must now always be referenced by their name.</li>
+          <li>Adds the ability to chose a color scheme based on the operating systems's dark/light mode setting. This will change live whenever the OS's dark/light mode setting changes as well (#604).</li>
           <li>Adds VT sequence DECSSCLS (change scroll speed) and properly handle DECSCLM (enable slow scrolling mode) (#1204)</li>
           <li>Adds percentage value to Indicator Statusline to indicate scroll offset in scrollback buffer.</li>
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - vt-extensions/index.md
     - vt-extensions/clickable-links.md
     - vt-extensions/vertical-line-marks.md
+    - vt-extensions/color-palette-update-notifications.md
     - vt-extensions/synchronized-output.md
     - vt-extensions/buffer-capture.md
     - vt-extensions/font-settings.md

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -111,7 +111,6 @@ target_compile_definitions(contour PRIVATE
 )
 
 set_target_properties(contour PROPERTIES AUTOMOC ON)
-
 set_target_properties(contour PROPERTIES AUTORCC ON)
 
 # Disable all deprecated Qt functions prior to Qt 6.0

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -132,6 +132,19 @@ struct InputModeConfig
     CursorConfig cursor;
 };
 
+struct DualColorConfig
+{
+    vtbackend::ColorPalette darkMode {};
+    vtbackend::ColorPalette lightMode {};
+};
+
+struct SimpleColorConfig
+{
+    vtbackend::ColorPalette colors {};
+};
+
+using ColorConfig = std::variant<SimpleColorConfig, DualColorConfig>;
+
 struct TerminalProfile
 {
     vtpty::Process::ExecInfo shell;
@@ -168,7 +181,7 @@ struct TerminalProfile
     } permissions;
 
     bool drawBoldTextWithBrightColors = false;
-    vtbackend::ColorPalette colors {};
+    ColorConfig colors = SimpleColorConfig {};
 
     vtbackend::LineCount modalCursorScrollOff { 8 };
 

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -4,16 +4,16 @@
 #include <contour/Config.h>
 #include <contour/ContourApp.h>
 #include <contour/TerminalSessionManager.h>
+#include <contour/helper.h>
 
 #include <vtpty/Process.h>
 
+#include <QtDBus/QDBusVariant>
 #include <QtQml/QQmlApplicationEngine>
 
 #include <filesystem>
-#include <list>
 #include <memory>
 #include <optional>
-#include <string_view>
 
 namespace contour
 {
@@ -55,7 +55,7 @@ class ContourGuiApp: public QObject, public ContourApp
     {
         if (const auto* const profile = config().profile(profileName()))
             return *profile;
-        fmt::print("Failed to access config profile.\n");
+        displayLog()("Failed to access config profile.");
         Require(false);
     }
 
@@ -69,6 +69,8 @@ class ContourGuiApp: public QObject, public ContourApp
 
     [[nodiscard]] static QUrl resolveResource(std::string_view path);
 
+    vtbackend::ColorPreference colorPreference() const noexcept { return _colorPreference; }
+
   private:
     static void ensureTermInfoFile();
     bool loadConfig(std::string const& target);
@@ -81,6 +83,8 @@ class ContourGuiApp: public QObject, public ContourApp
     int _argc = 0;
     char const** _argv = nullptr;
     std::optional<vtpty::Process::ExitStatus> _exitStatus;
+
+    vtbackend::ColorPreference _colorPreference = vtbackend::ColorPreference::Dark;
 
     std::unique_ptr<QQmlApplicationEngine> _qmlEngine;
 };

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -373,10 +373,7 @@ void TerminalSession::updateColorPreference(vtbackend::ColorPreference preferenc
     _currentColorPreference = preference;
     if (auto const* colorPalette = preferredColorPalette(_profile.colors, preference))
     {
-        _terminal.settings().colorPalette = *colorPalette;
-        _terminal.factorySettings().colorPalette = *colorPalette;
-        _terminal.colorPalette() = *colorPalette;
-        _terminal.defaultColorPalette() = *colorPalette;
+        _terminal.resetColorPalette(*colorPalette);
 
         emit backgroundColorChanged();
     }

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -12,6 +12,7 @@
 #include <vtpty/Pty.h>
 
 #include <crispy/StackTrace.h>
+#include <crispy/assert.h>
 
 #include <QtCore/QDebug>
 #include <QtCore/QFileInfo>
@@ -72,6 +73,24 @@ namespace
 #endif
     }
 
+    ColorPalette const* preferredColorPalette(config::ColorConfig const& config,
+                                              vtbackend::ColorPreference preference)
+    {
+        if (auto const* dualColorConfig = std::get_if<config::DualColorConfig>(&config))
+        {
+            switch (preference)
+            {
+                case vtbackend::ColorPreference::Dark: return &dualColorConfig->darkMode;
+                case vtbackend::ColorPreference::Light: return &dualColorConfig->lightMode;
+            }
+        }
+        else if (auto const* simpleColorConfig = std::get_if<config::SimpleColorConfig>(&config))
+            return &simpleColorConfig->colors;
+
+        errorLog()("preferredColorPalette: Unknown color config type.");
+        return nullptr;
+    }
+
     string normalize_crlf(QString&& text)
     {
 #if !defined(_WIN32)
@@ -100,7 +119,8 @@ namespace
     }
 
     vtbackend::Settings createSettingsFromConfig(config::Config const& config,
-                                                 config::TerminalProfile const& profile)
+                                                 config::TerminalProfile const& profile,
+                                                 ColorPreference colorPreference)
     {
         auto settings = vtbackend::Settings {};
 
@@ -118,7 +138,8 @@ namespace
         settings.statusDisplayPosition = profile.statusDisplayPosition;
         settings.syncWindowTitleWithHostWritableStatusDisplay =
             profile.syncWindowTitleWithHostWritableStatusDisplay;
-        settings.colorPalette = profile.colors;
+        if (auto const* p = preferredColorPalette(profile.colors, colorPreference))
+            settings.colorPalette = *p;
         settings.refreshRate = profile.refreshRate;
         settings.primaryScreen.allowReflowOnResize = config.reflowOnResize;
         settings.highlightDoubleClickedWord = profile.highlightDoubleClickedWord;
@@ -143,9 +164,11 @@ TerminalSession::TerminalSession(unique_ptr<vtpty::Pty> pty, ContourGuiApp& app)
     _profileName { app.profileName() },
     _profile { *_config.profile(_profileName) },
     _app { app },
-    _terminal {
-        *this, std::move(pty), createSettingsFromConfig(_config, _profile), std::chrono::steady_clock::now()
-    }
+    _currentColorPreference { app.colorPreference() },
+    _terminal { *this,
+                std::move(pty),
+                createSettingsFromConfig(_config, _profile, _currentColorPreference),
+                std::chrono::steady_clock::now() }
 {
     if (app.liveConfig())
     {
@@ -339,6 +362,23 @@ void TerminalSession::requestPermission(config::Permission allowedByConfig, Guar
             }
             break;
         }
+    }
+}
+
+void TerminalSession::updateColorPreference(vtbackend::ColorPreference preference)
+{
+    if (preference == _currentColorPreference)
+        return;
+
+    _currentColorPreference = preference;
+    if (auto const* colorPalette = preferredColorPalette(_profile.colors, preference))
+    {
+        _terminal.settings().colorPalette = *colorPalette;
+        _terminal.factorySettings().colorPalette = *colorPalette;
+        _terminal.colorPalette() = *colorPalette;
+        _terminal.defaultColorPalette() = *colorPalette;
+
+        emit backgroundColorChanged();
     }
 }
 
@@ -1293,8 +1333,7 @@ void TerminalSession::configureTerminal()
     //     return;
 
     configureCursor(_profile.inputModes.insert.cursor);
-    _terminal.colorPalette() = _profile.colors;
-    _terminal.defaultColorPalette() = _profile.colors;
+    updateColorPreference(_app.colorPreference());
     _terminal.setMaxHistoryLineCount(_profile.maxHistoryLineCount);
     _terminal.setHighlightTimeout(_profile.highlightTimeout);
     _terminal.viewport().setScrollOff(_profile.modalCursorScrollOff);

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -4,6 +4,7 @@
 #include <contour/Actions.h>
 #include <contour/Audio.h>
 #include <contour/Config.h>
+#include <contour/helper.h>
 
 #include <vtbackend/Terminal.h>
 
@@ -18,9 +19,7 @@
 #include <QtQml/QJSValue>
 
 #include <cstdint>
-#include <filesystem>
 #include <thread>
-#include <variant>
 
 #include <qcolor.h>
 
@@ -98,7 +97,8 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     }
     QString pathToBackground() const
     {
-        if (const auto& p = std::get_if<std::filesystem::path>(&(profile().colors.backgroundImage->location)))
+        if (const auto& p =
+                std::get_if<std::filesystem::path>(&(_terminal.colorPalette().backgroundImage->location)))
         {
             return QString("file:") + QString(p->string().c_str());
         }
@@ -108,19 +108,19 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     QColor getBackgroundColor() const noexcept
     {
         auto color = terminal().isModeEnabled(vtbackend::DECMode::ReverseVideo)
-                         ? _profile.colors.defaultForeground
-                         : _profile.colors.defaultBackground;
+                         ? _terminal.colorPalette().defaultForeground
+                         : _terminal.colorPalette().defaultBackground;
         return QColor(color.red, color.green, color.blue, static_cast<uint8_t>(_profile.backgroundOpacity));
     }
     float getOpacityBackground() const noexcept
     {
-        if (profile().colors.backgroundImage)
-            return profile().colors.backgroundImage->opacity;
+        if (_terminal.colorPalette().backgroundImage)
+            return _terminal.colorPalette().backgroundImage->opacity;
         return 0.0;
     }
     bool getIsImageBackground() const noexcept
     {
-        if (profile().colors.backgroundImage)
+        if (_terminal.colorPalette().backgroundImage)
             return true;
         return false;
     }
@@ -128,7 +128,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool getIsBlurBackground() const noexcept
     {
         if (getIsImageBackground())
-            return profile().colors.backgroundImage->blur;
+            return _terminal.colorPalette().backgroundImage->blur;
         return false;
     }
 
@@ -218,6 +218,8 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     Q_INVOKABLE void executePendingBufferCapture(bool answer, bool remember);
     Q_INVOKABLE void executeShowHostWritableStatusLine(bool answer, bool remember);
     Q_INVOKABLE void requestWindowResize(QJSValue w, QJSValue h);
+
+    void updateColorPreference(vtbackend::ColorPreference preference);
 
     // vtbackend::Events
     //
@@ -384,6 +386,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     config::TerminalProfile _profile;
     double _contentScale = 1.0;
     ContourGuiApp& _app;
+    vtbackend::ColorPreference _currentColorPreference;
 
     vtbackend::Terminal _terminal;
     bool _terminatedAndWaitingForKeyPress = false;

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -43,6 +43,12 @@ void TerminalSessionManager::removeSession(TerminalSession& thatSession)
     // Notify app if all sessions have been killed to trigger app termination.
 }
 
+void TerminalSessionManager::updateColorPreference(vtbackend::ColorPreference const& preference)
+{
+    for (auto& session: _sessions)
+        session->updateColorPreference(preference);
+}
+
 // {{{ QAbstractListModel
 QVariant TerminalSessionManager::data(const QModelIndex& index, int role) const
 {

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <contour/TerminalSession.h>
+#include <contour/helper.h>
 
 #include <QtCore/QAbstractListModel>
 #include <QtQml/QQmlEngine>
@@ -33,6 +34,8 @@ class TerminalSessionManager: public QAbstractListModel
     Q_INVOKABLE [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
     [[nodiscard]] int count() const noexcept { return static_cast<int>(_sessions.size()); }
+
+    void updateColorPreference(vtbackend::ColorPreference const& preference);
 
   private:
     ContourGuiApp& _app;

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -452,7 +452,16 @@ profiles:
             blur: false
 
         # Specifies a colorscheme to use (alternatively the colors can be inlined).
-        colors: "default"
+        #
+        # This can be either the name to a single colorscheme to always use,
+        # or a map with two keys (dark and light) to determine the color scheme to use for each.
+        #
+        # The dark color scheme is used when the system is configured to prefer dark mode and light theme otherwise.
+        #
+        # Default: "default"
+        colors:
+            light: default
+            dark: default
 
         # Hyperlinks (via OSC-8) can be stylized and colorized on hover.
         hyperlink_decoration:

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -37,11 +37,8 @@
 #include <QtQml/QQmlContext>
 #include <QtQuick/QQuickWindow>
 
-#include <algorithm>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <stdexcept>
 #include <string_view>
 #include <tuple>
 #include <vector>
@@ -292,7 +289,7 @@ void TerminalWidget::setSession(TerminalSession* newSession)
     _renderer =
         make_unique<vtrasterizer::Renderer>(newSession->profile().terminalSize,
                                             sanitizeFontDescription(profile().fonts, fontDPI()),
-                                            newSession->profile().colors,
+                                            _session->terminal().colorPalette(),
                                             newSession->config().textureAtlasHashtableSlots,
                                             newSession->config().textureAtlasTileCount,
                                             newSession->config().textureAtlasDirectMapping,

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -17,6 +17,12 @@
 namespace vtbackend
 {
 
+enum class ColorPreference
+{
+    Dark,
+    Light,
+};
+
 struct ImageData
 {
     vtbackend::ImageFormat format;
@@ -140,6 +146,21 @@ RGBColor apply(ColorPalette const& colorPalette, Color color, ColorTarget target
 } // namespace vtbackend
 
 // {{{ fmtlib custom formatter support
+template <>
+struct fmt::formatter<vtbackend::ColorPreference>: fmt::formatter<std::string_view>
+{
+    auto format(vtbackend::ColorPreference value, format_context& ctx) -> format_context::iterator
+    {
+        string_view name;
+        switch (value)
+        {
+            case vtbackend::ColorPreference::Dark: name = "Dark"; break;
+            case vtbackend::ColorPreference::Light: name = "Light"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};
+
 template <>
 struct fmt::formatter<vtbackend::ColorMode>: fmt::formatter<std::string_view>
 {

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -383,7 +383,8 @@ constexpr inline auto CHA         = detail::CSI(std::nullopt, 0, 1, std::nullopt
 constexpr inline auto CHT         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'I', VTType::VT100, "CHT", "Cursor Horizontal Forward Tabulation");
 constexpr inline auto CNL         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'E', VTType::VT100, "CNL", "Move cursor to next line");
 constexpr inline auto CPL         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'F', VTType::VT100, "CPL", "Move cursor to previous line");
-constexpr inline auto CPR         = detail::CSI(std::nullopt, 1, 1, std::nullopt, 'n', VTType::VT100, "CPR", "Request Cursor position");
+constexpr inline auto ANSIDSR     = detail::CSI(std::nullopt, 1, 1, std::nullopt, 'n', VTType::VT100, "DSR", "Device Status Report (ANSI)");
+constexpr inline auto DSR         = detail::CSI('?', 1, 1, std::nullopt, 'n', VTType::VT100, "DSR", "Device Status Report (DEC)");
 constexpr inline auto CUB         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'D', VTType::VT100, "CUB", "Move cursor backward");
 constexpr inline auto CUD         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'B', VTType::VT100, "CUD", "Move cursor down");
 constexpr inline auto CUF         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'C', VTType::VT100, "CUF", "Move cursor forward");
@@ -538,7 +539,6 @@ constexpr static auto allFunctionsArray() noexcept
         CHT,
         CNL,
         CPL,
-        CPR,
         CUB,
         CUD,
         CUF,
@@ -558,6 +558,8 @@ constexpr static auto allFunctionsArray() noexcept
         DECSED,
         DECSERA,
         DECSEL,
+        ANSIDSR,
+        DSR,
         XTRESTORE,
         XTSAVE,
         DECPS,

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -2785,12 +2785,21 @@ namespace impl
         }
 
         template <typename Cell>
-        ApplyResult CPR(Sequence const& seq, Screen<Cell>& screen)
+        ApplyResult ANSIDSR(Sequence const& seq, Screen<Cell>& screen)
         {
             switch (seq.param(0))
             {
                 case 5: screen.deviceStatusReport(); return ApplyResult::Ok;
                 case 6: screen.reportCursorPosition(); return ApplyResult::Ok;
+                default: return ApplyResult::Unsupported;
+            }
+        }
+
+        template <typename Cell>
+        ApplyResult DSR(Sequence const& seq, Screen<Cell>& screen)
+        {
+            switch (seq.param(0))
+            {
                 default: return ApplyResult::Unsupported;
             }
         }
@@ -3450,7 +3459,8 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
         case CPL:
             moveCursorToPrevLine(LineCount::cast_from(seq.param_or(0, Sequence::Parameter { 1 })));
             break;
-        case CPR: return impl::CPR(seq, *this);
+        case ANSIDSR: return impl::ANSIDSR(seq, *this);
+        case DSR: return impl::DSR(seq, *this);
         case CUB: moveCursorBackward(seq.param_or<ColumnCount>(0, ColumnCount { 1 })); break;
         case CUD: moveCursorDown(seq.param_or<LineCount>(0, LineCount { 1 })); break;
         case CUF: moveCursorForward(seq.param_or<ColumnCount>(0, ColumnCount { 1 })); break;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -50,6 +50,7 @@ class ScreenBase: public SequenceHandler
     void resetSavedCursorState() { _savedCursor = {}; }
     virtual void saveCursor() = 0;
     virtual void restoreCursor() = 0;
+    virtual void reportColorPaletteUpdate() = 0;
 
     [[nodiscard]] virtual Margin margin() const noexcept = 0;
     [[nodiscard]] virtual Margin& margin() noexcept = 0;
@@ -220,6 +221,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void deviceStatusReport();           // DSR
     void reportCursorPosition();         // CPR
     void reportExtendedCursorPosition(); // DECXCPR
+    void reportColorPaletteUpdate() override;
     void selectConformanceLevel(VTType level);
     void requestDynamicColor(DynamicColorName name);
     void requestCapability(capabilities::Code code);

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2184,6 +2184,19 @@ void Terminal::setHighlightRange(HighlightRange highlightRange)
 
 constexpr auto MagicStackTopId = size_t { 0 };
 
+void Terminal::setColorPalette(ColorPalette const& palette) noexcept
+{
+    _state.colorPalette = palette;
+}
+
+void Terminal::resetColorPalette(ColorPalette const& colors)
+{
+    _state.colorPalette = colors;
+    _state.defaultColorPalette = colors;
+    _settings.colorPalette = colors;
+    _factorySettings.colorPalette = colors;
+}
+
 void Terminal::pushColorPalette(size_t slot)
 {
     if (slot > MaxColorPaletteSaveStackSize)

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2195,6 +2195,9 @@ void Terminal::resetColorPalette(ColorPalette const& colors)
     _state.defaultColorPalette = colors;
     _settings.colorPalette = colors;
     _factorySettings.colorPalette = colors;
+
+    if (isModeEnabled(DECMode::ReportColorPaletteUpdated))
+        _currentScreen.get().reportColorPaletteUpdate();
 }
 
 void Terminal::pushColorPalette(size_t slot)

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1704,7 +1704,8 @@ void Terminal::softReset()
     setLeftRightMargin({}, boxed_cast<ColumnOffset>(_settings.pageSize.columns) - ColumnOffset(1)); // DECRLM
 
     _currentScreen.get().cursor().hyperlink = {};
-    _state.colorPalette = _state.defaultColorPalette;
+
+    resetColorPalette();
 
     setActiveStatusDisplay(ActiveStatusDisplay::Main);
     setStatusDisplay(StatusDisplayType::None);
@@ -1769,7 +1770,7 @@ void Terminal::hardReset()
     _state.imagePool.clear();
     _state.tabs.clear();
 
-    _state.colorPalette = _state.defaultColorPalette;
+    resetColorPalette();
 
     _hostWritableStatusLineScreen.margin() = Margin {
         Margin::Vertical { {}, boxed_cast<LineOffset>(_hostWritableStatusLineScreen.pageSize().lines) - 1 },
@@ -2217,7 +2218,7 @@ void Terminal::popColorPalette(size_t slot)
 
     auto const index = slot == MagicStackTopId ? _state.savedColorPalettes.size() - 1 : slot - 1;
 
-    _state.colorPalette = _state.savedColorPalettes[index];
+    setColorPalette(_state.savedColorPalettes[index]);
     if (slot == MagicStackTopId)
         _state.savedColorPalettes.pop_back();
 }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -375,12 +375,9 @@ class Terminal
     [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
     [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
 
-    void setColorPalette(ColorPalette const& palette) noexcept
-    {
-        _state.colorPalette = palette;
-    }
-
+    void setColorPalette(ColorPalette const& palette) noexcept;
     void resetColorPalette() noexcept { setColorPalette(defaultColorPalette()); }
+    void resetColorPalette(ColorPalette const& colors);
 
     void pushColorPalette(size_t slot);
     void popColorPalette(size_t slot);

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -375,6 +375,15 @@ class Terminal
     [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
     [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
 
+    void setDefaultColorPalette(ColorPalette palette) noexcept
+    {
+        _state.defaultColorPalette = std::move(palette);
+    }
+
+    void setColorPalette(ColorPalette const& palette) noexcept { _state.colorPalette = palette; }
+
+    void resetColorPalette() noexcept { setColorPalette(defaultColorPalette()); }
+
     void pushColorPalette(size_t slot);
     void popColorPalette(size_t slot);
     void reportColorPaletteStack();
@@ -691,6 +700,7 @@ class Terminal
     [[nodiscard]] std::tuple<std::u32string, CellLocationRange> extractWordUnderCursor(
         CellLocation position) const noexcept;
 
+    Settings& factorySettings() noexcept { return _factorySettings; }
     Settings const& factorySettings() const noexcept { return _factorySettings; }
     Settings const& settings() const noexcept { return _settings; }
     Settings& settings() noexcept { return _settings; }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -375,12 +375,10 @@ class Terminal
     [[nodiscard]] ColorPalette& colorPalette() noexcept { return _state.colorPalette; }
     [[nodiscard]] ColorPalette& defaultColorPalette() noexcept { return _state.defaultColorPalette; }
 
-    void setDefaultColorPalette(ColorPalette palette) noexcept
+    void setColorPalette(ColorPalette const& palette) noexcept
     {
-        _state.defaultColorPalette = std::move(palette);
+        _state.colorPalette = palette;
     }
-
-    void setColorPalette(ColorPalette const& palette) noexcept { _state.colorPalette = palette; }
 
     void resetColorPalette() noexcept { setColorPalette(defaultColorPalette()); }
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -588,13 +588,13 @@ class Terminal
     void notify(std::string_view title, std::string_view body);
     void reply(std::string_view text);
 
-    template <typename... T>
-    void reply(fmt::format_string<T...> fmt, T&&... args)
+    template <typename... Ts>
+    void reply(fmt::format_string<Ts...> message, Ts&&... args)
     {
-#if defined(__APPLE__)
-        reply(fmt::vformat(fmt, fmt::make_format_args(args...)));
+#if defined(__APPLE__) || defined(_MSC_VER)
+        reply(fmt::vformat(message, fmt::make_format_args(args...)));
 #else
-        reply(fmt::vformat(fmt, fmt::make_format_args(std::forward<T>(args)...)));
+        reply(fmt::vformat(message, fmt::make_format_args(std::forward<Ts>(args)...)));
 #endif
     }
 

--- a/src/vtbackend/TerminalState.cpp
+++ b/src/vtbackend/TerminalState.cpp
@@ -81,6 +81,7 @@ std::string to_string(DECMode mode)
         case DECMode::Unicode: return "Unicode";
         case DECMode::TextReflow: return "TextReflow";
         case DECMode::SixelCursorNextToGraphic: return "SixelCursorNextToGraphic";
+        case DECMode::ReportColorPaletteUpdated: return "ReportColorPaletteUpdated";
     }
     return fmt::format("({})", static_cast<unsigned>(mode));
 }

--- a/src/vtbackend/TerminalState.cpp
+++ b/src/vtbackend/TerminalState.cpp
@@ -10,6 +10,8 @@ class Terminal;
 TerminalState::TerminalState(Terminal& terminal):
     settings { terminal.settings() },
     cellPixelSize {},
+    defaultColorPalette { settings.colorPalette },
+    colorPalette { settings.colorPalette },
     effectiveImageCanvasSize { settings.maxImageSize },
     imageColorPalette { std::make_shared<SixelColorPalette>(maxImageColorRegisters, maxImageColorRegisters) },
     imagePool { [te = &terminal](Image const* image) {

--- a/src/vtbackend/VTWriter.h
+++ b/src/vtbackend/VTWriter.h
@@ -71,13 +71,13 @@ class VTWriter
     Color _currentBackgroundColor = DefaultColor();
 };
 
-template <typename... T>
-inline void VTWriter::write(fmt::format_string<T...> fmt, T&&... args)
+template <typename... Ts>
+inline void VTWriter::write(fmt::format_string<Ts...> fmt, Ts&&... args)
 {
 #if defined(__APPLE__)
     write(fmt::vformat(fmt, fmt::make_format_args(args...)));
 #else
-    write(fmt::vformat(fmt, fmt::make_format_args(std::forward<T>(args)...)));
+    write(fmt::vformat(fmt, fmt::make_format_args(std::forward<Ts>(args)...)));
 #endif
 }
 

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -686,6 +686,10 @@ enum class DECMode
     // intersecting with the main page area.
     ReportGridCellSelection = 2030,
 
+    // If enabled, the terminal will report color palette changes to the application,
+    // if modified by the user or operating system (e.g. dark/light mode adaption).
+    ReportColorPaletteUpdated = 2031,
+
     // If enabled (default, as per spec), then the cursor is left next to the graphic,
     // that is, the text cursor is placed at the position of the sixel cursor.
     // If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
@@ -791,6 +795,7 @@ constexpr unsigned toDECModeNum(DECMode m)
         case DECMode::MouseAlternateScroll: return 1007;
         case DECMode::MousePassiveTracking: return 2029;
         case DECMode::ReportGridCellSelection: return 2030;
+        case DECMode::ReportColorPaletteUpdated: return 2031;
         case DECMode::BatchedRendering: return 2026;
         case DECMode::Unicode: return 2027;
         case DECMode::TextReflow: return 2028;
@@ -837,6 +842,7 @@ constexpr bool isValidDECMode(unsigned int mode) noexcept
         case DECMode::MouseAlternateScroll:
         case DECMode::MousePassiveTracking:
         case DECMode::ReportGridCellSelection:
+        case DECMode::ReportColorPaletteUpdated:
         case DECMode::BatchedRendering:
         case DECMode::Unicode:
         case DECMode::TextReflow:


### PR DESCRIPTION
Closes #604 

### Checklist

- [x] get dark/light theme mode events on Linux
- [x] get dark/light theme mode events on MacOS
- [x] get dark/light theme mode events on Windows ([how](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/apply-windows-themes))
- [x] config: extend config to allow specifying dark and light mode themes (then the system setting will decide what to chose from) or just one and then this is always used
- [x] apply color scheme based on that.
- [x] propagate dark/light mode changes to the app (VT extension to query state and get realtime notifications on state changes)
- [x] reflect changes in documentation
- [x] changelog entry added to metainfo.xml




https://github.com/contour-terminal/contour/assets/56763/ea4b5867-defc-489b-bdf2-9aa635275ff0

