### PR TITLE
Improve Numpad input mapping (relevant for CSIu protocol)

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -594,6 +594,23 @@ namespace
             pair { "PrintScreen"sv, Key::PrintScreen },
             pair { "Pause"sv, Key::Pause },
             pair { "Menu"sv, Key::Menu },
+            pair { "Numpad_0"sv, Key::Numpad_0 },
+            pair { "Numpad_1"sv, Key::Numpad_1 },
+            pair { "Numpad_2"sv, Key::Numpad_2 },
+            pair { "Numpad_3"sv, Key::Numpad_3 },
+            pair { "Numpad_4"sv, Key::Numpad_4 },
+            pair { "Numpad_5"sv, Key::Numpad_5 },
+            pair { "Numpad_6"sv, Key::Numpad_6 },
+            pair { "Numpad_7"sv, Key::Numpad_7 },
+            pair { "Numpad_8"sv, Key::Numpad_8 },
+            pair { "Numpad_9"sv, Key::Numpad_9 },
+            pair { "Numpad_Decimal"sv, Key::Numpad_Decimal },
+            pair { "Numpad_Divide"sv, Key::Numpad_Divide },
+            pair { "Numpad_Multiply"sv, Key::Numpad_Multiply },
+            pair { "Numpad_Subtract"sv, Key::Numpad_Subtract },
+            pair { "Numpad_Add"sv, Key::Numpad_Add },
+            pair { "Numpad_Enter"sv, Key::Numpad_Enter },
+            pair { "Numpad_Equal"sv, Key::Numpad_Equal },
         };
 
         auto const lowerName = toLower(name);
@@ -623,7 +640,7 @@ namespace
             pair { "EQUAL"sv, '=' },       pair { "LEFT_BRACKET"sv, '[' }, pair { "MINUS"sv, '-' },
             pair { "MULTIPLY"sv, '*' },    pair { "PERIOD"sv, '.' },       pair { "RIGHT_BRACKET"sv, ']' },
             pair { "SEMICOLON"sv, ';' },   pair { "SLASH"sv, '/' },        pair { "SUBTRACT"sv, '-' },
-            pair { "SPACE"sv, ' ' }
+            pair { "SPACE"sv, ' ' },
         };
 
         auto const lowerName = toUpper(name);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -698,8 +698,7 @@ color_schemes:
 #   MINUS, MULTIPLY, PERIOD, RIGHT_BRACKET, SEMICOLON, SLASH, SUBTRACT, SPACE
 #   Enter, Backspace, Tab, Escape, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
 #   DownArrow, LeftArrow, RightArrow, UpArrow, Insert, Delete, Home, End, PageUp, PageDown,
-#   Numpad_NumLock, Numpad_Divide, Numpad_Multiply, Numpad_Subtract, Numpad_CapsLock,
-#   Numpad_Add, Numpad_Decimal, Numpad_Enter, Numpad_Equal,
+#   Numpad_Divide, Numpad_Multiply, Numpad_Subtract, Numpad_Add, Numpad_Decimal, Numpad_Enter, Numpad_Equal,
 #   Numpad_0, Numpad_1, Numpad_2, Numpad_3, Numpad_4,
 #   Numpad_5, Numpad_6, Numpad_7, Numpad_8, Numpad_9
 # or in case of standard characters, just the character.

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -238,6 +238,36 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
     auto const modifiers = makeModifier(event->modifiers());
     auto const key = event->key();
 
+    if (event->modifiers().testFlag(Qt::KeypadModifier))
+    {
+        std::optional<Key> mappedKey = nullopt;
+        switch (key)
+        {
+            case Qt::Key_0: mappedKey = Key::Numpad_0; break;
+            case Qt::Key_1: mappedKey = Key::Numpad_1; break;
+            case Qt::Key_2: mappedKey = Key::Numpad_2; break;
+            case Qt::Key_3: mappedKey = Key::Numpad_3; break;
+            case Qt::Key_4: mappedKey = Key::Numpad_4; break;
+            case Qt::Key_5: mappedKey = Key::Numpad_5; break;
+            case Qt::Key_6: mappedKey = Key::Numpad_6; break;
+            case Qt::Key_7: mappedKey = Key::Numpad_7; break;
+            case Qt::Key_8: mappedKey = Key::Numpad_8; break;
+            case Qt::Key_9: mappedKey = Key::Numpad_9; break;
+            case Qt::Key_Asterisk: mappedKey = Key::Numpad_Multiply; break;
+            case Qt::Key_Plus: mappedKey = Key::Numpad_Add; break;
+            case Qt::Key_Minus: mappedKey = Key::Numpad_Subtract; break;
+            case Qt::Key_Period: mappedKey = Key::Numpad_Decimal; break;
+            case Qt::Key_Slash: mappedKey = Key::Numpad_Divide; break;
+            case Qt::Key_Enter: mappedKey = Key::Numpad_Enter; break;
+            default: break;
+        }
+        if (mappedKey)
+        {
+            session.sendKeyEvent(*mappedKey, modifiers, eventType, now);
+            return true;
+        }
+    }
+
     // NOLINTNEXTLINE(readability-qualified-auto)
     if (auto const i = find_if(
             begin(KeyMappings), end(KeyMappings), [event](auto const& x) { return x.first == event->key(); });

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -121,8 +121,9 @@ constexpr inline vtbackend::Modifier makeModifier(Qt::KeyboardModifiers qtModifi
     if (qtModifiers & Qt::MetaModifier)
         modifiers |= Modifier::Meta;
 #endif
-    if (qtModifiers & Qt::KeypadModifier)
-        modifiers |= Modifier::NumLock;
+    // TODO: Get the actual numlock state. Problem is, Qt does not provide this info back to us.
+    // if (...)
+    //     modifiers |= Modifier::NumLock;
 
     return modifiers;
 }

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -358,6 +358,23 @@ bool ViInputHandler::sendKeyPressEvent(Key key, Modifier modifier)
     }
     // clang-format on
 
+    auto const charMappings = std::array<std::pair<Key, char32_t>, 10> { {
+        { Key::Numpad_0, '0' },
+        { Key::Numpad_1, '1' },
+        { Key::Numpad_2, '2' },
+        { Key::Numpad_3, '3' },
+        { Key::Numpad_4, '4' },
+        { Key::Numpad_5, '5' },
+        { Key::Numpad_6, '6' },
+        { Key::Numpad_7, '7' },
+        { Key::Numpad_8, '8' },
+        { Key::Numpad_9, '9' },
+    } };
+
+    for (auto const& [mappedKey, mappedText]: charMappings)
+        if (key == mappedKey)
+            return sendCharPressEvent(mappedText, modifier);
+
     if (modifier.any())
         return true;
 


### PR DESCRIPTION
Kinda hard to test and verify blindingly - while not having a keyboard that is having a keypad, but I think this is going into the right direction.

The problem of keypad not working was introduced by implementing CSIu, which strongly differenciates between numbers and numbers typed in from numpad.

## EDIT:

Now, also fixes #1325!

NB: No changelog needed because this problem was introduced post last release and only affects CSIu (new)