### PR TITLE
Add extended_word_selection

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Add ability to customize the indicator statusline through configuration (#687)</li>
           <li>Add generation of config file from internal state (#1282)</li>
           <li>Add SGRSAVE and SGRRESTORE VT sequences to save and restore SGR state (They intentionally conflict with XTPUSHSGR and XTPOPSGR)</li>
+          <li>Add extended word selection feature (#1023)</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Fixed overlap of glyphs for long codepoints (#1349)</li>
           <li>Fixed too verbose info during ssh session login (#1447)</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1858,11 +1858,10 @@ std::string createString(Config const& c)
         auto wordDelimiters = c.extendedWordDelimiters.value();
         wordDelimiters = std::regex_replace(wordDelimiters, std::regex("\\\\"), "\\$&"); /* \ -> \\ */
         wordDelimiters = std::regex_replace(wordDelimiters, std::regex("\""), "\\$&");   /* " -> \" */
-        doc.append(
-            fmt::format(fmt::runtime(writer.process(documentation::ExtendedWordDelimiters.value, wordDelimiters)),
-                        fmt::arg("comment", "#")));
+        doc.append(fmt::format(
+            fmt::runtime(writer.process(documentation::ExtendedWordDelimiters.value, wordDelimiters)),
+            fmt::arg("comment", "#")));
     };
-
 
     if (c.platformPlugin.value() == "")
     {

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -293,6 +293,7 @@ void YAMLConfigReader::load(Config& c)
         }
         loadFromEntry("default_profile", c.defaultProfileName);
         loadFromEntry("word_delimiters", c.wordDelimiters);
+        loadFromEntry("extended_word_delimiters", c.extendedWordDelimiters);
         loadFromEntry("read_buffer_size", c.ptyReadBufferSize);
         loadFromEntry("pty_buffer_size", c.ptyBufferObjectSize);
         loadFromEntry("images.sixel_register_count", c.maxImageColorRegisters);
@@ -1853,6 +1854,16 @@ std::string createString(Config const& c)
                         fmt::arg("comment", "#")));
     };
 
+    auto const processExtendedWordDelimiters = [&]() {
+        auto wordDelimiters = c.extendedWordDelimiters.value();
+        wordDelimiters = std::regex_replace(wordDelimiters, std::regex("\\\\"), "\\$&"); /* \ -> \\ */
+        wordDelimiters = std::regex_replace(wordDelimiters, std::regex("\""), "\\$&");   /* " -> \" */
+        doc.append(
+            fmt::format(fmt::runtime(writer.process(documentation::ExtendedWordDelimiters.value, wordDelimiters)),
+                        fmt::arg("comment", "#")));
+    };
+
+
     if (c.platformPlugin.value() == "")
     {
         processWithDoc(documentation::PlatformPlugin, std::string { "auto" });
@@ -1872,6 +1883,7 @@ std::string createString(Config const& c)
     });
 
     processWordDelimiters();
+    processExtendedWordDelimiters();
     process(c.ptyReadBufferSize);
     process(c.ptyBufferObjectSize);
     process(c.defaultProfileName);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -658,6 +658,10 @@ struct Config
     ConfigEntry<std::string, documentation::WordDelimiters> wordDelimiters {
         " /\\()\"'-.,:;<>~!@#$%^&*+=[]{{}}~?|│"
     };
