### PR TITLE
Update libunicode to latest

### DIFF
--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -26,9 +26,9 @@ $ThirdParties =
         Macro   = ""
     };
     [ThirdParty]@{
-        Folder  = "libunicode-c1474ddc3a90366629d61863628b8d41cd764fa8";
-        Archive = "libunicode-c1474ddc3a90366629d61863628b8d41cd764fa8.zip";
-        URI     = "https://github.com/contour-terminal/libunicode/archive/c1474ddc3a90366629d61863628b8d41cd764fa8.zip";
+        Folder  = "libunicode-23d7b30166a914b10526bb8fe7a469a9610c07dc";
+        Archive = "libunicode-23d7b30166a914b10526bb8fe7a469a9610c07dc.zip";
+        URI     = "https://github.com/contour-terminal/libunicode/archive/23d7b30166a914b10526bb8fe7a469a9610c07dc.zip";
         Macro   = "libunicode"
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -121,7 +121,7 @@ fetch_and_unpack_boxed()
 fetch_and_unpack_libunicode()
 {
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="c1474ddc3a90366629d61863628b8d41cd764fa8"
+        local libunicode_git_sha="23d7b30166a914b10526bb8fe7a469a9610c07dc"
         fetch_and_unpack \
             libunicode-$libunicode_git_sha \
             libunicode-$libunicode_git_sha.tar.gz \


### PR DESCRIPTION
It's currently just a tag, but if it all goes well, we should make it a release in libunicode, and depend on THAT instead, so we have an officiel libunicode release version we can point downstream maintainers to. :)