### PR TITLE
Fix qt resources call in cmake

### DIFF
--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -77,9 +77,9 @@ endif()
 
 set(_qt_resources resources.qrc)
 if(CONTOUR_QT_VERSION EQUAL "5")
-    qt5_add_resources(QT_RESOURCES ${_qt_resources})
+    qt5_add_resources(_qt_resources ${_qt_resources})
 else()
-    qt_add_resources(QT_RESOURCES ${_qt_resources})
+    qt_add_resources(_qt_resources ${_qt_resources})
 endif()
 
 # {{{ configure QML files and their imports


### PR DESCRIPTION
Fix call to add qt resources, see documentation for `qt_add_resources` https://doc.qt.io/qt-6/qt-add-resources.html

Refs https://github.com/contour-terminal/contour/issues/1466 
i was getting same error 