### PR TITLE
fix(readme): correct windows git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ It will neither build nor run on any prior Windows OS, due to libterminal making
 
 ```
 cd C:\
-git clone git clone https://github.com/Microsoft/vcpkg.git
+git clone https://github.com/Microsoft/vcpkg.git
 .\vcpkg\bootstrap-vcpkg.bat
 ```
 


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
`git clone git clone` is not a valid command as it has too many arguments.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Build documentation for windows was wrong, specifically the git clone command had `git clone git clone`.
```

## How Has This Been Tested?

`N/A`

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] (N/A) I have added tests to cover my changes. 
- [x] I have gone through all the steps, and have thoroughly read the instructions
