### PR TITLE
Check naming of class/struct members

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -114,6 +114,10 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.ClassMemberCase
     value:           camelBack
+  - key:             readability-identifier-naming.PublicMemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           camelBack
   - key:             readability-identifier-naming.PublicMemberPrefix
     value:           ''
   - key:             readability-identifier-naming.PrivateMemberPrefix

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1365,7 +1365,7 @@ namespace
                              terminalProfile.copyLastMarkRangeOffset,
                              logger);
         tryLoadChildRelative(
-            usedKeys, profile, basePath, "show_title_bar", terminalProfile.show_title_bar, logger);
+            usedKeys, profile, basePath, "show_title_bar", terminalProfile.showTitleBar, logger);
         tryLoadChildRelative(usedKeys,
                              profile,
                              basePath,
@@ -1683,7 +1683,7 @@ namespace
                              profile,
                              basePath,
                              "mouse.hide_while_typing",
-                             terminalProfile.mouse_hide_while_typing,
+                             terminalProfile.mouseHideWhileTyping,
                              logger);
 
         tryLoadChildRelative(usedKeys,

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -137,9 +137,9 @@ struct TerminalProfile
     vtpty::Process::ExecInfo shell;
     bool maximized = false;
     bool fullscreen = false;
-    bool show_title_bar = true;
+    bool showTitleBar = true;
     bool sizeIndicatorOnResize = true;
-    bool mouse_hide_while_typing = true;
+    bool mouseHideWhileTyping = true;
     vtbackend::RefreshRate refreshRate = { 0.0 }; // 0=auto
     vtbackend::LineOffset copyLastMarkRangeOffset = vtbackend::LineOffset(0);
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -632,7 +632,7 @@ void TerminalSession::sendKeyPressEvent(Key key, Modifier modifier, Timestamp no
         return;
     }
 
-    if (_profile.mouse_hide_while_typing)
+    if (_profile.mouseHideWhileTyping)
         _display->setMouseCursorShape(MouseCursorShape::Hidden);
 
     if (auto const* actions =
@@ -655,7 +655,7 @@ void TerminalSession::sendCharPressEvent(char32_t value, Modifier modifier, Time
         return;
     }
 
-    if (_profile.mouse_hide_while_typing)
+    if (_profile.mouseHideWhileTyping)
         _display->setMouseCursorShape(MouseCursorShape::Hidden);
 
     if (auto const* actions =

--- a/src/contour/display/Blur.h
+++ b/src/contour/display/Blur.h
@@ -61,21 +61,21 @@ class Blur: protected QOpenGLExtraFunctions
     QOpenGLShaderProgram* _shaderKawaseDown = nullptr;
     //.
 
-    QVector<QOpenGLFramebufferObject*> _FBO_vector;
+    QVector<QOpenGLFramebufferObject*> _vectorFBO;
     QOpenGLTexture* _textureToBlur = nullptr;
 
-    QOpenGLVertexArrayObject _VertexArrayObject;
+    QOpenGLVertexArrayObject _vertexArrayObject;
     QOpenGLBuffer _vertexBuffer;
 
     int _iterations = -1;
     QImage _imageToBlur;
 
     // GPU timer
-    GLuint64 _GPUtimerElapsedTime {};
+    GLuint64 _timerGPUElapsedTime {};
 
     // CPU timer
-    QElapsedTimer _CPUTimer;
-    quint64 _CPUTimerElapsedTime {};
+    QElapsedTimer _timerCPU;
+    quint64 _timerCPUElapsedTime {};
 };
 
 } // namespace contour::display

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -510,7 +510,7 @@ ImageSize OpenGLRenderer::renderBufferSize()
 
 struct ScopedRenderEnvironment
 {
-    QOpenGLExtraFunctions& _gl;
+    QOpenGLExtraFunctions& gl;
 
     bool savedBlend;          // QML seems to explicitly disable that, but we need it.
     GLenum savedDepthFunc {}; // Shuold be GL_LESS, but you never know.
@@ -518,33 +518,33 @@ struct ScopedRenderEnvironment
     GLenum savedBlendSource {};
     GLenum savedBlendDestination {};
 
-    ScopedRenderEnvironment(QOpenGLExtraFunctions& gl):
-        _gl { gl }, // clang-format off
-        savedBlend { _gl.glIsEnabled(GL_BLEND) != GL_FALSE } // clang-format on
+    ScopedRenderEnvironment(QOpenGLExtraFunctions& glIn):
+        gl { glIn }, // clang-format off
+        savedBlend { gl.glIsEnabled(GL_BLEND) != GL_FALSE } // clang-format on
     {
-        _gl.glGetIntegerv(GL_VERTEX_ARRAY_BINDING, (GLint*) &savedVAO);
+        gl.glGetIntegerv(GL_VERTEX_ARRAY_BINDING, (GLint*) &savedVAO);
 
-        _gl.glGetIntegerv(GL_DEPTH_FUNC, (GLint*) &savedDepthFunc);
-        _gl.glDepthFunc(GL_LEQUAL);
-        _gl.glDepthMask(GL_FALSE);
+        gl.glGetIntegerv(GL_DEPTH_FUNC, (GLint*) &savedDepthFunc);
+        gl.glDepthFunc(GL_LEQUAL);
+        gl.glDepthMask(GL_FALSE);
 
         // Enable color blending to allow drawing text/images on top of background.
-        _gl.glGetIntegerv(GL_BLEND_SRC, (GLint*) &savedBlendSource);
-        _gl.glGetIntegerv(GL_BLEND_DST, (GLint*) &savedBlendDestination);
-        _gl.glEnable(GL_BLEND);
+        gl.glGetIntegerv(GL_BLEND_SRC, (GLint*) &savedBlendSource);
+        gl.glGetIntegerv(GL_BLEND_DST, (GLint*) &savedBlendDestination);
+        gl.glEnable(GL_BLEND);
         // _gl.glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE);
-        _gl.glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+        gl.glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
     }
 
     ~ScopedRenderEnvironment()
     {
-        _gl.glBlendFunc(savedBlendSource, savedBlendDestination);
-        _gl.glDepthFunc(savedDepthFunc);
+        gl.glBlendFunc(savedBlendSource, savedBlendDestination);
+        gl.glDepthFunc(savedDepthFunc);
         if (!savedBlend)
-            _gl.glDisable(GL_BLEND);
+            gl.glDisable(GL_BLEND);
 
-        _gl.glBindVertexArray(savedVAO);
-        _gl.glDepthMask(GL_TRUE);
+        gl.glBindVertexArray(savedVAO);
+        gl.glDepthMask(GL_TRUE);
     }
 };
 

--- a/src/contour/display/TerminalWidget.cpp
+++ b/src/contour/display/TerminalWidget.cpp
@@ -287,7 +287,7 @@ void TerminalWidget::setSession(TerminalSession* newSession)
 
     _session->start();
 
-    window()->setFlag(Qt::FramelessWindowHint, !profile().show_title_bar);
+    window()->setFlag(Qt::FramelessWindowHint, !profile().showTitleBar);
 
     _renderer =
         make_unique<vtrasterizer::Renderer>(newSession->profile().terminalSize,

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -213,24 +213,24 @@ enum class RenderState
 /// either DirtyIdle if no painting is currently in progress, DirtyPainting otherwise.
 struct RenderStateManager
 {
-    std::atomic<RenderState> state_ = RenderState::CleanIdle;
-    bool renderingPressure_ = false;
+    std::atomic<RenderState> state = RenderState::CleanIdle;
+    bool renderingPressure = false;
 
-    RenderState fetchAndClear() { return state_.exchange(RenderState::CleanPainting); }
+    RenderState fetchAndClear() { return state.exchange(RenderState::CleanPainting); }
 
     bool touch()
     {
         for (;;)
         {
-            auto state = state_.load();
-            switch (state)
+            auto stateTmp = state.load();
+            switch (stateTmp)
             {
                 case RenderState::CleanIdle:
-                    if (state_.compare_exchange_strong(state, RenderState::DirtyIdle))
+                    if (state.compare_exchange_strong(stateTmp, RenderState::DirtyIdle))
                         return true;
                     break;
                 case RenderState::CleanPainting:
-                    if (state_.compare_exchange_strong(state, RenderState::DirtyPainting))
+                    if (state.compare_exchange_strong(stateTmp, RenderState::DirtyPainting))
                         return false;
                     break;
                 case RenderState::DirtyIdle:
@@ -245,8 +245,8 @@ struct RenderStateManager
     {
         for (;;)
         {
-            auto state = state_.load();
-            switch (state)
+            auto stateTmp = state.load();
+            switch (stateTmp)
             {
                 case RenderState::DirtyIdle:
                     // assert(!"The impossible happened, painting but painting. Shakesbeer.");
@@ -255,10 +255,10 @@ struct RenderStateManager
                     [[fallthrough]];
                 case RenderState::DirtyPainting: return false;
                 case RenderState::CleanPainting:
-                    if (!state_.compare_exchange_strong(state, RenderState::CleanIdle))
+                    if (!state.compare_exchange_strong(stateTmp, RenderState::CleanIdle))
                         break;
                     [[fallthrough]];
-                case RenderState::CleanIdle: renderingPressure_ = false; return true;
+                case RenderState::CleanIdle: renderingPressure = false; return true;
             }
         }
     }

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -231,11 +231,11 @@ struct directwrite_shaper::Private
         fontInfo.description.familyName = wStringConverter.to_bytes(resolvedFamilyName);
         fontInfo.description.wFamilyName = resolvedFamilyName;
         fontInfo.size = _size;
-        fontInfo.metrics.line_height = int(ceil(lineHeight * dipScalar));
+        fontInfo.metrics.lineHeight = int(ceil(lineHeight * dipScalar));
         fontInfo.metrics.ascender = int(ceil(dwMetrics.ascent * dipScalar));
         fontInfo.metrics.descender = int(ceil(dwMetrics.descent * dipScalar));
-        fontInfo.metrics.underline_position = int(ceil(dwMetrics.underlinePosition * dipScalar));
-        fontInfo.metrics.underline_thickness = int(ceil(dwMetrics.underlineThickness * dipScalar));
+        fontInfo.metrics.underlinePosition = int(ceil(dwMetrics.underlinePosition * dipScalar));
+        fontInfo.metrics.underlineThickness = int(ceil(dwMetrics.underlineThickness * dipScalar));
         fontInfo.metrics.advance = int(ceil(computeAverageAdvance(fontFace) * dipScalar));
 
         fontFace->QueryInterface(&fontInfo.fontFace);

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -174,7 +174,7 @@ struct font_description
     font_weight weight = font_weight::normal;
     font_slant slant = font_slant::normal;
     font_spacing spacing = font_spacing::proportional;
-    bool strict_spacing = false;
+    bool strictSpacing = false;
 
     std::vector<font_feature> features;
 
@@ -188,7 +188,7 @@ struct font_description
 inline bool operator==(font_description const& a, font_description const& b)
 {
     return a.familyName == b.familyName && a.weight == b.weight && a.slant == b.slant
-           && a.spacing == b.spacing && a.strict_spacing == b.strict_spacing;
+           && a.spacing == b.spacing && a.strictSpacing == b.strictSpacing;
 }
 
 inline bool operator!=(font_description const& a, font_description const& b)
@@ -198,12 +198,12 @@ inline bool operator!=(font_description const& a, font_description const& b)
 
 struct font_metrics
 {
-    int line_height;
+    int lineHeight;
     int advance;
     int ascender;
     int descender;
-    int underline_position;
-    int underline_thickness;
+    int underlinePosition;
+    int underlineThickness;
 };
 
 struct font_size
@@ -320,7 +320,7 @@ struct hash<text::font_description>
         auto fnv = crispy::fnv<char>();
         return size_t(
             fnv(fnv(fnv(fnv(fnv(fd.familyName), char(fd.weight)), char(fd.slant)), char(fd.spacing)),
-                char(fd.strict_spacing)));
+                char(fd.strictSpacing)));
     }
 };
 } // namespace std
@@ -403,7 +403,7 @@ struct fmt::formatter<text::font_description>: fmt::formatter<std::string>
                         desc.weight,
                         desc.slant,
                         desc.spacing,
-                        desc.strict_spacing ? "yes" : "no"),
+                        desc.strictSpacing ? "yes" : "no"),
             ctx);
     }
 };
