### PR TITLE
add quotes around chars for input logging

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -789,7 +789,7 @@ void TerminalSession::sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventTy
 void TerminalSession::sendCharEvent(
     char32_t value, uint32_t physicalKey, Modifiers modifiers, KeyboardEventType eventType, Timestamp now)
 {
-    inputLog()("Character {} event received: {} {}",
+    inputLog()("Character {} event received: {} '{}'",
                eventType,
                modifiers,
                crispy::escape(unicode::convert_to<char>(value)));


### PR DESCRIPTION
Adds quotes around characters inside input log so we can see space ther