### PR TITLE
Fixes font resize causing window to resize

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -500,7 +500,7 @@ void TerminalSession::copyToClipboard(std::string_view data)
 void TerminalSession::openDocument(std::string_view fileOrUrl)
 {
     auto stripped = strip_if(string(fileOrUrl), true);
-    fmt::print("TerminalSession.openDocument: {}\n", fileOrUrl);
+    sessionLog()("openDocument: {}\n", fileOrUrl);
     QDesktopServices::openUrl(QUrl(QString::fromStdString(std::string(fileOrUrl))));
 }
 

--- a/src/contour/display/TerminalWidget.h
+++ b/src/contour/display/TerminalWidget.h
@@ -217,7 +217,8 @@ class TerminalWidget: public QQuickItem
         return pageSizeForPixels(pixelSize(), _renderer->gridMetrics().cellSize);
     }
 
-    void updateSizeProperties();
+    void updateMinimumSize();
+    void updateImplicitSize();
 
     void statsSummary();
     void doResize(crispy::size size);

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -487,6 +487,7 @@ void applyResize(vtbackend::ImageSize newPixelSize,
     if (*newPixelSize.width == 0 || *newPixelSize.height == 0)
         return;
 
+    auto const oldPageSize = session.terminal().pageSize();
     auto const newPageSize = pageSizeForPixels(newPixelSize, renderer.gridMetrics().cellSize);
     vtbackend::Terminal& terminal = session.terminal();
     vtbackend::ImageSize cellSize = renderer.gridMetrics().cellSize;
@@ -495,6 +496,12 @@ void applyResize(vtbackend::ImageSize newPixelSize,
     renderer.renderTarget().setRenderSize(newPixelSize);
     renderer.setPageSize(newPageSize);
     renderer.setMargin(computeMargin(renderer.gridMetrics().cellSize, newPageSize, newPixelSize));
+
+    if (oldPageSize.lines != newPageSize.lines)
+        emit session.lineCountChanged(newPageSize.lines.as<int>());
+
+    if (oldPageSize.columns != newPageSize.columns)
+        emit session.columnsCountChanged(newPageSize.columns.as<int>());
 
     auto const viewSize = cellSize * newPageSize;
     displayLog()("Applying resize: {} (new pixel size) {} (view size)", newPixelSize, viewSize);

--- a/src/contour/ui.template/Terminal.qml.in
+++ b/src/contour/ui.template/Terminal.qml.in
@@ -249,6 +249,10 @@ ContourTerminal
         vt.fontSizeChanged.connect(updateFontSize);
         updateFontSize();
 
+        // Show cell-dimensions popup in case of page size changes
+        vt.lineCountChanged.connect(updateSizeWidget);
+        vt.columnsCountChanged.connect(updateSizeWidget);
+
         // Permission-wall related hooks.
         vt.requestPermissionForFontChange.connect(requestFontChangeDialog.open);
         vt.requestPermissionForBufferCapture.connect(requestBufferCaptureDialog.open);


### PR DESCRIPTION
Fixes the bug mentioned in #1271 with regards to font resize also causing the window to resize.

no changelog entry needed, because this bug was introduced after last release (related to QML merge)