### PR TITLE
Fix window resize events not respecting content scale 

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -696,7 +696,8 @@ void TerminalSession::requestWindowResize(LineCount lines, ColumnCount columns)
 
 void TerminalSession::requestWindowResize(QJSValue w, QJSValue h)
 {
-    requestWindowResize(Width(w.toInt()), Height(h.toInt()));
+    requestWindowResize(Width::cast_from(w.toNumber() * contentScale()),
+                        Height::cast_from(h.toNumber() * contentScale()));
 }
 
 void TerminalSession::requestWindowResize(Width width, Height height)

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -690,7 +690,7 @@ void TerminalSession::requestWindowResize(LineCount lines, ColumnCount columns)
     if (!_display)
         return;
 
-    sessionLog()("Application request to resize window: {}x{}", columns, lines);
+    sessionLog()("Application request to resize window: {}x{} cells", columns, lines);
     _display->post([this, lines, columns]() { _display->resizeWindow(lines, columns); });
 }
 
@@ -705,7 +705,7 @@ void TerminalSession::requestWindowResize(Width width, Height height)
     if (!_display)
         return;
 
-    sessionLog()("Application request to resize window: {}x{} px", width, height);
+    sessionLog()("Application request to resize window: {}x{} pixels", width, height);
     _display->post([this, width, height]() { _display->resizeWindow(width, height); });
 }
 

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -910,6 +910,10 @@ double TerminalDisplay::contentScale() const
                 if (forcedDPI >= 96.0)
                 {
                     auto const dpr = forcedDPI / 96.0;
+                    displayLog()("Forcing DPI to {} (DPR {}) as read from config file {}.",
+                                 forcedDPI,
+                                 dpr,
+                                 kcmFontsFile.value().string());
                     return dpr;
                 }
             }

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -895,31 +895,44 @@ void TerminalDisplay::onScrollBarValueChanged(int value)
     scheduleRedraw();
 }
 
-double TerminalDisplay::contentScale() const
+std::optional<double> TerminalDisplay::queryContentScaleOverride() const
 {
 #if !defined(__APPLE__) && !defined(_WIN32)
-    if (auto const kcmFontsFile = kcmFontsFilePath())
+    auto const kcmFontsFile = kcmFontsFilePath();
+    if (!kcmFontsFile)
+        return std::nullopt;
+
+    auto const contents = crispy::readFileAsString(*kcmFontsFile);
+    for (auto const line: crispy::split(contents, '\n'))
     {
-        auto const contents = crispy::readFileAsString(kcmFontsFile.value());
-        for (auto const line: crispy::split(contents, '\n'))
+        auto const fields = crispy::split(line, '=');
+        if (fields.size() == 2 && fields[0] == "forceFontDPI"sv)
         {
-            auto const fields = crispy::split(line, '=');
-            if (fields.size() == 2 && fields[0] == "forceFontDPI"sv)
+            auto const forcedDPI = static_cast<double>(crispy::to_integer(fields[1]).value_or(0.0));
+            if (forcedDPI >= 96.0)
             {
-                auto const forcedDPI = static_cast<double>(crispy::to_integer(fields[1]).value_or(0.0));
-                if (forcedDPI >= 96.0)
+                auto const dpr = forcedDPI / 96.0;
+                if (_lastReportedContentScale.value_or(0.0) != dpr)
                 {
-                    auto const dpr = forcedDPI / 96.0;
+                    _lastReportedContentScale = dpr;
                     displayLog()("Forcing DPI to {} (DPR {}) as read from config file {}.",
                                  forcedDPI,
                                  dpr,
                                  kcmFontsFile.value().string());
-                    return dpr;
                 }
+                return dpr;
             }
         }
     }
 #endif
+    return std::nullopt;
+}
+
+double TerminalDisplay::contentScale() const
+{
+    if (auto const contentScaleOverride = queryContentScaleOverride())
+        return *contentScaleOverride;
+
     if (!window())
         // This can only happen during TerminalDisplay instanciation
         return 1.0;

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -151,6 +151,7 @@ class TerminalDisplay: public QQuickItem
     void discardImage(vtbackend::Image const&);
     // }}}
 
+    [[nodiscard]] std::optional<double> queryContentScaleOverride() const;
     [[nodiscard]] double contentScale() const;
 
     Q_INVOKABLE void logDisplayInfo();
@@ -247,6 +248,9 @@ class TerminalDisplay: public QQuickItem
     TerminalSession* _session = nullptr;
     std::chrono::steady_clock::time_point _startTime;
     text::DPI _lastFontDPI;
+#if !defined(__APPLE__) && !defined(_WIN32)
+    mutable std::optional<double> _lastReportedContentScale;
+#endif
     std::unique_ptr<vtrasterizer::Renderer> _renderer;
     bool _renderingPressure = false;
     display::OpenGLRenderer* _renderTarget = nullptr;

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -541,12 +541,19 @@ void applyResize(vtbackend::ImageSize newPixelSize,
         emit session.columnsCountChanged(newPageSize.columns.as<int>());
 
     auto const viewSize = cellSize * newPageSize;
-    displayLog()("Applying resize: {} (new pixel size) {} (view size)", newPixelSize, viewSize);
+    displayLog()("Applying resize {}/{} pixels and {} -> {} cells.",
+                 viewSize,
+                 newPixelSize,
+                 terminal.pageSize(),
+                 newPageSize);
 
     auto const l = scoped_lock { terminal };
 
     if (newPageSize == terminal.pageSize())
+    {
+        displayLog()("No resize necessary. New size is same as old size of {}.", newPageSize);
         return;
+    }
 
     terminal.resizeScreen(newPageSize, viewSize);
     terminal.clearSelection();

--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -343,6 +343,8 @@ void UnixPty::resizeScreen(PageSize cells, std::optional<ImageSize> pixels)
     if (_masterFd < 0)
         return;
 
+    ptyLog()("Sending terminal size: {}x{} / {}", cells.columns, cells.lines, pixels.value_or(ImageSize {}));
+
     auto w = winsize {};
     w.ws_col = unbox<unsigned short>(cells.columns);
     w.ws_row = unbox<unsigned short>(cells.lines);


### PR DESCRIPTION
this is mostly affecting HiDPI screens, anything with a non-standard DPI setting.

no changelog entry needed, because it was introduced with the QML rework

Closes #1299.