### PR TITLE
Fix the use of margins within (host writable) statusline

### DIFF
--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -272,6 +272,7 @@ namespace // {{{ helper
 template <typename Cell>
 CRISPY_REQUIRES(CellConcept<Cell>)
 Screen<Cell>::Screen(Terminal& terminal,
+                     gsl::not_null<Margin*> margin,
                      PageSize pageSize,
                      bool reflowOnResize,
                      MaxHistoryLineCount maxHistoryLineCount,
@@ -279,6 +280,7 @@ Screen<Cell>::Screen(Terminal& terminal,
     _terminal { &terminal },
     _settings { &terminal.settings() },
     _state { &terminal.state() },
+    _margin { margin },
     _grid { pageSize, reflowOnResize, maxHistoryLineCount },
     _name { name }
 {
@@ -350,7 +352,7 @@ void Screen<Cell>::applyPageSizeToMainDisplay(PageSize mainDisplayPageSize)
         Margin { Margin::Vertical { {}, mainDisplayPageSize.lines.as<LineOffset>() - 1 },
                  Margin::Horizontal { {}, mainDisplayPageSize.columns.as<ColumnOffset>() - 1 } };
 
-    _terminal->state().margin = margin;
+    *_margin = margin;
 
     if (_cursor.position.column < boxed_cast<ColumnOffset>(mainDisplayPageSize.columns))
         _cursor.wrapPending = false;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -96,12 +96,14 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
 {
   public:
     /// @param terminal            reference to the terminal this display belongs to.
+    /// @param margin              margin of this display.
     /// @param pageSize            page size of this display. This is passed because it does not necessarily
     ///                            need to match the terminal's main display page size.
     /// @param reflowOnResize      whether or not to perform virtual line text reflow on resuze.
     /// @param maxHistoryLineCount maximum number of lines that are can be scrolled back to via Viewport.
     /// @param name                name of this screen, used for logging purposes.
     Screen(Terminal& terminal,
+           gsl::not_null<Margin*> margin,
            PageSize pageSize,
            bool reflowOnResize,
            MaxHistoryLineCount maxHistoryLineCount,
@@ -292,8 +294,8 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] PageSize pageSize() const noexcept { return _grid.pageSize(); }
     [[nodiscard]] ImageSize pixelSize() const noexcept { return _state->cellPixelSize * _settings->pageSize; }
 
-    [[nodiscard]] constexpr Margin margin() const noexcept { return _state->margin; }
-    [[nodiscard]] constexpr Margin& margin() noexcept { return _state->margin; }
+    [[nodiscard]] constexpr Margin margin() const noexcept { return *_margin; }
+    [[nodiscard]] constexpr Margin& margin() noexcept { return *_margin; }
 
     [[nodiscard]] bool isFullHorizontalMargins() const noexcept
     {
@@ -634,6 +636,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     gsl::not_null<Terminal*> _terminal;
     gsl::not_null<Settings*> _settings;
     gsl::not_null<TerminalState*> _state;
+    gsl::not_null<Margin*> _margin;
     Grid<Cell> _grid;
 
     CellLocation _lastCursorPosition {};

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -911,12 +911,13 @@ TEST_CASE("DECFI", "[screen]")
     REQUIRE(mock.terminal.isModeEnabled(DECMode::LeftRightMargin));
 
     mock.writeToScreen(DECSLRM(2, 4)); // Set left/right margin
-    REQUIRE(mock.terminal.state().margin.horizontal
+    REQUIRE(mock.terminal.state().mainScreenMargin.horizontal
             == Margin::Horizontal { ColumnOffset(1), ColumnOffset(3) });
     REQUIRE(screen.realCursorPosition() == CellLocation { LineOffset(0), ColumnOffset(0) });
 
     mock.writeToScreen(DECSTBM(2, 4)); // Set top/bottom margin
-    REQUIRE(mock.terminal.state().margin.vertical == Margin::Vertical { LineOffset(1), LineOffset(3) });
+    REQUIRE(mock.terminal.state().mainScreenMargin.vertical
+            == Margin::Vertical { LineOffset(1), LineOffset(3) });
     REQUIRE(screen.realCursorPosition() == CellLocation { LineOffset(0), ColumnOffset(0) });
 
     // from 0,0 to 0,1 (from outside margin to left border)

--- a/src/vtbackend/Sequencer.cpp
+++ b/src/vtbackend/Sequencer.cpp
@@ -7,7 +7,6 @@
 #include <vtbackend/primitives.h>
 
 #include <string_view>
-#include <utility>
 
 using std::get;
 using std::holds_alternative;
@@ -151,8 +150,10 @@ size_t Sequencer::maxBulkTextSequenceWidth() const noexcept
     if (!_terminal.primaryScreen().currentLine().isTrivialBuffer())
         return 0;
 
-    assert(_terminal.state().margin.horizontal.to >= _terminal.currentScreen().cursor().position.column);
-    return unbox<size_t>(_terminal.state().margin.horizontal.to
+    assert(_terminal.state().mainScreenMargin.horizontal.to
+           >= _terminal.currentScreen().cursor().position.column);
+
+    return unbox<size_t>(_terminal.state().mainScreenMargin.horizontal.to
                          - _terminal.currentScreen().cursor().position.column);
 }
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -205,11 +205,11 @@ class Terminal
 
     // {{{ cursor
     /// Clamps given logical coordinates to margins as used in when DECOM (origin mode) is enabled.
-    [[nodiscard]] CellLocation clampToOrigin(CellLocation coord) const noexcept
-    {
-        return { std::clamp(coord.line, LineOffset { 0 }, _state.margin.vertical.to),
-                 std::clamp(coord.column, ColumnOffset { 0 }, _state.margin.horizontal.to) };
-    }
+    // [[nodiscard]] CellLocation clampToOrigin(CellLocation coord) const noexcept
+    // {
+    //     return { std::clamp(coord.line, LineOffset { 0 }, _state.margin.vertical.to),
+    //              std::clamp(coord.column, ColumnOffset { 0 }, _state.margin.horizontal.to) };
+    // }
 
     [[nodiscard]] LineOffset clampedLine(LineOffset line) const noexcept
     {

--- a/src/vtbackend/TerminalState.cpp
+++ b/src/vtbackend/TerminalState.cpp
@@ -12,8 +12,12 @@ TerminalState::TerminalState(Terminal& terminal):
     cellPixelSize {},
     defaultColorPalette { settings.colorPalette },
     colorPalette { settings.colorPalette },
-    margin { Margin::Vertical { {}, settings.pageSize.lines.as<LineOffset>() - LineOffset(1) },
-             Margin::Horizontal { {}, settings.pageSize.columns.as<ColumnOffset>() - ColumnOffset(1) } },
+    mainScreenMargin { Margin::Vertical { {}, settings.pageSize.lines.as<LineOffset>() - LineOffset(1) },
+                       Margin::Horizontal {
+                           {}, settings.pageSize.columns.as<ColumnOffset>() - ColumnOffset(1) } },
+    hostWritableScreenMargin { Margin::Vertical { {}, LineOffset(0) },
+                               Margin::Horizontal {
+                                   {}, settings.pageSize.columns.as<ColumnOffset>() - ColumnOffset(1) } },
     effectiveImageCanvasSize { settings.maxImageSize },
     imageColorPalette { std::make_shared<SixelColorPalette>(maxImageColorRegisters, maxImageColorRegisters) },
     imagePool { [te = &terminal](Image const* image) {

--- a/src/vtbackend/TerminalState.h
+++ b/src/vtbackend/TerminalState.h
@@ -202,7 +202,9 @@ struct TerminalState
     // Screen margin - shared across all screens that are covering the main area,
     // i.e. the primary screen and alternate screen.
     // This excludes all status lines, title lines, etc.
-    Margin margin;
+    Margin mainScreenMargin;
+    Margin hostWritableScreenMargin;
+    Margin indicatorScreenMargin;
 
     unsigned maxImageColorRegisters = 256;
     ImageSize effectiveImageCanvasSize;


### PR DESCRIPTION
This bug was introduced when trying to fix semantics of margins in a6e49038507223ac2a9137db6f6a72936f79f312.

Thanks @Marenz for figuring this out.