### PR TITLE
Properly handle installation/upgrade by specifying product/upgrade GUID for Windows installer

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -80,3 +80,29 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
     set(${VersionStringVar} "${THE_VERSION_STRING}" PARENT_SCOPE)
 endfunction()
 
+# Converts a version such as 1.2.255 to 0x0102ff
+# Gratefully taken from https://github.com/Cisco-Talos/clamav/blob/17c9f5b64f4a9a3fd624b1c9668d034d898a2534/cmake/Version.cmake
+function(HexVersion version_hex_var major minor patch)
+    math(EXPR version_dec "${major} * 256 * 256 + ${minor} * 256 + ${patch}")
+    set(version_hex "0x")
+    foreach(i RANGE 5 0 -1)
+        math(EXPR num "(${version_dec} >> (4 * ${i})) & 15")
+        string(SUBSTRING "0123456789abcdef" ${num} 1 num_hex)
+        set(version_hex "${version_hex}${num_hex}")
+    endforeach()
+    set(${version_hex_var} "${version_hex}" PARENT_SCOPE)
+endfunction()
+
+# Converts a number such as 104 to 68
+# Gratefully taken from https://github.com/Cisco-Talos/clamav/blob/17c9f5b64f4a9a3fd624b1c9668d034d898a2534/cmake/Version.cmake
+function(NumberToHex number output)
+    set(hex "")
+    foreach(i RANGE 1)
+        math(EXPR nibble "${number} & 15")
+        string(SUBSTRING "0123456789abcdef" "${nibble}" 1 nibble_hex)
+        string(APPEND hex "${nibble_hex}")
+        math(EXPR number "${number} >> 4")
+    endforeach()
+    string(REGEX REPLACE "(.)(.)" "\\2\\1" hex "${hex}")
+    set("${output}" "${hex}" PARENT_SCOPE)
+endfunction()

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -10,6 +10,10 @@ endif()
 
 option(CONTOUR_PERF_STATS "Enables debug printing some performance stats." OFF)
 
+NumberToHex(${PROJECT_VERSION_MAJOR} HEX_MAJOR)
+NumberToHex(${PROJECT_VERSION_MINOR} HEX_MINOR)
+NumberToHex(${PROJECT_VERSION_PATCH} HEX_PATCH)
+
 # {{{ Setup QT_COMPONENTS
 # QT_COMPONENTS is the list of Qt libraries Contour requires for building.
 # NB: Widgets is rquired for SystemTrayIcon's fallback implementation
@@ -277,7 +281,11 @@ set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/res/images/contour-logo.ico"
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
 set(CPACK_CREATE_DESKTOP_LINKS contour)
-set(CPACK_WIX_UPGRADE_GUID "0E736497-2B72-4117-95E9-54EC6DC2432A")
+set(CPACK_WIX_PRODUCT_GUID "0E736497-2B72-4117-95E9-54EC6D${HEX_MAJOR}${HEX_MINOR}${HEX_PATCH}")
+set(CPACK_WIX_UPGRADE_GUID "0E736497-2B72-4117-95E9-54EC6D${HEX_MAJOR}${HEX_MINOR}00")
+if(WIN32)
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "Contour Terminal Emulator ${CONTOUR_VERSION_MAJOR}.${CONTOUR_VERSION_MINOR}")
+endif()
 if(APPLE)
     set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/res/images/contour-logo.icns")
 endif()


### PR DESCRIPTION
Fixes a long standing issue I had with windows installations, which is, seeing a very old version number (the one from the very first install), which does not reflect the actual installation.