### PR TITLE
Replace all occurrences of OS/X

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -44,7 +44,7 @@ body:
       - Windows 10.0.19042.0
       - Ubuntu Linux 20.04
       - Fedora Linux 35
-      - OS/X Monterey 12.0.1
+      - macOS Monterey 12.0.1
       - FreeBSD
   validations:
     required: true

--- a/.github/mock-font-locator.yml
+++ b/.github/mock-font-locator.yml
@@ -4,7 +4,7 @@ mock_font_locator:
     - { family: "monospace", slant: normal, weight: normal, path: "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf" }
     - { family: "emoji", slant: normal, weight: normal, path: "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf" }
 
-    # That would be it for Mac OS/X
+    # That would be it for macOS
     # - { family: "monospace", slant: normal, weight: normal, path: "/Users/trapni/Library/Fonts/JetBrains Mono Regular Nerd Font Complete Mono.ttf" }
     # - { family: "emoji", slant: normal, weight: normal, path: "/System/Library/Fonts/Apple Color Emoji.ttc" }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,9 +344,9 @@ jobs:
             ./build/src/vtrasterizer/vtrasterizer_test
             rm -rf _deps build
   # }}}
-  # {{{ OS/X
+  # {{{ macOS
   osx:
-    name: "OS/X"
+    name: "macOS"
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for everyday use. It is aiming for power users with a modern feature mindset.
 
 ## Features
 
-- ✅ Available on all 4 major platforms, Linux, OS/X, FreeBSD, Windows.
+- ✅ Available on all 4 major platforms, Linux, macOS, FreeBSD, Windows.
 - ✅ GPU-accelerated rendering.
 - ✅ Font ligatures support (such as in Fira Code).
 - ✅ Unicode: Emoji support (-: 🌈 💝 😛 👪 - including ZWJ, VS15, VS16 emoji :-)
@@ -70,7 +70,7 @@ Click the following button to install Contour from the Flathub store.
 
 ## Requirements
 
-- **operating system**: A *recent* operating system (OS/X 12, Windows 10+, an up-to-date Linux, or FreeBSD)
+- **operating system**: A *recent* operating system (macOS 12, Windows 10+, an up-to-date Linux, or FreeBSD)
 - **GPU**: driver must support at least OpenGL 3.3 hardware accelerated or as software rasterizer.
 - **CPU**: x86-64 AMD or Intel with AES-NI instruction set or ARMv8 with crypto extensions.
 
@@ -89,7 +89,7 @@ by default contour will be compiled with Qt 6, to change Qt version use
 `QTVER=5 ./scripts/install-deps.sh` to fetch dependencies and cmake flag
 `-D CONTOUR_QT_VERSION=5`.
 
-### UNIX-like systems (Linux, FreeBSD, OS/X)
+### UNIX-like systems (Linux, FreeBSD, macOS)
 
 #### Prerequisites
 

--- a/docs/configuration/advanced/misc.md
+++ b/docs/configuration/advanced/misc.md
@@ -8,7 +8,7 @@ Possible (incomplete list of) values are:
 
 - auto        The platform will be auto-detected.
 - xcb         Uses XCB plugin (for X11 environment).
-- cocoa       Used to be run on Mac OS/X.
+- cocoa       Used to be run on macOS.
 - direct2d    Windows platform plugin using Direct2D.
 - winrt       Windows platform plugin using WinRT.
 

--- a/docs/configuration/advanced/mouse.md
+++ b/docs/configuration/advanced/mouse.md
@@ -11,7 +11,7 @@ The same modifier values apply as with input modifiers (see below).
 Modifier to be pressed in order to initiate block-selection
 using the left mouse button.
 
-This is usually the Control modifier, but on OS/X that is not possible,
+This is usually the Control modifier, but on macOS that is not possible,
 so Alt or Meta would be recommended instead.
 
 Supported modifiers:

--- a/docs/drafts/terminal-emulators.md
+++ b/docs/drafts/terminal-emulators.md
@@ -22,7 +22,7 @@
 - Kitty                             | Extensibility (via kittens, Python)
 - Kuake                             | Quake-like terminal feeling
 - ST                                | <2k lines, minimalistic
