### PR TITLE
Add action to set custom delimiters for selection

### DIFF
--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -34,6 +34,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::CopyPreviousMarkRange>("CopyPreviousMarkRange"),
         mapAction<actions::CopySelection>("CopySelection"),
         mapAction<actions::CreateDebugDump>("CreateDebugDump"),
+        mapAction<actions::CreateSelection>("CreateSelection"),
         mapAction<actions::DecreaseFontSize>("DecreaseFontSize"),
         mapAction<actions::DecreaseOpacity>("DecreaseOpacity"),
         mapAction<actions::FocusNextSearchMatch>("FocusNextSearchMatch"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -35,6 +35,7 @@ struct ClearHistoryAndReset{};
 struct CopyPreviousMarkRange{};
 struct CopySelection{ CopyFormat format = CopyFormat::Text; };
 struct CreateDebugDump{};
+struct CreateSelection{ std::string delimiters; };
 struct DecreaseFontSize{};
 struct DecreaseOpacity{};
 struct FocusNextSearchMatch{};
@@ -89,6 +90,7 @@ using Action = std::variant<CancelSelection,
                             CopyPreviousMarkRange,
                             CopySelection,
                             CreateDebugDump,
+                            CreateSelection,
                             DecreaseFontSize,
                             DecreaseOpacity,
                             FocusNextSearchMatch,
@@ -154,6 +156,7 @@ DECLARE_ACTION_FMT(ClearHistoryAndReset)
 DECLARE_ACTION_FMT(CopyPreviousMarkRange)
 DECLARE_ACTION_FMT(CopySelection)
 DECLARE_ACTION_FMT(CreateDebugDump)
+DECLARE_ACTION_FMT(CreateSelection)
 DECLARE_ACTION_FMT(DecreaseFontSize)
 DECLARE_ACTION_FMT(DecreaseOpacity)
 DECLARE_ACTION_FMT(FocusNextSearchMatch)
@@ -263,6 +266,11 @@ struct fmt::formatter<contour::actions::Action>: fmt::formatter<std::string>
         {
             const auto WriteScreenAction = std::get<contour::actions::WriteScreen>(_action);
             name = fmt::format("{} chars: '{}'", WriteScreenAction, WriteScreenAction.chars);
+        }
+        if (std::holds_alternative<contour::actions::CreateSelection>(_action))
+        {
+            const auto CreateSelectionAction = std::get<contour::actions::CreateSelection>(_action);
+            name = fmt::format("{} delimiters: '{}'", CreateSelectionAction, CreateSelectionAction.delimiters);
         }
         // }}}
         return formatter<string_view>::format(name, ctx);

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1698,6 +1698,16 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
                 return std::nullopt;
         }
 
+        if (holds_alternative<actions::CreateSelection>(action))
+        {
+            if (auto delimiters = node["delimiters"]; delimiters.IsScalar())
+            {
+                return actions::CreateSelection { delimiters.as<std::string>() };
+            }
+            else
+                return std::nullopt;
+        }
+
         return action;
     }
     return std::nullopt;

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -987,6 +987,12 @@ bool TerminalSession::operator()(actions::CreateDebugDump)
     return true;
 }
 
+bool TerminalSession::operator()(actions::CreateSelection customSelector)
+{
+    _terminal.triggerWordWiseSelectionWithCustomDelimiters(customSelector.delimiters);
+    return true;
+}
+
 bool TerminalSession::operator()(actions::DecreaseFontSize)
 {
     auto constexpr OnePt = text::font_size { 1.0 };

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -301,6 +301,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::CopyPreviousMarkRange);
     bool operator()(actions::CopySelection);
     bool operator()(actions::CreateDebugDump);
+    bool operator()(actions::CreateSelection);
     bool operator()(actions::DecreaseFontSize);
     bool operator()(actions::DecreaseOpacity);
     bool operator()(actions::FollowHyperlink);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -770,6 +770,7 @@ color_schemes:
 # - ClearHistoryAndReset    Clears the history, performs a terminal hard reset and attempts to force a redraw of the currently running application.
 # - CopyPreviousMarkRange   Copies the most recent range that is delimited by vertical line marks into clipboard.
 # - CopySelection     Copies the current selection into the clipboard buffer.
+# - CreateSelection   Creates selection with custom delimiters configured via `delimiters` member.
 # - DecreaseFontSize  Decreases the font size by 1 pixel.
 # - DecreaseOpacity   Decreases the default-background opacity by 5%.
 # - FocusNextSearchMatch     Focuses the next search match (if any).

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -953,6 +953,8 @@ class Terminal
     [[nodiscard]] bool usePrivateColorRegisters() const noexcept { return _usePrivateColorRegisters; }
     // }}}
 
+    void triggerWordWiseSelectionWithCustomDelimiters(std::string const& delimiters);
+
   private:
     void mainLoop();
     void fillRenderBufferInternal(RenderBuffer& output, bool includeSelection);
@@ -1068,6 +1070,7 @@ class Terminal
     std::unique_ptr<Selection> _selection;
     TheSelectionHelper _selectionHelper;
     TheSelectionHelper _extendedSelectionHelper;
+    TheSelectionHelper _customSelectionHelper;
     // }}}
 
     // {{{ Render buffer state


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1023

PR adds action to trigger selection with custom delimiters
@cqexbesd you can add following entry in config file:
```
   - { mods: [Control],        mouse: Left,        action: CreateSelection, chars: " " }
```
