### PR TITLE
Code cleanups

### DIFF
--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -195,7 +195,7 @@ void Terminal::setLastMarkRangeOffset(LineOffset value) noexcept
     _settings.copyLastMarkRangeOffset = value;
 }
 
-vtpty::Pty::ReadResult Terminal::readFromPty()
+std::optional<vtpty::Pty::ReadResult> Terminal::readFromPty()
 {
     auto const timeout =
 #if defined(LIBTERMINAL_PASSIVE_RENDER_BUFFER_UPDATE)
@@ -272,8 +272,8 @@ bool Terminal::processInputOnce()
         _pty->close();
         return false;
     }
-    string_view const buf = std::get<0>(*readResult);
-    _usingStdoutFastPipe = std::get<1>(*readResult);
+    string_view const buf = readResult->data;
+    _usingStdoutFastPipe = readResult->fromStdoutFastPipe;
 
     if (buf.empty())
     {

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1007,7 +1007,7 @@ class Terminal
     }
 
     // Reads from PTY.
-    [[nodiscard]] vtpty::Pty::ReadResult readFromPty();
+    [[nodiscard]] std::optional<vtpty::Pty::ReadResult> readFromPty();
 
     // Writes partially or all input data to the PTY buffer object and returns a string view to it.
     [[nodiscard]] std::string_view lockedWriteToPtyBuffer(std::string_view data);

--- a/src/vtbackend/bench-headless.cpp
+++ b/src/vtbackend/bench-headless.cpp
@@ -246,7 +246,7 @@ class ContourHeadlessBench: public crispy::app
                 auto const readResult = pty.read(*bufferObject, std::chrono::seconds(2), PtyReadSize);
                 if (!readResult)
                     break;
-                auto const dataChunk = get<string_view>(readResult.value());
+                auto const dataChunk = readResult.value().data;
                 if (dataChunk.empty())
                     break;
                 bytesTransferred += dataChunk.size();

--- a/src/vtpty/ConPty.cpp
+++ b/src/vtpty/ConPty.cpp
@@ -137,9 +137,9 @@ void ConPty::close()
     }
 }
 
-Pty::ReadResult ConPty::read(crispy::buffer_object<char>& buffer,
-                             std::optional<std::chrono::milliseconds> timeout,
-                             size_t size)
+std::optional<Pty::ReadResult> ConPty::read(crispy::buffer_object<char>& buffer,
+                                            std::optional<std::chrono::milliseconds> timeout,
+                                            size_t size)
 {
     // TODO: wait for timeout time at most AND got woken up upon wakeupReader() invokcation.
     (void) timeout;
@@ -153,7 +153,7 @@ Pty::ReadResult ConPty::read(crispy::buffer_object<char>& buffer,
     if (ptyInLog)
         ptyInLog()("{} received: \"{}\"", "master", crispy::escape(buffer.hotEnd(), buffer.hotEnd() + nread));
 
-    return { tuple { string_view { buffer.hotEnd(), nread }, false } };
+    return ReadResult { .data = string_view { buffer.hotEnd(), nread }, .fromStdoutFastPipe = false };
 }
 
 void ConPty::wakeupReader()

--- a/src/vtpty/ConPty.h
+++ b/src/vtpty/ConPty.h
@@ -26,9 +26,9 @@ class ConPty: public Pty
     void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
 
-    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
-                                  std::optional<std::chrono::milliseconds> timeout,
-                                  size_t size) override;
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> timeout,
+                                                 size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;

--- a/src/vtpty/MockPty.h
+++ b/src/vtpty/MockPty.h
@@ -18,9 +18,9 @@ class MockPty: public Pty
     ~MockPty() override = default;
 
     PtySlave& slave() noexcept override;
-    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
-                                  std::optional<std::chrono::milliseconds> timeout,
-                                  size_t size) override;
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> timeout,
+                                                 size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;

--- a/src/vtpty/MockViewPty.cpp
+++ b/src/vtpty/MockViewPty.cpp
@@ -4,10 +4,6 @@
 
 #include <crispy/BufferObject.h>
 
-using std::optional;
-using std::string_view;
-using std::tuple;
-
 namespace vtpty
 {
 
@@ -22,14 +18,14 @@ PtySlave& MockViewPty::slave() noexcept
     return _slave;
 }
 
