### PR TITLE
contour.yml: fix incorrect default for frozen dev modes

### DIFF
--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -276,8 +276,7 @@ profiles:
         #         2027: true
         #
         # Default: (empty object)
-        frozen_dec_modes:
-            2026: false
+        #frozen_dec_modes:
 
         # Defines the number of milliseconds to wait before
         # actually executing the LF (linefeed) control code


### PR DESCRIPTION
I assume the proper to do this is to comment out the key, which works without error messages.
I initially tried leaving the key with no value (based on the comment) but that caused `[error] Invalid frozen_dec_modes entry.`. Using a value of `{}` worked but seemed more confusing than anything.