### PR TITLE
pragmatic fix of shell quick exit

### DIFF
--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -427,7 +427,9 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     std::optional<vtbackend::FontDef> _pendingFontChange;
     PermissionCache _rememberedPermissions;
     std::unique_ptr<QThread> _exitWatcherThread;
-    bool _onClosedHandled = false;
+
+    std::atomic<bool> _onClosedHandled = false;
+    std::mutex _onClosedMutex;
 };
 
 } // namespace contour

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -30,6 +30,7 @@ set(crispy_SOURCES
     reference.h
     ring.h
     times.h
+    utils.cpp utils.h
 )
 
 add_library(crispy-core STATIC ${crispy_SOURCES})

--- a/src/crispy/utils.cpp
+++ b/src/crispy/utils.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(_WIN32)
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+#else
+    #include <pthread.h>
+#endif
+
+#include <crispy/utils.h>
+
+namespace crispy
+{
+
+using namespace std::string_literals;
+
+std::string threadName()
+{
+#if defined(_WIN32)
+    auto const ThreadHandle = GetCurrentThread();
+    PWSTR pwsz = nullptr;
+    HRESULT hr = GetThreadDescription(ThreadHandle, &pwsz);
+    if (SUCCEEDED(hr))
+    {
+        int const len = WideCharToMultiByte(CP_UTF8, 0, pwsz, -1, nullptr, 0, nullptr, nullptr);
+        std::string utf8Str(len, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, pwsz, -1, utf8Str.data(), len, nullptr, nullptr);
+        utf8Str.resize(len - 1);
+        LocalFree(pwsz);
+        return utf8Str;
+    }
+    return ""s;
+#else
+    char text[32] = {};
+    pthread_getname_np(pthread_self(), text, sizeof(text));
+    return text;
+#endif
+}
+
+} // namespace crispy

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -536,4 +536,6 @@ inline bool beginsWith(std::basic_string_view<T> text, std::basic_string_view<T>
     return true;
 }
 
+std::string threadName();
+
 } // namespace crispy

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -9,6 +9,7 @@
 #include <crispy/read_selector.h>
 
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #if defined(__APPLE__)
@@ -78,6 +79,7 @@ class UnixPty final: public Pty
     PageSize _pageSize;
     std::optional<ImageSize> _pixels;
     std::unique_ptr<Slave> _slave;
+    std::mutex _mutex;
 };
 
 } // namespace vtpty


### PR DESCRIPTION
## NOTES

We're having two events to watch out for. PTY may be closed and the process may exit. One does not imply the other. We are about to consider the PTY session to be finished whenever one of those two conditions arise, no matter which one comes in first. Sometimes (e.g. quick exit, e.g. just spawning `/bin/true` as shell) the process will terminate so fast, that we didn't even fully initialize the GUI. We need to properly terminate on that condition as well as expect that both events (PTY closed **and** process terminated) happens at the same time. Both events call `onClosed()`. This is why i've guarded it with a mutex to avoid concurrent calling (which happened before).