### PR TITLE
Fix notcurses github action

### DIFF
--- a/scripts/ci/Xvfb-contour-run.sh
+++ b/scripts/ci/Xvfb-contour-run.sh
@@ -7,6 +7,7 @@ set -x
 LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-true}"
 CONTOUR_BIN=${CONTOUR_BIN:-contour}
 LOG="error,config,pty,gui.session,gui.display,vt.renderer,font.locator" # "all"
+LOG="all"
 DISPLAY=:99
 #CONTOUR_PREFIX=gdb --batch --command=./scripts/test.gdb --args
 

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -265,10 +265,10 @@ bool Terminal::processInputOnce()
 
     if (!readResult)
     {
+        terminalLog()("PTY read failed. {}", strerror(errno));
         if (errno == EINTR || errno == EAGAIN)
             return true;
 
-        terminalLog()("PTY read failed. {}", strerror(errno));
         _pty->close();
         return false;
     }


### PR DESCRIPTION
It looks like actions are working well now, even though nothing significant has been changed, apart from the logging level for these tests. Locally, I notice that notucrses-demo can fail from time to time due to events like terminal resizing. I think it is sufficient for us to have this PR merged at the moment and if needed to investigate further how to deal with it. for example to build notcurses from source inside actions as @christianparpart  few times proposed 

Closes https://github.com/contour-terminal/contour/issues/1402