### PR TITLE
Implement font fallback on MacOS

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -114,7 +114,6 @@
           <li>Add generation of config file from internal state (#1282)</li>
           <li>Add SGRSAVE and SGRRESTORE VT sequences to save and restore SGR state (They intentionally conflict with XTPUSHSGR and XTPOPSGR)</li>
           <li>Add extended word selection feature (#1023)</li>
-          <li>Add extended word selection feature (#1023)</li>
           <li>Add some more missing vi input motions, such as `y$`, `o$`, and many others as initiated by `y` and `o` (#1441)</li>
           <li>Add shell integration for bash shell.</li>
           <li>Add better bell sound (#1378)</li>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.4.4" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Add CoreText font fallback implementation for macOS (#1533)</li>
           <li>Add Ubuntu-24.04 in github actions (#1460)</li>
           <li>Add 'early_exit_threshold' config option (#1460)</li>
           <li>Add AppImage package with Qt6 support (#586)</li>

--- a/src/text_shaper/shaper.cpp
+++ b/src/text_shaper/shaper.cpp
@@ -62,8 +62,7 @@ namespace
 tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, vtbackend::ImageSize boundingBox)
 {
     // NB: We're only supporting down-scaling.
-    assert(bitmap.bitmapSize.width >= boundingBox.width);
-    assert(bitmap.bitmapSize.height >= boundingBox.height);
+    assert(bitmap.bitmapSize.width >= boundingBox.width || bitmap.bitmapSize.height >= boundingBox.height);
 
     auto const ratioX = unbox<double>(bitmap.bitmapSize.width) / unbox<double>(boundingBox.width);
     auto const ratioY = unbox<double>(bitmap.bitmapSize.height) / unbox<double>(boundingBox.height);


### PR DESCRIPTION
Closes #1533.

Adds implementation of font fallback discovery on MacOS.

Requires at least MacOS 13.1