### PR TITLE
Fix fmt compilation.

### DIFF
--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -631,7 +631,7 @@ class Terminal
 #if defined(__APPLE__) || defined(_MSC_VER)
         reply(fmt::vformat(message, fmt::make_format_args(args...)));
 #else
-        reply(fmt::vformat(message, fmt::make_format_args(std::forward<Ts>(args)...)));
+        reply(fmt::vformat(message, fmt::make_format_args(args...)));
 #endif
     }
 


### PR DESCRIPTION
from fmt release page :  
https://github.com/fmtlib/fmt/releases/tag/10.1.0
```
Disallowed passing temporaries to make_format_args to improve API safety by preventing dangling references.
```
closes https://github.com/contour-terminal/contour/issues/1350
