### PR TITLE
Restrict forwarding of some of the inputs while in normal mode

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -119,6 +119,7 @@
           <li>Add better bell sound (#1378)</li>
           <li>Add config entry to configure behaviour on exit from search mode</li>
           <li>Update of contour.desktop file (#1423)</li>
+          <li>Fixed forwarding of input while in normal mode (#1468)</li>
           <li>Fixed overlap of glyphs for long codepoints (#1349)</li>
           <li>Fixed too verbose info during ssh session login (#1447)</li>
           <li>Fixes corruption of sixel image on high resolution (#1049)</li>

--- a/src/vtbackend/InputHandler.h
+++ b/src/vtbackend/InputHandler.h
@@ -23,8 +23,10 @@ class InputHandler
 {
   public:
     virtual ~InputHandler() = default;
-    virtual Handled sendKeyPressEvent(Key key, Modifiers modifiers) = 0;
-    virtual Handled sendCharPressEvent(char32_t codepoint, Modifiers modifiers) = 0;
+    virtual Handled sendKeyPressEvent(Key key, Modifiers modifiers, KeyboardEventType eventType) = 0;
+    virtual Handled sendCharPressEvent(char32_t codepoint,
+                                       Modifiers modifiers,
+                                       KeyboardEventType eventType) = 0;
 };
 
 } // namespace vtbackend

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -598,12 +598,10 @@ Handled Terminal::sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventType e
     _cursorBlinkState = 1;
     _lastCursorBlink = now;
 
-    if (allowInput() && eventType != KeyboardEventType::Release
-        && _inputHandler.sendKeyPressEvent(key, modifiers))
+    if (!allowInput())
         return Handled { true };
 
-    // Early exit if KAM is enabled.
-    if (isModeEnabled(AnsiMode::KeyboardAction))
+    if (_inputHandler.sendKeyPressEvent(key, modifiers, eventType))
         return Handled { true };
 
     bool const success = _inputGenerator.generate(key, modifiers, eventType);
@@ -622,10 +620,10 @@ Handled Terminal::sendCharEvent(
     _lastCursorBlink = now;
 
     // Early exit if KAM is enabled.
-    if (isModeEnabled(AnsiMode::KeyboardAction))
+    if (!allowInput())
         return Handled { true };
 
-    if (eventType != KeyboardEventType::Release && _inputHandler.sendCharPressEvent(ch, modifiers))
+    if (_inputHandler.sendCharPressEvent(ch, modifiers, eventType))
         return Handled { true };
 
     auto const success = _inputGenerator.generate(ch, physicalKey, modifiers, eventType);

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -992,7 +992,8 @@ class Terminal
     bool allowPassMouseEventToApp(Modifiers currentlyPressedModifier) const noexcept
     {
         return _inputGenerator.mouseProtocol().has_value() && allowInput()
-               && !allowBypassAppMouseGrabViaModifier(currentlyPressedModifier);
+               && !allowBypassAppMouseGrabViaModifier(currentlyPressedModifier)
+               && _inputHandler.mode() == ViMode::Insert;
     }
 
     template <typename BlinkerState>

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -188,8 +188,8 @@ class ViInputHandler: public InputHandler
 
     ViInputHandler(Executor& theExecutor, ViMode initialMode);
 
-    Handled sendKeyPressEvent(Key key, Modifiers modifiers) override;
-    Handled sendCharPressEvent(char32_t ch, Modifiers modifiers) override;
+    Handled sendKeyPressEvent(Key key, Modifiers modifiers, KeyboardEventType eventType) override;
+    Handled sendCharPressEvent(char32_t ch, Modifiers modifiers, KeyboardEventType eventType) override;
 
     void setMode(ViMode mode);
     void toggleMode(ViMode mode);
@@ -238,7 +238,7 @@ class ViInputHandler: public InputHandler
                          std::vector<std::string_view> const& commands,
                          CommandHandler const& handler);
     void appendModifierToPendingInput(Modifiers modifiers);
-    [[nodiscard]] bool handlePendingInput();
+    void handlePendingInput();
     void clearPendingInput();
     [[nodiscard]] unsigned count() const noexcept { return _count ? _count : 1; }
 


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1468
Restrict forwarding of some of the events while in normal mode:
* mouse press 
* keys like 'Enter', 'ESC', 'Tab', 'Shift' 