### PR TITLE
Fix CSIu for Ctrl+Alt (AltGr) on Windows

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -2102,6 +2102,22 @@ void loadConfigFromFile(Config& config, fs::path const& fileName)
 
     tryLoadValue(usedKeys, doc, "live_config", config.live, logger);
 
+    if (auto const loggingNode = doc["logging"]; loggingNode.IsMap())
+    {
+        usedKeys.emplace("logging");
+
+        if (auto const tagsNode = loggingNode["tags"]; tagsNode.IsSequence())
+        {
+            usedKeys.emplace("logging.tags");
+            for (auto const& tagNode: tagsNode)
+            {
+                auto const tag = tagNode.as<string>();
+                usedKeys.emplace("logging.tags." + tag);
+                logstore::enable(tag);
+            }
+        }
+    }
+
     auto logEnabled = false;
     tryLoadValue(usedKeys, doc, "logging.enabled", logEnabled, logger);
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -674,24 +674,24 @@ namespace
         cursorConfig.cursorBlinkInterval = chrono::milliseconds(uintValue);
     }
 
-    optional<vtbackend::Modifier::Key> parseModifierKey(string const& key)
+    optional<vtbackend::Modifier> parseModifierKey(string const& key)
     {
         using vtbackend::Modifier;
         auto const upperKey = toUpper(key);
         if (upperKey == "ALT")
-            return Modifier::Key::Alt;
+            return Modifier::Alt;
         if (upperKey == "CONTROL")
-            return Modifier::Key::Control;
+            return Modifier::Control;
         if (upperKey == "SHIFT")
-            return Modifier::Key::Shift;
+            return Modifier::Shift;
         if (upperKey == "SUPER")
-            return Modifier::Key::Super;
+            return Modifier::Super;
         if (upperKey == "META")
             // TODO: This is technically not correct, but we used the term Meta up until now,
             // to refer to the Windows/Cmd key. But Qt also exposes another modifier called
             // Meta, which rarely exists on modern keyboards (?), but it we need to support it
             // as well, especially since extended CSIu protocol exposes it as well.
-            return Modifier::Key::Super; // Return Modifier::Key::Meta in the future.
+            return Modifier::Super; // Return Modifier::Meta in the future.
         return nullopt;
     }
 
@@ -752,11 +752,12 @@ namespace
         return matchModes;
     }
 
-    optional<vtbackend::Modifier> parseModifier(UsedKeys& usedKeys,
-                                                string const& prefix,
-                                                YAML::Node const& node)
+    optional<vtbackend::Modifiers> parseModifiers(UsedKeys& usedKeys,
+                                                  string const& prefix,
+                                                  YAML::Node const& node)
     {
         using vtbackend::Modifier;
+        using vtbackend::Modifiers;
         if (!node)
             return nullopt;
         usedKeys.emplace(prefix);
@@ -765,7 +766,7 @@ namespace
         if (!node.IsSequence())
             return nullopt;
 
-        vtbackend::Modifier mods;
+        vtbackend::Modifiers mods;
         for (const auto& i: node)
         {
             if (!i.IsScalar())
@@ -783,13 +784,13 @@ namespace
     template <typename Input>
     void appendOrCreateBinding(vector<vtbackend::InputBinding<Input, ActionList>>& bindings,
                                vtbackend::MatchModes modes,
-                               vtbackend::Modifier modifier,
+                               vtbackend::Modifiers modifiers,
                                Input input,
                                Action action)
     {
         for (auto& binding: bindings)
         {
-            if (match(binding, modes, modifier, input))
+            if (match(binding, modes, modifiers, input))
             {
                 binding.binding.emplace_back(std::move(action));
                 return;
@@ -797,12 +798,12 @@ namespace
         }
 
         bindings.emplace_back(vtbackend::InputBinding<Input, ActionList> {
-            modes, modifier, input, ActionList { std::move(action) } });
+            modes, modifiers, input, ActionList { std::move(action) } });
     }
 
     bool tryAddKey(InputMappings& inputMappings,
                    vtbackend::MatchModes modes,
-                   vtbackend::Modifier modifier,
+                   vtbackend::Modifiers modifiers,
                    YAML::Node const& node,
                    Action action)
     {
@@ -819,12 +820,12 @@ namespace
         if (holds_alternative<vtbackend::Key>(*input))
         {
             appendOrCreateBinding(
-                inputMappings.keyMappings, modes, modifier, get<vtbackend::Key>(*input), std::move(action));
+                inputMappings.keyMappings, modes, modifiers, get<vtbackend::Key>(*input), std::move(action));
         }
         else if (holds_alternative<char32_t>(*input))
         {
             appendOrCreateBinding(
-                inputMappings.charMappings, modes, modifier, get<char32_t>(*input), std::move(action));
+                inputMappings.charMappings, modes, modifiers, get<char32_t>(*input), std::move(action));
         }
         else
             assert(false && "The impossible happened.");
