### PR TITLE
Fixes `CSI 8 ; (COLS) ; (ROWS) t` to resize the terminal with respect to High-DPI

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -116,6 +116,7 @@
           <li>Fixes corruption of sixel image on high resolution (#1049)</li>
           <li>Fixes bad wording of OS/X to macOS (#1462)</li>
           <li>Fixes key bindings and search prompt collision (#1472)</li>
+          <li>Fixes `CSI 8 ; (COLS) ; (ROWS) t` to resize the terminal with respect to High-DPI</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1185,12 +1185,14 @@ void TerminalDisplay::resizeWindow(vtbackend::LineCount newLineCount, vtbackend:
     if (*newLineCount)
         requestedPageSize.lines = newLineCount;
 
-    auto const pixels = vtbackend::ImageSize {
-        boxed_cast<vtbackend::Width>(requestedPageSize.columns) * gridMetrics().cellSize.width,
-        boxed_cast<vtbackend::Height>(requestedPageSize.lines) * gridMetrics().cellSize.height
+    // Qt uses unscaled pixels, so we need to adjust the requested size to the actual content scale.
+    auto const unscaledCellSize = gridMetrics().cellSize / contentScale();
+    auto const unscaledViewSize = vtbackend::ImageSize {
+        unscaledCellSize.width * boxed_cast<vtbackend::Width>(requestedPageSize.columns),
+        unscaledCellSize.height * boxed_cast<vtbackend::Height>(requestedPageSize.lines)
     };
 
-    window()->resize(QSize(pixels.width.as<int>(), pixels.height.as<int>()));
+    window()->resize(QSize(unscaledViewSize.width.as<int>(), unscaledViewSize.height.as<int>()));
 }
 
 void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)


### PR DESCRIPTION
this is only noticeable on displays that have a DPI scaling (of != 1) configured