### PR TITLE
Changes VT sequence `DECSCUSR`'s default parameter reset to user-configured cursor style

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,7 +107,7 @@
     <release version="0.4.1" urgency="medium" type="development">
       <description>
         <ul>
-          <li> ... </li>
+          <li>Changes VT sequence `DECSCUSR` (`CSI ? 0 SP q` and `CSI ? SP q`) to reset to user-configured cursor style (#1377).</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -131,6 +131,8 @@ namespace
         settings.maxHistoryLineCount = profile.maxHistoryLineCount;
         settings.copyLastMarkRangeOffset = profile.copyLastMarkRangeOffset;
         settings.cursorBlinkInterval = profile.inputModes.insert.cursor.cursorBlinkInterval;
+        settings.cursorShape = profile.inputModes.insert.cursor.cursorShape;
+        settings.cursorDisplay = profile.inputModes.insert.cursor.cursorDisplay;
         settings.smoothLineScrolling = profile.smoothLineScrolling;
         settings.wordDelimiters = unicode::from_utf8(config.wordDelimiters);
         settings.mouseProtocolBypassModifiers = config.bypassMouseProtocolModifiers;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -242,7 +242,6 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void setForegroundColor(Color color);
     void setBackgroundColor(Color color);
     void setUnderlineColor(Color color);
-    void setCursorStyle(CursorDisplay display, CursorShape shape);
     void setGraphicsRendition(GraphicsRendition rendition);
     void screenAlignmentPattern();
     void applicationKeypadMode(bool enable);

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1430,6 +1430,9 @@ void Terminal::setCursorStyle(CursorDisplay display, CursorShape shape)
 {
     _settings.cursorDisplay = display;
     _settings.cursorShape = shape;
+
+    _state.cursorDisplay = display;
+    _state.cursorShape = shape;
 }
 
 void Terminal::setCursorVisibility(bool /*visible*/)


### PR DESCRIPTION
Closes #1377.

This PR also does a mini cleanup around DECSCUSR's implementation.