### PR TITLE
minor keyboard input changes: adding more key mappings in preparation to future work

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -123,6 +123,7 @@
           <li>Fixes LCD subpixel rendering for overly wide US-ASCII glyphs (#1022)</li>
           <li>Fixes alive process when GUI is closed</li>
           <li>Fixes vi mode `f` action freeze on last line</li>
+          <li>Fixes AltGr handling on Windows (#150)</li>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -532,47 +532,69 @@ namespace
     optional<vtbackend::Key> parseKey(string const& name)
     {
         using vtbackend::Key;
-        auto static constexpr Mappings = array { pair { "F1"sv, Key::F1 },
-                                                 pair { "F2"sv, Key::F2 },
-                                                 pair { "F3"sv, Key::F3 },
-                                                 pair { "F4"sv, Key::F4 },
-                                                 pair { "F5"sv, Key::F5 },
-                                                 pair { "F6"sv, Key::F6 },
-                                                 pair { "F7"sv, Key::F7 },
-                                                 pair { "F8"sv, Key::F8 },
-                                                 pair { "F9"sv, Key::F9 },
-                                                 pair { "F10"sv, Key::F10 },
-                                                 pair { "F11"sv, Key::F11 },
-                                                 pair { "F12"sv, Key::F12 },
-                                                 pair { "DownArrow"sv, Key::DownArrow },
-                                                 pair { "LeftArrow"sv, Key::LeftArrow },
-                                                 pair { "RightArrow"sv, Key::RightArrow },
-                                                 pair { "UpArrow"sv, Key::UpArrow },
-                                                 pair { "Insert"sv, Key::Insert },
-                                                 pair { "Delete"sv, Key::Delete },
-                                                 pair { "Home"sv, Key::Home },
-                                                 pair { "End"sv, Key::End },
-                                                 pair { "PageUp"sv, Key::PageUp },
-                                                 pair { "PageDown"sv, Key::PageDown },
-                                                 pair { "Numpad_NumLock"sv, Key::Numpad_NumLock },
-                                                 pair { "Numpad_Divide"sv, Key::Numpad_Divide },
-                                                 pair { "Numpad_Multiply"sv, Key::Numpad_Multiply },
-                                                 pair { "Numpad_Subtract"sv, Key::Numpad_Subtract },
-                                                 pair { "Numpad_CapsLock"sv, Key::Numpad_CapsLock },
-                                                 pair { "Numpad_Add"sv, Key::Numpad_Add },
-                                                 pair { "Numpad_Decimal"sv, Key::Numpad_Decimal },
-                                                 pair { "Numpad_Enter"sv, Key::Numpad_Enter },
-                                                 pair { "Numpad_Equal"sv, Key::Numpad_Equal },
-                                                 pair { "Numpad_0"sv, Key::Numpad_0 },
-                                                 pair { "Numpad_1"sv, Key::Numpad_1 },
-                                                 pair { "Numpad_2"sv, Key::Numpad_2 },
-                                                 pair { "Numpad_3"sv, Key::Numpad_3 },
-                                                 pair { "Numpad_4"sv, Key::Numpad_4 },
-                                                 pair { "Numpad_5"sv, Key::Numpad_5 },
-                                                 pair { "Numpad_6"sv, Key::Numpad_6 },
-                                                 pair { "Numpad_7"sv, Key::Numpad_7 },
-                                                 pair { "Numpad_8"sv, Key::Numpad_8 },
-                                                 pair { "Numpad_9"sv, Key::Numpad_9 } };
+        auto static constexpr Mappings = array {
+            pair { "F1"sv, Key::F1 },
+            pair { "F2"sv, Key::F2 },
+            pair { "F3"sv, Key::F3 },
+            pair { "F4"sv, Key::F4 },
+            pair { "F5"sv, Key::F5 },
+            pair { "F6"sv, Key::F6 },
+            pair { "F7"sv, Key::F7 },
+            pair { "F8"sv, Key::F8 },
+            pair { "F9"sv, Key::F9 },
+            pair { "F10"sv, Key::F10 },
+            pair { "F11"sv, Key::F11 },
+            pair { "F12"sv, Key::F12 },
+            pair { "F13"sv, Key::F13 },
+            pair { "F14"sv, Key::F14 },
+            pair { "F15"sv, Key::F15 },
+            pair { "F16"sv, Key::F16 },
+            pair { "F17"sv, Key::F17 },
+            pair { "F18"sv, Key::F18 },
+            pair { "F19"sv, Key::F19 },
+            pair { "F20"sv, Key::F20 },
+            pair { "F21"sv, Key::F21 },
+            pair { "F22"sv, Key::F22 },
+            pair { "F23"sv, Key::F23 },
+            pair { "F24"sv, Key::F24 },
+            pair { "F25"sv, Key::F25 },
+            pair { "F26"sv, Key::F26 },
+            pair { "F27"sv, Key::F27 },
+            pair { "F28"sv, Key::F28 },
+            pair { "F29"sv, Key::F29 },
+            pair { "F30"sv, Key::F30 },
+            pair { "F31"sv, Key::F31 },
+            pair { "F32"sv, Key::F32 },
+            pair { "F33"sv, Key::F33 },
+            pair { "F34"sv, Key::F34 },
+            pair { "F35"sv, Key::F35 },
+            pair { "Escape"sv, Key::Escape },
+            pair { "Enter"sv, Key::Enter },
+            pair { "Tab"sv, Key::Tab },
+            pair { "Backspace"sv, Key::Backspace },
+            pair { "DownArrow"sv, Key::DownArrow },
+            pair { "LeftArrow"sv, Key::LeftArrow },
+            pair { "RightArrow"sv, Key::RightArrow },
+            pair { "UpArrow"sv, Key::UpArrow },
+            pair { "Insert"sv, Key::Insert },
+            pair { "Delete"sv, Key::Delete },
+            pair { "Home"sv, Key::Home },
+            pair { "End"sv, Key::End },
+            pair { "PageUp"sv, Key::PageUp },
+            pair { "PageDown"sv, Key::PageDown },
+            pair { "MediaPlay"sv, Key::MediaPlay },
+            pair { "MediaStop"sv, Key::MediaStop },
+            pair { "MediaPrevious"sv, Key::MediaPrevious },
+            pair { "MediaNext"sv, Key::MediaNext },
+            pair { "MediaPause"sv, Key::MediaPause },
+            pair { "MediaTogglePlayPause"sv, Key::MediaTogglePlayPause },
+            pair { "VolumeUp"sv, Key::VolumeUp },
+            pair { "VolumeDown"sv, Key::VolumeDown },
+            pair { "VolumeMute"sv, Key::VolumeMute },
+            pair { "PrintScreen"sv, Key::PrintScreen },
+            pair { "Pause"sv, Key::Pause },
+            pair { "Menu"sv, Key::Menu },
+        };
 
         auto const lowerName = toLower(name);
 
@@ -594,31 +616,15 @@ namespace
         if (text.size() == 1)
             return static_cast<char32_t>(text[0]);
 
-        auto constexpr NamedChars = array { pair { "ENTER"sv, (char) C0::CR },
-                                            pair { "BACKSPACE"sv, (char) C0::BS },
-                                            pair { "TAB"sv, (char) C0::HT },
-                                            pair { "ESCAPE"sv, (char) C0::ESC },
-
-                                            pair { "LESS"sv, '<' },
-                                            pair { "GREATER"sv, '>' },
-                                            pair { "PLUS"sv, '+' },
-
-                                            pair { "APOSTROPHE"sv, '\'' },
-                                            pair { "ADD"sv, '+' },
-                                            pair { "BACKSLASH"sv, 'x' },
-                                            pair { "COMMA"sv, ',' },
-                                            pair { "DECIMAL"sv, '.' },
-                                            pair { "DIVIDE"sv, '/' },
-                                            pair { "EQUAL"sv, '=' },
-                                            pair { "LEFT_BRACKET"sv, '[' },
-                                            pair { "MINUS"sv, '-' },
-                                            pair { "MULTIPLY"sv, '*' },
-                                            pair { "PERIOD"sv, '.' },
-                                            pair { "RIGHT_BRACKET"sv, ']' },
-                                            pair { "SEMICOLON"sv, ';' },
-                                            pair { "SLASH"sv, '/' },
-                                            pair { "SUBTRACT"sv, '-' },
-                                            pair { "SPACE"sv, ' ' } };
+        auto constexpr NamedChars = array {
+            pair { "LESS"sv, '<' },        pair { "GREATER"sv, '>' },      pair { "PLUS"sv, '+' },
+            pair { "APOSTROPHE"sv, '\'' }, pair { "ADD"sv, '+' },          pair { "BACKSLASH"sv, 'x' },
+            pair { "COMMA"sv, ',' },       pair { "DECIMAL"sv, '.' },      pair { "DIVIDE"sv, '/' },
+            pair { "EQUAL"sv, '=' },       pair { "LEFT_BRACKET"sv, '[' }, pair { "MINUS"sv, '-' },
+            pair { "MULTIPLY"sv, '*' },    pair { "PERIOD"sv, '.' },       pair { "RIGHT_BRACKET"sv, ']' },
+            pair { "SEMICOLON"sv, ';' },   pair { "SLASH"sv, '/' },        pair { "SUBTRACT"sv, '-' },
+            pair { "SPACE"sv, ' ' }
+        };
 
         auto const lowerName = toUpper(name);
         for (auto const& mapping: NamedChars)
@@ -661,8 +667,14 @@ namespace
             return Modifier::Key::Control;
         if (upperKey == "SHIFT")
             return Modifier::Key::Shift;
+        if (upperKey == "SUPER")
+            return Modifier::Key::Super;
         if (upperKey == "META")
-            return Modifier::Key::Meta;
+            // TODO: This is technically not correct, but we used the term Meta up until now,
+            // to refer to the Windows/Cmd key. But Qt also exposes another modifier called
+            // Meta, which rarely exists on modern keyboards (?), but it we need to support it
+            // as well, especially since extended CSIu protocol exposes it as well.
+            return Modifier::Key::Super; // Return Modifier::Key::Meta in the future.
         return nullopt;
     }
 

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -176,6 +176,35 @@ bool sendKeyEvent(QKeyEvent* event, TerminalSession& session)
         pair { Qt::Key_F18, Key::F18 },
         pair { Qt::Key_F19, Key::F19 },
         pair { Qt::Key_F20, Key::F20 },
+
+        pair { Qt::Key_MediaPlay, Key::MediaPlay },
+        pair { Qt::Key_MediaStop, Key::MediaStop },
+        pair { Qt::Key_MediaPrevious, Key::MediaPrevious },
+        pair { Qt::Key_MediaNext, Key::MediaNext },
+        pair { Qt::Key_MediaPause, Key::MediaPause },
+        pair { Qt::Key_MediaTogglePlayPause, Key::MediaTogglePlayPause },
+
+        pair { Qt::Key_VolumeUp, Key::VolumeUp },
+        pair { Qt::Key_VolumeDown, Key::VolumeDown },
+        pair { Qt::Key_VolumeMute, Key::VolumeMute },
+
+        pair { Qt::Key_Control, Key::Control },
+        pair { Qt::Key_Alt, Key::Alt },
+        pair { Qt::Key_Super_L, Key::LeftSuper },
+        pair { Qt::Key_Super_R, Key::RightSuper },
+        pair { Qt::Key_Hyper_L, Key::LeftHyper },
+        pair { Qt::Key_Hyper_R, Key::RightHyper },
+        pair { Qt::Key_Meta, Key::Meta },
+
+        pair { Qt::Key_CapsLock, Key::CapsLock },
+        pair { Qt::Key_ScrollLock, Key::ScrollLock },
+        pair { Qt::Key_NumLock, Key::NumLock },
+        pair { Qt::Key_Print, Key::PrintScreen },
+        pair { Qt::Key_Pause, Key::Pause },
+        pair { Qt::Key_Menu, Key::Menu },
+
+        // pair { Qt::Key_Num
+
     }; // }}}
 
     static auto constexpr CharMappings = array {

--- a/src/crispy/flags.h
+++ b/src/crispy/flags.h
@@ -23,6 +23,9 @@ template <typename flag_type>
 class flags
 {
   public:
+    flags() noexcept = default;
+    flags(flag_type flag) noexcept { enable(flag); }
+
     constexpr void enable(flag_type flag) noexcept { _value |= static_cast<unsigned>(flag); }
     constexpr void disable(flag_type flag) noexcept { _value &= ~static_cast<unsigned>(flag); }
 
@@ -45,7 +48,30 @@ class flags
         return *this;
     }
 
+    [[nodiscard]] constexpr bool none() const noexcept { return _value == 0; }
+    [[nodiscard]] constexpr bool any() const noexcept { return _value != 0; }
+
     [[nodiscard]] constexpr unsigned value() const noexcept { return _value; }
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    [[nodiscard]] static constexpr flags<flag_type> from_value(unsigned value) noexcept
+    {
+        auto result = flags<flag_type> {};
+        result._value = value;
+        return result;
+    }
+
+    [[nodiscard]] constexpr flags<flag_type> with(flag_type flag) const noexcept
+    {
+        return flags<flag_type>::from_value(_value) | flag;
+    }
+
+    [[nodiscard]] constexpr flags<flag_type> without(flag_type flag) const noexcept
+    {
+        auto result = flags<flag_type>::from_value(_value);
+        result &= flag;
+        return result;
+    }
 
   private:
     unsigned _value = 0;

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -126,25 +126,6 @@ namespace mappings
 
     array<KeyMapping, 21> const applicationKeypad {
         // clang-format off
-        KeyMapping { Key::Numpad_NumLock, SS3 "P" },
-        KeyMapping { Key::Numpad_Divide, SS3 "Q" },
-        KeyMapping { Key::Numpad_Multiply, SS3 "Q" },
-        KeyMapping { Key::Numpad_Subtract, SS3 "Q" },
-        KeyMapping { Key::Numpad_CapsLock, SS3 "m" },
-        KeyMapping { Key::Numpad_Add, SS3 "l" },
-        KeyMapping { Key::Numpad_Decimal, SS3 "n" },
-        KeyMapping { Key::Numpad_Enter, SS3 "M" },
-        KeyMapping { Key::Numpad_Equal, SS3 "X" },
-        KeyMapping { Key::Numpad_0, SS3 "p" },
-        KeyMapping { Key::Numpad_1, SS3 "q" },
-        KeyMapping { Key::Numpad_2, SS3 "r" },
-        KeyMapping { Key::Numpad_3, SS3 "s" },
-        KeyMapping { Key::Numpad_4, SS3 "t" },
-        KeyMapping { Key::Numpad_5, SS3 "u" },
-        KeyMapping { Key::Numpad_6, SS3 "v" },
-        KeyMapping { Key::Numpad_7, SS3 "w" },
-        KeyMapping { Key::Numpad_8, SS3 "x" },
-        KeyMapping { Key::Numpad_9, SS3 "y" },
         KeyMapping { Key::PageUp, CSI "5~" },
         KeyMapping { Key::PageDown, CSI "6~" },
         // KeyMapping{Key::Space,    SS3 " "}, // TODO
@@ -230,7 +211,7 @@ bool InputGenerator::generate(char32_t characterEvent, Modifier modifier)
     char const chr = static_cast<char>(characterEvent);
 
     // See section "Alt and Meta Keys" in ctlseqs.txt from xterm.
-    if (modifier.alt())
+    if (modifier == Modifier::Alt)
         // NB: There are other modes in xterm to send Alt+Key options or even send ESC on Meta key instead.
         append("\033");
 

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -41,7 +41,11 @@ class Modifier
         Shift = 1,
         Alt = 2,
         Control = 4,
-        Meta = 8,
+        Super = 8,
+        Hyper = 16,
+        Meta = 32,
+        CapsLock = 32,
+        NumLock = 64,
     };
 
     constexpr Modifier(Key key): _mask { static_cast<unsigned>(key) } {}
@@ -59,7 +63,12 @@ class Modifier
     [[nodiscard]] constexpr bool shift() const noexcept { return value() & Shift; }
     [[nodiscard]] constexpr bool alt() const noexcept { return value() & Alt; }
     [[nodiscard]] constexpr bool control() const noexcept { return value() & Control; }
+    [[nodiscard]] constexpr bool super() const noexcept { return value() & Super; }
+    // hyper is called hyperKey because in MSVC/Win32 there is a `typedef hyper __uint64;` :-(
+    [[nodiscard]] constexpr bool hyperKey() const noexcept { return value() & Hyper; }
     [[nodiscard]] constexpr bool meta() const noexcept { return value() & Meta; }
+    [[nodiscard]] constexpr bool capsLock() const noexcept { return value() & CapsLock; }
+    [[nodiscard]] constexpr bool numLock() const noexcept { return value() & NumLock; }
 
     constexpr operator unsigned() const noexcept { return _mask; }
 
@@ -159,6 +168,26 @@ enum class Key
     F18,
     F19,
     F20,
+    F21,
+    F22,
+    F23,
+    F24,
+    F25,
+    F26,
+    F27,
+    F28,
+    F29,
+    F30,
+    F31,
+    F32,
+    F33,
+    F34,
+    F35,
+
+    Escape,
+    Enter,
+    Tab,
+    Backspace,
 
     // cursor keys
     DownArrow,
@@ -174,28 +203,34 @@ enum class Key
     PageUp,
     PageDown,
 
-    // numpad keys
-    // NOLINTBEGIN(readability-identifier-naming)
-    Numpad_NumLock,
-    Numpad_Divide,
-    Numpad_Multiply,
-    Numpad_Subtract,
-    Numpad_CapsLock,
-    Numpad_Add,
-    Numpad_Decimal,
-    Numpad_Enter,
-    Numpad_Equal,
-    Numpad_0,
-    Numpad_1,
-    Numpad_2,
-    Numpad_3,
-    Numpad_4,
-    Numpad_5,
-    Numpad_6,
-    Numpad_7,
-    Numpad_8,
-    Numpad_9,
-    // NOLINTEND(readability-identifier-naming)
+    // media keys
+    MediaPlay,
+    MediaStop,
+    MediaPrevious,
+    MediaNext,
+    MediaPause,
+    MediaTogglePlayPause,
+
+    VolumeUp,
+    VolumeDown,
+    VolumeMute,
+
+    // modifier keys
+    Control,
+    Alt,
+    LeftSuper,
+    RightSuper,
+    LeftHyper,
+    RightHyper,
+    Meta,
+
+    // other special keys
+    CapsLock,
+    ScrollLock,
+    NumLock,
+    PrintScreen,
+    Pause,
+    Menu,
 };
 
 std::string to_string(Key key);
@@ -542,6 +577,25 @@ struct fmt::formatter<vtbackend::Key>: formatter<std::string_view>
             case vtbackend::Key::F18: name = "F18"; break;
             case vtbackend::Key::F19: name = "F19"; break;
             case vtbackend::Key::F20: name = "F20"; break;
+            case vtbackend::Key::F21: name = "F21"; break;
+            case vtbackend::Key::F22: name = "F22"; break;
+            case vtbackend::Key::F23: name = "F23"; break;
+            case vtbackend::Key::F24: name = "F24"; break;
+            case vtbackend::Key::F25: name = "F25"; break;
+            case vtbackend::Key::F26: name = "F26"; break;
+            case vtbackend::Key::F27: name = "F27"; break;
+            case vtbackend::Key::F28: name = "F28"; break;
+            case vtbackend::Key::F29: name = "F29"; break;
+            case vtbackend::Key::F30: name = "F30"; break;
+            case vtbackend::Key::F31: name = "F31"; break;
+            case vtbackend::Key::F32: name = "F32"; break;
+            case vtbackend::Key::F33: name = "F33"; break;
+            case vtbackend::Key::F34: name = "F34"; break;
+            case vtbackend::Key::F35: name = "F35"; break;
+            case vtbackend::Key::Escape: name = "Escape"; break;
+            case vtbackend::Key::Enter: name = "Enter"; break;
+            case vtbackend::Key::Tab: name = "Tab"; break;
+            case vtbackend::Key::Backspace: name = "Backspace"; break;
             case vtbackend::Key::DownArrow: name = "DownArrow"; break;
             case vtbackend::Key::LeftArrow: name = "LeftArrow"; break;
             case vtbackend::Key::RightArrow: name = "RightArrow"; break;
@@ -552,25 +606,28 @@ struct fmt::formatter<vtbackend::Key>: formatter<std::string_view>
             case vtbackend::Key::End: name = "End"; break;
             case vtbackend::Key::PageUp: name = "PageUp"; break;
             case vtbackend::Key::PageDown: name = "PageDown"; break;
-            case vtbackend::Key::Numpad_NumLock: name = "Numpad_NumLock"; break;
-            case vtbackend::Key::Numpad_Divide: name = "Numpad_Divide"; break;
-            case vtbackend::Key::Numpad_Multiply: name = "Numpad_Multiply"; break;
-            case vtbackend::Key::Numpad_Subtract: name = "Numpad_Subtract"; break;
-            case vtbackend::Key::Numpad_CapsLock: name = "Numpad_CapsLock"; break;
-            case vtbackend::Key::Numpad_Add: name = "Numpad_Add"; break;
-            case vtbackend::Key::Numpad_Decimal: name = "Numpad_Decimal"; break;
-            case vtbackend::Key::Numpad_Enter: name = "Numpad_Enter"; break;
-            case vtbackend::Key::Numpad_Equal: name = "Numpad_Equal"; break;
-            case vtbackend::Key::Numpad_0: name = "Numpad_0"; break;
-            case vtbackend::Key::Numpad_1: name = "Numpad_1"; break;
-            case vtbackend::Key::Numpad_2: name = "Numpad_2"; break;
-            case vtbackend::Key::Numpad_3: name = "Numpad_3"; break;
-            case vtbackend::Key::Numpad_4: name = "Numpad_4"; break;
-            case vtbackend::Key::Numpad_5: name = "Numpad_5"; break;
-            case vtbackend::Key::Numpad_6: name = "Numpad_6"; break;
-            case vtbackend::Key::Numpad_7: name = "Numpad_7"; break;
-            case vtbackend::Key::Numpad_8: name = "Numpad_8"; break;
-            case vtbackend::Key::Numpad_9: name = "Numpad_9"; break;
+            case vtbackend::Key::MediaPlay: name = "MediaPlay"; break;
+            case vtbackend::Key::MediaStop: name = "MediaStop"; break;
+            case vtbackend::Key::MediaPrevious: name = "MediaPrevious"; break;
+            case vtbackend::Key::MediaNext: name = "MediaNext"; break;
+            case vtbackend::Key::MediaPause: name = "MediaPause"; break;
+            case vtbackend::Key::MediaTogglePlayPause: name = "MediaTogglePlayPause"; break;
+            case vtbackend::Key::VolumeDown: name = "VolumeDown"; break;
+            case vtbackend::Key::VolumeUp: name = "VolumeUp"; break;
+            case vtbackend::Key::VolumeMute: name = "VolumeMute"; break;
+            case vtbackend::Key::Control: name = "Control"; break;
+            case vtbackend::Key::Alt: name = "Alt"; break;
+            case vtbackend::Key::LeftSuper: name = "LeftSuper"; break;
+            case vtbackend::Key::RightSuper: name = "RightSuper"; break;
+            case vtbackend::Key::LeftHyper: name = "LeftHyper"; break;
+            case vtbackend::Key::RightHyper: name = "RightHyper"; break;
+            case vtbackend::Key::Meta: name = "Meta"; break;
+            case vtbackend::Key::CapsLock: name = "CapsLock"; break;
+            case vtbackend::Key::ScrollLock: name = "ScrollLock"; break;
+            case vtbackend::Key::NumLock: name = "NumLock"; break;
+            case vtbackend::Key::PrintScreen: name = "PrintScreen"; break;
+            case vtbackend::Key::Pause: name = "Pause"; break;
+            case vtbackend::Key::Menu: name = "Menu"; break;
         }
         return formatter<string_view>::format(name, ctx);
     }

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE("InputGenerator.Modifier.encodings")
     auto constexpr Alt = Modifier(Modifier::Alt);
     auto constexpr Shift = Modifier(Modifier::Shift);
     auto constexpr Control = Modifier(Modifier::Control);