@@ -856,7 +857,7 @@ namespace
 
     bool tryAddMouse(vector<MouseInputMapping>& bindings,
                      vtbackend::MatchModes modes,
-                     vtbackend::Modifier modifier,
+                     vtbackend::Modifiers modifiers,
                      YAML::Node const& node,
                      Action action)
     {
@@ -864,7 +865,7 @@ namespace
         if (!mouseButton)
             return false;
 
-        appendOrCreateBinding(bindings, modes, modifier, *mouseButton, std::move(action));
+        appendOrCreateBinding(bindings, modes, modifiers, *mouseButton, std::move(action));
         return true;
     }
 
@@ -986,7 +987,7 @@ namespace
         using namespace vtbackend;
 
         auto const action = parseAction(usedKeys, prefix, mapping);
-        auto const mods = parseModifier(usedKeys, prefix + ".mods", mapping["mods"]);
+        auto const mods = parseModifiers(usedKeys, prefix + ".mods", mapping["mods"]);
         auto const mode = parseMatchModes(usedKeys, prefix + ".mode", mapping["mode"]);
         if (action && mods && mode)
         {
@@ -2042,14 +2043,14 @@ void loadConfigFromFile(Config& config, fs::path const& fileName)
     tryLoadValue(usedKeys, doc, "word_delimiters", config.wordDelimiters, logger);
 
     if (auto opt =
-            parseModifier(usedKeys, "bypass_mouse_protocol_modifier", doc["bypass_mouse_protocol_modifier"]);
+            parseModifiers(usedKeys, "bypass_mouse_protocol_modifier", doc["bypass_mouse_protocol_modifier"]);
         opt.has_value())
-        config.bypassMouseProtocolModifier = opt.value();
+        config.bypassMouseProtocolModifiers = opt.value();
 
     if (auto opt =
-            parseModifier(usedKeys, "mouse_block_selection_modifier", doc["mouse_block_selection_modifier"]);
+            parseModifiers(usedKeys, "mouse_block_selection_modifier", doc["mouse_block_selection_modifier"]);
         opt.has_value())
-        config.mouseBlockSelectionModifier = opt.value();
+        config.mouseBlockSelectionModifiers = opt.value();
 
     if (doc["on_mouse_select"].IsDefined())
     {

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -107,12 +107,12 @@ template <typename Input>
 std::vector<actions::Action> const* apply(
     std::vector<vtbackend::InputBinding<Input, ActionList>> const& mappings,
     Input input,
-    vtbackend::Modifier modifier,
+    vtbackend::Modifiers modifiers,
     uint8_t actualModeFlags)
 {
     for (vtbackend::InputBinding<Input, ActionList> const& mapping: mappings)
     {
-        if (mapping.modifier == modifier && mapping.input == input
+        if (mapping.modifiers == modifiers && mapping.input == input
             && helper::testMatchMode(actualModeFlags, mapping.modes))
         {
             return &mapping.binding;
@@ -308,9 +308,9 @@ struct Config
 
     // selection
     std::string wordDelimiters;
-    vtbackend::Modifier bypassMouseProtocolModifier = vtbackend::Modifier::Shift;
+    vtbackend::Modifiers bypassMouseProtocolModifiers = vtbackend::Modifier::Shift;
     SelectionAction onMouseSelection = SelectionAction::CopyToSelectionClipboard;
-    vtbackend::Modifier mouseBlockSelectionModifier = vtbackend::Modifier::Control;
+    vtbackend::Modifiers mouseBlockSelectionModifiers = vtbackend::Modifier::Control;
 
     // input mapping
     InputMappings inputMappings;

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -250,22 +250,22 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     // Input Events
     using Timestamp = std::chrono::steady_clock::time_point;
     void sendKeyEvent(vtbackend::Key key,
-                      vtbackend::Modifier modifier,
+                      vtbackend::Modifiers modifiers,
                       vtbackend::KeyboardEventType eventType,
                       Timestamp now);
     void sendCharEvent(char32_t value,
                        uint32_t physicalKey,
-                       vtbackend::Modifier modifier,
+                       vtbackend::Modifiers modifiers,
                        vtbackend::KeyboardEventType eventType,
                        Timestamp now);
 
-    void sendMousePressEvent(vtbackend::Modifier modifier,
+    void sendMousePressEvent(vtbackend::Modifiers modifiers,
                              vtbackend::MouseButton button,
                              vtbackend::PixelCoordinate pixelPosition);
-    void sendMouseMoveEvent(vtbackend::Modifier modifier,
+    void sendMouseMoveEvent(vtbackend::Modifiers modifiers,
                             vtbackend::CellLocation pos,
                             vtbackend::PixelCoordinate pixelPosition);
-    void sendMouseReleaseEvent(vtbackend::Modifier modifier,
+    void sendMouseReleaseEvent(vtbackend::Modifiers modifiers,
                                vtbackend::MouseButton button,
                                vtbackend::PixelCoordinate pixelPosition);
 

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -139,6 +139,8 @@ namespace
 
 bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, TerminalSession& session)
 {
+    qDebug() << "sendKeyEvent: " << event->key() << " " << event->text() << " " << event->modifiers();
+
     using vtbackend::Key;
     using vtbackend::Modifier;
 

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -235,7 +235,7 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         pair { Qt::Key_QuoteLeft, '`' },   pair { Qt::Key_Underscore, '_' },
     }; // }}}
 
-    auto const modifiers = makeModifier(event->modifiers());
+    auto const modifiers = makeModifiers(event->modifiers());
     auto const key = event->key();
 
     if (event->modifiers().testFlag(Qt::KeypadModifier))
@@ -303,7 +303,7 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
     }
 #endif
 
-    if (0x20 <= key && key < 0x80 && (modifiers.control()))
+    if (0x20 <= key && key < 0x80 && (modifiers & Modifier::Control))
     {
         session.sendCharEvent(static_cast<char32_t>(key), physicalKey, modifiers, eventType, now);
         return true;
@@ -348,7 +348,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
     auto const xDelta = event->angleDelta().x() > 0 ? 1 : event->angleDelta().x() < 0 ? -1 : 0;
     if (xDelta)
     {
-        auto const modifier = makeModifier(event->modifiers());
+        auto const modifier = makeModifiers(event->modifiers());
         auto const button = xDelta > 0 ? VTMouseButton::WheelRight : VTMouseButton::WheelLeft;
         auto const pixelPosition = makeMousePixelPosition(event, session.contentScale());
 
@@ -359,7 +359,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
     auto const yDelta = mouseWheelDelta(event);
     if (yDelta)
     {
-        auto const modifier = makeModifier(event->modifiers());
+        auto const modifier = makeModifiers(event->modifiers());
         auto const button = yDelta > 0 ? VTMouseButton::WheelUp : VTMouseButton::WheelDown;
         auto const pixelPosition = makeMousePixelPosition(event, session.contentScale());
 
@@ -370,7 +370,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
 
 void sendMousePressEvent(QMouseEvent* event, TerminalSession& session)
 {
-    session.sendMousePressEvent(makeModifier(event->modifiers()),
+    session.sendMousePressEvent(makeModifiers(event->modifiers()),
                                 makeMouseButton(event->button()),
                                 makeMousePixelPosition(event, session.contentScale()));
     event->accept();
@@ -378,7 +378,7 @@ void sendMousePressEvent(QMouseEvent* event, TerminalSession& session)
 
 void sendMouseReleaseEvent(QMouseEvent* event, TerminalSession& session)
 {
-    session.sendMouseReleaseEvent(makeModifier(event->modifiers()),
+    session.sendMouseReleaseEvent(makeModifiers(event->modifiers()),
                                   makeMouseButton(event->button()),
                                   makeMousePixelPosition(event, session.contentScale()));
     event->accept();
@@ -386,7 +386,7 @@ void sendMouseReleaseEvent(QMouseEvent* event, TerminalSession& session)
 
 void sendMouseMoveEvent(QMouseEvent* event, TerminalSession& session)
 {
-    session.sendMouseMoveEvent(makeModifier(event->modifiers()),
+    session.sendMouseMoveEvent(makeModifiers(event->modifiers()),
                                makeMouseCellLocation(event->pos().x(), event->pos().y(), session),
                                makeMousePixelPosition(event, session.contentScale()));
     event->accept();
@@ -399,7 +399,7 @@ void sendMouseMoveEvent(QHoverEvent* event, TerminalSession& session)
 #else
     auto const position = event->pos();
 #endif
-    session.sendMouseMoveEvent(makeModifier(event->modifiers()),
+    session.sendMouseMoveEvent(makeModifiers(event->modifiers()),
                                makeMouseCellLocation(position.x(), position.y(), session),
                                makeMousePixelPosition(event, session.contentScale()));
     event->accept();

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -97,11 +97,12 @@ constexpr inline char32_t makeChar(Qt::Key key, Qt::KeyboardModifiers mods)
     return 0;
 }
 
-constexpr inline vtbackend::Modifier makeModifier(Qt::KeyboardModifiers qtModifiers)
+constexpr inline vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers)
 {
     using vtbackend::Modifier;
+    using vtbackend::Modifiers;
 
-    Modifier modifiers {};
+    Modifiers modifiers {};
 
     if (qtModifiers & Qt::AltModifier)
         modifiers |= Modifier::Alt;

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -104,6 +104,10 @@ constexpr inline vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModi
 
     Modifiers modifiers {};
 
+    // TODO: Can we safely enable this? Especially with respect to CSIu?
+    // if (qtModifiers & Qt::KeypadModifier)
+    //     modifiers |= Modifier::NumLock;
+
     if (qtModifiers & Qt::AltModifier)
         modifiers |= Modifier::Alt;
     if (qtModifiers & Qt::ShiftModifier)
@@ -122,9 +126,6 @@ constexpr inline vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModi
     if (qtModifiers & Qt::MetaModifier)
         modifiers |= Modifier::Meta;
 #endif
-    // TODO: Get the actual numlock state. Problem is, Qt does not provide this info back to us.
-    // if (...)
-    //     modifiers |= Modifier::NumLock;
 
     return modifiers;
 }

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -127,6 +127,16 @@ constexpr inline vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModi
         modifiers |= Modifier::Meta;
 #endif
 
+#if defined(_WIN32)
+    // Deal with AltGr on Windows, which is seen by the app as Ctrl+Alt, because
+    // the user may alternatively press Ctrl+Alt to emulate AltGr on keyboard
+    // that are missing the AltGr key.
+    // Microsoft does not recommend using Ctrl+Alt modifier for shortcuts.
+    auto constexpr AltGrEquivalent = Modifiers { Modifier::Alt, Modifier::Control };
+    if (modifiers.contains(AltGrEquivalent))
+        modifiers = modifiers.without(AltGrEquivalent);
+#endif
+
     return modifiers;
 }
 

--- a/src/vtbackend/InputBinding.h
+++ b/src/vtbackend/InputBinding.h
@@ -13,21 +13,21 @@ template <typename Input, typename Binding>
 struct InputBinding
 {
     MatchModes modes;
-    Modifier modifier;
+    Modifiers modifiers;
     Input input;
     Binding binding;
 };
 
 template <typename Input, typename Binding>
-bool match(InputBinding<Input, Binding> const& binding, MatchModes modes, Modifier modifier, Input input)
+bool match(InputBinding<Input, Binding> const& binding, MatchModes modes, Modifiers modifiers, Input input)
 {
-    return binding.modes == modes && binding.modifier == modifier && binding.input == input;
+    return binding.modes == modes && binding.modifiers == modifiers && binding.input == input;
 }
 
 template <typename I, typename O>
 bool operator==(InputBinding<I, O> const& a, InputBinding<I, O> const& b) noexcept
 {
-    return a.modes == b.modes && a.modifier == b.modifier && a.input == b.input;
+    return a.modes == b.modes && a.modifiers == b.modifiers && a.input == b.input;
 }
 
 template <typename I, typename O>
@@ -44,9 +44,9 @@ bool operator<(InputBinding<I, O> const& a, InputBinding<I, O> const& b) noexcep
     if (a.modes != b.modes)
         return false;
 
-    if (a.modifier < b.modifier)
+    if (a.modifiers < b.modifiers)
         return true;
-    if (a.modifier != b.modifier)
+    if (a.modifiers != b.modifiers)
         return false;
 
     if (a.input < b.input)
@@ -64,6 +64,6 @@ struct fmt::formatter<vtbackend::InputBinding<I, O>>
     static auto format(vtbackend::InputBinding<I, O> const& binding, format_context& ctx)
         -> format_context::iterator
     {
-        return fmt::format_to(ctx.out(), "{} {} {}", binding.modes, binding.modifier, binding.input);
+        return fmt::format_to(ctx.out(), "{} {} {}", binding.modes, binding.modifiers, binding.input);
     }
 };

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -19,10 +19,10 @@ TEST_CASE("InputGenerator.Modifier.encodings")
     // Ensures we can construct the correct values that are needed
     // as parameters for input events in the VT protocol.
 
-    auto constexpr Alt = Modifier(Modifier::Alt);
-    auto constexpr Shift = Modifier(Modifier::Shift);
-    auto constexpr Control = Modifier(Modifier::Control);
-    auto constexpr Super = Modifier(Modifier::Super);
+    auto constexpr Alt = Modifiers { Modifier::Alt };
+    auto constexpr Shift = Modifiers { Modifier::Shift };
+    auto constexpr Control = Modifiers { Modifier::Control };
+    auto constexpr Super = Modifiers { Modifier::Super };
 
     CHECK((1 + Shift.value()) == 2);
     CHECK((1 + Alt.value()) == 3);

--- a/src/vtbackend/InputHandler.h
+++ b/src/vtbackend/InputHandler.h
@@ -16,8 +16,8 @@ class InputHandler
 {
   public:
     virtual ~InputHandler() = default;
-    virtual bool sendKeyPressEvent(Key key, Modifier modifier) = 0;
-    virtual bool sendCharPressEvent(char32_t codepoint, Modifier modifier) = 0;
+    virtual bool sendKeyPressEvent(Key key, Modifiers modifiers) = 0;
+    virtual bool sendCharPressEvent(char32_t codepoint, Modifiers modifiers) = 0;
 };
 
 } // namespace vtbackend

--- a/src/vtbackend/Settings.h
+++ b/src/vtbackend/Settings.h
@@ -65,8 +65,8 @@ struct Settings
     // This value must be integer-devisable by 16.
     size_t ptyReadBufferSize = 4096;
     std::u32string wordDelimiters;
-    Modifier mouseProtocolBypassModifier = Modifier::Shift;
-    Modifier mouseBlockSelectionModifier = Modifier::Control;
+    Modifiers mouseProtocolBypassModifiers = Modifier::Shift;
+    Modifiers mouseBlockSelectionModifiers = Modifier::Control;
     LineOffset copyLastMarkRangeOffset = LineOffset(0);
     bool visualizeSelectedWord = true;
     std::chrono::milliseconds highlightTimeout = std::chrono::milliseconds { 150 };

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -274,23 +274,23 @@ class Terminal
 
     void clearScreen();
 
-    void setMouseProtocolBypassModifier(Modifier value) { _settings.mouseProtocolBypassModifier = value; }
-    void setMouseBlockSelectionModifier(Modifier value) { _settings.mouseBlockSelectionModifier = value; }
+    void setMouseProtocolBypassModifiers(Modifiers value) { _settings.mouseProtocolBypassModifiers = value; }
+    void setMouseBlockSelectionModifiers(Modifiers value) { _settings.mouseBlockSelectionModifiers = value; }
 
     // {{{ input proxy
     using Timestamp = std::chrono::steady_clock::time_point;
-    bool sendKeyEvent(Key key, Modifier modifier, KeyboardEventType eventType, Timestamp now);
+    bool sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventType eventType, Timestamp now);
     bool sendCharEvent(
-        char32_t ch, uint32_t physicalKey, Modifier modifier, KeyboardEventType eventType, Timestamp now);
-    bool sendMousePressEvent(Modifier modifier,
+        char32_t ch, uint32_t physicalKey, Modifiers modifiers, KeyboardEventType eventType, Timestamp now);
+    bool sendMousePressEvent(Modifiers modifiers,
                              MouseButton button,
                              PixelCoordinate pixelPosition,
                              bool uiHandledHint);
-    void sendMouseMoveEvent(Modifier modifier,
+    void sendMouseMoveEvent(Modifiers modifiers,
                             CellLocation newPosition,
                             PixelCoordinate pixelPosition,
                             bool uiHandledHint);
-    bool sendMouseReleaseEvent(Modifier modifier,
+    bool sendMouseReleaseEvent(Modifiers modifiers,
                                MouseButton button,
                                PixelCoordinate pixelPosition,
                                bool uiHandledHint);
@@ -759,7 +759,7 @@ class Terminal
     void updateIndicatorStatusLine();
     void updateCursorVisibilityState() const noexcept;
     void updateHoveringHyperlinkState();
-    bool handleMouseSelection(Modifier modifier);
+    bool handleMouseSelection(Modifiers modifiers);
 
     /// Tests if the text selection should be extended by the given mouse position or not.
     ///
@@ -770,13 +770,13 @@ class Terminal
 
     // Tests if the App mouse protocol is explicitly being bypassed by the user,
     // by pressing a special bypass modifier (usualy Shift).
-    bool allowBypassAppMouseGrabViaModifier(Modifier modifier) const noexcept
+    bool allowBypassAppMouseGrabViaModifier(Modifiers modifiers) const noexcept
     {
-        return _settings.mouseProtocolBypassModifier != Modifier::None
-               && modifier.contains(_settings.mouseProtocolBypassModifier);
+        return _settings.mouseProtocolBypassModifiers != Modifier::None
+               && modifiers.contains(_settings.mouseProtocolBypassModifiers);
     }
 
-    bool allowPassMouseEventToApp(Modifier currentlyPressedModifier) const noexcept
+    bool allowPassMouseEventToApp(Modifiers currentlyPressedModifier) const noexcept
     {
         return _state.inputGenerator.mouseProtocol().has_value() && allowInput()
                && !allowBypassAppMouseGrabViaModifier(currentlyPressedModifier);

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -187,8 +187,8 @@ class ViInputHandler: public InputHandler
 
     ViInputHandler(Executor& theExecutor, ViMode initialMode);
 
-    bool sendKeyPressEvent(Key key, Modifier modifier) override;
-    bool sendCharPressEvent(char32_t ch, Modifier modifier) override;
+    bool sendKeyPressEvent(Key key, Modifiers modifiers) override;
+    bool sendCharPressEvent(char32_t ch, Modifiers modifiers) override;
 
     void setMode(ViMode mode);
     void toggleMode(ViMode mode);
@@ -229,15 +229,15 @@ class ViInputHandler: public InputHandler
     void registerCommand(ModeSelect modes,
                          std::vector<std::string_view> const& commands,
                          CommandHandler const& handler);
-    void appendModifierToPendingInput(Modifier modifier);
+    void appendModifierToPendingInput(Modifiers modifiers);
     [[nodiscard]] bool handlePendingInput();
     void clearPendingInput();
     [[nodiscard]] unsigned count() const noexcept { return _count ? _count : 1; }
 
-    bool parseCount(char32_t ch, Modifier modifier);
-    bool parseTextObject(char32_t ch, Modifier modifier);
-    bool handleSearchEditor(char32_t ch, Modifier modifier);
-    bool handleModeSwitches(char32_t ch, Modifier modifier);
+    bool parseCount(char32_t ch, Modifiers modifiers);
+    bool parseTextObject(char32_t ch, Modifiers modifiers);
+    bool handleSearchEditor(char32_t ch, Modifiers modifiers);
+    bool handleModeSwitches(char32_t ch, Modifiers modifiers);
     void startSearch();
 
     ViMode _viMode = ViMode::Normal;


### PR DESCRIPTION
- polish flags API to be more generally usable
- adds `logging.tags` to contour configuration (this is more useful for debugging on Windows)
- refactor vtbackend's Modifiers API to make use of recently introduced `flags<T>` API
- attempt to fix AltGr-use on Windows (also when CSIu input protocol is used)