-optional<tuple<string_view, bool>> MockViewPty::read(crispy::buffer_object<char>& storage,
-                                                     std::optional<std::chrono::milliseconds> /*timeout*/,
-                                                     size_t size)
+std::optional<Pty::ReadResult> MockViewPty::read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> /*timeout*/,
+                                                 size_t size)
 {
     auto const n = std::min(std::min(_outputBuffer.size(), storage.bytesAvailable()), size);
     auto result = storage.writeAtEnd(_outputBuffer.substr(0, n));
     _outputBuffer.remove_prefix(n);
-    return { tuple { string_view(result.data(), result.size()), false } };
+    return ReadResult { .data = std::string_view(result.data(), result.size()), .fromStdoutFastPipe = false };
 }
 
 void MockViewPty::wakeupReader()

--- a/src/vtpty/MockViewPty.h
+++ b/src/vtpty/MockViewPty.h
@@ -17,10 +17,9 @@ class MockViewPty: public Pty
     void setReadData(std::string_view data);
 
     PtySlave& slave() noexcept override;
-    [[nodiscard]] std::optional<std::tuple<std::string_view, bool>> read(
-        crispy::buffer_object<char>& storage,
-        std::optional<std::chrono::milliseconds> timeout,
-        size_t size) override;
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> timeout,
+                                                 size_t size) override;
     void wakeupReader() override;
     int write(std::string_view data) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -95,7 +95,7 @@ class [[nodiscard]] Process: public Pty
     void close() override { pty().close(); }
     void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override { return pty().isClosed(); }
-    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage, std::optional<std::chrono::milliseconds> timeout, size_t n) override { return pty().read(storage, timeout, n); }
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage, std::optional<std::chrono::milliseconds> timeout, size_t n) override { return pty().read(storage, timeout, n); }
     void wakeupReader() override { return pty().wakeupReader(); }
     [[nodiscard]] int write(std::string_view data) override { return pty().write(data); }
     [[nodiscard]] PageSize pageSize() const noexcept override { return pty().pageSize(); }

--- a/src/vtpty/Pty.h
+++ b/src/vtpty/Pty.h
@@ -52,7 +52,11 @@ class PtySlaveDummy: public PtySlave
 class Pty
 {
   public:
-    using ReadResult = std::optional<std::tuple<std::string_view, bool>>;
+    struct ReadResult
+    {
+        std::string_view data {};
+        bool fromStdoutFastPipe = false;
+    };
 
     virtual ~Pty() = default;
 
@@ -82,9 +86,9 @@ class Pty
     /// @returns A view to the consumed buffer. The boolean in the ReadResult
     ///          indicates whether or not this data was coming through
     ///          the stdout-fastpipe.
-    [[nodiscard]] virtual ReadResult read(crispy::buffer_object<char>& storage,
-                                          std::optional<std::chrono::milliseconds> timeout,
-                                          size_t size) = 0;
+    [[nodiscard]] virtual std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                         std::optional<std::chrono::milliseconds> timeout,
+                                                         size_t size) = 0;
 
     /// Inerrupts the read() operation on this PTY if a read() is currently in progress.
     ///

--- a/src/vtpty/SshSession.h
+++ b/src/vtpty/SshSession.h
@@ -59,9 +59,9 @@ class SshSession final: public Pty
     void close() override;
     void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
-    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
-                                  std::optional<std::chrono::milliseconds> timeout,
-                                  size_t size) override;
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> timeout,
+                                                 size_t size) override;
     void wakeupReader() override;
     [[nodiscard]] int write(std::string_view buf) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -59,9 +59,9 @@ class UnixPty final: public Pty
     void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override;
     void wakeupReader() noexcept override;
-    [[nodiscard]] ReadResult read(crispy::buffer_object<char>& storage,
-                                  std::optional<std::chrono::milliseconds> timeout,
-                                  size_t size) override;
+    [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage,
+                                                 std::optional<std::chrono::milliseconds> timeout,
+                                                 size_t size) override;
     int write(std::string_view data) override;
     [[nodiscard]] PageSize pageSize() const noexcept override;
     void resizeScreen(PageSize cells, std::optional<ImageSize> pixels = std::nullopt) override;


### PR DESCRIPTION
overall code cleanups

- [vtpty] Make Pty::ReadResult more intuitive to use (less cryptic)