### PR TITLE
Fix CSIu encoding of shift modifier produced characters

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
       <description>
         <ul>
           <li>Fixes Command modifier for input mappings, such as Command+C or Command+V on on MacOS (#1379).</li>
+          <li>Fixes CSIu encoding of shift modifier produced characters (#1373).</li>
           <li>Changes VT sequence `DECSCUSR` (`CSI ? 0 SP q` and `CSI ? SP q`) to reset to user-configured cursor style (#1377).</li>
           <li>Remove `contour-latest` terminfo file. Please use `contour` terminfo instead.</li>
           <li>Adds `Command` as modifier to input mappings on MacOS to work along with `Meta` for convenience reasons (#1379).</li>

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -257,7 +257,8 @@ bool ExtendedKeyboardInputGenerator::generateChar(char32_t characterEvent,
     if (enabled(eventType))
     {
         if (enabled(KeyboardEventFlag::DisambiguateEscapeCodes)
-            && (modifiers.any() || enabled(KeyboardEventFlag::ReportAllKeysAsEscapeCodes)))
+            && (modifiers.without(Modifier::Shift).any()
+                || enabled(KeyboardEventFlag::ReportAllKeysAsEscapeCodes)))
         {
             append("\033[{};{}u",
                    encodeCharacter(characterEvent, physicalKey, modifiers),


### PR DESCRIPTION
When `CSI > 1 u` was used to enter CSI u mode with DisambiguateEscapeCodes flag set, then (e.g. on German keyboard layout), a double quote is produced with Shift + 2, which generate the double quotes: `"`

This should not needed to be disambiguated (unless explicitly requested)



Closes #1373 