### PR TITLE
Add SGRSAVE and SGRRESTORE VT sequences to save and restore SGR state

### DIFF
--- a/docs/vt-extensions/save-and-restore-sgr-attributes.md
+++ b/docs/vt-extensions/save-and-restore-sgr-attributes.md
@@ -1,0 +1,14 @@
+# Save and Restore SGR attributes.
+
+## Feature detection
+
+Use `SGRSAVE` (`CSI # {`) save the currently set SGR attributes,
+and `SGRRESTORE` (`CSI # }`) to restore the previously saved SGR attributes.
+
+## Relation to xterm's XTPUSHSGR / XTPOPSGR
+
+Both, `XTPUSHSGR` and `XTPOPSGR` are in its most basic form equivalent to `SGRSAVE` and `SGRRESTORE`,
+but the xterm extenions push and pop using a stack rather than save and restore using a simple 
+storage location, and the xterm equivalent does allow pushing/popping only certain SGR attributes.
+
+This is needless functionality that should not be implemented by a terminal but rather in the applications itself.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li> Add generation of config file from internal state (#1282) </li>
           <li> Fixes corruption of sixel image on high resolution (#1049) </li>
+          <li>Add SGRSAVE and SGRRESTORE VT sequences to save and restore SGR state (They intentionally conflict with XTPUSHSGR and XTPOPSGR)</li>
         </ul>
       </description>
     </release>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - vt-extensions/buffer-capture.md
     - vt-extensions/font-settings.md
     - vt-extensions/line-reflow-mode.md
+    - vt-extensions/save-and-restore-sgr-attributes.md
   - Internals:
     - internals/index.md
     - internals/CODING_STYLE.md

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -117,6 +117,8 @@ constexpr inline auto WINMANIP = FunctionDocumentation { .mnemonic = "WINMANIP",
 constexpr inline auto XTCAPTURE = FunctionDocumentation { .mnemonic = "XTCAPTURE", .comment = "Report screen buffer capture." };
 constexpr inline auto XTPOPCOLORS = FunctionDocumentation { .mnemonic = "XTPOPCOLORS", .comment = "Pops the color palette from the palette's saved-stack." };
 constexpr inline auto XTPUSHCOLORS = FunctionDocumentation { .mnemonic = "XTPUSHCOLORS", .comment = "Pushes the color palette onto the palette's saved-stack." };
+constexpr inline auto SGRRESTORE = FunctionDocumentation { .mnemonic = "SGRRESTORE", .comment = "Restores video attributes." };
+constexpr inline auto SGRSAVE = FunctionDocumentation { .mnemonic = "SGRSAVE", .comment = "Saves video attributes onto stack." };
 constexpr inline auto XTREPORTCOLORS = FunctionDocumentation { .mnemonic = "XTREPORTCOLORS", .comment = "Reports number of color palettes on the stack." };
 constexpr inline auto XTRESTORE = FunctionDocumentation { .mnemonic = "XTRESTORE", .comment = "Restore DEC private modes." };
 constexpr inline auto XTSAVE = FunctionDocumentation { .mnemonic = "XTSAVE", .comment = "Save DEC private modes." };
@@ -578,6 +580,8 @@ constexpr inline auto WINMANIP    = detail::CSI(std::nullopt, 1, 3, std::nullopt
 constexpr inline auto XTCAPTURE   = detail::CSI('>', 0, 2, std::nullopt, 't', VTExtension::Contour, documentation::XTCAPTURE);
 constexpr inline auto XTPOPCOLORS    = detail::CSI(std::nullopt, 0, ArgsMax, '#', 'Q', VTExtension::XTerm, documentation::XTPOPCOLORS);
 constexpr inline auto XTPUSHCOLORS   = detail::CSI(std::nullopt, 0, ArgsMax, '#', 'P', VTExtension::XTerm, documentation::XTPUSHCOLORS);
+constexpr inline auto SGRRESTORE  = detail::CSI(std::nullopt, 0, ArgsMax, '#', '}', VTExtension::XTerm, documentation:: SGRRESTORE);
+constexpr inline auto SGRSAVE     = detail::CSI(std::nullopt, 0, ArgsMax, '#', '{', VTExtension::XTerm, documentation::SGRSAVE);
 constexpr inline auto XTREPORTCOLORS = detail::CSI(std::nullopt, 0, 0, '#', 'R', VTExtension::XTerm, documentation::XTREPORTCOLORS);
 constexpr inline auto XTRESTORE   = detail::CSI('?', 0, ArgsMax, std::nullopt, 'r', VTExtension::XTerm, documentation::XTRESTORE);
 constexpr inline auto XTSAVE      = detail::CSI('?', 0, ArgsMax, std::nullopt, 's', VTExtension::XTerm, documentation::XTSAVE);
@@ -726,6 +730,8 @@ constexpr static auto allFunctionsArray() noexcept
         SD,
         SETMARK,
         SGR,
+        SGRRESTORE,
+        SGRSAVE,
         SM,
         SU,
         TBC,

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -805,6 +805,20 @@ void Screen<Cell>::setCurrentColumn(ColumnOffset n)
 
 template <typename Cell>
 CRISPY_REQUIRES(CellConcept<Cell>)
+void Screen<Cell>::restoreGraphicsRendition()
+{
+    _cursor.graphicsRendition = _savedGraphicsRenditions;
+}
+
+template <typename Cell>
+CRISPY_REQUIRES(CellConcept<Cell>)
+void Screen<Cell>::saveGraphicsRendition()
+{
+    _savedGraphicsRenditions = _cursor.graphicsRendition;
+}
+
+template <typename Cell>
+CRISPY_REQUIRES(CellConcept<Cell>)
 string Screen<Cell>::renderMainPageText() const
 {
     return _grid.renderMainPageText();
@@ -3735,6 +3749,8 @@ ApplyResult Screen<Cell>::apply(FunctionDefinition const& function, Sequence con
         case SD: scrollDown(seq.param_or<LineCount>(0, LineCount { 1 })); break;
         case SETMARK: setMark(); break;
         case SGR: return impl::applySGR(*_terminal, seq, 0, seq.parameterCount());
+        case SGRRESTORE: restoreGraphicsRendition(); return ApplyResult::Ok;
+        case SGRSAVE: saveGraphicsRendition(); return ApplyResult::Ok;
         case SM: {
             ApplyResult r = ApplyResult::Ok;
             crispy::for_each(crispy::times(seq.parameterCount()), [&](size_t i) {

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -597,6 +597,9 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void restoreCursor() override;
     void restoreCursor(Cursor const& savedCursor);
 
+    void restoreGraphicsRendition();
+    void saveGraphicsRendition();
+
   private:
     void writeTextInternal(char32_t codepoint);
 
@@ -638,6 +641,8 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     gsl::not_null<TerminalState*> _state;
     gsl::not_null<Margin*> _margin;
     Grid<Cell> _grid;
+
+    GraphicsAttributes _savedGraphicsRenditions {};
 
     CellLocation _lastCursorPosition {};
 

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -3705,6 +3705,28 @@ TEST_CASE("DECSTR", "[screen]")
             == CellLocation { LineOffset(0), ColumnOffset(0) });
 }
 
+TEST_CASE("SGRSAVE and SGRRESTORE", "[screen]")
+{
+    auto mock = MockTerm { ColumnCount(8), LineCount(4) };
+
+    mock.writeToScreen(SGR(31, 42, 4)); // red on green, underline
+    auto& cursor = mock.terminal.currentScreen().cursor();
+    REQUIRE(cursor.graphicsRendition.foregroundColor == IndexedColor::Red);
+    REQUIRE(cursor.graphicsRendition.backgroundColor == IndexedColor::Green);
+    REQUIRE(cursor.graphicsRendition.flags.contains(CellFlag::Underline));
+
+    mock.writeToScreen(SGRSAVE());
+    mock.writeToScreen(SGR(33, 44, 24)); // yellow on blue, no underline
+    REQUIRE(cursor.graphicsRendition.foregroundColor == IndexedColor::Yellow);
+    REQUIRE(cursor.graphicsRendition.backgroundColor == IndexedColor::Blue);
+    REQUIRE(!cursor.graphicsRendition.flags.contains(CellFlag::Underline));
+
+    mock.writeToScreen(SGRRESTORE());
+    REQUIRE(cursor.graphicsRendition.foregroundColor == IndexedColor::Red);
+    REQUIRE(cursor.graphicsRendition.backgroundColor == IndexedColor::Green);
+    REQUIRE(cursor.graphicsRendition.flags.contains(CellFlag::Underline));
+}
+
 TEST_CASE("LS1 and LS0", "[screen]")
 {
     auto mock = MockTerm { ColumnCount(8), LineCount(4) };


### PR DESCRIPTION
Closes #1473 but does not implement #1473. This is because XTPUSHSGR / XTPOPSGR are conceptionally plain wrong.

However, having the ability to save and restore all SGR attribs at once is a really good idea that does suffice the general use-cases.

Having a stack only works around poor application implementations. This includes pushing specific SGR attribs alone.

This is why SGRSAVE and SGRRESTORE are simply saving and restoring the all the SGR attributes, including colors, and all other SGR attributes.

The chosen VT sequences intentionally conflict with XTPUSHSGR / XTPOPSGR because:

1. the trivial case is semantically the same (no parameters given)
2. providing parameters is fundamentally wrong
3. adding yet another stack is fundamentally wrong


## Checklist

- [x] basic implementation
- [x] test cases added
- [x] documentation added to explain new VT extensions (and their relation to XTPUSHSGR / XTPOPSGR)