-    auto constexpr Meta = Modifier(Modifier::Meta);
+    auto constexpr Super = Modifier(Modifier::Super);
 
     CHECK((1 + Shift.value()) == 2);
     CHECK((1 + Alt.value()) == 3);
@@ -32,14 +32,14 @@ TEST_CASE("InputGenerator.Modifier.encodings")
     CHECK((1 + (Shift | Control).value()) == 6);
     CHECK((1 + (Alt | Control).value()) == 7);
     CHECK((1 + (Shift | Alt | Control).value()) == 8);
-    CHECK((1 + Meta.value()) == 9);
-    CHECK((1 + (Meta | Shift).value()) == 10);
-    CHECK((1 + (Meta | Alt).value()) == 11);
-    CHECK((1 + (Meta | Alt | Shift).value()) == 12);
-    CHECK((1 + (Meta | Control).value()) == 13);
-    CHECK((1 + (Meta | Control | Shift).value()) == 14);
-    CHECK((1 + (Meta | Control | Alt).value()) == 15);
-    CHECK((1 + (Meta | Control | Alt | Shift).value()) == 16);
+    CHECK((1 + Super.value()) == 9);
+    CHECK((1 + (Super | Shift).value()) == 10);
+    CHECK((1 + (Super | Alt).value()) == 11);
+    CHECK((1 + (Super | Alt | Shift).value()) == 12);
+    CHECK((1 + (Super | Control).value()) == 13);
+    CHECK((1 + (Super | Control | Shift).value()) == 14);
+    CHECK((1 + (Super | Control | Alt).value()) == 15);
+    CHECK((1 + (Super | Control | Alt | Shift).value()) == 16);
 }
 
 TEST_CASE("InputGenerator.consume")


### PR DESCRIPTION
drop-out commits from PR #1250.

closes #150 

not just adding keys, but also removing numpad keys, because they were never used in Contour and it seems like I cannot disambiguate them from within Qt API anyways?

also contains a little commit on extending the new `flags<T>` API