### PR TITLE
Attempting to fix assertion failure when running in RHEL Linux

### DIFF
--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -598,8 +598,8 @@ void applyResize(vtbackend::ImageSize newPixelSize,
     vtbackend::Terminal& terminal = session.terminal();
     vtbackend::ImageSize cellSize = renderer.gridMetrics().cellSize;
 
-    Require(renderer.hasRenderTarget());
-    renderer.renderTarget().setRenderSize(newPixelSize);
+    if (renderer.hasRenderTarget())
+        renderer.renderTarget().setRenderSize(newPixelSize);
     renderer.setPageSize(newPageSize);
     renderer.setMargin(computeMargin(renderer.gridMetrics().cellSize,
                                      newPageSize,


### PR DESCRIPTION
This is probably related to building using Qt 5 rather than Qt 6.


This should fix #1384's comment on failing to run Contour on RHEL. I think maybe it's building against Qt5 rather than Qt6 on that platform, and that Qt5 us inducing somewhat different execution order on Contour-side. 🤔 