### PR TITLE
Fixes application window icon on (KDE) Wayland

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -130,6 +130,7 @@
           <li>Fixes screen sampling with multiple monitors (#940)</li>
           <li>Fixes bell sound in spawned window in same process (#1515)</li>
           <li>Fixes status line crush (#1511)</li>
+          <li>Fixes application window icon on (KDE) Wayland</li>
         </ul>
       </description>
     </release>

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -149,6 +149,7 @@ target_compile_definitions(contour PRIVATE
     CONTOUR_VERSION_PATCH=${PROJECT_VERSION_PATCH}
     CONTOUR_VERSION_STRING="${CONTOUR_VERSION_STRING}"
     CONTOUR_PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+    CONTOUR_APP_ID="${AppId}"
 )
 
 # Disable all deprecated Qt functions prior to Qt 6.0

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -313,7 +313,7 @@ struct TerminalProfile
     ConfigEntry<bool, documentation::MouseHideWhileTyping> mouseHideWhileTyping { true };
     ConfigEntry<bool, documentation::SeachModeSwitch> searchModeSwitch { true };
     ConfigEntry<vtbackend::LineOffset, documentation::CopyLastMarkRangeOffset> copyLastMarkRangeOffset { 0 };
-    ConfigEntry<std::string, documentation::WMClass> wmClass { "contour" };
+    ConfigEntry<std::string, documentation::WMClass> wmClass {};
     ConfigEntry<WindowMargins, documentation::Margins> margins { { HorizontalMargin { 0u },
                                                                    VerticalMargin { 0u } } };
     ConfigEntry<vtbackend::PageSize, documentation::TerminalSize> terminalSize { {

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -468,7 +468,7 @@ void ContourGuiApp::setupQCoreApplication()
     auto const* profile = _config.profile(profileName());
     Require(profile);
 
-    auto const defaultAppName = QStringLiteral("contour");
+    auto const defaultAppName = QStringLiteral(CONTOUR_APP_ID);
     auto const defaultOrgDomain = QStringLiteral("contour-terminal.org");
     auto const defaultOrgName = QStringLiteral("contour");
 
@@ -489,6 +489,8 @@ void ContourGuiApp::setupQCoreApplication()
     // application id on Wayland when using Qt.
     if (platformName == "wayland" && !wmClass.isEmpty())
         QGuiApplication::setDesktopFileName(wmClass);
+    else
+        QGuiApplication::setDesktopFileName(defaultAppName);
 
     QCoreApplication::setOrganizationDomain(defaultOrgDomain);
     QCoreApplication::setOrganizationName(defaultOrgName);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -238,7 +238,9 @@ profiles:
             alert: true
 
         # Defines the class part of the WM_CLASS property of the window.
-        wm_class: "contour"
+        # This is specific to X11, but also used on Wayland.
+        # Default: "org.contourterminal.Contour"
+        wm_class: "org.contourterminal.Contour"
 
         # Tells Contour how to handle Option-Key events on MacOS.
         # This value is ignored on other platforms.


### PR DESCRIPTION
Contour's app icon in the window title bar (on KDE plasma on Wayland) was showing a default W-icon rather than our own one. This fixes it.