### PR TITLE
Fix infinite loop when next line does not exist

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -122,6 +122,7 @@
           <li>Fixes URI re-encoding of local files in `OSC 8` (#1199)</li>
           <li>Fixes LCD subpixel rendering for overly wide US-ASCII glyphs (#1022)</li>
           <li>Fixes alive process when GUI is closed</li>
+          <li>Fixes vi mode `f` action freeze on last line</li>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -1042,13 +1042,17 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
 optional<CellLocation> ViCommands::toCharRight(CellLocation startPosition) const noexcept
 {
     auto result = next(startPosition);
-
+    auto const rightMargin = _terminal.pageSize().columns.as<ColumnOffset>() - 1;
     while (true)
     {
+        // if on wrong line
         if (result.line != startPosition.line)
             return std::nullopt;
         if (_terminal.currentScreen().compareCellTextAt(result, _lastChar))
             return result;
+        // if reached end of the line
+        if (result.column == rightMargin)
+            return std::nullopt;
         result = next(result);
     }
 }


### PR DESCRIPTION
Fix error found by @Utkarsh-khambra  on vim `f` press. 
Issue is that when looking for next character to the right not always we can go to the next line 