### PR TITLE
Add some more missing vi input motions, such as `y$`, `o$`, and many others as initiated by `y` and `o` 

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -115,6 +115,7 @@
           <li>Add SGRSAVE and SGRRESTORE VT sequences to save and restore SGR state (They intentionally conflict with XTPUSHSGR and XTPOPSGR)</li>
           <li>Add extended word selection feature (#1023)</li>
           <li>Add extended word selection feature (#1023)</li>
+          <li>Add some more missing vi input motions, such as `y$`, `o$`, and many others as initiated by `y` and `o` (#1441)</li>
           <li>Add shell integration for bash shell.</li>
           <li>Add better bell sound (#1378)</li>
           <li>Add config entry to configure behaviour on exit from search mode</li>


### PR DESCRIPTION
Closes #1441.