### PR TITLE
docs: fixed markup for backticks text object

### DIFF
--- a/docs/input-modes.md
+++ b/docs/input-modes.md
@@ -59,7 +59,7 @@ the terminal to scroll the view to make that target line visible.
 - `ip`, `ap` - backtick enclosed string
 - `i(`, `a(` - round brackets enclosed string
 - `i'`, `a'` - single quoted string
-- `i\``, `a\`` - backtick enclosed string
+- `` i` ``, `` a` `` - backtick enclosed string
 - `i[`, `a[` - square bracket enclosed string
 - `iw`, `aw` - regular word
 - `iW`, `aW` - space delimited word


### PR DESCRIPTION
Markdown has a lot of weird obscure corners; TIL there's a specific markup for inline code that can contain backticks.

## Motivation and Context

![image](https://github.com/contour-terminal/contour/assets/5877043/396f93bf-151b-428d-94f9-47a999380aa9)
