### PR TITLE
feat: Add OpenSelection action, and honor case in the configuration bindings

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -135,6 +135,7 @@
           <li>Adds capital `A` and `I` keys to switch from normal mode back to insert mode, too.</li>
           <li>Adds size indicator window on resize (#1203).</li>
           <li>Adds config entry `profile.*.size_indicator_on_resize` to control size indicator on resize and makes resize indicator small.</li>
+          <li>Adds OpenSelection action, and honor case in the configuration bindings</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -48,6 +48,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::NoSearchHighlight>("NoSearchHighlight"),
         mapAction<actions::OpenConfiguration>("OpenConfiguration"),
         mapAction<actions::OpenFileManager>("OpenFileManager"),
+        mapAction<actions::OpenSelection>("OpenSelection"),
         mapAction<actions::PasteClipboard>("PasteClipboard"),
         mapAction<actions::PasteSelection>("PasteSelection"),
         mapAction<actions::Quit>("Quit"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -46,6 +46,7 @@ struct NewTerminal{ std::optional<std::string> profileName; };
 struct NoSearchHighlight{};
 struct OpenConfiguration{};
 struct OpenFileManager{};
+struct OpenSelection{};
 struct PasteClipboard{ bool strip = false; };
 struct PasteSelection{};
 struct Quit{};
@@ -99,6 +100,7 @@ using Action = std::variant<CancelSelection,
                             NoSearchHighlight,
                             OpenConfiguration,
                             OpenFileManager,
+                            OpenSelection,
                             PasteClipboard,
                             PasteSelection,
                             Quit,
@@ -163,6 +165,7 @@ DECLARE_ACTION_FMT(NewTerminal)
 DECLARE_ACTION_FMT(NoSearchHighlight)
 DECLARE_ACTION_FMT(OpenConfiguration)
 DECLARE_ACTION_FMT(OpenFileManager)
+DECLARE_ACTION_FMT(OpenSelection)
 DECLARE_ACTION_FMT(PasteClipboard)
 DECLARE_ACTION_FMT(PasteSelection)
 DECLARE_ACTION_FMT(Quit)
@@ -227,6 +230,7 @@ struct fmt::formatter<contour::actions::Action>: fmt::formatter<std::string>
         HANDLE_ACTION(NoSearchHighlight);
         HANDLE_ACTION(OpenConfiguration);
         HANDLE_ACTION(OpenFileManager);
+        HANDLE_ACTION(OpenSelection);
         HANDLE_ACTION(PasteClipboard);
         HANDLE_ACTION(PasteSelection);
         HANDLE_ACTION(Quit);

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -592,7 +592,7 @@ namespace
 
         auto const text = QString::fromUtf8(name.c_str()).toUcs4();
         if (text.size() == 1)
-            return static_cast<char32_t>(toupper(static_cast<int>(text[0])));
+            return static_cast<char32_t>(text[0]);
 
         auto constexpr NamedChars = array { pair { "ENTER"sv, (char) C0::CR },
                                             pair { "BACKSPACE"sv, (char) C0::BS },

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -938,6 +938,12 @@ bool TerminalSession::operator()(actions::OpenFileManager)
     return true;
 }
 
+bool TerminalSession::operator()(actions::OpenSelection)
+{
+    QDesktopServices::openUrl(QUrl(QString::fromUtf8(terminal().extractSelectionText().c_str())));
+    return true;
+}
+
 bool TerminalSession::operator()(actions::PasteClipboard paste)
 {
     pasteFromClipboard(1, paste.strip);

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -280,6 +280,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::NoSearchHighlight);
     bool operator()(actions::OpenConfiguration);
     bool operator()(actions::OpenFileManager);
+    bool operator()(actions::OpenSelection);
     bool operator()(actions::PasteClipboard);
     bool operator()(actions::PasteSelection);
     bool operator()(actions::Quit);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -711,6 +711,7 @@ color_schemes:
 # - NoSearchHighlight Disables current search highlighting, if anything is still highlighted due to a prior search.
 # - OpenConfiguration Opens the configuration file.
 # - OpenFileManager   Opens the current working directory in a system file manager.
+# - OpenSelection     Open the current terminal selection with the default system application (eg; xdg-open)
 # - PasteClipboard    Pastes clipboard to standard input. Pass boolean parameter 'strip' to indicate whether or not to strip repetitive whitespaces down to one and newlines to whitespaces.
 # - PasteSelection    Pastes current selection to standard input.
 # - Quit              Quits the application.


### PR DESCRIPTION
## Description

This patch adds the `OpenSelection` action, which can be used to quickly open a link in the buffer. With an appropriate word selector, one can select an URL and open it with a keybind.

It is a variation of this patch:
https://st.suckless.org/patches/open_copied_url/, which I use daily to quickly open URLs in chat, mails, diffs, etc.

I have not tested it, but it should work with other URIs, like file:// and such.

I've also fixed a minor behavior I encountered while developing this patch: By default, the Config will upper() the keybind used when it is a simple key, but for simple Alt+Key binds (in my case, I use Alt+o for this feature), the event sent to the terminal is Alt+o (Alt+6F), while the configuration stores Alt+O (Alt+4F). I've corrected this behavior, which might break stuff; but it seemed more logical to me this way.

- [X] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [X] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have gone through all the steps, and have thoroughly read the instructions