@@ -414,12 +414,12 @@ struct fmt::formatter<text::font_metrics>: fmt::formatter<std::string>
     auto format(text::font_metrics const& metrics, format_context& ctx) -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}, {}, {}, {}, {}, {})",
-                                                          metrics.line_height,
+                                                          metrics.lineHeight,
                                                           metrics.advance,
                                                           metrics.ascender,
                                                           metrics.descender,
-                                                          metrics.underline_position,
-                                                          metrics.underline_thickness),
+                                                          metrics.underlinePosition,
+                                                          metrics.underlineThickness),
                                               ctx);
     }
 };

--- a/src/text_shaper/fontconfig_locator.cpp
+++ b/src/text_shaper/fontconfig_locator.cpp
@@ -234,7 +234,7 @@ font_source_list fontconfig_locator::locate(font_description const& description)
 
         int spacing = -1;
         FcPatternGetInteger(font, FC_SPACING, 0, &spacing);
-        if (description.strict_spacing)
+        if (description.strictSpacing)
         {
             // Some fonts don't seem to tell us their spacing attribute. ;-(
             // But instead of ignoring them all together, try to be more friendly.

--- a/src/text_shaper/mock_font_locator.cpp
+++ b/src/text_shaper/mock_font_locator.cpp
@@ -49,7 +49,7 @@ font_source_list mock_font_locator::locate(font_description const& description)
         if (item.description.weight != description.weight)
             continue;
 
-        if (item.description.spacing != description.spacing && description.strict_spacing)
+        if (item.description.spacing != description.spacing && description.strictSpacing)
             continue;
 
         output.emplace_back(item.source);

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -405,7 +405,7 @@ struct open_shaper::Private // {{{
     // (file_path, file_mtime, font_weight, font_slant, pixel_size)
 
     unordered_map<glyph_key, rasterized_glyph> glyphs;
-    hb_buffer_ptr hb_buf;
+    hb_buffer_ptr hbBuf;
     font_key nextFontKey;
 
     font_key create_font_key()
@@ -458,14 +458,14 @@ struct open_shaper::Private // {{{
 
         font_metrics output {};
 
-        output.line_height = scaleVertical(ftFace, ftFace->height);
+        output.lineHeight = scaleVertical(ftFace, ftFace->height);
         output.advance = computeAverageAdvance(ftFace);
         if (!output.advance)
-            output.advance = int(double(output.line_height) * 2.0 / 3.0);
+            output.advance = int(double(output.lineHeight) * 2.0 / 3.0);
         output.ascender = scaleVertical(ftFace, ftFace->ascender);
         output.descender = scaleVertical(ftFace, ftFace->descender);
-        output.underline_position = scaleVertical(ftFace, ftFace->underline_position);
-        output.underline_thickness = scaleVertical(ftFace, ftFace->underline_thickness);
+        output.underlinePosition = scaleVertical(ftFace, ftFace->underline_position);
+        output.underlineThickness = scaleVertical(ftFace, ftFace->underline_thickness);
 
         return output;
     }
