### PR TITLE
Adapting CellFlags and LineFlags to new `flags<T>`

### DIFF
--- a/src/vtbackend/CellFlags.h
+++ b/src/vtbackend/CellFlags.h
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <crispy/flags.h>
+
 #include <fmt/format.h>
 
-#include <array>
 #include <cstdint>
-#include <string_view>
-#include <utility>
 
 namespace vtbackend
 {
 
-enum class CellFlags : uint32_t
+enum class CellFlag : uint32_t
 {
     None = 0,
 
@@ -35,87 +34,44 @@ enum class CellFlags : uint32_t
     WideCharContinuation = (1 << 17), // Cell is a continuation of a wide char.
 };
 
-constexpr CellFlags& operator|=(CellFlags& a, CellFlags b) noexcept
-{
-    a = static_cast<CellFlags>(static_cast<unsigned>(a) | static_cast<unsigned>(b));
-    return a;
-}
-
-constexpr CellFlags& operator&=(CellFlags& a, CellFlags b) noexcept
-{
-    a = static_cast<CellFlags>(static_cast<unsigned>(a) & static_cast<unsigned>(b));
-    return a;
-}
-
-/// Tests if @p b is contained in @p a.
-constexpr bool operator&(CellFlags a, CellFlags b) noexcept
-{
-    return (static_cast<unsigned>(a) & static_cast<unsigned>(b)) != 0;
-}
-
-constexpr bool contains_all(CellFlags base, CellFlags test) noexcept
-{
-    return (static_cast<unsigned>(base) & static_cast<unsigned>(test)) == static_cast<unsigned>(test);
-}
-
-/// Merges two CellFlags sets.
-constexpr CellFlags operator|(CellFlags a, CellFlags b) noexcept
-{
-    return static_cast<CellFlags>(static_cast<unsigned>(a) | static_cast<unsigned>(b));
-}
-
-/// Inverts the flags set.
-constexpr CellFlags operator~(CellFlags a) noexcept
-{
-    return static_cast<CellFlags>(~static_cast<unsigned>(a));
-}
-
-/// Tests for all flags cleared state.
-constexpr bool operator!(CellFlags a) noexcept
-{
-    return static_cast<unsigned>(a) == 0;
-}
+using CellFlags = crispy::flags<CellFlag>;
 
 } // namespace vtbackend
 
 // {{{
 template <>
