### PR TITLE
some more dependency packaging improvements/updates

### DIFF
--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -32,9 +32,9 @@ $ThirdParties =
         Macro   = "libunicode"
     };
     [ThirdParty]@{
-        Folder  = "termbench-pro-a4feadd3a698e4fe2d9dd5b03d5f941534a25a91";
-        Archive = "termbench-pro-a4feadd3a698e4fe2d9dd5b03d5f941534a25a91.zip";
-        URI     = "https://github.com/contour-terminal/termbench-pro/archive/a4feadd3a698e4fe2d9dd5b03d5f941534a25a91.zip";
+        Folder  = "termbench-pro-7f86c882b2dab88a0cceeffd7e3848f55fa5f6f2";
+        Archive = "termbench-pro-7f86c882b2dab88a0cceeffd7e3848f55fa5f6f2.zip";
+        URI     = "https://github.com/contour-terminal/termbench-pro/archive/7f86c882b2dab88a0cceeffd7e3848f55fa5f6f2.zip";
         Macro   = "termbench_pro"
     }
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -100,7 +100,7 @@ fetch_and_unpack_gsl()
 
 fetch_and_unpack_termbenchpro()
 {
-    local termbench_pro_git_sha="a4feadd3a698e4fe2d9dd5b03d5f941534a25a91"
+    local termbench_pro_git_sha="7f86c882b2dab88a0cceeffd7e3848f55fa5f6f2"
     fetch_and_unpack \
         termbench-pro-$termbench_pro_git_sha \
         termbench-pro-$termbench_pro_git_sha.tar.gz \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -439,6 +439,7 @@ install_deps_fedora()
     local os_version=`grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"'`
 
     local packages="
+        catch-devel
         cmake
         extra-cmake-modules
         fontconfig-devel
@@ -460,13 +461,6 @@ install_deps_fedora()
         packages="$packages fmt"
     else
         fetch_and_unpack_fmtlib
-    fi
-
-    # catch-devel on Fedora 38 is too new, so we need to use the one we downloaded.
-    if test "$os_version" -lt 38; then
-        packages="$packages catch-devel"
-    else
-        fetch_and_unpack_Catch2
     fi
 
     [ x$PREPARE_ONLY_EMBEDS = xON ] && return

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -148,7 +148,12 @@ if(LIBTERMINAL_TESTING)
             CONTOUR_VERSION_STRING="${CONTOUR_VERSION_STRING}"
             CONTOUR_PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
         )
-        target_link_libraries(bench-headless fmt::fmt-header-only vtbackend termbench)
+
+        target_link_libraries(bench-headless
+            fmt::fmt-header-only
+            termbench::termbench
+            vtbackend
+        )
 
         if(CONTOUR_INSTALL_TOOLS)
             if(WIN32)


### PR DESCRIPTION
* Catch2 for fedora is now used from package system (since we do not support older Fedora)
* termbench library is updated to latest master (containing only packaging improvements itself)