@@ -476,7 +476,7 @@ struct open_shaper::Private // {{{
         } },
         locator { &locator },
         dpi { dpi },
-        hb_buf(hb_buffer_create(), [](auto p) { hb_buffer_destroy(p); }),
+        hbBuf(hb_buffer_create(), [](auto p) { hb_buffer_destroy(p); }),
         nextFontKey {}
     {
         if (auto const ec = FT_Init_FreeType(&ft); ec != FT_Err_Ok)
@@ -510,7 +510,7 @@ struct open_shaper::Private // {{{
                 continue;
 
             // Skip if main font is monospace but fallbacks font is not.
-            if (fontInfo.description.strict_spacing
+            if (fontInfo.description.strictSpacing
                 && fontInfo.description.spacing != font_spacing::proportional)
             {
                 Require(fontKeyToHbFontInfoMapping.count(fallbackKeyOpt.value()) == 1);
@@ -650,7 +650,7 @@ void open_shaper::shape(font_key font,
     Require(_d->fontKeyToHbFontInfoMapping.count(font) == 1);
     HbFontInfo& fontInfo = _d->fontKeyToHbFontInfoMapping.at(font);
     hb_font_t* hbFont = fontInfo.hbFont.get();
-    hb_buffer_t* hbBuf = _d->hb_buf.get();
+    hb_buffer_t* hbBuf = _d->hbBuf.get();
 
     if (textShapingLog)
     {

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -42,10 +42,10 @@ namespace
         auto const m = textShaper.metrics(font);
 
         gm.cellSize.width = vtbackend::Width::cast_from(m.advance);
-        gm.cellSize.height = vtbackend::Height::cast_from(m.line_height);
-        gm.baseline = m.line_height - m.ascender;
-        gm.underline.position = gm.baseline + m.underline_position;
-        gm.underline.thickness = m.underline_thickness;
+        gm.cellSize.height = vtbackend::Height::cast_from(m.lineHeight);
+        gm.baseline = m.lineHeight - m.ascender;
+        gm.underline.position = gm.baseline + m.underlinePosition;
+        gm.underline.thickness = m.underlineThickness;
 
         rendererLog()("Loading grid metrics {}", gm);
     }


### PR DESCRIPTION
Add clang-tiy checks for naming of data mamebers inside struct/class
I was confused previouslu and was thinking that `ClassMemberCase` will check naming convention for the class/struct members, but it only checks `static` members. 
This PR adds clang-tidy checks for the names of private and public members 