### PR TITLE
Fixes setting window class (`app_id`) on Wayland

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -127,6 +127,7 @@
           <li>Fixes AltGr handling on Windows (#150)</li>
           <li>Fixes rarely happening bad access to GPU texture atlas (#1309)</li>
           <li>Fixes terminal session not being terminated when the process terminated, but the PTY handle was still open (e.g. by other processes).</li>
+          <li>Fixes setting window class (`app_id`) on Wayland (#1336)</li>
           <li>Do not clear search term when entering search editor again.</li>
           <li>Clear search term when switch to insert vi mode (#1135)</li>
           <li>Delete dpi_scale entry in configuration (#1137)</li>

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -76,6 +76,7 @@ class ContourGuiApp: public QObject, public ContourApp
 
   private:
     static void ensureTermInfoFile();
+    void setupQCoreApplication();
     bool loadConfig(std::string const& target);
     int terminalGuiAction();
     int fontConfigAction();


### PR DESCRIPTION
On Wayland, there's no such thing as WM_CLASS (X11), but a user can use the `app_id` to identify and group Application windows. However, Qt sets that not via QCoreApplication::setApplicationName but rather uses QCoreApplication::setOrganizationDomain's information in reverse name order.

Closes #1336.