-struct fmt::formatter<vtbackend::CellFlags>: fmt::formatter<std::string>
+struct fmt::formatter<vtbackend::CellFlag>: fmt::formatter<std::string_view>
 {
-    auto format(const vtbackend::CellFlags flags, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::CellFlag value, format_context& ctx) -> format_context::iterator
     {
-        static const std::array<std::pair<vtbackend::CellFlags, std::string_view>, 18> nameMap = {
-            std::pair { vtbackend::CellFlags::Bold, std::string_view("Bold") },
-            std::pair { vtbackend::CellFlags::Faint, std::string_view("Faint") },
-            std::pair { vtbackend::CellFlags::Italic, std::string_view("Italic") },
-            std::pair { vtbackend::CellFlags::Underline, std::string_view("Underline") },
-            std::pair { vtbackend::CellFlags::Blinking, std::string_view("Blinking") },
-            std::pair { vtbackend::CellFlags::RapidBlinking, std::string_view("RapidBlinking") },
-            std::pair { vtbackend::CellFlags::Inverse, std::string_view("Inverse") },
-            std::pair { vtbackend::CellFlags::Hidden, std::string_view("Hidden") },
-            std::pair { vtbackend::CellFlags::CrossedOut, std::string_view("CrossedOut") },
-            std::pair { vtbackend::CellFlags::DoublyUnderlined, std::string_view("DoublyUnderlined") },
-            std::pair { vtbackend::CellFlags::CurlyUnderlined, std::string_view("CurlyUnderlined") },
-            std::pair { vtbackend::CellFlags::DottedUnderline, std::string_view("DottedUnderline") },
-            std::pair { vtbackend::CellFlags::DashedUnderline, std::string_view("DashedUnderline") },
-            std::pair { vtbackend::CellFlags::Framed, std::string_view("Framed") },
-            std::pair { vtbackend::CellFlags::Encircled, std::string_view("Encircled") },
-            std::pair { vtbackend::CellFlags::Overline, std::string_view("Overline") },
-            std::pair { vtbackend::CellFlags::CharacterProtected, std::string_view("CharacterProtected") },
-            std::pair { vtbackend::CellFlags::WideCharContinuation,
-                        std::string_view("WideCharContinuation") },
-        };
-        std::string s;
-        for (auto const& mapping: nameMap)
+        string_view s;
+
+        // clang-format off
+        switch (value)
         {
-            if (mapping.first & flags)
-            {
-                if (!s.empty())
-                    s += ",";
-                s += mapping.second;
-            }
+            case vtbackend::CellFlag::None: s = std::string_view("None"); break;
+            case vtbackend::CellFlag::Bold: s = std::string_view("Bold"); break;
+            case vtbackend::CellFlag::Faint: s = std::string_view("Faint"); break;
+            case vtbackend::CellFlag::Italic: s = std::string_view("Italic"); break;
+            case vtbackend::CellFlag::Underline: s = std::string_view("Underline"); break;
+            case vtbackend::CellFlag::Blinking: s = std::string_view("Blinking"); break;
+            case vtbackend::CellFlag::RapidBlinking: s = std::string_view("RapidBlinking"); break;
+            case vtbackend::CellFlag::Inverse: s = std::string_view("Inverse"); break;
+            case vtbackend::CellFlag::Hidden: s = std::string_view("Hidden"); break;
+            case vtbackend::CellFlag::CrossedOut: s = std::string_view("CrossedOut"); break;
+            case vtbackend::CellFlag::DoublyUnderlined: s = std::string_view("DoublyUnderlined"); break;
+            case vtbackend::CellFlag::CurlyUnderlined: s = std::string_view("CurlyUnderlined"); break;
+            case vtbackend::CellFlag::DottedUnderline: s = std::string_view("DottedUnderline"); break;
+            case vtbackend::CellFlag::DashedUnderline: s = std::string_view("DashedUnderline"); break;
+            case vtbackend::CellFlag::Framed: s = std::string_view("Framed"); break;
+            case vtbackend::CellFlag::Encircled: s = std::string_view("Encircled"); break;
+            case vtbackend::CellFlag::Overline: s = std::string_view("Overline"); break;
+            case vtbackend::CellFlag::CharacterProtected: s = std::string_view("CharacterProtected"); break;
+            case vtbackend::CellFlag::WideCharContinuation: s = std::string_view("WideCharContinuation"); break;
         }
-        return formatter<std::string>::format(s, ctx);
+        // clang-format on
+
+        return formatter<string_view>::format(s, ctx);
     }
 };
 // }}}

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -39,7 +39,7 @@ namespace detail
                             bool reflowOnResize,
                             GraphicsAttributes initialSGR)
     {
-        auto const defaultLineFlags = reflowOnResize ? LineFlags::Wrappable : LineFlags::None;
+        auto const defaultLineFlags = reflowOnResize ? LineFlag::Wrappable : LineFlag::None;
         auto const totalLineCount = unbox<size_t>(pageSize.lines + maxHistoryLineCount);
 
         Lines<Cell> lines;
@@ -80,7 +80,7 @@ namespace detail
         {
             auto from = logicalLineBuffer.begin();
             auto to = from + newColumnCount.as<std::ptrdiff_t>();
-            auto const wrappedFlag = i == 0 && initialNoWrap ? LineFlags::None : LineFlags::Wrapped;
+            auto const wrappedFlag = i == 0 && initialNoWrap ? LineFlag::None : LineFlag::Wrapped;
             targetLines.emplace_back(baseFlags | wrappedFlag, LineBuffer(from, to));
             logicalLineBuffer.erase(from, to);
             ++i;
@@ -88,7 +88,7 @@ namespace detail
 
         if (logicalLineBuffer.size() > 0)
         {
-            auto const wrappedFlag = i == 0 && initialNoWrap ? LineFlags::None : LineFlags::Wrapped;
+            auto const wrappedFlag = i == 0 && initialNoWrap ? LineFlag::None : LineFlag::Wrapped;
             ++i;
             logicalLineBuffer.resize(unbox<size_t>(newColumnCount));
             targetLines.emplace_back(baseFlags | wrappedFlag, std::move(logicalLineBuffer));
@@ -755,7 +755,7 @@ CellLocation Grid<Cell>::resize(PageSize newSize, CellLocation currentCursorPos,
             Lines<Cell> grownLines;
             LineBuffer
                 logicalLineBuffer; // Temporary state, representing wrapped columns from the line "below".
-            LineFlags logicalLineFlags = LineFlags::None;
+            LineFlags logicalLineFlags = LineFlag::None;
 
             auto const appendToLogicalLine = [&logicalLineBuffer](gsl::span<Cell const> cells) {
                 for (auto const& cell: cells)
@@ -804,7 +804,7 @@ CellLocation Grid<Cell>::resize(PageSize newSize, CellLocation currentCursorPos,
                     {
                         // logLogicalLine(line.flags(), " - start new logical line");
                         appendToLogicalLine(line.cells());
-                        logicalLineFlags = line.flags() & ~LineFlags::Wrapped;
+                        logicalLineFlags = line.flags().without(LineFlag::Wrapped);
                     }
                 }
             }
@@ -936,7 +936,7 @@ CellLocation Grid<Cell>::resize(PageSize newSize, CellLocation currentCursorPos,
 
             while (shrinkedLines.size() < totalLineCount)
                 shrinkedLines.emplace_back(
-                    LineFlags::None,
+                    LineFlag::None,
                     TrivialLineBuffer { newColumnCount, GraphicsAttributes {}, GraphicsAttributes {} });
 
             shrinkedLines.rotate_left(
@@ -1041,7 +1041,7 @@ std::ostream& dumpGrid(std::ostream& os, Grid<Cell> const& grid)
         os << fmt::format("[{:>2}] \"{}\" | {}\n",
                           lineOffset,
                           grid.lineText(LineOffset::cast_from(lineOffset)),
-                          (unsigned) lineAttribs.flags());
+                          lineAttribs.flags());
     }
 
     return os;

--- a/src/vtbackend/Grid.h
+++ b/src/vtbackend/Grid.h
@@ -842,7 +842,7 @@ template <typename Cell>
 CRISPY_REQUIRES(CellConcept<Cell>)
 constexpr LineFlags Grid<Cell>::defaultLineFlags() const noexcept
 {
-    return _reflowOnResize ? LineFlags::Wrappable : LineFlags::None;
+    return _reflowOnResize ? LineFlag::Wrappable : LineFlag::None;
 }
 
 template <typename Cell>

--- a/src/vtbackend/Grid.h
+++ b/src/vtbackend/Grid.h
@@ -882,8 +882,8 @@ template <typename RendererT>
         if (line.isTrivialBuffer() && highlightSearchMatches == HighlightSearchMatches::No)
         {
             auto const cellFlags = line.trivialBuffer().textAttributes.flags;
-            hints.containsBlinkingCells = hints.containsBlinkingCells || (CellFlags::Blinking & cellFlags)
-                                          || (CellFlags::RapidBlinking & cellFlags);
+            hints.containsBlinkingCells = hints.containsBlinkingCells || (cellFlags & CellFlag::Blinking)
+                                          || (cellFlags & CellFlag::RapidBlinking);
             render.renderTrivialLine(line.trivialBuffer(), y);
         }
         else
@@ -892,8 +892,8 @@ template <typename RendererT>
             for (Cell const& cell: line.cells())
             {
                 hints.containsBlinkingCells = hints.containsBlinkingCells
-                                              || (CellFlags::Blinking & cell.flags())
-                                              || (CellFlags::RapidBlinking & cell.flags());
+                                              || (cell.flags() & CellFlag::Blinking)
+                                              || (cell.flags() & CellFlag::RapidBlinking);
                 render.renderCell(cell, y, x++);
             }
             render.endLine();

--- a/src/vtbackend/Grid_test.cpp
+++ b/src/vtbackend/Grid_test.cpp
@@ -35,7 +35,7 @@ void logGridText(Grid<Cell> const& grid, string const& headline = "")
             fmt::format("{:>2}: \"{}\" {}\n",
                         line,
                         grid.lineText(LineOffset::cast_from(line - grid.historyLineCount().as<int>())),
-                        (unsigned) grid.lineAt(LineOffset::cast_from(line)).flags()));
+                        grid.lineAt(LineOffset::cast_from(line)).flags()));
     }
 }
 