-- Terminal.app                      | OS/X default
+- Terminal.app                      | macOS default
 - Terminator                        | GUI multiplexer
 - Terminology                       | visually appealing features
 - Termite (libvte)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 ## Main Features
 
-:material-check-bold:{.check-mark}  Available on all 4 major platforms, Linux, OS/X, FreeBSD, Windows. <br/>
+:material-check-bold:{.check-mark}  Available on all 4 major platforms, Linux, macOS, FreeBSD, Windows. <br/>
 :material-check-bold:{.check-mark}  GPU-accelerated rendering. <br/>
 :material-check-bold:{.check-mark}  [Font ligatures](demo/font-ligatures.md) support (very useful for programming and scripting) <br/>
 :material-check-bold:{.check-mark}  Unicode: Emoji support (-: 🌈  💝  😛  👪  - including ZWJ, VS15, VS16 emoji :-) <br/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Contour is modern, fast, and designed for everyday use.
 It's not just a terminal emulator, but a powerhouse of features tailored for those who seek efficiency and control. With GPU-accelerated rendering and high-DPI support, experience the smoothest and most responsive terminal emulator like never before.
 
-Contour is designed with the advanced power user in mind, offering high-speed, feature-rich functionality across all major platforms. From Linux and OS/X to FreeBSD and Windows, we've got you covered. <br/>
+Contour is designed with the advanced power user in mind, offering high-speed, feature-rich functionality across all major platforms. From Linux and macOS to FreeBSD and Windows, we've got you covered. <br/>
 Contour offers a suite of unique features designed to enhance your productivity and user experience. Enjoy support for font ligatures, emoji, and Unicode grapheme clusters. Navigate quickly with vertical line markers and vi-like input modes. Control your settings with runtime configuration reload and customizable key bindings. <br/>
 Bring your terminal to life with color schemes, profiles, and sixel inline images. Enjoy the convenience of clickable hyperlinks, and set your clipboard with OSC 52.  <br/>
 
@@ -17,7 +17,7 @@ Bring your terminal to life with color schemes, profiles, and sixel inline image
 
 ## Key Features
 
