### PR TITLE
Various fixes that lately broke master

### DIFF
--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -116,16 +116,18 @@ bool StandardKeyboardInputGenerator::generateChar(char32_t characterEvent,
 
 std::string StandardKeyboardInputGenerator::select(Modifier modifier, FunctionKeyMapping mapping) const
 {
+    auto const prefix = modifier.alt() ? "\033" : ""s;
+
     if (applicationCursorKeys() && !mapping.appCursor.empty())
-        return std::string(mapping.appCursor);
+        return prefix + std::string(mapping.appCursor);
 
     if (applicationKeypad() && !mapping.appKeypad.empty())
-        return std::string(mapping.appKeypad);
+        return prefix + std::string(mapping.appKeypad);
 
     if (modifier && !mapping.mods.empty())
-        return crispy::replace(mapping.mods, "{}"sv, makeVirtualTerminalParam(modifier));
+        return prefix + crispy::replace(mapping.mods, "{}"sv, makeVirtualTerminalParam(modifier));
 
-    return std::string(mapping.std);
+    return prefix + std::string(mapping.std);
 }
 
 bool StandardKeyboardInputGenerator::generateKey(Key key, Modifier modifier, KeyboardEventType eventType)
@@ -174,7 +176,7 @@ bool StandardKeyboardInputGenerator::generateKey(Key key, Modifier modifier, Key
         case Key::Escape: append("\033"); break;
         case Key::Enter: append(select(modifier, { .std = "\r", .appKeypad = SS3 "M" })); break;
         case Key::Tab: append(select(modifier, { .std = "\t", .appKeypad = SS3 "I" })); break;
-        case Key::Backspace: append(modifier.control() ? "\x7f" : "\x08"); break;
+        case Key::Backspace: append(select(modifier, { .std = modifier.control() ? "\x7f" : "\x08" })); break;
         case Key::UpArrow: append(select(modifier, { .std = CSI "A", .mods = CSI "1;{}A", .appCursor = SS3 "A" })); break;
         case Key::DownArrow: append(select(modifier, { .std = CSI "B", .mods = CSI "1;{}B", .appCursor = SS3 "B" })); break;
         case Key::RightArrow: append(select(modifier, { .std = CSI "C", .mods = CSI "1;{}C", .appCursor = SS3 "C" })); break;

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -386,6 +386,32 @@ constexpr pair<unsigned, char> mapKey(Key key) noexcept
     }
 }
 
+constexpr bool isModifierKey(Key key) noexcept
+{
+    // clang-format off
+    switch (key)
+    {
+        case Key::LeftShift:
+        case Key::LeftControl:
+        case Key::LeftAlt:
+        case Key::LeftSuper:
+        case Key::LeftHyper:
+        case Key::LeftMeta:
+        case Key::RightShift:
+        case Key::RightControl:
+        case Key::RightAlt:
+        case Key::RightSuper:
+        case Key::RightHyper:
+        case Key::RightMeta:
+        case Key::IsoLevel3Shift:
+        case Key::IsoLevel5Shift:
+            return true;
+        default:
+            return false;
+    }
+    // clang-format on
+}
+
 bool ExtendedKeyboardInputGenerator::generateKey(Key key, Modifier modifier, KeyboardEventType eventType)
 {
     if (!enabled(eventType))
@@ -393,6 +419,9 @@ bool ExtendedKeyboardInputGenerator::generateKey(Key key, Modifier modifier, Key
 
     if (!enabled(KeyboardEventFlag::DisambiguateEscapeCodes))
         return StandardKeyboardInputGenerator::generateKey(key, modifier, eventType);
+
+    if (isModifierKey(key) && !enabled(KeyboardEventFlag::ReportAllKeysAsEscapeCodes))
+        return false;
 
     auto const [code, function] = mapKey(key);
     auto const encodedModifiers = encodeModifiers(modifier, eventType);

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -325,9 +325,14 @@ bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
 {
     if (_searchEditMode != SearchEditMode::Disabled)
     {
-        // Do we want to do anything in here?
         // TODO: support cursor movements.
-        errorLog()("ViInputHandler: Ignoring key input {}+{}.", modifier, key);
+        switch (key)
+        {
+            case Key::Backspace: return handleSearchEditor('\x08', modifier);
+            case Key::Enter: return handleSearchEditor('\x0D', modifier);
+            case Key::Escape: return handleSearchEditor('\x1B', modifier);
+            default: break;
+        }
         return true;
     }
 

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -275,7 +275,8 @@ void ViInputHandler::appendModifierToPendingInput(Modifier modifier)
 
 bool ViInputHandler::handlePendingInput()
 {
-    Require(!_pendingInput.empty());
+    if (_pendingInput.empty())
+        return false;
 
     auto constexpr TrieMapAllowWildcardDot = true;
 
@@ -372,6 +373,12 @@ bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
             break;
         }
 
+    if (_pendingInput.empty())
+    {
+        errorLog()("ViInputHandler: Unhandled key: {} ({})", key, modifier);
+        return false;
+    }
+
     return handlePendingInput();
 }
 
@@ -466,6 +473,12 @@ bool ViInputHandler::sendCharPressEvent(char32_t ch, Modifier modifier)
         _pendingInput += "<NL>";
     else
         _pendingInput += unicode::convert_to<char>(ch);
+
+    if (_pendingInput.empty())
+    {
+        errorLog()("ViInputHandler: Unhandled char: {} ({})", static_cast<uint32_t>(ch), modifier);
+        return false;
+    }
 
     if (handlePendingInput())
         return true;

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -344,9 +344,16 @@ bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
         case ViMode::Insert:
             return false;
         case ViMode::Normal:
+            break;
         case ViMode::Visual:
         case ViMode::VisualLine:
         case ViMode::VisualBlock:
+            if (key == Key::Escape && modifier.none())
+            {
+                clearPendingInput();
+                setMode(ViMode::Normal);
+                return true;
+            }
             break;
     }
     // clang-format on

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -263,7 +263,8 @@ void ViInputHandler::registerCommand(ModeSelect modes, std::string_view command,
 
 void ViInputHandler::appendModifierToPendingInput(Modifier modifier)
 {
-    if (modifier.meta())
+    if (modifier.super())
+        // Super key is usually also named as Meta, conflicting with the actual Meta key.
         _pendingInput += "M-";
     if (modifier.alt())
         _pendingInput += "A-";


### PR DESCRIPTION
- [x] Fix leaking CSIu events for modifier keys when not requested
- [x] Fix Alt+Key events in legacy input encoding (e.g. Alt+Backspace)
- [x] Fix Key (Backspace|Enter|Escape) in search edit mode
- [x] Avoid terminating terminal when unable to map vi-input event (log and continue instead)
- [x] Fix ESC not moving from visual back to normal mode.