### PR TITLE
[scripts] Fix OS misdetection in install-deps.sh for FreeBSD

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -556,7 +556,7 @@ main()
         Darwin)
             install_deps_darwin
             ;;
-        freebsd)
+        FreeBSD)
             install_deps_FreeBSD
             ;;
         *)


### PR DESCRIPTION
The script used to say that FreeBSD is unsupported despite there
being an explicit case for it.

Fix by correcting the casing.