-:material-check-bold:{.check-mark}  Available on all 4 major platforms, Linux, OS/X, FreeBSD, Windows. <br/>
+:material-check-bold:{.check-mark}  Available on all 4 major platforms, Linux, macOS, FreeBSD, Windows. <br/>
 :material-check-bold:{.check-mark}  [Font ligatures](demo/font-ligatures.md) support (very useful for programming and scripting) <br/>
 ![demo](/screenshots/contour-font-ligatures.png){ align=left }
 :material-check-bold:{.check-mark}  Complex Unicode support, including colored Emoji (-: 🌈  💝  😛  👪  - including ZWJ, VS15, VS16 emoji :-) <br/>

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@
 
 Please download Contour for Windows (the `.msi` file) from our [release page](https://github.com/contour-terminal/contour/releases/latest/), and double click on it to install.
 
-## Mac OS/X
+## macOS
 
 ```sh
 brew install contour
@@ -52,7 +52,7 @@ Contour is best installed from supported package managers, but you can build
 from source by following the instruction below. You can Qt 5 or Qt 6,
 by default contour will be compiler with Qt 6, to change Qt version use `QTVER=5 ./scripts/install-deps.sh` to fetch dependencies and cmake flag `-D CONTOUR_QT_VERSION=5`.
 
-### UNIX-like systems (Linux, FreeBSD, OS/X)
+### UNIX-like systems (Linux, FreeBSD, macOS)
 
 #### Prerequisites
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -39,7 +39,7 @@
       for everyday use. It is aiming for power users with a modern feature mindset.
     </p>
     <ul>
-      <li>Available on all 4 major platforms, Linux, OS/X, FreeBSD, Windows.</li>
+      <li>Available on all 4 major platforms, Linux, macOS, FreeBSD, Windows.</li>
       <li>GPU-accelerated rendering.</li>
       <li>Font ligatures support (such as in Fira Code).</li>
       <li>Unicode: Emoji support (-: 🌈 💝 😛 👪 - including ZWJ, VS15, VS16 emoji :-)</li>
@@ -161,7 +161,7 @@
           <li>Fixes GUI terminating on idle input in some conditions.</li>
           <li>Fixes search term rendering highlighting for search terms containing whitespaces (#966).</li>
           <li>Fixes rendering in cases of glyphs with inverted orientation (#1115).</li>
-          <li>Fixes Emoji rendering being too small on OS/X (#1215)</li>
+          <li>Fixes Emoji rendering being too small on macOS (#1215)</li>
           <li>Fixes config option `show_title_bar` (#1153)</li>
           <li>Fixes VT sequence DECSTBM and DECSLRM defaulting parameters (#1164).</li>
           <li>Fixes VT sequence DECFRA (#1189).</li>
@@ -316,7 +316,7 @@
           <li>Fixes mouse reporting in primary screen when viewport has been scrolled into the scrollback area.</li>
           <li>Fixes VT sequence `DECSTR` (soft reset) to not move the cursor to home position.</li>
           <li>Fixes cursor movements for the vi-like cursor (normal mode).</li>
-          <li>Fixes Alt+Backspace on OS/X.</li>
+          <li>Fixes Alt+Backspace on macOS.</li>
           <li>Fixes default config entry `profiles.*.draw_bold_text_with_bright_colors` (it was renamed from `profiles.*.bold_is_bright`). Please rename this in your existing configuration if not done yet.</li>
           <li>Fixes sometimes rendering two cursors when statusline is shown.</li>
           <li>Fixes normal mode's page top (S-H)/ page bottom (S-L) cursor movements to respect scroll offset.</li>
@@ -488,7 +488,7 @@
       <description>
         <ul>
           <li>Adds Vi-like input modes for improved selection and copy'n'paste experience.</li>
-          <li>Adds contour executable to search path for spawned shell process on OS/X and Windows.</li>
+          <li>Adds contour executable to search path for spawned shell process on macOS and Windows.</li>
           <li>Adds customizability to dim colors (#664).</li>
           <li>Adds the profile configuration option: `draw_bold_text_with_bright_colors`.</li>
           <li>Fixes `CSI K` accidentally removing line flags, e.g. line marks (#658).</li>
@@ -614,7 +614,7 @@
           <li>Changes tcap-query feature from experimental to always enabled (not configurable anymore).</li>
           <li>Automatically detect if `contour` or `contour-latest` terminfo entries are present use that as default.</li>
           <li>Fixes VT sequences that cause a cursor restore to sometimes crash.</li>
-          <li>Fixes terminfo installation path on OS/X and tries to auto-set `TERMINFO_DIRS` to it on startup (#443).</li>
+          <li>Fixes terminfo installation path on macOS and tries to auto-set `TERMINFO_DIRS` to it on startup (#443).</li>
           <li>Fixes terminfo entry `pairs`.</li>
           <li>Fixes SGR 24 to remove any kind of underline (#451).</li>
           <li>Fixes font fallback for `open_shaper` where in rare cases the text was not rendered at all.</li>
@@ -624,7 +624,7 @@
           <li>Fixes SEGV with overflowing (Sixel) images (#409).</li>
           <li>Fixes XTSMGRAPHICS for invalid SetValue actions and setting Sixel image size limits (#422).</li>
           <li>Fixes internal pixel width/height tracking in VT screen, which did affect sizes of rendered Sixel images (#408).</li>
-          <li>Fixes configuring a custom shell on OS/X (#425).</li>
+          <li>Fixes configuring a custom shell on macOS (#425).</li>
           <li>Fixes off-by-one bug in builtin box drawing (#424).</li>
           <li>Fixes assertion in text renderer with regards to colored glyphs.</li>
           <li>Fixes Sixel background select to support transparency (#450).</li>
@@ -663,7 +663,7 @@
           <li>Adds support for bypassing the mouse protocol via Shift-click (configurable via `bypass_mouse_protocol_modifier`)</li>
           <li>Adds improved debug logging. via CLI flag `-d` (`--enable-debug`) to accept a comma seperated list of tags to enable logging for. Appending a `*` at the end of a debug tag will enable all debug tags that match prefix its prefix.  The list of available debuglog tags can be found via CLI flag `-D` (`--list-debug-tags`).</li>
           <li>Adds support for different font render modes: `lcd`, `light`, `gray`, `monochrome` in `profiles.NAME.font.render_mode` (default: `lcd`).</li>
-          <li>Adds support for different text render engines: `OpenShaper`, `DirectWrite` and `CoreText` for upcoming native platform support on Windows (and later OS/X).</li>
+          <li>Adds support for different text render engines: `OpenShaper`, `DirectWrite` and `CoreText` for upcoming native platform support on Windows (and later macOS).</li>
           <li>Adds support for different font location engines: `fontconfig` (others will follow).</li>
           <li>Adds experimental text reflow.</li>
           <li>Adds OpenFileManager action to configuration.</li>
@@ -697,7 +697,7 @@
           <li>Adds new CLI command: `contour set profile to NAME` to change the profile on the fly.</li>
           <li>Adds new CLI command: `contour generate terminfo output OUTPUT_FILE` to create a Contour terminfo file.</li>
           <li>Adds new CLI command: `contour generate config output OUTPUT_FILE` to create a new default config.</li>
-          <li>Adds new CLI command: `contour generate integration shell SHELL output OUTPUT_FILE` to create the shell integreation file for the given shell (only zsh supported for now). Also adds a pre-generated shell integration file for Linux (and OS/X) to `/usr/share/contour/shell-integration.zsh`.</li>
+          <li>Adds new CLI command: `contour generate integration shell SHELL output OUTPUT_FILE` to create the shell integreation file for the given shell (only zsh supported for now). Also adds a pre-generated shell integration file for Linux (and macOS) to `/usr/share/contour/shell-integration.zsh`.</li>
           <li>Unicode data updated to version 14.0 beta.</li>
           <li>Adds support for building with Qt 6 (disabled by default).</li>
           <li>Adds support for building with mimalloc (experimental, disabled by default).</li>
@@ -722,7 +722,7 @@
     <release version="0.1.0" date="2020-12-24">
       <description>
         <ul>
-          <li>Available on all 3 major platforms, Linux, OS/X, Windows.</li>
+          <li>Available on all 3 major platforms, Linux, macOS, Windows.</li>
           <li>Emoji support (-: 🌈 💝 😛 👪 :-)</li>
           <li>Font ligatures support (such as in Fira Code).</li>
           <li>Bold and italic fonts</li>

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -461,7 +461,7 @@ elseif(APPLE)
     endforeach()
     # }}}
 
-    set(CODE_SIGN_CERTIFICATE_ID "-" CACHE STRING "Mac OS/X Code signature ID") # TODO: Use proper ID on CI
+    set(CODE_SIGN_CERTIFICATE_ID "-" CACHE STRING "macOS Code signature ID") # TODO: Use proper ID on CI
     include(DeployQt)  # Just to get access to ${MACDEPLOYQT_EXECUTABLE}
     get_filename_component(_macdeployqt_path "${MACDEPLOYQT_EXECUTABLE}" PATH)
     message(STATUS "macdeployqt path: ${_macdeployqt_path}")

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -5,7 +5,7 @@
 # Possible (incomplete list of) values are:
 # - auto        The platform will be auto-detected.
 # - xcb         Uses XCB plugin (for X11 environment).
-# - cocoa       Used to be run on Mac OS/X.
+# - cocoa       Used to be run on macOS.
 # - direct2d    Windows platform plugin using Direct2D.
 # - winrt       Windows platform plugin using WinRT.
 #
@@ -89,7 +89,7 @@ bypass_mouse_protocol_modifier: Shift
 # Modifier to be pressed in order to initiate block-selection
 # using the left mouse button.
 #
-# This is usually the Control modifier, but on OS/X that is not possible,
+# This is usually the Control modifier, but on macOS that is not possible,
 # so Alt or Meta would be recommended instead.
 #
 # Supported modifiers:
@@ -363,7 +363,7 @@ profiles:
             # Possible values are:
             # - native          : automatically choose the best available on the current platform
             # - fontconfig      : uses fontconfig to select fonts
-            # - CoreText        : uses OS/X CoreText to select fonts.
+            # - CoreText        : uses macOS CoreText to select fonts.
             # - DirectWrite     : selects DirectWrite engine (Windows only)
             locator: native
 
@@ -373,7 +373,7 @@ profiles:
                 # Supported values are:
                 # - native      : automatically choose the best available on the current platform.
                 # - DirectWrite : selects DirectWrite engine (Windows only)
-                # - CoreText    : selects CoreText engine (Mac OS/X only) (currently not implemented)
+                # - CoreText    : selects CoreText engine (macOS only) (currently not implemented)
                 # - OpenShaper  : selects OpenShaper (harfbuzz/freetype/fontconfig, available on all
                 #                 platforms)
                 engine: native
@@ -746,7 +746,7 @@ color_schemes:
 # - Alt
 # - Control
 # - Shift
-# - Meta (this is the Windows key on Windows OS, and the Command key on OS/X, and Meta on anything else)
+# - Meta (this is the Windows key on Windows OS, and the Command key on macOS, and Meta on anything else)
 #
 # Keys can be expressed case-insensitively symbolic:
 #   APOSTROPHE, ADD, BACKSLASH, COMMA, DECIMAL, DIVIDE, EQUAL, LEFT_BRACKET,

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -45,7 +45,7 @@
 
 namespace fs = std::filesystem;
 
-// Temporarily disabled (I think it was OS/X that didn't like glDebugMessageCallback).
+// Temporarily disabled (I think it was macOS that didn't like glDebugMessageCallback).
 // #define CONTOUR_DEBUG_OPENGL 1
 
 #if defined(_MSC_VER)

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -409,8 +409,8 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         auto const codepoints = event->text().toUcs4();
         assert(codepoints.size() == 1);
 #if defined(__APPLE__)
-        // On OS/X the Alt-modifier does not seem to be passed to the terminal apps
-        // but rather remapped to whatever OS/X is mapping them to.
+        // On macOS the Alt-modifier does not seem to be passed to the terminal apps
+        // but rather remapped to whatever macOS is mapping them to.
         for (char32_t const ch: codepoints)
             session.sendCharEvent(ch, physicalKey, modifiers.without(Modifier::Alt), eventType, now);
 #else

--- a/src/text_shaper/fontconfig_locator.cpp
+++ b/src/text_shaper/fontconfig_locator.cpp
@@ -222,7 +222,7 @@ font_source_list fontconfig_locator::locate(font_description const& description)
         if (FcPatternGetString(font, FC_FILE, 0, &file) != FcResultMatch)
             continue;
 
-#if defined(FC_COLOR) // Not available on OS/X?
+#if defined(FC_COLOR) // Not available on macOS?
 // FcBool color = FcFalse;
 // FcPatternGetInteger(font, FC_COLOR, 0, &color);
 // if (color && !color)

--- a/src/vtrasterizer/FontDescriptions.h
+++ b/src/vtrasterizer/FontDescriptions.h
@@ -11,7 +11,7 @@ enum class TextShapingEngine
 {
     OpenShaper, //!< Uses open-source implementation: harfbuzz/freetype/fontconfig
     DWrite,     //!< native platform support: Windows
-    CoreText,   //!< native platform support: OS/X
+    CoreText,   //!< native platform support: macOS
 };
 
 enum class FontLocatorEngine
@@ -19,7 +19,7 @@ enum class FontLocatorEngine
     Mock,       //!< mock font locator API
     FontConfig, //!< platform independant font locator API
     DWrite,     //!< native platform support: Windows
-    CoreText,   //!< native font locator on OS/X
+    CoreText,   //!< native font locator on macOS
 };
 
 using DPI = text::DPI;

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -766,7 +766,7 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
         }
 
         // Assume colored (RGBA) bitmap glyphs to be emoji.
-        // At least on MacOS/X, the emoji font reports bad positioning, so we simply center them ourself.
+        // At least on macOS, the emoji font reports bad positioning, so we simply center them ourself.
         glyph.position.x = unbox<int>(emojiBoundingBox.width - glyph.bitmapSize.width) / 2;
         glyph.position.y = unbox<int>(emojiBoundingBox.height)
                            - max(0, unbox<int>(emojiBoundingBox.height - glyph.bitmapSize.height) / 2);


### PR DESCRIPTION
The Macintosh operating system underwent many name changes over the years,
from being nameless to "System" to "Mac OS" to "OS X" to "macOS".

But at no point in time was it ever called "OS/X" :-)
