### PR TITLE
Accumulate scroll distance instead of immediately trigger scroll

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.4.1" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Fixes fast scrolling when using trackpad (#1360)</li>
           <li>Fixes variable fonts loading</li>
           <li>Fixes Command modifier for input mappings, such as Command+C or Command+V on on MacOS (#1379).</li>
           <li>Fixes CSIu encoding of shift modifier produced characters (#1373).</li>

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -149,6 +149,14 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
         return true;
     }
 
+    int getScrollX() const noexcept { return _accumulatedScrollX; }
+    void addScrollX(int v) noexcept { _accumulatedScrollX += v; }
+    void resetScrollX() noexcept { _accumulatedScrollX = 0; }
+
+    int getScrollY() const noexcept { return _accumulatedScrollY; }
+    void addScrollY(int v) noexcept { _accumulatedScrollY += v; }
+    void resetScrollY() noexcept { _accumulatedScrollY = 0; }
+
     QString title() const;
     void setTitle(QString const& value) { terminal().setWindowTitle(value.toStdString()); }
 
@@ -398,6 +406,9 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     double _contentScale = 1.0;
     ContourGuiApp& _app;
     vtbackend::ColorPreference _currentColorPreference;
+
+    int _accumulatedScrollX;
+    int _accumulatedScrollY;
 
     vtbackend::Terminal _terminal;
     bool _terminatedAndWaitingForKeyPress = false;

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -420,8 +420,14 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
     auto const xDelta = event->angleDelta().x() > 0 ? 1 : event->angleDelta().x() < 0 ? -1 : 0;
     if (xDelta)
     {
+        session.addScrollX(xDelta);
+        inputLog()("Accumulate x scroll with current value {} ", session.getScrollX());
+    }
+    if (std::abs(session.getScrollX()) > unbox(session.terminal().cellPixelSize().width))
+    {
         auto const modifier = makeModifiers(event->modifiers());
-        auto const button = xDelta > 0 ? VTMouseButton::WheelRight : VTMouseButton::WheelLeft;
+        auto const button = session.getScrollX() > 0 ? VTMouseButton::WheelRight : VTMouseButton::WheelLeft;
+        session.resetScrollX();
         auto const pixelPosition =
             makeMousePixelPosition(event, session.profile().margins, session.contentScale());
 
@@ -432,8 +438,14 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
     auto const yDelta = mouseWheelDelta(event);
     if (yDelta)
     {
+        session.addScrollY(yDelta);
+        inputLog()("Accumulate y scroll with current value {} ", session.getScrollY());
+    }
+    if (std::abs(session.getScrollY()) > unbox(session.terminal().cellPixelSize().height))
+    {
         auto const modifier = makeModifiers(event->modifiers());
-        auto const button = yDelta > 0 ? VTMouseButton::WheelUp : VTMouseButton::WheelDown;
+        auto const button = session.getScrollY() > 0 ? VTMouseButton::WheelUp : VTMouseButton::WheelDown;
+        session.resetScrollY();
         auto const pixelPosition =
             makeMousePixelPosition(event, session.profile().margins, session.contentScale());
 


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1360

Qt backend sends a lot of mouse events on scroll with touchpad, this PR introduce time restiction between mouse events that we apply to terminal, this must affect only scroll on touchpads since all other manuall events can not be separated in time for such small duration as 50 ms   