### PR TITLE
Bump of boxed-cpp and code update

### DIFF
--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -54,7 +54,7 @@ message(STATUS "================================================================
 message(STATUS "    Contour ThirdParties: ${ContourThirdParties}")
 
 set(LIBUNICODE_MINIMAL_VERSION "0.4.0")
-set(BOXED_CPP_MINIMAL_VERSION "1.2.2")
+set(BOXED_CPP_MINIMAL_VERSION "1.4.2")
 set(TERMBENCH_PRO_COMMIT_HASH "96c6bb7897af4110d1b99a93b982f8ec10e71183")
 set(FMT_VERSION "10.0.0")
 set(CATCH_VERSION "3.4.0")

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -26,9 +26,9 @@ $ThirdParties =
         Macro   = "termbench_pro"
     }
     [ThirdParty]@{
-        Folder  = "boxed-cpp-1.2.2";
-        Archive = "boxed-cpp-1.2.2.zip";
-        URI     = "https://github.com/contour-terminal/boxed-cpp/archive/refs/tags/v1.2.2.zip";
+        Folder  = "boxed-cpp-1.4.2";
+        Archive = "boxed-cpp-1.4.2.zip";
+        URI     = "https://github.com/contour-terminal/boxed-cpp/archive/refs/tags/v1.4.2.zip";
         Macro   = "boxed_cpp"
     }
 )

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -110,7 +110,7 @@ fetch_and_unpack_termbenchpro()
 
 fetch_and_unpack_boxed()
 {
-    local boxed_cpp_version="1.2.2"
+    local boxed_cpp_version="1.4.2"
     fetch_and_unpack \
         boxed-cpp-$boxed_cpp_version \
         boxed-cpp-$boxed_cpp_version.tar.gz \


### PR DESCRIPTION
Bump of boxed-cpp and  code update to use new functionality of creation boxed types without extra tags

Some info about compiler support: https://github.com/NVIDIA/stdexec/issues/1143#issuecomment-1937482532 
tl;dr
we need gcc-14 and we see that windows build is failing