### PR TITLE
Add Keyboard protocol extension `CSI u`

### DIFF
--- a/docs/vt-extensions/csi-u-extended-keyboard-protocol.md
+++ b/docs/vt-extensions/csi-u-extended-keyboard-protocol.md
@@ -1,0 +1,125 @@
+# CSIu Extended Keyboard Protocol
+
+## TL;DR
+
+The main problem with the classic way of processing keyboard input is, that it is highly ambiuous
+when modifiers need to be used.
+
+CSIu aims to solve this by enabling disambiguation of keyboard events that would be ambiguous otherwise.
+
+## New VT Sequences
+
+VT sequence                | Short description
+---------------------------|--------------------------
+`CSI > {flags} u`          | Enter extended keyboard protocol mode
+`CSI = {flags} u`          | Request enhancement to the currently active protocol
+`CSI = {flags} ; {mode} u` | Request enhancement to the currently active protocol
+`CSI < {count} u`          | Leave the current keyboard protocol mode
+`CSI < u`                  | Leave the current keyboard protocol mode
+
+## How entering and leaving works
+
+In order to more conveniently enable the application to configure the keyboard without
+breaking the calling application, when the current program is about to exit, the terminal
+leverages an internal stack of keyboard protocol flags.
+
+When an application starts, it can push a new desired protocol state onto the keyboard protocol stack,
+and thus get keyboard events respectively to the flags being set.
+
+When the application exits, the flags are being previously stored on the top of the stack,
+are now simply being popped from the flag stack, thus, effectively making the old state active again.
+
+This stack must store at most 32 flags. The bottom-most stack has no flags set, and thus, will
+act like the legacy keyboard protocol. This bottom-most stack item cannot be popped from the stack.
+
+When the terminal hard-resets, the keyboard's flag stack is being set back to 1 element (the legacy flags).
+
+## Operating Mode Flags
+
+This is the number of flags that can be **or**'d together into a flag bitset either when entering
+a new keyboard-protocol session, or when enhancing the currently active keyboard protocol session.
+
+Binary      | Decimal | short description
+------------|---------|------------
+`0b0'0001`  |  ` 1`   | Disambiguation
+`0b0'0010`  |  ` 2`   | Report all event types (press, repeat, release)
+`0b0'0100`  |  ` 4`   | Report alternate keys
+`0b0'1000`  |  ` 8`   | Report all keys as control sequence
+`0b1'0000`  |  `16`   | Report associated text
+
+## Entering CSIu mode
+
+Syntax: `CSI > {flags} u`
+
+By default, `flags` is set to `1`, but `flags` ben a a binary-or'd set of flags to enable.
+
+Passing `0` will act like `1`.
+
+### Flag: Disambiguation
+
+Any non-ambiuous key event, such as regular text without any modifiers pressed, is is sent out in UTF-8 text as is.
+
+Non-printable key events (such as `F3` or `ESC`), and printable text key events with modifiers being pressed,
+are sent out in form of a control sequence.
+
+Syntax (for some key events): `CSI ? {Code} ; {Modifier} ~`
+
+Syntax (for text and most other key events): `CSI ? {Code} ; {Modifier} u`
+
+`{Code}` is the numerical form of the unicode codepoint for textual key events,
+and a special assigned numeric value from the Unicode PUA range otherwise.
+
+Key       | Code | Final Char
+----------|-------------------
+`<Enter>` | `27` | `u`
+
+### Flag: Report all event types
+
+With this flag enabled, an additional sub parameter to the modifier is passed
+to indicate if the key was just pressed, repeated, or released.
+A repeat-event is usually triggered by the operating system to simulate key press events
+at a fixed rate without needing to press and release that key many times.
+
+Event type  | Code
+------------|-----------
+Key Press   | `1`
+Key Repeat  | `2`
+Key Release | `3`
+
+### Report alternate keys
+
+TODO ...
+
+### Report all keys as control sequence
+
+With this flag enabled, not just otherwise ambiguous events are sent as control sequence,
+but every key event is sent as control sequence instead.
+
+### Report associated text
+
+TODO ...
+
+## Change currently active protocol
+
+Syntax: `CSI = {flags} ; {mode} u`
+
+The top of the keyboard's flags stack can be changed in one of the three ways:
+
+Mode value | description
+-----------|------------------------------------------------
+`1`        | set given flags to currently active flags
+`2`        | add given flags to currently active flags
+`3`        | remove given flags from currently active flags
+
+This will immediately take affect.
+
+## Leaving CSIu mode
+
+Syntax: `CSI < {count} u`
+
+When terminating an application session, an application must pop off what was previously pushed
+onto the keyboard's flags stack.
+
+`count` can be greater than `1` in order to pop multiple flags at once.
+Passing a bigger number than the number of elements in the flags stack minus the bottom-most legacy entry,
+will truncate the number `count` value to number of elements in the flags stack minus `1`.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -132,6 +132,8 @@
           <li>Adds VT sequence DECSSCLS (change scroll speed) and properly handle DECSCLM (enable slow scrolling mode) (#1204)</li>
           <li>Adds VT sequence parameter ?996 to DSR to request a report of current color scheme dark/light mode hint.</li>
           <li>Adds VT sequence `SM ?2031` and `RM ?2031` to enable/disable unsolicited DSR for color scheme updates by the user or OS.</li>
+          <li>Adds support the extended `CSIu` keyboard protocol to better report key modifiers.</li>
+          <li>Adds extended keyboard protocol support (CSI u) to better report key modifiers.</li>
           <li>Adds support vor horizontal mouse scrolling event reporting sequences.</li>
           <li>Adds percentage value to Indicator Statusline to indicate scroll offset in scrollback buffer.</li>
           <li>Adds inheritance of profiles in configuration file based on default profile (#1063).</li>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
     - vt-extensions/clickable-links.md
     - vt-extensions/vertical-line-marks.md
     - vt-extensions/color-palette-update-notifications.md
+    # TODO(publish when ready): - vt-extensions/csi-u-extended-keyboard-protocol.md
     - vt-extensions/synchronized-output.md
     - vt-extensions/buffer-capture.md
     - vt-extensions/font-settings.md

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -694,10 +694,8 @@ void TerminalSession::sendKeyEvent(Key key, Modifier modifier, KeyboardEventType
     terminal().sendKeyEvent(key, modifier, eventType, now);
 }
 
-void TerminalSession::sendCharEvent(char32_t value,
-                                    Modifier modifier,
-                                    KeyboardEventType eventType,
-                                    Timestamp now)
+void TerminalSession::sendCharEvent(
+    char32_t value, uint32_t physicalKey, Modifier modifier, KeyboardEventType eventType, Timestamp now)
 {
     inputLog()("Character {} event received: {} {}",
                eventType,
@@ -724,7 +722,7 @@ void TerminalSession::sendCharEvent(char32_t value,
             return;
         }
     }
-    terminal().sendCharEvent(value, modifier, eventType, now);
+    terminal().sendCharEvent(value, physicalKey, modifier, eventType, now);
 }
 
 void TerminalSession::sendMousePressEvent(Modifier modifier,

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -254,6 +254,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
                       vtbackend::KeyboardEventType eventType,
                       Timestamp now);
     void sendCharEvent(char32_t value,
+                       uint32_t physicalKey,
                        vtbackend::Modifier modifier,
                        vtbackend::KeyboardEventType eventType,
                        Timestamp now);

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -247,19 +247,20 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         return true;
     }
 
+    auto const physicalKey = event->nativeVirtualKey();
     // NOLINTNEXTLINE(readability-qualified-auto)
     if (auto const i = find_if(begin(CharMappings),
                                end(CharMappings),
                                [event](auto const& x) { return x.first == event->key(); });
         i != end(CharMappings))
     {
-        session.sendCharEvent(static_cast<char32_t>(i->second), modifiers, eventType, now);
+        session.sendCharEvent(static_cast<char32_t>(i->second), physicalKey, modifiers, eventType, now);
         return true;
     }
 
     if (key == Qt::Key_Backtab)
     {
-        session.sendCharEvent(U'\t', modifiers.with(Modifier::Shift), eventType, now);
+        session.sendCharEvent(U'\t', physicalKey, modifiers.with(Modifier::Shift), eventType, now);
         return true;
     }
 
@@ -267,23 +268,26 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
     if (0x20 <= key && key < 0x80 && (modifiers.alt() && session.profile().optionKeyAsAlt))
     {
         auto const ch = static_cast<char32_t>(modifiers.shift() ? std::toupper(key) : std::tolower(key));
-        session.sendCharEvent(ch, modifiers, eventType, now);
+        session.sendCharEvent(ch, physicalKey, modifiers, eventType, now);
         return true;
     }
 #endif
 
     if (0x20 <= key && key < 0x80 && (modifiers.control()))
     {
-        session.sendCharEvent(static_cast<char32_t>(key), modifiers, eventType, now);
+        session.sendCharEvent(static_cast<char32_t>(key), physicalKey, modifiers, eventType, now);
         return true;
     }
 
     switch (key)
     {
-        case Qt::Key_BraceLeft: session.sendCharEvent(L'[', modifiers, eventType, now); return true;
-        case Qt::Key_Equal: session.sendCharEvent(L'=', modifiers, eventType, now); return true;
-        case Qt::Key_BraceRight: session.sendCharEvent(L']', modifiers, eventType, now); return true;
-        case Qt::Key_Backspace: session.sendCharEvent(0x08, modifiers, eventType, now); return true;
+            // clang-format off
+        case Qt::Key_BraceLeft: session.sendCharEvent(L'[', physicalKey, modifiers, eventType, now); return true;
+        case Qt::Key_Equal: session.sendCharEvent(L'=', physicalKey, modifiers, eventType, now); return true;
+        case Qt::Key_BraceRight: session.sendCharEvent(L']', physicalKey, modifiers, eventType, now); return true;
+        case Qt::Key_Backspace: session.sendCharEvent(0x08, physicalKey, modifiers, eventType, now); return true;
+        default: break;
+            // clang-format on
     }
 
     if (!event->text().isEmpty())
@@ -294,10 +298,10 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         // On OS/X the Alt-modifier does not seem to be passed to the terminal apps
         // but rather remapped to whatever OS/X is mapping them to.
         for (char32_t const ch: codepoints)
-            session.sendCharEvent(ch, modifiers.without(Modifier::Alt), eventType, now);
+            session.sendCharEvent(ch, physicalKey, modifiers.without(Modifier::Alt), eventType, now);
 #else
         for (char32_t const ch: codepoints)
-            session.sendCharEvent(ch, modifiers, eventType, now);
+            session.sendCharEvent(ch, physicalKey, modifiers, eventType, now);
 #endif
 
         return true;

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -146,6 +146,12 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
 
     static auto constexpr KeyMappings = array {
         // {{{
+        pair { Qt::Key_Escape, Key::Escape },
+        pair { Qt::Key_Enter, Key::Enter },
+        pair { Qt::Key_Return, Key::Enter },
+        pair { Qt::Key_Tab, Key::Tab },
+        pair { Qt::Key_Backspace, Key::Backspace },
+
         pair { Qt::Key_Insert, Key::Insert },
         pair { Qt::Key_Delete, Key::Delete },
         pair { Qt::Key_Right, Key::RightArrow },
@@ -176,6 +182,21 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         pair { Qt::Key_F18, Key::F18 },
         pair { Qt::Key_F19, Key::F19 },
         pair { Qt::Key_F20, Key::F20 },
+        pair { Qt::Key_F21, Key::F21 },
+        pair { Qt::Key_F22, Key::F22 },
+        pair { Qt::Key_F23, Key::F23 },
+        pair { Qt::Key_F24, Key::F24 },
+        pair { Qt::Key_F25, Key::F25 },
+        pair { Qt::Key_F26, Key::F26 },
+        pair { Qt::Key_F27, Key::F27 },
+        pair { Qt::Key_F28, Key::F28 },
+        pair { Qt::Key_F29, Key::F29 },
+        pair { Qt::Key_F30, Key::F30 },
+        pair { Qt::Key_F31, Key::F31 },
+        pair { Qt::Key_F32, Key::F32 },
+        pair { Qt::Key_F33, Key::F33 },
+        pair { Qt::Key_F34, Key::F34 },
+        pair { Qt::Key_F35, Key::F35 },
 
         pair { Qt::Key_MediaPlay, Key::MediaPlay },
         pair { Qt::Key_MediaStop, Key::MediaStop },
@@ -188,13 +209,13 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         pair { Qt::Key_VolumeDown, Key::VolumeDown },
         pair { Qt::Key_VolumeMute, Key::VolumeMute },
 
-        pair { Qt::Key_Control, Key::Control },
-        pair { Qt::Key_Alt, Key::Alt },
+        pair { Qt::Key_Control, Key::LeftControl }, // NB: Qt cannot distinguish between left and right
+        pair { Qt::Key_Alt, Key::LeftAlt },         // NB: Qt cannot distinguish between left and right
+        pair { Qt::Key_Meta, Key::LeftMeta },       // NB: Qt cannot distinguish between left and right
         pair { Qt::Key_Super_L, Key::LeftSuper },
         pair { Qt::Key_Super_R, Key::RightSuper },
         pair { Qt::Key_Hyper_L, Key::LeftHyper },
         pair { Qt::Key_Hyper_R, Key::RightHyper },
-        pair { Qt::Key_Meta, Key::Meta },
 
         pair { Qt::Key_CapsLock, Key::CapsLock },
         pair { Qt::Key_ScrollLock, Key::ScrollLock },
@@ -202,19 +223,16 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         pair { Qt::Key_Print, Key::PrintScreen },
         pair { Qt::Key_Pause, Key::Pause },
         pair { Qt::Key_Menu, Key::Menu },
-
-        // pair { Qt::Key_Num
-
     }; // }}}
 
     static auto constexpr CharMappings = array {
         // {{{
-        pair { Qt::Key_Return, '\r' },      pair { Qt::Key_AsciiCircum, '^' },
-        pair { Qt::Key_AsciiTilde, '~' },   pair { Qt::Key_Backslash, '\\' },
-        pair { Qt::Key_Bar, '|' },          pair { Qt::Key_BraceLeft, '{' },
-        pair { Qt::Key_BraceRight, '}' },   pair { Qt::Key_BracketLeft, '[' },
-        pair { Qt::Key_BracketRight, ']' }, pair { Qt::Key_QuoteLeft, '`' },
-        pair { Qt::Key_Underscore, '_' },
+        // pair { Qt::Key_Return, '\r' },
+        pair { Qt::Key_AsciiCircum, '^' }, pair { Qt::Key_AsciiTilde, '~' },
+        pair { Qt::Key_Backslash, '\\' },  pair { Qt::Key_Bar, '|' },
+        pair { Qt::Key_BraceLeft, '{' },   pair { Qt::Key_BraceRight, '}' },
+        pair { Qt::Key_BracketLeft, '[' }, pair { Qt::Key_BracketRight, ']' },
+        pair { Qt::Key_QuoteLeft, '`' },   pair { Qt::Key_Underscore, '_' },
     }; // }}}
 
     auto const modifiers = makeModifier(event->modifiers());

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -118,6 +118,8 @@ constexpr inline vtbackend::Modifier makeModifier(Qt::KeyboardModifiers qtModifi
 #else
     if (qtModifiers & Qt::ControlModifier)
         modifiers |= Modifier::Control;
+    if (qtModifiers & Qt::KeypadModifier)
+        modifiers |= Modifier::NumLock;
     if (qtModifiers & Qt::MetaModifier)
         modifiers |= Modifier::Meta;
 #endif

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -118,11 +118,11 @@ constexpr inline vtbackend::Modifier makeModifier(Qt::KeyboardModifiers qtModifi
 #else
     if (qtModifiers & Qt::ControlModifier)
         modifiers |= Modifier::Control;
-    if (qtModifiers & Qt::KeypadModifier)
-        modifiers |= Modifier::NumLock;
     if (qtModifiers & Qt::MetaModifier)
         modifiers |= Modifier::Meta;
 #endif
+    if (qtModifiers & Qt::KeypadModifier)
+        modifiers |= Modifier::NumLock;
 
     return modifiers;
 }

--- a/src/crispy/flags.h
+++ b/src/crispy/flags.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <fmt/format.h>
+
 namespace crispy
 {
 
@@ -23,11 +25,22 @@ template <typename flag_type>
 class flags
 {
   public:
-    flags() noexcept = default;
-    flags(flag_type flag) noexcept { enable(flag); }
+    constexpr flags(flag_type flag) noexcept { enable(flag); }
+    constexpr flags() noexcept = default;
+    constexpr flags(flags&&) noexcept = default;
+    constexpr flags(flags const&) noexcept = default;
+    constexpr flags& operator=(flags&&) noexcept = default;
+    constexpr flags& operator=(flags const&) noexcept = default;
 
     constexpr void enable(flag_type flag) noexcept { _value |= static_cast<unsigned>(flag); }
     constexpr void disable(flag_type flag) noexcept { _value &= ~static_cast<unsigned>(flag); }
+
+    constexpr void enable(flags<flag_type> flags) noexcept { _value |= static_cast<unsigned>(flags._value); }
+
+    constexpr void disable(flags<flag_type> flags) noexcept
+    {
+        _value &= ~static_cast<unsigned>(flags._value);
+    }
 
     [[nodiscard]] constexpr bool test(flag_type flag) const noexcept
     {
@@ -35,6 +48,12 @@ class flags
     }
 
     [[nodiscard]] constexpr bool operator&(flag_type flag) const noexcept { return test(flag); }
+
+    constexpr flags& operator|=(flags<flag_type> flags) noexcept
+    {
+        _value |= flags._value;
+        return *this;
+    }
 
     [[nodiscard]] constexpr flags& operator|=(flag_type flag) noexcept
     {
@@ -78,3 +97,29 @@ class flags
 };
 
 } // namespace crispy
+
+template <typename Enum>
+struct fmt::formatter<crispy::flags<Enum>>: public fmt::formatter<std::string>
+{
+    auto format(crispy::flags<Enum> const& flags, format_context& ctx) -> format_context::iterator
+    {
+        std::string result;
+        for (auto i = 0u; i < sizeof(Enum) * 8; ++i)
+        {
+            auto const flag = static_cast<Enum>(1 << i);
+            if (!flags.test(flag))
+                continue;
+
+            // We assume that only valid enum values resulting into non-empty strings.
+            auto const element = fmt::format("{}", flag);
+            if (element.empty())
+                continue;
+
+            if (!result.empty())
+                result += '|';
+
+            result += element;
+        }
+        return formatter<std::string>::format(result, ctx);
+    }
+};

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -452,6 +452,12 @@ constexpr inline auto DECSSDT     = detail::CSI(std::nullopt, 0, 1, '$', '~', VT
 constexpr inline auto DECSASD     = detail::CSI(std::nullopt, 0, 1, '$', '}', VTType::VT420, "DECSASD", "Select Active Status Display");
 constexpr inline auto DECPS       = detail::CSI(std::nullopt, 3, 18, ',', '~', VTType::VT520, "DECPS", "Controls the sound frequency or notes");
 
+// CSI u functions
+constexpr inline auto CSIUENTER = detail::CSI('>', 0, 1, std::nullopt, 'u', VTExtension::Unknown, "CSIUENTER", "Enter Extended keyboard mode");
+constexpr inline auto CSIUQUERY = detail::CSI('?', 0, 0, std::nullopt, 'u', VTExtension::Unknown, "CSIUQUERY", "Report Extended keyboard mode");
+constexpr inline auto CSIUENHCE = detail::CSI('=', 1, 2, std::nullopt, 'u', VTExtension::Unknown, "CSIUENHCE", "Request enhancement to extended keyboard mode");
+constexpr inline auto CSIULEAVE = detail::CSI('<', 0, 1, std::nullopt, 'u', VTExtension::Unknown, "CSIULEAVE", "Leave Extended keyboard mode");
+
 // DCS functions
 constexpr inline auto STP         = detail::DCS(std::nullopt, 0, 0, '$', 'p', VTExtension::Contour, "XTSETPROFILE", "Set Terminal Profile");
 constexpr inline auto DECRQSS     = detail::DCS(std::nullopt, 0, 0, '$', 'q', VTType::VT420, "DECRQSS", "Request Status String");
@@ -563,6 +569,10 @@ constexpr static auto allFunctionsArray() noexcept
         XTRESTORE,
         XTSAVE,
         DECPS,
+        CSIUENTER,
+        CSIUQUERY,
+        CSIUENHCE,
+        CSIULEAVE,
         DECRM,
         DECRQM,
         DECRQM_ANSI,

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -191,13 +191,20 @@ bool StandardKeyboardInputGenerator::generateKey(Key key, Modifier modifier, Key
         case Key::VolumeUp:
         case Key::VolumeDown:
         case Key::VolumeMute:
-        case Key::Control:
-        case Key::Alt:
+        case Key::LeftShift:
+        case Key::RightShift:
+        case Key::LeftControl:
+        case Key::RightControl:
+        case Key::LeftAlt:
+        case Key::RightAlt:
         case Key::LeftSuper:
         case Key::RightSuper:
         case Key::LeftHyper:
         case Key::RightHyper:
-        case Key::Meta:
+        case Key::LeftMeta:
+        case Key::RightMeta:
+        case Key::IsoLevel3Shift:
+        case Key::IsoLevel5Shift:
         case Key::CapsLock:
         case Key::ScrollLock:
         case Key::NumLock:

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -221,7 +221,7 @@ bool StandardKeyboardInputGenerator::generateKey(Key key, Modifier modifier, Key
 
 void InputGenerator::reset()
 {
-    _standardKeyboardInputGenerator.reset();
+    _keyboardInputGenerator.reset();
     _bracketedPaste = false;
     _generateFocusEvents = false;
     _mouseProtocol = std::nullopt;
@@ -236,28 +236,28 @@ void InputGenerator::reset()
 void InputGenerator::setCursorKeysMode(KeyMode mode)
 {
     inputLog()("set cursor keys mode: {}", mode);
-    _standardKeyboardInputGenerator.setCursorKeysMode(mode);
+    _keyboardInputGenerator.setCursorKeysMode(mode);
 }
 
 void InputGenerator::setNumpadKeysMode(KeyMode mode)
 {
     inputLog()("set numpad keys mode: {}", mode);
-    _standardKeyboardInputGenerator.setNumpadKeysMode(mode);
+    _keyboardInputGenerator.setNumpadKeysMode(mode);
 }
 
 void InputGenerator::setApplicationKeypadMode(bool enable)
 {
-    _standardKeyboardInputGenerator.setApplicationKeypadMode(enable);
+    _keyboardInputGenerator.setApplicationKeypadMode(enable);
     inputLog()("set application keypad mode: {}", enable);
 }
 
 bool InputGenerator::generate(char32_t characterEvent, Modifier modifier, KeyboardEventType eventType)
 {
-    bool const success = _standardKeyboardInputGenerator.generateChar(characterEvent, modifier, eventType);
+    bool const success = _keyboardInputGenerator.generateChar(characterEvent, modifier, eventType);
 
     if (success)
     {
-        _pendingSequence += _standardKeyboardInputGenerator.take();
+        _pendingSequence += _keyboardInputGenerator.take();
         inputLog()("Sending {} \"{}\" {}.",
                    modifier,
                    crispy::escape(unicode::convert_to<char>(characterEvent)),
@@ -269,11 +269,11 @@ bool InputGenerator::generate(char32_t characterEvent, Modifier modifier, Keyboa
 
 bool InputGenerator::generate(Key key, Modifier modifier, KeyboardEventType eventType)
 {
-    bool const success = _standardKeyboardInputGenerator.generateKey(key, modifier, eventType);
+    bool const success = _keyboardInputGenerator.generateKey(key, modifier, eventType);
 
     if (success)
     {
-        _pendingSequence += _standardKeyboardInputGenerator.take();
+        _pendingSequence += _keyboardInputGenerator.take();
         inputLog()("Sending {} \"{}\" {}.", modifier, key, eventType);
     }
 

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -40,9 +40,12 @@ string to_string(MouseButton button)
 
 // {{{ StandardKeyboardInputGenerator
 bool StandardKeyboardInputGenerator::generateChar(char32_t characterEvent,
+                                                  uint32_t physicalKey,
                                                   Modifier modifier,
                                                   KeyboardEventType eventType)
 {
+    crispy::ignore_unused(physicalKey);
+
     if (eventType == KeyboardEventType::Release)
         return false;
 
@@ -219,6 +222,190 @@ bool StandardKeyboardInputGenerator::generateKey(Key key, Modifier modifier, Key
 }
 // }}}
 
+// {{{ ExtendedKeyboardInputGenerator
+bool ExtendedKeyboardInputGenerator::generateChar(char32_t characterEvent,
+                                                  uint32_t physicalKey,
+                                                  Modifier modifier,
+                                                  KeyboardEventType eventType)
+{
+    if (enabled(eventType))
+    {
+        if (enabled(KeyboardEventFlag::DisambiguateEscapeCodes)
+            && (modifier.any() || enabled(KeyboardEventFlag::ReportAllKeysAsEscapeCodes)))
+        {
+            append("\033[{};{}u",
+                   encodeCharacter(characterEvent, physicalKey, modifier),
+                   encodeModifiers(modifier, eventType));
+            return true;
+        }
+    }
+
+    return StandardKeyboardInputGenerator::generateChar(characterEvent, physicalKey, modifier, eventType);
+}
+
+constexpr unsigned encodeEventType(KeyboardEventType eventType) noexcept
+{
+    return static_cast<unsigned>(eventType);
+}
+
+std::string ExtendedKeyboardInputGenerator::encodeModifiers(Modifier modifier,
+                                                            KeyboardEventType eventType) const
+{
+    if (enabled(KeyboardEventFlag::ReportEventTypes))
+        return fmt::format("{}:{}", modifier.value(), encodeEventType(eventType));
+
+    if (modifier.value() != 0)
+        return std::to_string(1 + modifier.value());
+
+    return "";
+}
+
+std::string ExtendedKeyboardInputGenerator::encodeCharacter(char32_t ch,
+                                                            uint32_t physicalKey,
+                                                            Modifier modifier) const
+{
+    // The codepoint is always the lower-case form
+    // TODO: use libunicode for down-shifting
+    auto unshiftedKey = ch < 0x80 ? fmt::format("{}", std::tolower(static_cast<char>(ch))) : ""s;
+
+    auto result = std::move(unshiftedKey);
+
+    if (enabled(KeyboardEventFlag::ReportAlternateKeys))
+    {
+        // The shifted key is simply the upper-case version of unicode-codepoint
+        auto const shiftedKey = static_cast<uint32_t>(
+            (modifier.shift() && (0x20 <= ch && ch < 0x80)) ? std::toupper(static_cast<char>(ch)) : 0);
+        // TODO: use libunicode for up-shifting
+
+        bool const showPhysicalKey = physicalKey && physicalKey != ch && physicalKey != shiftedKey;
+        if (shiftedKey || showPhysicalKey)
+            result += ':';
+        if (shiftedKey)
+            result += std::to_string(shiftedKey);
+
+        // The base layout key is the key corresponding to the physical key in the standard PC-101 key layout
+        if (showPhysicalKey)
+        {
+            result += ':';
+            result += std::to_string(physicalKey);
+        }
+    }
+
+    return result;
+}
+
+struct ExtendedKeyMapping
+{
+    Key key;
+    Modifier modifier;
+    std::string_view code;
+};
+
+constexpr pair<unsigned, char> mapKey(Key key) noexcept
+{
+    switch (key)
+    {
+        case Key::Escape: return { 27, 'u' };
+        case Key::Enter: return { 13, 'u' };
+        case Key::Tab: return { 9, 'u' };
+        case Key::Backspace: return { 127, 'u' };
+        case Key::Insert: return { 2, '~' };
+        case Key::Delete: return { 3, '~' };
+        case Key::LeftArrow: return { 1, 'D' };
+        case Key::RightArrow: return { 1, 'C' };
+        case Key::UpArrow: return { 1, 'A' };
+        case Key::DownArrow: return { 1, 'B' };
+        case Key::PageUp: return { 5, '~' };
+        case Key::PageDown: return { 6, '~' };
+        case Key::Home: return { 7, '~' }; // or 1 H
+        case Key::End: return { 8, '~' };  // or 1 F
+        case Key::CapsLock: return { 57358, 'u' };
+        case Key::ScrollLock: return { 57359, 'u' };
+        case Key::NumLock: return { 57360, 'u' };
+        case Key::PrintScreen: return { 57361, 'u' };
+        case Key::Pause: return { 57362, 'u' };
+        case Key::Menu: return { 57363, 'u' };
+        case Key::F1: return { 11, '~' }; // or 1 P
+        case Key::F2: return { 12, '~' }; // or 1 Q
+        case Key::F3: return { 13, '~' }; // or 1 R (not anymore)
+        case Key::F4: return { 14, '~' }; // or 1 S
+        case Key::F5: return { 15, '~' };
+        case Key::F6: return { 17, '~' };
+        case Key::F7: return { 18, '~' };
+        case Key::F8: return { 19, '~' };
+        case Key::F9: return { 20, '~' };
+        case Key::F10: return { 21, '~' };
+        case Key::F11: return { 23, '~' };
+        case Key::F12: return { 24, '~' };
+        case Key::F13: return { 57376, 'u' };
+        case Key::F14: return { 57377, 'u' };
+        case Key::F15: return { 57378, 'u' };
+        case Key::F16: return { 57379, 'u' };
+        case Key::F17: return { 57380, 'u' };
+        case Key::F18: return { 57381, 'u' };
+        case Key::F19: return { 57382, 'u' };
+        case Key::F20: return { 57383, 'u' };
+        case Key::F21: return { 57384, 'u' };
+        case Key::F22: return { 57385, 'u' };
+        case Key::F23: return { 57386, 'u' };
+        case Key::F24: return { 57387, 'u' };
+        case Key::F25: return { 57388, 'u' };
+        case Key::F26: return { 57389, 'u' };
+        case Key::F27: return { 57390, 'u' };
+        case Key::F28: return { 57391, 'u' };
+        case Key::F29: return { 57392, 'u' };
+        case Key::F30: return { 57393, 'u' };
+        case Key::F31: return { 57394, 'u' };
+        case Key::F32: return { 57395, 'u' };
+        case Key::F33: return { 57396, 'u' };
+        case Key::F34: return { 57397, 'u' };
+        case Key::F35: return { 57398, 'u' };
+        case Key::MediaPlay: return { 57428, 'u' };
+        case Key::MediaPause: return { 57429, 'u' };
+        case Key::MediaTogglePlayPause: return { 57430, 'u' };
+        case Key::MediaStop: return { 57432, 'u' };
+        case Key::MediaNext: return { 57435, 'u' };
+        case Key::MediaPrevious: return { 57436, 'u' };
+        case Key::VolumeDown: return { 57438, 'u' };
+        case Key::VolumeUp: return { 57439, 'u' };
+        case Key::VolumeMute: return { 57440, 'u' };
+        case Key::LeftShift: return { 57441, 'u' };
+        case Key::LeftControl: return { 57442, 'u' };
+        case Key::LeftAlt: return { 57443, 'u' };
+        case Key::LeftSuper: return { 57444, 'u' };
+        case Key::LeftHyper: return { 57445, 'u' };
+        case Key::LeftMeta: return { 57446, 'u' };
+        case Key::RightShift: return { 57447, 'u' };
+        case Key::RightControl: return { 57448, 'u' };
+        case Key::RightAlt: return { 57449, 'u' };
+        case Key::RightSuper: return { 57450, 'u' };
+        case Key::RightHyper: return { 57451, 'u' };
+        case Key::RightMeta: return { 57452, 'u' };
+        case Key::IsoLevel3Shift: return { 57453, 'u' };
+        case Key::IsoLevel5Shift: return { 57454, 'u' };
+    }
+}
+
+bool ExtendedKeyboardInputGenerator::generateKey(Key key, Modifier modifier, KeyboardEventType eventType)
+{
+    if (!enabled(eventType))
+        return false;
+
+    if (!enabled(KeyboardEventFlag::DisambiguateEscapeCodes))
+        return StandardKeyboardInputGenerator::generateKey(key, modifier, eventType);
+
+    auto const [code, function] = mapKey(key);
+    auto const encodedModifiers = encodeModifiers(modifier, eventType);
+    auto controlSequence = fmt::format("\033[{}", code);
+    if (!encodedModifiers.empty())
+        controlSequence += fmt::format(";{}", encodedModifiers);
+    controlSequence += function;
+    append(controlSequence);
+
+    return true;
+}
+// }}}
+
 void InputGenerator::reset()
 {
     _keyboardInputGenerator.reset();
@@ -251,9 +438,13 @@ void InputGenerator::setApplicationKeypadMode(bool enable)
     inputLog()("set application keypad mode: {}", enable);
 }
 
-bool InputGenerator::generate(char32_t characterEvent, Modifier modifier, KeyboardEventType eventType)
+bool InputGenerator::generate(char32_t characterEvent,
+                              uint32_t physicalKey,
+                              Modifier modifier,
+                              KeyboardEventType eventType)
 {
-    bool const success = _keyboardInputGenerator.generateChar(characterEvent, modifier, eventType);
+    bool const success =
+        _keyboardInputGenerator.generateChar(characterEvent, physicalKey, modifier, eventType);
 
     if (success)
     {

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -374,20 +374,17 @@ class InputGenerator
 
     [[nodiscard]] bool normalCursorKeys() const noexcept
     {
-        return _standardKeyboardInputGenerator.normalCursorKeys();
+        return _keyboardInputGenerator.normalCursorKeys();
     }
     [[nodiscard]] bool applicationCursorKeys() const noexcept
     {
-        return _standardKeyboardInputGenerator.applicationCursorKeys();
+        return _keyboardInputGenerator.applicationCursorKeys();
     }
 
-    [[nodiscard]] bool numericKeypad() const noexcept
-    {
-        return _standardKeyboardInputGenerator.numericKeypad();
-    }
+    [[nodiscard]] bool numericKeypad() const noexcept { return _keyboardInputGenerator.numericKeypad(); }
     [[nodiscard]] bool applicationKeypad() const noexcept
     {
-        return _standardKeyboardInputGenerator.applicationKeypad();
+        return _keyboardInputGenerator.applicationKeypad();
     }
 
     [[nodiscard]] bool bracketedPaste() const noexcept { return _bracketedPaste; }
@@ -513,7 +510,7 @@ class InputGenerator
 
     std::set<MouseButton> _currentlyPressedMouseButtons {};
     CellLocation _currentMousePosition {}; // current mouse position
-    StandardKeyboardInputGenerator _standardKeyboardInputGenerator {};
+    StandardKeyboardInputGenerator _keyboardInputGenerator {};
 };
 
 inline std::string to_string(InputGenerator::MouseEventType value)

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -47,8 +47,8 @@ class Modifier
         Super = 8,
         Hyper = 16,
         Meta = 32,
-        CapsLock = 32,
-        NumLock = 64,
+        CapsLock = 64,
+        NumLock = 128,
     };
 
     constexpr Modifier(Key key): _mask { static_cast<unsigned>(key) } {}
@@ -219,13 +219,20 @@ enum class Key
     VolumeMute,
 
     // modifier keys
-    Control,
-    Alt,
+    LeftShift,
+    RightShift,
+    LeftControl,
+    RightControl,
+    LeftAlt,
+    RightAlt,
     LeftSuper,
     RightSuper,
     LeftHyper,
     RightHyper,
-    Meta,
+    LeftMeta,
+    RightMeta,
+    IsoLevel3Shift,
+    IsoLevel5Shift,
 
     // other special keys
     CapsLock,
@@ -277,9 +284,9 @@ enum class MouseTransport
 
 enum class KeyboardEventType
 {
-    Press,
-    Repeat,
-    Release,
+    Press = 1,
+    Repeat = 2,
+    Release = 3,
 };
 
 class KeyboardInputGenerator
@@ -722,13 +729,20 @@ struct fmt::formatter<vtbackend::Key>: formatter<std::string_view>
             case vtbackend::Key::VolumeDown: name = "VolumeDown"; break;
             case vtbackend::Key::VolumeUp: name = "VolumeUp"; break;
             case vtbackend::Key::VolumeMute: name = "VolumeMute"; break;
-            case vtbackend::Key::Control: name = "Control"; break;
-            case vtbackend::Key::Alt: name = "Alt"; break;
+            case vtbackend::Key::LeftShift: name = "LeftShift"; break;
+            case vtbackend::Key::RightShift: name = "RightShift"; break;
+            case vtbackend::Key::LeftControl: name = "LeftControl"; break;
+            case vtbackend::Key::RightControl: name = "RightControl"; break;
+            case vtbackend::Key::LeftAlt: name = "LeftAlt"; break;
+            case vtbackend::Key::RightAlt: name = "RightAlt"; break;
             case vtbackend::Key::LeftSuper: name = "LeftSuper"; break;
             case vtbackend::Key::RightSuper: name = "RightSuper"; break;
             case vtbackend::Key::LeftHyper: name = "LeftHyper"; break;
             case vtbackend::Key::RightHyper: name = "RightHyper"; break;
-            case vtbackend::Key::Meta: name = "Meta"; break;
+            case vtbackend::Key::LeftMeta: name = "LeftMeta"; break;
+            case vtbackend::Key::RightMeta: name = "RightMeta"; break;
+            case vtbackend::Key::IsoLevel3Shift: name = "IsoLevel3Shift"; break;
+            case vtbackend::Key::IsoLevel5Shift: name = "IsoLevel5Shift"; break;
             case vtbackend::Key::CapsLock: name = "CapsLock"; break;
             case vtbackend::Key::ScrollLock: name = "ScrollLock"; break;
             case vtbackend::Key::NumLock: name = "NumLock"; break;

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -563,25 +563,34 @@ struct fmt::formatter<vtbackend::MouseProtocol>: formatter<std::string_view>
 };
 
 template <>
+struct fmt::formatter<vtbackend::Modifier::Key>: formatter<std::string_view>
+{
+    auto format(vtbackend::Modifier::Key value, format_context& ctx) -> format_context::iterator
+    {
+        std::string_view name;
+        switch (value)
+        {
+            case vtbackend::Modifier::Key::None: name = "None"; break;
+            case vtbackend::Modifier::Key::Shift: name = "Shift"; break;
+            case vtbackend::Modifier::Key::Alt: name = "Alt"; break;
+            case vtbackend::Modifier::Key::Control: name = "Control"; break;
+            case vtbackend::Modifier::Key::Super: name = "Super"; break;
+            case vtbackend::Modifier::Key::Hyper: name = "Hyper"; break;
+            case vtbackend::Modifier::Key::Meta: name = "Meta"; break;
+            case vtbackend::Modifier::Key::CapsLock: name = "CapsLock"; break;
+            case vtbackend::Modifier::Key::NumLock: name = "NumLock"; break;
+        }
+        return formatter<std::string_view>::format(name, ctx);
+    }
+};
+
+template <>
 struct fmt::formatter<vtbackend::Modifier>: formatter<std::string>
 {
     auto format(vtbackend::Modifier modifier, format_context& ctx) -> format_context::iterator
     {
-        std::string s;
-        auto const advance = [&](bool cond, std::string_view text) {
-            if (!cond)
-                return;
-            if (!s.empty())
-                s += ',';
-            s += text;
-        };
-        advance(modifier.alt(), "Alt");
-        advance(modifier.shift(), "Shift");
-        advance(modifier.control(), "Control");
-        advance(modifier.meta(), "Meta");
-        if (s.empty())
-            s = "None";
-        return formatter<std::string>::format(s, ctx);
+        auto mk = crispy::flags<vtbackend::Modifier::Key>::from_value(modifier.value());
+        return formatter<std::string>::format(fmt::format("{}", mk), ctx);
     }
 };
 

--- a/src/vtbackend/MockTerm.h
+++ b/src/vtbackend/MockTerm.h
@@ -39,9 +39,12 @@ class MockTerm: public Terminal::NullEvents
 
     bool sendCharEvent(char32_t ch, Modifier modifier, Terminal::Timestamp now)
     {
-        if (!terminal.sendCharEvent(ch, modifier, KeyboardEventType::Press, now))
+        // Simulate physical key here, as we don't have a real keyboard.
+        auto const physicalKey = static_cast<uint32_t>(ch);
+
+        if (!terminal.sendCharEvent(ch, physicalKey, modifier, KeyboardEventType::Press, now))
             return false;
-        terminal.sendCharEvent(ch, modifier, KeyboardEventType::Release, now);
+        terminal.sendCharEvent(ch, physicalKey, modifier, KeyboardEventType::Release, now);
         return true;
     }
 

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -3394,9 +3394,14 @@ void Screen<Cell>::processSequence(Sequence const& seq)
 {
 #if defined(LIBTERMINAL_LOG_TRACE)
     if (vtTraceSequenceLog)
-        vtTraceSequenceLog()("Processing {:<14} {}",
-                             seq.functionDefinition(_terminal->activeSequences())->mnemonic,
-                             seq.text());
+    {
+        if (auto const* fd = seq.functionDefinition(_terminal->activeSequences()))
+        {
+            vtTraceSequenceLog()("Processing {:<14} {}", fd->mnemonic, seq.text());
+        }
+        else
+            vtTraceSequenceLog()("Processing unknown sequence: {}", seq.text());
+    }
 #endif
 
     // std::cerr << fmt::format("\t{} \t; {}\n", seq,

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -647,7 +647,8 @@ bool Terminal::sendKeyEvent(Key key, Modifier modifier, KeyboardEventType eventT
     return success;
 }
 
-bool Terminal::sendCharEvent(char32_t ch, Modifier modifier, KeyboardEventType eventType, Timestamp now)
+bool Terminal::sendCharEvent(
+    char32_t ch, uint32_t physicalKey, Modifier modifier, KeyboardEventType eventType, Timestamp now)
 {
     _cursorBlinkState = 1;
     _lastCursorBlink = now;
@@ -659,7 +660,7 @@ bool Terminal::sendCharEvent(char32_t ch, Modifier modifier, KeyboardEventType e
     if (eventType != KeyboardEventType::Release && _state.inputHandler.sendCharPressEvent(ch, modifier))
         return true;
 
-    auto const success = _state.inputGenerator.generate(ch, modifier, eventType);
+    auto const success = _state.inputGenerator.generate(ch, physicalKey, modifier, eventType);
 
     flushInput();
     _viewport.scrollToBottom();

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -280,7 +280,8 @@ class Terminal
     // {{{ input proxy
     using Timestamp = std::chrono::steady_clock::time_point;
     bool sendKeyEvent(Key key, Modifier modifier, KeyboardEventType eventType, Timestamp now);
-    bool sendCharEvent(char32_t ch, Modifier modifier, KeyboardEventType eventType, Timestamp now);
+    bool sendCharEvent(
+        char32_t ch, uint32_t physicalKey, Modifier modifier, KeyboardEventType eventType, Timestamp now);
     bool sendMousePressEvent(Modifier modifier,
                              MouseButton button,
                              PixelCoordinate pixelPosition,
@@ -693,6 +694,12 @@ class Terminal
 
     [[nodiscard]] ViInputHandler& inputHandler() noexcept { return _state.inputHandler; }
     [[nodiscard]] ViInputHandler const& inputHandler() const noexcept { return _state.inputHandler; }
+
+    [[nodiscard]] ExtendedKeyboardInputGenerator& keyboardProtocol() noexcept
+    {
+        return _state.inputGenerator.keyboardProtocol();
+    }
+
     void resetHighlight();
 
     StatusDisplayType statusDisplayType() const noexcept { return _state.statusDisplayType; }


### PR DESCRIPTION
Initial support for extended CSIu.

Well, it works for shortcuts as much as neovim is concerned. I have some open minor questions and the problem that Qt does not expose ALL information the way I need it, but it's already an improvement and works backwards compatible. :)