### PR TITLE
Fixes terminal session not being terminated when the process terminated but PTY handle still open

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -126,6 +126,7 @@
           <li>Fixes vi mode `f` action freeze on last line</li>
           <li>Fixes AltGr handling on Windows (#150)</li>
           <li>Fixes rarely happening bad access to GPU texture atlas (#1309)</li>
+          <li>Fixes terminal session not being terminated when the process terminated, but the PTY handle was still open (e.g. by other processes).</li>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -16,6 +16,7 @@
 
 #include <QtCore/QAbstractItemModel>
 #include <QtCore/QFileSystemWatcher>
+#include <QtCore/QThread>
 #include <QtQml/QJSValue>
 
 #include <cstdint>
@@ -423,6 +424,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     std::optional<CaptureBufferRequest> _pendingBufferCapture;
     std::optional<vtbackend::FontDef> _pendingFontChange;
     PermissionCache _rememberedPermissions;
+    std::unique_ptr<QThread> _exitWatcherThread;
 };
 
 } // namespace contour

--- a/src/vtpty/ConPty.cpp
+++ b/src/vtpty/ConPty.cpp
@@ -107,6 +107,12 @@ void ConPty::start()
         throw runtime_error { GetLastErrorAsString() };
 }
 
+void ConPty::waitForClosed()
+{
+    while (!isClosed())
+        Sleep(1000);
+}
+
 void ConPty::close()
 {
     ptyLog()("ConPty.close()");

--- a/src/vtpty/ConPty.h
+++ b/src/vtpty/ConPty.h
@@ -23,6 +23,7 @@ class ConPty: public Pty
 
     void start() override;
     void close() override;
+    void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 
     [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,

--- a/src/vtpty/MockPty.cpp
+++ b/src/vtpty/MockPty.cpp
@@ -65,6 +65,11 @@ void MockPty::close()
     _closed = true;
 }
 
+void MockPty::waitForClosed()
+{
+    // No-op. as we're a mock-pty.
+}
+
 bool MockPty::isClosed() const noexcept
 {
     return _closed;

--- a/src/vtpty/MockPty.h
+++ b/src/vtpty/MockPty.h
@@ -28,6 +28,7 @@ class MockPty: public Pty
 
     void start() override;
     void close() override;
+    void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 
     [[nodiscard]] std::string& stdinBuffer() noexcept { return _inputBuffer; }

--- a/src/vtpty/MockViewPty.cpp
+++ b/src/vtpty/MockViewPty.cpp
@@ -66,6 +66,11 @@ void MockViewPty::close()
     _closed = true;
 }
 
+void MockViewPty::waitForClosed()
+{
+    // No-op. as we're a mock-pty.
+}
+
 bool MockViewPty::isClosed() const noexcept
 {
     return _closed;

--- a/src/vtpty/MockViewPty.h
+++ b/src/vtpty/MockViewPty.h
@@ -28,6 +28,7 @@ class MockViewPty: public Pty
 
     void start() override;
     void close() override;
+    void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 
     [[nodiscard]] std::string& stdinBuffer() noexcept { return _inputBuffer; }

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -92,6 +92,7 @@ class [[nodiscard]] Process: public Pty
     void start() override;
     [[nodiscard]] PtySlave& slave() noexcept override { return pty().slave(); }
     void close() override { pty().close(); }
+    void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override { return pty().isClosed(); }
     [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage, std::optional<std::chrono::milliseconds> timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }

--- a/src/vtpty/Process_unix.cpp
+++ b/src/vtpty/Process_unix.cpp
@@ -252,6 +252,11 @@ Pty const& Process::pty() const noexcept
     return *_d->pty;
 }
 
+void Process::waitForClosed()
+{
+    (void) wait();
+}
+
 optional<Process::ExitStatus> Process::checkStatus() const
 {
     return _d->checkStatus(false);

--- a/src/vtpty/Process_win32.cpp
+++ b/src/vtpty/Process_win32.cpp
@@ -250,6 +250,14 @@ void Process::start()
     });
 }
 
+void Process::waitForClosed()
+{
+    Require(static_cast<ConPty const*>(_d->pty.get()));
+
+    // TODO: Should probably wait for process exit instead here
+    _d->pty->waitForClosed();
+}
+
 Pty& Process::pty() noexcept
 {
     return *_d->pty;

--- a/src/vtpty/Pty.h
+++ b/src/vtpty/Pty.h
@@ -66,6 +66,9 @@ class Pty
     /// This is automatically invoked when the destructor is called.
     virtual void close() = 0;
 
+    /// Blocks until the underlying PTY is closed.
+    virtual void waitForClosed() = 0;
+
     /// Returns true if the underlying PTY is closed, otherwise false.
     [[nodiscard]] virtual bool isClosed() const noexcept = 0;
 

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -14,6 +14,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 #if defined(__APPLE__)
     #include <util.h>
@@ -111,6 +112,20 @@ PtySlaveHandle UnixPty::Slave::handle() const noexcept
 void UnixPty::Slave::close()
 {
     _slaveFd.close();
+}
+
+void UnixPty::waitForClosed()
+{
+    crispy::read_selector selector;
+    selector.want_read(_masterFd);
+    while (true)
+    {
+        selector.wait_one();
+        if (isClosed())
+            break;
+
+        std::this_thread::yield();
+    }
 }
 
 bool UnixPty::Slave::isClosed() const noexcept

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -55,6 +55,7 @@ class UnixPty final: public Pty
     [[nodiscard]] PtyMasterHandle handle() const noexcept;
     void start() override;
     void close() override;
+    void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
     [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,


### PR DESCRIPTION
PTY handle can still be open by e.g. another process (caused by commands like `long running command &` in a typical shell.


Closes #866.