+    ConfigEntry<std::string, documentation::ExtendedWordDelimiters> extendedWordDelimiters {
+        " /\\()\"'-.,:;<>~!@#$%^&*+=[]{{}}~?|│"
+    };
+
     ConfigEntry<vtbackend::Modifiers, documentation::BypassMouseProtocolModifiers>
         bypassMouseProtocolModifiers { vtbackend::Modifier::Shift };
     ConfigEntry<contour::config::SelectionAction, documentation::OnMouseSelection> onMouseSelection {

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -571,6 +571,14 @@ constexpr StringLiteral WordDelimiters { "{comment} Word delimiters when selecti
                                          "word_delimiters: \"{}\" \n"
                                          "\n" };
 
+constexpr StringLiteral ExtendedWordDelimiters {
+    "{comment} Word delimiters for second selection when selecting word-wise. \n"
+    "{comment} Setting allows you to set less strict boundaried between words, for example \n"
+    "{comment} if you want to select whole ip address during selection set delimieters to \" \" (space) \n"
+    "extended_word_delimiters: \"{}\" \n"
+    "\n"
+};
+
 constexpr StringLiteral BypassMouseProtocolModifiers {
     "{comment} This keyboard modifier can be used to bypass the terminal's mouse protocol, \n"
     "{comment} which can be used to select screen content even if the an application \n"

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1450,6 +1450,7 @@ void TerminalSession::configureTerminal()
     sessionLog()("Configuring terminal.");
 
     _terminal.setWordDelimiters(_config.wordDelimiters.value());
+    _terminal.setExtendedWordDelimiters(_config.extendedWordDelimiters.value());
     _terminal.setMouseProtocolBypassModifiers(_config.bypassMouseProtocolModifiers.value());
     _terminal.setMouseBlockSelectionModifiers(_config.mouseBlockSelectionModifiers.value());
     _terminal.setLastMarkRangeOffset(_profile.copyLastMarkRangeOffset.value());

--- a/src/vtbackend/Selector.h
+++ b/src/vtbackend/Selector.h
@@ -20,8 +20,8 @@ namespace vtbackend
 struct SelectionHelper
 {
     virtual ~SelectionHelper() = default;
+    std::function<bool(CellLocation)> wordDelimited;
     [[nodiscard]] virtual PageSize pageSize() const noexcept = 0;
-    [[nodiscard]] virtual bool wordDelimited(CellLocation pos) const noexcept = 0;
     [[nodiscard]] virtual bool wrappedLine(LineOffset line) const noexcept = 0;
     [[nodiscard]] virtual bool cellEmpty(CellLocation pos) const noexcept = 0;
     [[nodiscard]] virtual int cellWidth(CellLocation pos) const noexcept = 0;

--- a/src/vtbackend/Selector_test.cpp
+++ b/src/vtbackend/Selector_test.cpp
@@ -20,7 +20,6 @@ struct TestSelectionHelper: public vtbackend::SelectionHelper
     explicit TestSelectionHelper(Screen<T>& self): screen { &self } {}
 
     [[nodiscard]] PageSize pageSize() const noexcept override { return screen->pageSize(); }
-    [[nodiscard]] bool wordDelimited(CellLocation /*pos*/) const noexcept override { return true; } // TODO
     [[nodiscard]] bool wrappedLine(LineOffset line) const noexcept override
     {
         return screen->isLineWrapped(line);

--- a/src/vtbackend/Settings.h
+++ b/src/vtbackend/Settings.h
@@ -73,6 +73,7 @@ struct Settings
     // This value must be integer-devisable by 16.
     size_t ptyReadBufferSize = 4096;
     std::u32string wordDelimiters;
+    std::u32string extendedWordDelimiters;
     Modifiers mouseProtocolBypassModifiers = Modifier::Shift;
     Modifiers mouseBlockSelectionModifiers = Modifier::Control;
     LineOffset copyLastMarkRangeOffset = LineOffset(0);

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -877,7 +877,8 @@ class Terminal
 
     // Tests if the grid cell at the given location does contain a word delimiter.
     [[nodiscard]] bool wordDelimited(CellLocation position) const noexcept;
-    [[nodiscard]] bool wordDelimited(CellLocation position, std::u32string_view wordDelimiters) const noexcept;
+    [[nodiscard]] bool wordDelimited(CellLocation position,
+                                     std::u32string_view wordDelimiters) const noexcept;
 
     [[nodiscard]] std::tuple<std::u32string, CellLocationRange> extractWordUnderCursor(
         CellLocation position) const noexcept;
@@ -1161,8 +1162,8 @@ class Terminal
 template <>
 struct fmt::formatter<vtbackend::TraceHandler::PendingSequence>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::TraceHandler::PendingSequence const& pendingSequence, format_context& ctx)
-        -> format_context::iterator
+    auto format(vtbackend::TraceHandler::PendingSequence const& pendingSequence,
+                format_context& ctx) -> format_context::iterator
     {
         std::string value;
         if (auto const* p = std::get_if<vtbackend::Sequence>(&pendingSequence))

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -654,8 +654,8 @@ class Terminal
     // }}}
 
     // {{{ selection management
-    // TODO: move you, too?
     void setWordDelimiters(std::string const& wordDelimiters);
+    void setExtendedWordDelimiters(std::string const& wordDelimiters);
     std::u32string const& wordDelimiters() const noexcept { return _settings.wordDelimiters; }
 
     Selection const* selector() const noexcept { return _selection.get(); }
@@ -877,6 +877,7 @@ class Terminal
 
     // Tests if the grid cell at the given location does contain a word delimiter.
     [[nodiscard]] bool wordDelimited(CellLocation position) const noexcept;
+    [[nodiscard]] bool wordDelimited(CellLocation position, std::u32string_view wordDelimiters) const noexcept;
 
     [[nodiscard]] std::tuple<std::u32string, CellLocationRange> extractWordUnderCursor(
         CellLocation position) const noexcept;
@@ -1058,12 +1059,12 @@ class Terminal
         Terminal* terminal;
         explicit SelectionHelper(Terminal* self): terminal { self } {}
         [[nodiscard]] PageSize pageSize() const noexcept override;
-        [[nodiscard]] bool wordDelimited(CellLocation pos) const noexcept override;
         [[nodiscard]] bool wrappedLine(LineOffset line) const noexcept override;
         [[nodiscard]] bool cellEmpty(CellLocation pos) const noexcept override;
         [[nodiscard]] int cellWidth(CellLocation pos) const noexcept override;
     };
     SelectionHelper _selectionHelper;
+    SelectionHelper _extendedSelectionHelper;
     // }}}
 
     // {{{ Render buffer state

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -959,6 +959,17 @@ class Terminal
     void updateIndicatorStatusLine();
     void updateCursorVisibilityState() const noexcept;
     void updateHoveringHyperlinkState();
+
+    struct TheSelectionHelper: public vtbackend::SelectionHelper
+    {
+        Terminal* terminal;
+        explicit TheSelectionHelper(Terminal* self): terminal { self } {}
+        [[nodiscard]] PageSize pageSize() const noexcept override;
+        [[nodiscard]] bool wrappedLine(LineOffset line) const noexcept override;
+        [[nodiscard]] bool cellEmpty(CellLocation pos) const noexcept override;
+        [[nodiscard]] int cellWidth(CellLocation pos) const noexcept override;
+    };
+    void triggerWordWiseSelection(CellLocation startPos, TheSelectionHelper const& selectionHelper);
     bool handleMouseSelection(Modifiers modifiers);
 
     /// Tests if the text selection should be extended by the given mouse position or not.
@@ -1054,17 +1065,8 @@ class Terminal
 
     // {{{ selection states
     std::unique_ptr<Selection> _selection;
-    struct SelectionHelper: public vtbackend::SelectionHelper
-    {
-        Terminal* terminal;
-        explicit SelectionHelper(Terminal* self): terminal { self } {}
-        [[nodiscard]] PageSize pageSize() const noexcept override;
-        [[nodiscard]] bool wrappedLine(LineOffset line) const noexcept override;
-        [[nodiscard]] bool cellEmpty(CellLocation pos) const noexcept override;
-        [[nodiscard]] int cellWidth(CellLocation pos) const noexcept override;
-    };
-    SelectionHelper _selectionHelper;
-    SelectionHelper _extendedSelectionHelper;
+    TheSelectionHelper _selectionHelper;
+    TheSelectionHelper _extendedSelectionHelper;
     // }}}
 
     // {{{ Render buffer state


### PR DESCRIPTION
This PR implements additional step during word selection that uses `extended_word_delimiters` configuration entry.
Closes https://github.com/contour-terminal/contour/issues/1023