### PR TITLE
Get rid of LIBTERMINAL_CACHE_CURRENT_LINE_POINTER

### DIFF
--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -4,7 +4,6 @@ find_package(Threads)
 
 option(LIBTERMINAL_TESTING "Enables building of unittests for libterminal [default: ON]" ${CONTOUR_TESTING})
 option(LIBTERMINAL_LOG_TRACE "Enables VT sequence tracing. [default: ON]" ON)
-option(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER "Enables caching the pointer to the current line, which should improve performance. [default: OFF]" OFF)
 
 # This is an optimization feature that hopefully improves performance when enabled.
 # But it's currently disabled by default as I am not fully satisfied with it yet.
@@ -109,9 +108,6 @@ target_link_libraries(vtbackend PUBLIC
 if(LIBTERMINAL_LOG_TRACE)
     target_compile_definitions(vtbackend PUBLIC LIBTERMINAL_LOG_TRACE=1)
 endif()
-if(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER)
-    target_compile_definitions(vtbackend PUBLIC LIBTERMINAL_CACHE_CURRENT_LINE_POINTER=1)
-endif()
 if(CONTOUR_PERF_STATS)
     target_compile_definitions(vtbackend PUBLIC CONTOUR_PERF_STATS=1)
 endif()
@@ -185,7 +181,6 @@ endif()
 
 message(STATUS "[vtbackend] Compile unit tests: ${LIBTERMINAL_TESTING}")
 message(STATUS "[vtbackend] Enable VT sequence tracing: ${LIBTERMINAL_LOG_TRACE}")
-message(STATUS "[vtbackend] Enable caching of current line pointer: ${LIBTERMINAL_CACHE_CURRENT_LINE_POINTER}")
 message(STATUS "[vtbackend] Enable passive render buffer update: ${LIBTERMINAL_PASSIVE_RENDER_BUFFER_UPDATE}")
 message(STATUS "[vtbackend] Build bench-headless: ${LIBTERMINAL_BUILD_BENCH_HEADLESS}")
 message(STATUS "[vtbackend] Build documentation tool: ${VTBACKEND_DOC_TOOL}")

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -374,30 +374,11 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
         return useCellAt(_lastCursorPosition.line, _lastCursorPosition.column);
     }
 
-    void updateCursorIterator() noexcept override
-    {
-#if defined(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER)
-        _currentLine = &_grid.lineAt(_cursor.position.line);
-#endif
-    }
+    void updateCursorIterator() noexcept override { _currentLine = &_grid.lineAt(_cursor.position.line); }
 
-    [[nodiscard]] Line<Cell>& currentLine() noexcept
-    {
-#if defined(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER)
-        return *_currentLine;
-#else
-        return _grid.lineAt(_cursor.position.line);
-#endif
-    }
+    [[nodiscard]] Line<Cell>& currentLine() noexcept { return *_currentLine; }
 
-    [[nodiscard]] Line<Cell> const& currentLine() const noexcept
-    {
-#if defined(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER)
-        return *_currentLine;
-#else
-        return _grid.lineAt(_cursor.position.line);
-#endif
-    }
+    [[nodiscard]] Line<Cell> const& currentLine() const noexcept { return *_currentLine; }
 
     [[nodiscard]] Cell& useCurrentCell() noexcept { return currentLine().useCellAt(_cursor.position.column); }
 
@@ -589,9 +570,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
 
     CellLocation _lastCursorPosition {};
 
-#if defined(LIBTERMINAL_CACHE_CURRENT_LINE_POINTER)
     Line<Cell>* _currentLine = nullptr;
-#endif
     std::unique_ptr<SixelImageBuilder> _sixelImageBuilder;
 
 #if defined(LIBTERMINAL_LOG_TRACE)


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1229