@@ -459,13 +459,13 @@ TEST_CASE("resize_shrink_columns_with_reflow_and_unwrappable", "[grid]")
     CHECK(grid.lineText(LineOffset(0)) == "JK");
     CHECK(grid.lineText(LineOffset(1)) == "L ");
 
-    CHECK(grid.lineAt(LineOffset(-5)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(-4)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
-    CHECK(grid.lineAt(LineOffset(-3)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(-2)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
-    CHECK(grid.lineAt(LineOffset(-1)).flags() == LineFlags::None);
-    CHECK(grid.lineAt(LineOffset(0)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(1)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
+    CHECK(grid.lineAt(LineOffset(-5)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(-4)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
+    CHECK(grid.lineAt(LineOffset(-3)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(-2)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
+    CHECK(grid.lineAt(LineOffset(-1)).flags() == LineFlag::None);
+    CHECK(grid.lineAt(LineOffset(0)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(1)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
 }
 
 TEST_CASE("resize_shrink_columns_with_reflow_grow_lines_and_unwrappable", "[grid]")
@@ -498,13 +498,13 @@ TEST_CASE("resize_shrink_columns_with_reflow_grow_lines_and_unwrappable", "[grid
     CHECK(grid.lineText(LineOffset(2)) == "JK");
     CHECK(grid.lineText(LineOffset(3)) == "L ");
 
-    CHECK(grid.lineAt(LineOffset(-3)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(-2)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
-    CHECK(grid.lineAt(LineOffset(-1)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(0)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
-    CHECK(grid.lineAt(LineOffset(1)).flags() == LineFlags::None);
-    CHECK(grid.lineAt(LineOffset(2)).flags() == LineFlags::Wrappable);
-    CHECK(grid.lineAt(LineOffset(3)).flags() == (LineFlags::Wrappable | LineFlags::Wrapped));
+    CHECK(grid.lineAt(LineOffset(-3)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(-2)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
+    CHECK(grid.lineAt(LineOffset(-1)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(0)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
+    CHECK(grid.lineAt(LineOffset(1)).flags() == LineFlag::None);
+    CHECK(grid.lineAt(LineOffset(2)).flags() == LineFlag::Wrappable);
+    CHECK(grid.lineAt(LineOffset(3)).flags() == LineFlags({ LineFlag::Wrappable, LineFlag::Wrapped }));
 }
 // }}}
 
@@ -886,7 +886,7 @@ TEST_CASE("Grid resize", "[grid]")
     auto const bufferFragment = bufferObject->ref(0, 4);
     auto const sgr = GraphicsAttributes {};
     auto const trivial = TrivialLineBuffer { width, sgr, sgr, HyperlinkId {}, width, bufferFragment };
-    auto lineTrivial = Line<Cell>(LineFlags::None, trivial);
+    auto lineTrivial = Line<Cell>(LineFlag::None, trivial);
     grid.lineAt(LineOffset(0)) = lineTrivial;
     REQUIRE(grid.lineAt(LineOffset(0)).isTrivialBuffer());
     REQUIRE(grid.lineAt(LineOffset(1)).isTrivialBuffer());

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -330,7 +330,10 @@ class ExtendedKeyboardInputGenerator final: public StandardKeyboardInputGenerato
 
     [[nodiscard]] constexpr KeyboardEventFlags& flags() noexcept { return _flags.at(_currentStackTop); }
 
-    [[nodiscard]] constexpr bool enabled(KeyboardEventFlag flag) const noexcept { return flags() & flag; }
+    [[nodiscard]] constexpr bool enabled(KeyboardEventFlag flag) const noexcept
+    {
+        return flags().contains(flag);
+    }
 
     [[nodiscard]] constexpr bool enabled(KeyboardEventType eventType) const noexcept
     {

--- a/src/vtbackend/Line.cpp
+++ b/src/vtbackend/Line.cpp
@@ -181,7 +181,7 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
         {
             while (gapPending > 0)
             {
-                columns.emplace_back(input.textAttributes.with(CellFlags::WideCharContinuation),
+                columns.emplace_back(input.textAttributes.with(CellFlag::WideCharContinuation),
                                      input.hyperlink);
                 --gapPending;
             }

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -98,19 +98,13 @@ class Line
     using reverse_iterator = typename InflatedBuffer::reverse_iterator;
     using const_iterator = typename InflatedBuffer::const_iterator;
 
-    Line(LineFlags flags, TrivialBuffer buffer):
-        _storage { std::move(buffer) }, _flags { static_cast<unsigned>(flags) }
-    {
-    }
+    Line(LineFlags flags, TrivialBuffer buffer): _storage { std::move(buffer) }, _flags { flags } {}
 
-    Line(LineFlags flags, InflatedBuffer buffer):
-        _storage { std::move(buffer) }, _flags { static_cast<unsigned>(flags) }
-    {
-    }
+    Line(LineFlags flags, InflatedBuffer buffer): _storage { std::move(buffer) }, _flags { flags } {}
 
     void reset(LineFlags flags, GraphicsAttributes attributes) noexcept
     {
-        _flags = static_cast<unsigned>(flags);
+        _flags = flags;
         if (isTrivialBuffer())
             trivialBuffer().reset(attributes);
         else
@@ -119,7 +113,7 @@ class Line
 
     void reset(LineFlags flags, GraphicsAttributes attributes, ColumnCount count) noexcept
     {
-        _flags = static_cast<unsigned>(flags);
+        _flags = flags;
         setBuffer(TrivialBuffer { count, attributes });
     }
 
@@ -132,7 +126,7 @@ class Line
             reset(flags, attributes);
         else
         {
-            _flags = static_cast<unsigned>(flags);
+            _flags = flags;
             for (Cell& cell: inflatedBuffer())
             {
                 cell.reset();
@@ -238,46 +232,43 @@ class Line
 
     [[nodiscard]] LineFlags flags() const noexcept { return static_cast<LineFlags>(_flags); }
 
-    [[nodiscard]] bool marked() const noexcept { return isFlagEnabled(LineFlags::Marked); }
-    void setMarked(bool enable) { setFlag(LineFlags::Marked, enable); }
+    [[nodiscard]] bool marked() const noexcept { return isFlagEnabled(LineFlag::Marked); }
+    void setMarked(bool enable) { setFlag(LineFlag::Marked, enable); }
 
-    [[nodiscard]] bool wrapped() const noexcept { return isFlagEnabled(LineFlags::Wrapped); }
-    void setWrapped(bool enable) { setFlag(LineFlags::Wrapped, enable); }
+    [[nodiscard]] bool wrapped() const noexcept { return isFlagEnabled(LineFlag::Wrapped); }
+    void setWrapped(bool enable) { setFlag(LineFlag::Wrapped, enable); }
 
-    [[nodiscard]] bool wrappable() const noexcept { return isFlagEnabled(LineFlags::Wrappable); }
-    void setWrappable(bool enable) { setFlag(LineFlags::Wrappable, enable); }
+    [[nodiscard]] bool wrappable() const noexcept { return isFlagEnabled(LineFlag::Wrappable); }
+    void setWrappable(bool enable) { setFlag(LineFlag::Wrappable, enable); }
 
     [[nodiscard]] LineFlags wrappableFlag() const noexcept
     {
-        return wrappable() ? LineFlags::Wrappable : LineFlags::None;
+        return wrappable() ? LineFlag::Wrappable : LineFlag::None;
     }
     [[nodiscard]] LineFlags wrappedFlag() const noexcept
     {
-        return marked() ? LineFlags::Wrapped : LineFlags::None;
+        return marked() ? LineFlag::Wrapped : LineFlag::None;
     }
     [[nodiscard]] LineFlags markedFlag() const noexcept
     {
-        return marked() ? LineFlags::Marked : LineFlags::None;
+        return marked() ? LineFlag::Marked : LineFlag::None;
     }
 
     [[nodiscard]] LineFlags inheritableFlags() const noexcept
     {
-        auto constexpr Inheritables = unsigned(LineFlags::Wrappable) | unsigned(LineFlags::Marked);
-        return static_cast<LineFlags>(_flags & Inheritables);
+        auto constexpr Inheritables = LineFlags({ LineFlag::Wrappable, LineFlag::Marked });
+        return _flags & Inheritables;
     }
 
-    void setFlag(LineFlags flag, bool enable) noexcept
+    void setFlag(LineFlags flags, bool enable) noexcept
     {
         if (enable)
-            _flags |= static_cast<unsigned>(flag);
+            _flags.enable(flags);
         else
-            _flags &= ~static_cast<unsigned>(flag);
+            _flags.disable(flags);
     }
 
-    [[nodiscard]] bool isFlagEnabled(LineFlags flag) const noexcept
-    {
-        return (_flags & static_cast<unsigned>(flag)) != 0;
-    }
+    [[nodiscard]] bool isFlagEnabled(LineFlags flags) const noexcept { return (_flags & flags).any(); }
 
     [[nodiscard]] InflatedBuffer reflow(ColumnCount newColumnCount);
     [[nodiscard]] std::string toUtf8() const;
@@ -434,23 +425,8 @@ class Line
 
   private:
     Storage _storage;
-    unsigned _flags = 0;
+    LineFlags _flags;
 };
-
-constexpr LineFlags operator|(LineFlags a, LineFlags b) noexcept
-{
-    return LineFlags(unsigned(a) | unsigned(b));
-}
-
-constexpr LineFlags operator~(LineFlags a) noexcept
-{
-    return LineFlags(~unsigned(a));
-}
-
-constexpr LineFlags operator&(LineFlags a, LineFlags b) noexcept
-{
-    return LineFlags(unsigned(a) & unsigned(b));
-}
 
 template <typename Cell>
 inline typename Line<Cell>::InflatedBuffer& Line<Cell>::inflatedBuffer()
@@ -474,14 +450,14 @@ struct fmt::formatter<vtbackend::LineFlags>: formatter<std::string>
     auto format(const vtbackend::LineFlags flags, format_context& ctx) -> format_context::iterator
     {
         static const std::array<std::pair<vtbackend::LineFlags, std::string_view>, 3> nameMap = {
-            std::pair { vtbackend::LineFlags::Wrappable, std::string_view("Wrappable") },
-            std::pair { vtbackend::LineFlags::Wrapped, std::string_view("Wrapped") },
-            std::pair { vtbackend::LineFlags::Marked, std::string_view("Marked") },
+            std::pair { vtbackend::LineFlag::Wrappable, std::string_view("Wrappable") },
+            std::pair { vtbackend::LineFlag::Wrapped, std::string_view("Wrapped") },
+            std::pair { vtbackend::LineFlag::Marked, std::string_view("Marked") },
         };
         std::string s;
         for (auto const& mapping: nameMap)
         {
-            if ((mapping.first & flags) != vtbackend::LineFlags::None)
+            if ((mapping.first & flags) != vtbackend::LineFlag::None)
             {
                 if (!s.empty())
                     s += ",";

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -9,6 +9,7 @@
 #include <crispy/BufferObject.h>
 #include <crispy/Comparison.h>
 #include <crispy/assert.h>
+#include <crispy/flags.h>
 
 #include <libunicode/convert.h>
 
@@ -22,7 +23,7 @@
 namespace vtbackend
 {
 
-enum class LineFlags : uint8_t
+enum class LineFlag : uint8_t
 {
     None = 0x0000,
     Wrappable = 0x0001,
@@ -31,6 +32,8 @@ enum class LineFlags : uint8_t
     // TODO: DoubleWidth  = 0x0010,
     // TODO: DoubleHeight = 0x0020,
 };
+
+using LineFlags = crispy::flags<LineFlag>;
 
 // clang-format off
 template <typename, bool> struct OptionalProperty;

--- a/src/vtbackend/Line_test.cpp
+++ b/src/vtbackend/Line_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Line.resize", "[Line]")
     auto const trivial =
         TrivialLineBuffer { DisplayWidth, sgr, sgr, HyperlinkId {}, DisplayWidth, bufferFragment };
     CHECK(trivial.text.view() == string_view(text.data()));
-    auto lineTrivial = Line<Cell>(LineFlags::None, trivial);
+    auto lineTrivial = Line<Cell>(LineFlag::None, trivial);
     CHECK(lineTrivial.isTrivialBuffer());
 
     lineTrivial.resize(ColumnCount(10));
@@ -68,7 +68,7 @@ TEST_CASE("Line.reflow", "[Line]")
     auto const trivial =
         TrivialLineBuffer { DisplayWidth, sgr, sgr, HyperlinkId {}, DisplayWidth, bufferFragment };
     CHECK(trivial.text.view() == string_view(text.data()));
-    auto lineTrivial = Line<Cell>(LineFlags::None, trivial);
+    auto lineTrivial = Line<Cell>(LineFlag::None, trivial);
     CHECK(lineTrivial.isTrivialBuffer());
 
     (void) lineTrivial.reflow(ColumnCount(5));

--- a/src/vtbackend/Line_test.cpp
+++ b/src/vtbackend/Line_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Line.inflate", "[Line]")
     sgr.foregroundColor = RGBColor(0x123456);
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
-    sgr.flags |= CellFlags::CurlyUnderlined;
+    sgr.flags |= CellFlag::CurlyUnderlined;
     auto const trivial =
         TrivialLineBuffer { ColumnCount(10), sgr, sgr, HyperlinkId {}, ColumnCount(10), bufferFragment };
 
@@ -126,7 +126,7 @@ TEST_CASE("Line.inflate.Unicode", "[Line]")
     sgr.foregroundColor = RGBColor(0x123456);
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
-    sgr.flags |= CellFlags::CurlyUnderlined;
+    sgr.flags |= CellFlag::CurlyUnderlined;
     auto const trivial =
         TrivialLineBuffer { DisplayWidth, sgr, sgr, HyperlinkId {}, DisplayWidth, bufferFragment };
 
@@ -176,13 +176,13 @@ TEST_CASE("Line.inflate.Unicode.FamilyEmoji", "[Line]")
     sgr.foregroundColor = RGBColor(0x123456);
     sgr.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     sgr.underlineColor = Color::Indexed(IndexedColor::Red);
-    sgr.flags |= CellFlags::CurlyUnderlined;
+    sgr.flags |= CellFlag::CurlyUnderlined;
 
     auto fillSGR = GraphicsAttributes {};
     fillSGR.foregroundColor = RGBColor(0x123456);
     fillSGR.backgroundColor = Color::Indexed(IndexedColor::Yellow);
     fillSGR.underlineColor = Color::Indexed(IndexedColor::Red);
-    fillSGR.flags |= CellFlags::CurlyUnderlined;
+    fillSGR.flags |= CellFlag::CurlyUnderlined;
 
     auto const trivial =
         TrivialLineBuffer { DisplayWidth, sgr, fillSGR, HyperlinkId {}, UsedColumnCount, bufferFragment };

--- a/src/vtbackend/RenderBufferBuilder.cpp
+++ b/src/vtbackend/RenderBufferBuilder.cpp
@@ -227,8 +227,8 @@ RenderCell RenderBufferBuilder<Cell>::makeRenderCell(ColorPalette const& colorPa
         // TODO(decoration): Move property into Terminal.
         auto const decoration =
             href->state == HyperlinkState::Hover
-                ? CellFlags::Underline             // TODO: decorationRenderer_.hyperlinkHover()
-                : CellFlags::DottedUnderline;      // TODO: decorationRenderer_.hyperlinkNormal();
+                ? CellFlag::Underline              // TODO: decorationRenderer_.hyperlinkHover()
+                : CellFlag::DottedUnderline;       // TODO: decorationRenderer_.hyperlinkNormal();
         renderCell.attributes.flags |= decoration; // toCellStyle(decoration);
         renderCell.attributes.decorationColor = color;
     }
@@ -577,7 +577,7 @@ bool RenderBufferBuilder<Cell>::tryRenderInputMethodEditor(CellLocation screenPo
         auto textAttributes = GraphicsAttributes {};
         textAttributes.foregroundColor = inputMethodEditorStyles.foreground;
         textAttributes.backgroundColor = inputMethodEditorStyles.background;
-        textAttributes.flags |= CellFlags::Bold | CellFlags::Underline;
+        textAttributes.flags.enable({ CellFlag::Bold, CellFlag::Underline });
 
         if (!_output->cells.empty())
             _output->cells.back().groupEnd = true;

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -533,7 +533,7 @@ void Screen<Cell>::crlfIfWrapPending()
         bool const lineWrappable = currentLine().wrappable();
         crlf();
         if (lineWrappable)
-            currentLine().setFlag(LineFlags::Wrappable | LineFlags::Wrapped, true);
+            currentLine().setFlag(LineFlags { LineFlag::Wrappable, LineFlag::Wrapped }, true);
     }
 }
 

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -210,22 +210,22 @@ namespace // {{{ helper
 
         // TODO: sgr.styles;
         auto constexpr Masks = array {
-            pair { CellFlags::Bold, "1"sv },
-            pair { CellFlags::Faint, "2"sv },
-            pair { CellFlags::Italic, "3"sv },
-            pair { CellFlags::Underline, "4"sv },
-            pair { CellFlags::Blinking, "5"sv },
-            pair { CellFlags::RapidBlinking, "6"sv },
-            pair { CellFlags::Inverse, "7"sv },
-            pair { CellFlags::Hidden, "8"sv },
-            pair { CellFlags::CrossedOut, "9"sv },
-            pair { CellFlags::DoublyUnderlined, "4:2"sv },
-            pair { CellFlags::CurlyUnderlined, "4:3"sv },
-            pair { CellFlags::DottedUnderline, "4:4"sv },
-            pair { CellFlags::DashedUnderline, "4:5"sv },
-            pair { CellFlags::Framed, "51"sv },
-            // TODO(impl or completely remove): pair{CellFlags::Encircled, ""sv},
-            pair { CellFlags::Overline, "53"sv },
+            pair { CellFlag::Bold, "1"sv },
+            pair { CellFlag::Faint, "2"sv },
+            pair { CellFlag::Italic, "3"sv },
+            pair { CellFlag::Underline, "4"sv },
+            pair { CellFlag::Blinking, "5"sv },
+            pair { CellFlag::RapidBlinking, "6"sv },
+            pair { CellFlag::Inverse, "7"sv },
+            pair { CellFlag::Hidden, "8"sv },
+            pair { CellFlag::CrossedOut, "9"sv },
+            pair { CellFlag::DoublyUnderlined, "4:2"sv },
+            pair { CellFlag::CurlyUnderlined, "4:3"sv },
+            pair { CellFlag::DottedUnderline, "4:4"sv },
+            pair { CellFlag::DashedUnderline, "4:5"sv },
+            pair { CellFlag::Framed, "51"sv },
+            // TODO(impl or completely remove): pair{CellFlag::Encircled, ""sv},
+            pair { CellFlag::Overline, "53"sv },
         };
 
         for (auto const& mask: Masks)
@@ -586,7 +586,7 @@ void Screen<Cell>::writeCharToCurrentAndAdvance(char32_t codepoint) noexcept
         cell.reset();
 #endif
 
-    if (cell.isFlagEnabled(CellFlags::WideCharContinuation) && _cursor.position.column > ColumnOffset(0))
+    if (cell.isFlagEnabled(CellFlag::WideCharContinuation) && _cursor.position.column > ColumnOffset(0))
     {
         // Erase the left half of the wide char.
         Cell& prevCell = line.useCellAt(_cursor.position.column - 1);
@@ -630,7 +630,7 @@ void Screen<Cell>::clearAndAdvance(int offset) noexcept
         for (int i = 1; i < n; ++i) // XXX It's not even clear if other TEs are doing that, too.
         {
             line.useCellAt(_cursor.position.column)
-                .reset(_cursor.graphicsRendition.with(CellFlags::WideCharContinuation), _cursor.hyperlink);
+                .reset(_cursor.graphicsRendition.with(CellFlag::WideCharContinuation), _cursor.hyperlink);
             _cursor.position.column++;
         }
     }
@@ -1085,7 +1085,7 @@ void Screen<Cell>::selectiveErase(LineOffset line, ColumnOffset begin, ColumnOff
     Cell const* e = i + unbox<uintptr_t>(end - begin);
     while (i != e)
     {
-        if (i->isFlagEnabled(CellFlags::CharacterProtected))
+        if (i->isFlagEnabled(CellFlag::CharacterProtected))
         {
             ++i;
             continue;
@@ -1108,7 +1108,7 @@ bool Screen<Cell>::containsProtectedCharacters(LineOffset line, ColumnOffset beg
     Cell const* e = i + unbox<uintptr_t>(end - begin);
     while (i != e)
     {
-        if (i->isFlagEnabled(CellFlags::CharacterProtected))
+        if (i->isFlagEnabled(CellFlag::CharacterProtected))
             return true;
         ++i;
     }
@@ -1166,7 +1166,7 @@ void Screen<Cell>::selectiveEraseArea(Rect area)
                              .useRange(ColumnOffset::cast_from(left),
                                        ColumnCount::cast_from(right.value - left.value + 1)))
         {
-            if (!cell.isFlagEnabled(CellFlags::CharacterProtected))
+            if (!cell.isFlagEnabled(CellFlag::CharacterProtected))
             {
                 cell.writeTextOnly(L' ', 1);
                 cell.setHyperlink(HyperlinkId(0));
@@ -2152,7 +2152,7 @@ void Screen<Cell>::requestStatusString(RequestStatusString value)
             case RequestStatusString::SGR:
                 return fmt::format("0;{}m", vtSequenceParameterString(_cursor.graphicsRendition));
             case RequestStatusString::DECSCA: {
-                auto const isProtected = _cursor.graphicsRendition.flags & CellFlags::CharacterProtected;
+                auto const isProtected = _cursor.graphicsRendition.flags & CellFlag::CharacterProtected;
                 return fmt::format("{}\"q", isProtected ? 1 : 2);
             }
             case RequestStatusString::DECSASD:
@@ -3587,11 +3587,11 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
             switch (pc)
             {
                 case 1:
-                    _cursor.graphicsRendition.flags |= CellFlags::CharacterProtected;
+                    _cursor.graphicsRendition.flags.enable(CellFlag::CharacterProtected);
                     return ApplyResult::Ok;
                 case 0:
                 case 2:
-                    _cursor.graphicsRendition.flags &= ~CellFlags::CharacterProtected;
+                    _cursor.graphicsRendition.flags.disable(CellFlag::CharacterProtected);
                     return ApplyResult::Ok;
                 default: return ApplyResult::Invalid;
             }

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -557,17 +557,17 @@ void Terminal::updateIndicatorStatusLine()
     if (!allowInput())
     {
         _indicatorStatusScreen.cursor().graphicsRendition.foregroundColor = BrightColor::Red;
-        _indicatorStatusScreen.cursor().graphicsRendition.flags |= CellFlags::Bold;
+        _indicatorStatusScreen.cursor().graphicsRendition.flags.enable(CellFlag::Bold);
         _indicatorStatusScreen.writeTextFromExternal(" (PROTECTED)");
         _indicatorStatusScreen.cursor().graphicsRendition.foregroundColor = colors.foreground;
-        _indicatorStatusScreen.cursor().graphicsRendition.flags &= ~CellFlags::Bold;
+        _indicatorStatusScreen.cursor().graphicsRendition.flags.disable(CellFlag::Bold);
     }
 
     if (_state.executionMode != ExecutionMode::Normal)
     {
         _indicatorStatusScreen.writeTextFromExternal(" | ");
         _indicatorStatusScreen.cursor().graphicsRendition.foregroundColor = BrightColor::Yellow;
-        _indicatorStatusScreen.cursor().graphicsRendition.flags |= CellFlags::Bold;
+        _indicatorStatusScreen.cursor().graphicsRendition.flags |= CellFlag::Bold;
         _indicatorStatusScreen.writeTextFromExternal("TRACING");
         if (!_traceHandler.pendingSequences().empty())
             _indicatorStatusScreen.writeTextFromExternal(
@@ -576,7 +576,7 @@ void Terminal::updateIndicatorStatusLine()
                             _traceHandler.pendingSequences().front()));
 
         _indicatorStatusScreen.cursor().graphicsRendition.foregroundColor = colors.foreground;
-        _indicatorStatusScreen.cursor().graphicsRendition.flags &= ~CellFlags::Bold;
+        _indicatorStatusScreen.cursor().graphicsRendition.flags.disable(CellFlag::Bold);
     }
 
     // TODO: Disabled for now, but generally I want that functionality, but configurable somehow.

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace std;
 using namespace std::chrono_literals;
-using vtbackend::CellFlags;
+using vtbackend::CellFlag;
 using vtbackend::ColumnCount;
 using vtbackend::ColumnOffset;
 using vtbackend::LineCount;
@@ -130,8 +130,8 @@ TEST_CASE("Terminal.DECCARA", "[terminal]")
             auto const colorDec = fmt::format("{}/{}/{}", unsigned(rgb.red), unsigned(rgb.green), unsigned(rgb.blue));
             INFO(fmt::format("at line {} column {}, flags {}", line, column, someCell.flags()));
             CHECK(colorDec == "171/178/191");
-            CHECK(someCell.isFlagEnabled(vtbackend::CellFlags::Bold));
-            CHECK(someCell.isFlagEnabled(vtbackend::CellFlags::Underline));
+            CHECK(someCell.isFlagEnabled(vtbackend::CellFlag::Bold));
+            CHECK(someCell.isFlagEnabled(vtbackend::CellFlag::Underline));
             // clang-format on
         }
 }
@@ -353,15 +353,15 @@ TEST_CASE("Terminal.CurlyUnderline", "[terminal]")
 
     auto& screen = mc.terminal.primaryScreen();
 
-    CHECK(screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlags::CurlyUnderlined));
-    CHECK(screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlags::CurlyUnderlined));
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlags::CurlyUnderlined));
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlags::CurlyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::CurlyUnderlined));
 
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlags::Italic));
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlags::Italic));
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlags::Italic));
-    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlags::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::Italic));
 }
 
 TEST_CASE("Terminal.TextSelection", "[terminal]")

--- a/src/vtbackend/VTWriter.cpp
+++ b/src/vtbackend/VTWriter.cpp
@@ -203,7 +203,7 @@ void VTWriter::write(Line<Cell> const& line)
     {
         for (Cell const& cell: line.inflatedBuffer())
         {
-            if (cell.flags() & CellFlags::Bold)
+            if (cell.flags() & CellFlag::Bold)
                 sgrAdd(GraphicsRendition::Bold);
             else
                 sgrAdd(GraphicsRendition::Normal);

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -315,7 +315,7 @@ void ViCommands::toggleLineMark()
 {
     auto const currentLineFlags = _terminal->currentScreen().lineFlagsAt(cursorPosition.line);
     _terminal->currentScreen().enableLineFlags(
-        cursorPosition.line, LineFlags::Marked, !unsigned(currentLineFlags & LineFlags::Marked));
+        cursorPosition.line, LineFlag::Marked, !(currentLineFlags & LineFlag::Marked));
 }
 
 void ViCommands::searchCurrentWord()
@@ -641,16 +641,14 @@ CellLocationRange ViCommands::translateToCellRange(TextObjectScope scope,
         case TextObject::DoubleQuotes: return expandMatchingPair(scope, '"', '"');
         case TextObject::LineMark:
             // Walk the line upwards until we find a marked line.
-            while (
-                a.line > gridTop
-                && !(unsigned(_terminal->currentScreen().lineFlagsAt(a.line)) & unsigned(LineFlags::Marked)))
+            while (a.line > gridTop
+                   && !(_terminal->currentScreen().lineFlagsAt(a.line).contains(LineFlag::Marked)))
                 --a.line;
             if (scope == TextObjectScope::Inner && a != cursorPosition)
                 ++a.line;
             // Walk the line downwards until we find a marked line.
-            while (
-                b.line < gridBottom
-                && !(unsigned(_terminal->currentScreen().lineFlagsAt(b.line)) & unsigned(LineFlags::Marked)))
+            while (b.line < gridBottom
+                   && !(_terminal->currentScreen().lineFlagsAt(b.line).contains(LineFlag::Marked)))
                 ++b.line;
             if (scope == TextObjectScope::Inner && b != cursorPosition)
                 --b.line;
@@ -905,10 +903,10 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
             while (count > 0)
             {
                 if (result.line > gridTop
-                    && _terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
+                    && _terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlag::Marked))
                     --result.line;
                 while (result.line > gridTop
-                       && !_terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlags::Marked))
+                       && !_terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlag::Marked))
                     --result.line;
                 --count;
             }
@@ -924,8 +922,7 @@ CellLocation ViCommands::translateToCellLocation(ViMotion motion, unsigned count
                     ++result.line;
                 while (result.line < pageBottom)
                 {
-                    if (unsigned(_terminal->currentScreen().lineFlagsAt(result.line))
-                        & unsigned(LineFlags::Marked))
+                    if (_terminal->currentScreen().lineFlagsAt(result.line).contains(LineFlag::Marked))
                         break;
                     ++result.line;
                 }

--- a/src/vtbackend/cell/CompactCell.h
+++ b/src/vtbackend/cell/CompactCell.h
@@ -49,7 +49,7 @@ struct CellExtra
     std::shared_ptr<ImageFragment> imageFragment = nullptr;
 
     /// Cell flags.
-    CellFlags flags = CellFlags::None;
+    CellFlags flags = CellFlag::None;
 
     /// In terminals, the Unicode's East asian Width property is used to determine the
     /// number of columns, a graphical character is spanning.
@@ -98,12 +98,15 @@ class CRISPY_PACKED CompactCell
 
     [[nodiscard]] CellFlags flags() const noexcept;
 
-    [[nodiscard]] bool isFlagEnabled(CellFlags testFlags) const noexcept { return flags() & testFlags; }
+    [[nodiscard]] bool isFlagEnabled(CellFlags testFlags) const noexcept
+    {
+        return flags().contains(testFlags);
+    }
 
     void resetFlags() noexcept
     {
         if (_extra)
-            _extra->flags = CellFlags::None;
+            _extra->flags = CellFlag::None;
     }
 
     void resetFlags(CellFlags flags) noexcept { extra().flags = flags; }
@@ -171,7 +174,7 @@ inline CompactCell::CompactCell(GraphicsAttributes attributes, HyperlinkId hyper
     if (attributes.underlineColor != DefaultColor() || _extra)
         extra().underlineColor = attributes.underlineColor;
 
-    if (attributes.flags != CellFlags::None || _extra)
+    if (attributes.flags != CellFlag::None || _extra)
         extra().flags = attributes.flags;
 }
 
@@ -209,7 +212,7 @@ inline void CompactCell::reset(GraphicsAttributes const& attributes) noexcept
     _foregroundColor = attributes.foregroundColor;
     _backgroundColor = attributes.backgroundColor;
     _extra.reset();
-    if (attributes.flags != CellFlags::None)
+    if (attributes.flags != CellFlag::None)
         extra().flags = attributes.flags;
     if (attributes.underlineColor != DefaultColor())
         extra().underlineColor = attributes.underlineColor;
@@ -229,7 +232,7 @@ inline void CompactCell::write(GraphicsAttributes const& attributes, char32_t ch
     _foregroundColor = attributes.foregroundColor;
     _backgroundColor = attributes.backgroundColor;
 
-    if (attributes.flags != CellFlags::None || _extra)
+    if (attributes.flags != CellFlag::None || _extra)
         extra().flags = attributes.flags;
 
     if (attributes.underlineColor != DefaultColor())
@@ -251,7 +254,7 @@ inline void CompactCell::write(GraphicsAttributes const& attributes,
     _foregroundColor = attributes.foregroundColor;
     _backgroundColor = attributes.backgroundColor;
 
-    if (attributes.flags != CellFlags::None || _extra || attributes.underlineColor != DefaultColor()
+    if (attributes.flags != CellFlag::None || _extra || attributes.underlineColor != DefaultColor()
         || !!hyperlink)
     {
         CellExtra& ext = extra();
@@ -278,7 +281,7 @@ inline void CompactCell::reset(GraphicsAttributes const& attributes, HyperlinkId
     _extra.reset();
     if (attributes.underlineColor != DefaultColor())
         extra().underlineColor = attributes.underlineColor;
-    if (attributes.flags != CellFlags::None)
+    if (attributes.flags != CellFlag::None)
         extra().flags = attributes.flags;
     if (hyperlink != HyperlinkId())
         extra().hyperlink = hyperlink;
@@ -370,7 +373,7 @@ inline CellExtra& CompactCell::extra() noexcept
 inline CellFlags CompactCell::flags() const noexcept
 {
     if (!_extra)
-        return CellFlags::None;
+        return CellFlag::None;
     else
         return const_cast<CompactCell*>(this)->_extra->flags;
 }

--- a/src/vtbackend/cell/SimpleCell.h
+++ b/src/vtbackend/cell/SimpleCell.h
@@ -55,7 +55,7 @@ class SimpleCell
 
     [[nodiscard]] CellFlags flags() const noexcept;
     [[nodiscard]] bool isFlagEnabled(CellFlags flags) const noexcept;
-    void resetFlags(CellFlags flags = CellFlags::None) noexcept;
+    void resetFlags(CellFlags flags = CellFlag::None) noexcept;
 
     void setGraphicsRendition(GraphicsRendition sgr) noexcept;
     void setForegroundColor(Color color) noexcept;
@@ -197,7 +197,7 @@ inline CellFlags SimpleCell::flags() const noexcept
 
 inline bool SimpleCell::isFlagEnabled(CellFlags testFlags) const noexcept
 {
-    return _graphicsAttributes.flags & testFlags;
+    return _graphicsAttributes.flags.contains(testFlags);
 }
 
 inline void SimpleCell::resetFlags(CellFlags flags) noexcept

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -35,15 +35,15 @@ namespace vtrasterizer
 namespace
 {
     auto constexpr CellFlagDecorationMappings = array {
-        pair { vtbackend::CellFlags::Underline, Decorator::Underline },
-        pair { vtbackend::CellFlags::DoublyUnderlined, Decorator::DoubleUnderline },
-        pair { vtbackend::CellFlags::CurlyUnderlined, Decorator::CurlyUnderline },
-        pair { vtbackend::CellFlags::DottedUnderline, Decorator::DottedUnderline },
-        pair { vtbackend::CellFlags::DashedUnderline, Decorator::DashedUnderline },
-        pair { vtbackend::CellFlags::Overline, Decorator::Overline },
-        pair { vtbackend::CellFlags::CrossedOut, Decorator::CrossedOut },
-        pair { vtbackend::CellFlags::Framed, Decorator::Framed },
-        pair { vtbackend::CellFlags::Encircled, Decorator::Encircle },
+        pair { vtbackend::CellFlag::Underline, Decorator::Underline },
+        pair { vtbackend::CellFlag::DoublyUnderlined, Decorator::DoubleUnderline },
+        pair { vtbackend::CellFlag::CurlyUnderlined, Decorator::CurlyUnderline },
+        pair { vtbackend::CellFlag::DottedUnderline, Decorator::DottedUnderline },
+        pair { vtbackend::CellFlag::DashedUnderline, Decorator::DashedUnderline },
+        pair { vtbackend::CellFlag::Overline, Decorator::Overline },
+        pair { vtbackend::CellFlag::CrossedOut, Decorator::CrossedOut },
+        pair { vtbackend::CellFlag::Framed, Decorator::Framed },
+        pair { vtbackend::CellFlag::Encircled, Decorator::Encircle },
     };
 }
 

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -243,11 +243,11 @@ namespace
 
     constexpr TextStyle makeTextStyle(vtbackend::CellFlags mask)
     {
-        if (contains_all(mask, vtbackend::CellFlags::Bold | vtbackend::CellFlags::Italic))
+        if (mask == vtbackend::CellFlags { vtbackend::CellFlag::Bold, vtbackend::CellFlag::Italic })
             return TextStyle::BoldItalic;
-        if (mask & vtbackend::CellFlags::Bold)
+        if (mask & vtbackend::CellFlag::Bold)
             return TextStyle::Bold;
-        if (mask & vtbackend::CellFlags::Italic)
+        if (mask & vtbackend::CellFlag::Italic)
             return TextStyle::Italic;
         return TextStyle::Regular;
     }


### PR DESCRIPTION
streamlining flags to avoid unnecessary code bloat.

should make the code also more streamlined.