### PR TITLE
Fixes screen destruction on sibling cells when overwriting wide characters

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Fixes variable fonts loading</li>
           <li>Fixes Command modifier for input mappings, such as Command+C or Command+V on on MacOS (#1379).</li>
           <li>Fixes CSIu encoding of shift modifier produced characters (#1373).</li>
+          <li>Fixes screen destruction on sibling cells when overwriting wide characters, such as Emoji, Kanji, etc.</li>
           <li>Changes VT sequence `DECSCUSR` (`CSI ? 0 SP q` and `CSI ? SP q`) to reset to user-configured cursor style (#1377).</li>
           <li>Remove `contour-latest` terminfo file. Please use `contour` terminfo instead.</li>
           <li>Adds `Command` as modifier to input mappings on MacOS to work along with `Meta` for convenience reasons (#1379).</li>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -423,7 +423,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
         session.addScrollX(xDelta);
         inputLog()("Accumulate x scroll with current value {} ", session.getScrollX());
     }
-    if (std::abs(session.getScrollX()) > unbox(session.terminal().cellPixelSize().width))
+    if (std::abs(session.getScrollX()) > unbox<int>(session.terminal().cellPixelSize().width))
     {
         auto const modifier = makeModifiers(event->modifiers());
         auto const button = session.getScrollX() > 0 ? VTMouseButton::WheelRight : VTMouseButton::WheelLeft;
@@ -441,7 +441,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
         session.addScrollY(yDelta);
         inputLog()("Accumulate y scroll with current value {} ", session.getScrollY());
     }
-    if (std::abs(session.getScrollY()) > unbox(session.terminal().cellPixelSize().height))
+    if (std::abs(session.getScrollY()) > unbox<int>(session.terminal().cellPixelSize().height))
     {
         auto const modifier = makeModifiers(event->modifiers());
         auto const button = session.getScrollY() > 0 ? VTMouseButton::WheelUp : VTMouseButton::WheelDown;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -616,7 +616,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void linefeed(ColumnOffset column);
 
     void writeCharToCurrentAndAdvance(char32_t codepoint) noexcept;
-    void clearAndAdvance(int offset) noexcept;
+    void clearAndAdvance(int oldWidth, int newWidth) noexcept;
 
     void scrollUp(LineCount n, GraphicsAttributes sgr, Margin margin);
     void scrollUp(LineCount n, Margin margin);


### PR DESCRIPTION
Refs #1275, #1268.

When writing a wide character, the next cell should be reset with the current SGR plus an additional flag to indicate that the next cell is a continuation cell of its left sibling cell.

But when overwriting such a character, the next cell must be cleared again, too, regardless of the new width.