### PR TITLE
[clang-tidy] Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.ref != 'refs/heads/master'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -92,46 +92,18 @@ jobs:
       run: sudo env QTVER=6 ./scripts/install-deps.sh
     - name: "Post-fix embedded dependency permissions."
       run: sudo find _deps/sources -exec chown $UID {} \;
-    - name: Install Clang
-      run: sudo apt install -y clang-18 clang-tidy-18
+    - name: Install clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 18
     - name: "cmake"
       run: |
-        cmake \
-            -DCMAKE_BUILD_TYPE="Debug" \
-            -DCMAKE_CXX_COMPILER="clang++-18" \
-            -DCONTOUR_INSTALL_TOOLS=ON \
-            -DCONTOUR_QT_VERSION=6 \
-            -DCONTOUR_TESTING=ON \
-            -DENABLE_TIDY=OFF \
-            -DLIBTERMINAL_BUILD_BENCH_HEADLESS=ON \
-            -DLIBUNICODE_UCD_BASE_DIR=$PWD/_ucd \
-            -S . -B build
-    - name: "build libunicode"
-      run: cmake --build build/ --target unicode -- -j3
-    - uses: ZedThree/clang-tidy-review@v0.17.0
-      id: review
-      with:
-        lgtm_comment_body: ""
-        annotations: true
-        build_dir: build
-        max_comments: 10
-    - uses: ZedThree/clang-tidy-review/upload@v0.17.0 # Uploads an artefact containing clang_fixes.json
-      id: upload-review
-    - if: steps.review.outputs.total_comments > 0 # If there are any comments, fail the check
-      run: exit 1
-    # - name: run clang-tidy
-    #   run: |
-    #     set -ex
-    #     for dir in src/*; do
-    #       FILES=$(find $dir -name '*.cpp' -print)
-    #       for file in $FILES; do
-    #         echo "Checking file $file ..."
-    #         clang-tidy \
-    #                   -p build \
-    #                   -header-filter=$PWD/src \
-    #                   $file
-    #       done
-    #     done
+        cmake --preset linux-debug -B build -G Ninja \
+        -D CMAKE_CXX_COMPILER="clang++-18" \
+        -D ENABLE_TIDY=ON -D CLANG_TIDY_EXE=/usr/bin/clang-tidy-18
+    - name: "build"
+      run: cmake --build build
 
   check_links:
     name: "Check links"

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >-
   -bugprone-reserved-identifier,
   -bugprone-suspicious-include,
   -bugprone-unchecked-optional-access,
+  -bugprone-chained-comparison,
   clang-analyzer-core.*,
   clang-analyzer-cplusplus.*,
   clang-analyzer-deadcode.*,
@@ -66,12 +67,12 @@ Checks: >-
   -readability-use-anyofallof,
   misc-const-correctness,
 WarningsAsErrors: >-
+  performance-enum-size,
   readability-identifier-naming,
   misc-const-correctness,
   modernize-use-nullptr,
 UseColor: true
-HeaderFilterRegex: 'src/(contour|crispy|text_shaper|vtpty|vtparser|vtbackend|vtrasterizer)/'
-AnalyzeTemporaryDtors: false
+HeaderFilterRegex: "contour\/src\/(.*)h"
 FormatStyle:     none
 CheckOptions:
   - key:             bugprone-easily-swappable-parameters.MinimumLength

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -75,6 +75,7 @@ WarningsAsErrors: >-
   misc-const-correctness,
   modernize-use-nullptr,
   modernize-use-constraints,
+  bugprone-narrowing-conversions,
 UseColor: true
 HeaderFilterRegex: 'src/(contour|crispy|text_shaper|vtpty|vtparser|vtbackend|vtrasterizer)/'
 FormatStyle:     none

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -55,6 +55,7 @@ Checks: >-
   -readability-avoid-unconditional-preprocessor-if,
   -readability-braces-around-statements,
   -readability-container-contains,
+  -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -72,7 +72,7 @@ WarningsAsErrors: >-
   misc-const-correctness,
   modernize-use-nullptr,
 UseColor: true
-HeaderFilterRegex: "contour\/src\/(.*)h"
+HeaderFilterRegex: "contour/src"
 FormatStyle:     none
 CheckOptions:
   - key:             bugprone-easily-swappable-parameters.MinimumLength

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -72,6 +72,7 @@ Checks: >-
 WarningsAsErrors: >-
   performance-enum-size,
   readability-identifier-naming,
+  readability-avoid-nested-conditional-operator,
   misc-const-correctness,
   modernize-use-nullptr,
   modernize-use-constraints,

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -65,12 +65,16 @@ Checks: >-
   -readability-simplify-boolean-expr,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,
+  -readability-redundant-member-init,
+  -readability-redundant-inline-specifier,
+  -readability-redundant-casting,
   misc-const-correctness,
 WarningsAsErrors: >-
   performance-enum-size,
   readability-identifier-naming,
   misc-const-correctness,
   modernize-use-nullptr,
+  modernize-use-constraints,
 UseColor: true
 HeaderFilterRegex: "contour/src"
 FormatStyle:     none

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -76,7 +76,7 @@ WarningsAsErrors: >-
   modernize-use-nullptr,
   modernize-use-constraints,
 UseColor: true
-HeaderFilterRegex: "contour/src"
+HeaderFilterRegex: 'src/(contour|crispy|text_shaper|vtpty|vtparser|vtbackend|vtrasterizer)/'
 FormatStyle:     none
 CheckOptions:
   - key:             bugprone-easily-swappable-parameters.MinimumLength

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -13,7 +13,7 @@ namespace contour::actions
 {
 
 // Defines the format to use when extracting a selection range from the terminal.
-enum class CopyFormat
+enum class CopyFormat : uint8_t
 {
     // Copies purely the text (with their whitespaces, and newlines, but no formatting).
     Text,

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -264,14 +264,14 @@ struct fmt::formatter<contour::actions::Action>: fmt::formatter<std::string>
         HANDLE_ACTION(ViNormalMode);
         if (std::holds_alternative<contour::actions::WriteScreen>(_action))
         {
-            const auto WriteScreenAction = std::get<contour::actions::WriteScreen>(_action);
-            name = fmt::format("{} chars: '{}'", WriteScreenAction, WriteScreenAction.chars);
+            const auto writeScreenAction = std::get<contour::actions::WriteScreen>(_action);
+            name = fmt::format("{} chars: '{}'", writeScreenAction, writeScreenAction.chars);
         }
         if (std::holds_alternative<contour::actions::CreateSelection>(_action))
         {
-            const auto CreateSelectionAction = std::get<contour::actions::CreateSelection>(_action);
+            const auto createSelectionAction = std::get<contour::actions::CreateSelection>(_action);
             name =
-                fmt::format("{} delimiters: '{}'", CreateSelectionAction, CreateSelectionAction.delimiters);
+                fmt::format("{} delimiters: '{}'", createSelectionAction, createSelectionAction.delimiters);
         }
         // }}}
         return formatter<string_view>::format(name, ctx);

--- a/src/contour/Audio.cpp
+++ b/src/contour/Audio.cpp
@@ -1,7 +1,9 @@
+
 #include <contour/Audio.h>
 
 #include <crispy/assert.h>
 #include <crispy/logstore.h>
+#include <crispy/times.h>
 
 #include <qbuffer.h>
 #include <qthread.h>
@@ -29,7 +31,7 @@ auto createMusicalNote(double volume, double duration, double frequency) noexcep
     volume /= 7;
     std::vector<std::int16_t> buffer;
     buffer.reserve(static_cast<size_t>(std::ceil(duration * SampleRate)));
-    for (double i = 0; i < duration * SampleRate; ++i)
+    for (const auto i: crispy::times(static_cast<int>(std::ceil(duration * SampleRate))))
         buffer.push_back(static_cast<int16_t>(0x7fff * volume * square_wave(frequency / SampleRate * i * 2)));
     return buffer;
 }

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -252,6 +252,7 @@ optional<std::string> readConfigFile(std::string const& filename)
     return nullopt;
 }
 
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
 void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
                                      std::string const& entry,
                                      std::filesystem::path& where)
@@ -985,6 +986,7 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
             where = opt.value();
     }
 }
+// NOLINTEND(readability-convert-member-functions-to-static)
 
 void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
                                      std::string const& entry,
@@ -1334,6 +1336,7 @@ void YAMLConfigReader::defaultSettings(vtpty::Process::ExecInfo& shell)
         shell.env["COLORTERM"] = "truecolor";
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::optional<vtbackend::MouseButton> YAMLConfigReader::parseMouseButton(YAML::Node const& node)
 {
     using namespace std::literals::string_view_literals;
@@ -1422,6 +1425,7 @@ std::optional<std::variant<vtbackend::Key, char32_t>> YAMLConfigReader::parseKey
     return std::nullopt;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::optional<vtbackend::Key> YAMLConfigReader::parseKey(std::string const& name)
 {
     using vtbackend::Key;
@@ -1583,6 +1587,7 @@ std::optional<vtbackend::Modifiers> YAMLConfigReader::parseModifier(YAML::Node c
     return mods;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::optional<vtbackend::Modifiers> YAMLConfigReader::parseModifierKey(std::string const& key)
 {
     using vtbackend::Modifier;

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -470,7 +470,8 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
         logger()("color palette loading from file {}", filePath.string());
         try
         {
-            return loadFromEntry(YAML::Load(fileContents.value()), where);
+            loadFromEntry(YAML::Load(fileContents.value()), where);
+            return;
         }
         catch (std::exception const& e)
         {
@@ -1874,7 +1875,7 @@ std::string createString(Config const& c)
             fmt::arg("comment", "#")));
     };
 
-    if (c.platformPlugin.value() == "")
+    if (c.platformPlugin.value().empty())
     {
         processWithDoc(documentation::PlatformPlugin, std::string { "auto" });
     }

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -64,21 +64,21 @@
 namespace contour::config
 {
 
-enum class ScrollBarPosition
+enum class ScrollBarPosition : uint8_t
 {
     Hidden,
     Left,
     Right
 };
 
-enum class Permission
+enum class Permission : uint8_t
 {
     Deny,
     Allow,
     Ask
 };
 
-enum class SelectionAction
+enum class SelectionAction : uint8_t
 {
     Nothing,
     CopyToSelectionClipboard,
@@ -179,7 +179,7 @@ struct SimpleColorConfig
 
 using ColorConfig = std::variant<SimpleColorConfig, DualColorConfig>;
 
-enum class RenderingBackend
+enum class RenderingBackend : uint8_t
 {
     Default,
     Software,

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -209,14 +209,13 @@ struct ConfigEntry
 
     std::string documentation = doc.value;
     constexpr ConfigEntry(): _value {} {}
-    //clang-format off
-    constexpr explicit ConfigEntry(T&& in): _value { std::forward<T>(in) } {}
+    constexpr explicit ConfigEntry(T in): _value { std::move(in) } {}
 
     template <typename F>
+        requires(!std::is_same_v<std::remove_cvref_t<F>, T>)
     constexpr explicit ConfigEntry(F&& in): _value { std::forward<F>(in) }
     {
     }
-    //clang-format on
 
     [[nodiscard]] constexpr T const& value() const { return _value; }
     [[nodiscard]] constexpr T& value() { return _value; }
@@ -932,20 +931,20 @@ struct YAMLConfigWriter: Writer
 
     static constexpr int OneOffset = 4;
     using Writer::format;
-    std::string static addOffset(std::string const& doc, size_t off)
+    std::string static addOffset(std::string_view doc, size_t off)
     {
         auto offset = std::string(off, ' ');
-        return std::regex_replace(doc, std::regex(".+\n"), offset + "$&");
+        return std::regex_replace(std::string { doc }, std::regex(".+\n"), offset + "$&");
     }
 
     template <typename T>
-    std::string process(std::string doc, T val)
+    std::string process(std::string_view doc, T val)
     {
         return format(addOffset(doc, Offset::levels * OneOffset), val);
     }
 
     template <typename... T>
-    std::string process(std::string doc, T... val)
+    std::string process(std::string_view doc, T... val)
     {
         return format(addOffset(doc, Offset::levels * OneOffset), val...);
     }

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -544,7 +544,6 @@ void TerminalSession::copyToClipboard(std::string_view data)
 
 void TerminalSession::openDocument(std::string_view fileOrUrl)
 {
-    auto stripped = strip_if(string(fileOrUrl), true);
     sessionLog()("openDocument: {}\n", fileOrUrl);
     QDesktopServices::openUrl(QUrl(QString::fromStdString(std::string(fileOrUrl))));
 }
@@ -987,7 +986,7 @@ bool TerminalSession::operator()(actions::CreateDebugDump)
     return true;
 }
 
-bool TerminalSession::operator()(actions::CreateSelection customSelector)
+bool TerminalSession::operator()(actions::CreateSelection const& customSelector)
 {
     _terminal.triggerWordWiseSelectionWithCustomDelimiters(customSelector.delimiters);
     return true;
@@ -1093,7 +1092,7 @@ bool TerminalSession::operator()(actions::NoSearchHighlight)
     return true;
 }
 
-bool TerminalSession::operator()(actions::OpenConfiguration)
+bool TerminalSession::operator()(actions::OpenConfiguration) const
 {
     if (!QDesktopServices::openUrl(QUrl(QString::fromUtf8(_config.configFile.string().c_str()))))
         errorLog()("Could not open configuration file \"{}\".", _config.configFile.generic_string());

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -189,6 +189,8 @@ TerminalSession::TerminalSession(unique_ptr<vtpty::Pty> pty, ContourGuiApp& app)
     _profile { *_config.profile(_profileName) },
     _app { app },
     _currentColorPreference { app.colorPreference() },
+    _accumulatedScrollX { 0 },
+    _accumulatedScrollY { 0 },
     _terminal { *this,
                 std::move(pty),
                 createSettingsFromConfig(_config, _profile, _currentColorPreference),

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -243,26 +243,26 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     void attachDisplay(display::TerminalDisplay& display);
     void detachDisplay(display::TerminalDisplay& display);
 
-    Q_INVOKABLE void applyPendingFontChange(bool answer, bool remember);
-    Q_INVOKABLE void executePendingBufferCapture(bool answer, bool remember);
-    Q_INVOKABLE void executeShowHostWritableStatusLine(bool answer, bool remember);
+    Q_INVOKABLE void applyPendingFontChange(bool allow, bool remember);
+    Q_INVOKABLE void executePendingBufferCapture(bool allow, bool remember);
+    Q_INVOKABLE void executeShowHostWritableStatusLine(bool allow, bool remember);
     Q_INVOKABLE void adaptToWidgetSize();
 
     void updateColorPreference(vtbackend::ColorPreference preference);
 
     // vtbackend::Events
     //
-    void requestCaptureBuffer(vtbackend::LineCount lineCount, bool logical) override;
+    void requestCaptureBuffer(vtbackend::LineCount lines, bool logical) override;
     void bell() override;
     void bufferChanged(vtbackend::ScreenType) override;
     void renderBufferUpdated() override;
     void screenUpdated() override;
     vtbackend::FontDef getFontDef() override;
-    void setFontDef(vtbackend::FontDef const& fontSpec) override;
+    void setFontDef(vtbackend::FontDef const& fontDef) override;
     void copyToClipboard(std::string_view data) override;
     void openDocument(std::string_view /*fileOrUrl*/) override;
     void inspect() override;
-    void notify(std::string_view title, std::string_view body) override;
+    void notify(std::string_view title, std::string_view content) override;
     void onClosed() override;
     void pasteFromClipboard(unsigned count, bool strip) override;
     void onSelectionCompleted() override;
@@ -311,7 +311,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::CopyPreviousMarkRange);
     bool operator()(actions::CopySelection);
     bool operator()(actions::CreateDebugDump);
-    bool operator()(actions::CreateSelection);
+    bool operator()(actions::CreateSelection const&);
     bool operator()(actions::DecreaseFontSize);
     bool operator()(actions::DecreaseOpacity);
     bool operator()(actions::FollowHyperlink);
@@ -321,7 +321,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::IncreaseOpacity);
     bool operator()(actions::NewTerminal const&);
     bool operator()(actions::NoSearchHighlight);
-    bool operator()(actions::OpenConfiguration);
+    bool operator()(actions::OpenConfiguration) const;
     bool operator()(actions::OpenFileManager);
     bool operator()(actions::OpenSelection);
     bool operator()(actions::PasteClipboard);

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -37,7 +37,7 @@ class ContourGuiApp;
 /**
  * A set of user-facing activities that are guarded behind a permission-check wall.
  */
-enum class GuardedRole
+enum class GuardedRole : uint8_t
 {
     ChangeFont,
     CaptureBuffer,

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -104,16 +104,6 @@ namespace
         bindable.release();
     }
 
-    template <typename F>
-    inline void checkedGL(F&& region,
-                          logstore::source_location location = logstore::source_location::current()) noexcept
-    {
-        region();
-        auto err = GLenum {};
-        while ((err = glGetError()) != GL_NO_ERROR)
-            displayLog(location)("OpenGL error {} for call.", err);
-    }
-
     QMatrix4x4 ortho(float left, float right, float bottom, float top)
     {
         constexpr float NearPlane = -1.0f;

--- a/src/contour/display/ShaderConfig.h
+++ b/src/contour/display/ShaderConfig.h
@@ -23,7 +23,7 @@
 namespace contour::display
 {
 
-enum class ShaderClass
+enum class ShaderClass : uint8_t
 {
     Background,
     Text

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -521,8 +521,8 @@ void TerminalDisplay::onBeforeSynchronize()
         return;
 
     // find screen with biggest width
-    QScreen* screenToUse = window()->screen();
-    for (auto screen: window()->screen()->virtualSiblings())
+    auto* screenToUse = window()->screen();
+    for (auto* screen: window()->screen()->virtualSiblings())
     {
         if (screen->size().width() > screenToUse->size().width())
         {

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1119,7 +1119,7 @@ void TerminalDisplay::doDumpStateInternal()
         fs.close();
     }
 
-    enum class ImageBufferFormat
+    enum class ImageBufferFormat : uint8_t
     {
         RGBA,
         RGB,

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -52,7 +52,7 @@ namespace detail
     };
 } // namespace detail
 
-enum class MouseCursorShape
+enum class MouseCursorShape : uint8_t
 {
     Hidden,
     PointingHand,
@@ -222,7 +222,7 @@ constexpr Qt::CursorShape toQtMouseShape(MouseCursorShape shape)
 }
 
 /// Declares the screen-dirtiness-vs-rendering state.
-enum class RenderState
+enum class RenderState : uint8_t
 {
     CleanIdle,     //!< No screen updates and no rendering currently in progress.
     DirtyIdle,     //!< Screen updates pending and no rendering currently in progress.

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -169,8 +169,9 @@ vtbackend::FontDef getFontDefinition(vtrasterizer::Renderer& renderer);
 
 constexpr config::WindowMargins applyContentScale(config::WindowMargins margins, double contentScale) noexcept
 {
-    return { .horizontal = config::HorizontalMargin(unbox(margins.horizontal) * contentScale),
-             .vertical = config::VerticalMargin(unbox(margins.vertical) * contentScale) };
+    return { .horizontal =
+                 config::HorizontalMargin(static_cast<int>(unbox(margins.horizontal) * contentScale)),
+             .vertical = config::VerticalMargin(static_cast<int>(unbox(margins.vertical) * contentScale)) };
 }
 
 vtrasterizer::PageMargin computeMargin(vtbackend::ImageSize cellSize,

--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -264,8 +264,6 @@ void app::customizeLogStoreOutput()
             return { tagStart, msgStart, resetSGR };
         }();
 
-        auto const fileName = fs::path(msg.location().file_name()).filename().string();
-
         // // fileName with path to file relative to project root
         // auto const srcIndex = string_view(msg.location().file_name()).find("src");
         // auto const fileName = string(srcIndex != string_view::npos

--- a/src/crispy/BufferObject.cpp
+++ b/src/crispy/BufferObject.cpp
@@ -5,7 +5,7 @@ namespace crispy
 {
 
 template class buffer_object<char>;
-template class BufferFragment<char>;
+template class buffer_fragment<char>;
 template class buffer_object_pool<char>;
 
 } // namespace crispy

--- a/src/crispy/BufferObject.h
+++ b/src/crispy/BufferObject.h
@@ -36,7 +36,7 @@ template <BufferObjectElementType>
 class buffer_object;
 
 template <BufferObjectElementType>
-class BufferFragment;
+class buffer_fragment;
 
 template <BufferObjectElementType T>
 using buffer_object_release = std::function<void(buffer_object<T>*)>;
@@ -95,7 +95,7 @@ class buffer_object: public std::enable_shared_from_this<buffer_object<T>>
     [[nodiscard]] T* data() noexcept;
     [[nodiscard]] T const* data() const noexcept;
 
-    [[nodiscard]] BufferFragment<T> ref(std::size_t offset, std::size_t size) noexcept;
+    [[nodiscard]] buffer_fragment<T> ref(std::size_t offset, std::size_t size) noexcept;
 
     /// Returns a pointer to the first byte in the internal data storage.
     T* begin() noexcept { return data(); }
@@ -130,7 +130,7 @@ class buffer_object: public std::enable_shared_from_this<buffer_object<T>>
     T* _hotEnd;
     T* _end;
 
-    friend class BufferFragment<T>;
+    friend class buffer_fragment<T>;
 
     std::mutex _mutex;
 };
@@ -165,18 +165,18 @@ class buffer_object_pool
  * BufferFragment safely holds a reference to a region of buffer_object.
  */
 template <BufferObjectElementType T>
-class BufferFragment
+class buffer_fragment
 {
   public:
     using span_type = gsl::span<T const>;
 
-    BufferFragment(buffer_object_ptr<T> buffer, span_type region) noexcept;
+    buffer_fragment(buffer_object_ptr<T> buffer, span_type region) noexcept;
 
-    BufferFragment() noexcept = default;
-    BufferFragment(BufferFragment&&) noexcept = default;
-    BufferFragment(BufferFragment const&) noexcept = default;
-    BufferFragment& operator=(BufferFragment&&) noexcept = default;
-    BufferFragment& operator=(BufferFragment const&) noexcept = default;
+    buffer_fragment() noexcept = default;
+    buffer_fragment(buffer_fragment&&) noexcept = default;
+    buffer_fragment(buffer_fragment const&) noexcept = default;
+    buffer_fragment& operator=(buffer_fragment&&) noexcept = default;
+    buffer_fragment& operator=(buffer_fragment const&) noexcept = default;
 
     void reset() noexcept { _region = {}; }
 
@@ -210,10 +210,10 @@ class BufferFragment
 };
 
 template <BufferObjectElementType T>
-BufferFragment(buffer_object_ptr<T>, gsl::span<T const>) -> BufferFragment<T>;
+buffer_fragment(buffer_object_ptr<T>, gsl::span<T const>) -> buffer_fragment<T>;
 
 template <BufferObjectElementType T>
-BufferFragment(buffer_object_ptr<T>, std::basic_string_view<T>) -> BufferFragment<T>;
+buffer_fragment(buffer_object_ptr<T>, std::basic_string_view<T>) -> buffer_fragment<T>;
 
 // {{{ buffer_object implementation
 template <BufferObjectElementType T>
@@ -314,28 +314,28 @@ inline void buffer_object<T>::clear() noexcept
 }
 
 template <BufferObjectElementType T>
-inline BufferFragment<T> buffer_object<T>::ref(std::size_t offset, std::size_t size) noexcept
+inline buffer_fragment<T> buffer_object<T>::ref(std::size_t offset, std::size_t size) noexcept
 {
-    return BufferFragment<T>(this->shared_from_this(), gsl::span<T const>(this->data() + offset, size));
+    return buffer_fragment<T>(this->shared_from_this(), gsl::span<T const>(this->data() + offset, size));
 }
 // }}}
 
 // {{{ BufferFragment implementation
 template <BufferObjectElementType T>
-BufferFragment<T>::BufferFragment(buffer_object_ptr<T> buffer, gsl::span<T const> region) noexcept:
+buffer_fragment<T>::buffer_fragment(buffer_object_ptr<T> buffer, gsl::span<T const> region) noexcept:
     _buffer { std::move(buffer) }, _region { region }
 {
     assert(_buffer->begin() <= _region.data() && (_region.data() + _region.size()) <= _buffer->end());
 }
 
 template <BufferObjectElementType T>
-inline std::size_t BufferFragment<T>::startOffset() const noexcept
+inline std::size_t buffer_fragment<T>::startOffset() const noexcept
 {
     return static_cast<std::size_t>(std::distance((T const*) _buffer->data(), (T const*) data()));
 }
 
 template <BufferObjectElementType T>
-inline std::size_t BufferFragment<T>::endOffset() const noexcept
+inline std::size_t buffer_fragment<T>::endOffset() const noexcept
 {
     return startOffset() + size();
 }

--- a/src/crispy/CLI.h
+++ b/src/crispy/CLI.h
@@ -21,7 +21,7 @@ namespace crispy::cli
 using value = std::variant<int, unsigned int, std::string, double, bool>;
 using name = std::string;
 
-enum class presence
+enum class presence : uint8_t
 {
     Optional,
     Required,
@@ -61,7 +61,7 @@ struct option
 
 using option_list = std::vector<option>;
 
-enum class command_select
+enum class command_select : uint8_t
 {
     Explicit,
     Implicit, // only one command at a scope level can be implicit
@@ -87,7 +87,7 @@ struct command
 
 using command_list = command::command_list;
 
-enum class option_style
+enum class option_style : uint8_t
 {
     Natural,
     Posix,
@@ -142,7 +142,7 @@ std::optional<flag_store> parse(command const& command, string_view_list const& 
  */
 std::optional<flag_store> parse(command const& command, int argc, char const* const* argv);
 
-enum class help_element
+enum class help_element : uint8_t
 {
     Header,
     Braces,

--- a/src/crispy/CLI_test.cpp
+++ b/src/crispy/CLI_test.cpp
@@ -44,6 +44,7 @@ namespace cli = crispy::cli;
 using namespace std::string_view_literals;
 using namespace std::string_literals;
 
+// NOLINTBEGIN(misc-const-correctness)
 TEST_CASE("CLI.option.type.bool")
 {
     auto const cmd = cli::command {
@@ -119,3 +120,4 @@ TEST_CASE("CLI.contour-full-test")
     CHECK(flags.values.at("contour.capture.output") == cli::value { "out.vt"s });
     CHECK(flags.values.at("contour.capture.timeout") == cli::value { 1.0 });
 }
+// NOLINTEND(misc-const-correctness)

--- a/src/crispy/Comparison.h
+++ b/src/crispy/Comparison.h
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <cstdint>
 
 namespace crispy
 {
 
-enum class comparison
+enum class comparison : uint8_t
 {
     Less,
     Equal,

--- a/src/crispy/escape.h
+++ b/src/crispy/escape.h
@@ -13,7 +13,7 @@
 namespace crispy
 {
 
-enum class numeric_escape
+enum class numeric_escape : uint8_t
 {
     Octal,
     Hex
@@ -85,7 +85,7 @@ inline std::string unescape(std::string_view escapedText)
     std::string out;
     out.reserve(escapedText.size());
 
-    enum class state_type
+    enum class state_type : uint8_t
     {
         Text,
         Escape,

--- a/src/crispy/logstore.h
+++ b/src/crispy/logstore.h
@@ -125,12 +125,12 @@ class category
 {
   public:
     using formatter = std::function<std::string(message_builder const&)>;
-    enum class state
+    enum class state : uint8_t
     {
         Enabled,
         Disabled
     };
-    enum class visibility
+    enum class visibility : uint8_t
     {
         Public,
         Hidden

--- a/src/crispy/result.h
+++ b/src/crispy/result.h
@@ -39,9 +39,9 @@ class failure
     constexpr failure& operator=(const failure&) = default;
     constexpr failure& operator=(failure&&) noexcept = default;
 
-    constexpr const E& error() const& noexcept { return _value; }
+    [[nodiscard]] constexpr const E& error() const& noexcept { return _value; }
     constexpr E& error() & noexcept { return _value; }
-    constexpr const E&& error() const&& noexcept { return std::move(_value); }
+    [[nodiscard]] constexpr const E&& error() const&& noexcept { return std::move(_value); }
     constexpr E&& error() && noexcept { return std::move(_value); }
 
     constexpr void swap(failure& other) noexcept { std::swap(_value, other._value); }

--- a/src/crispy/result.h
+++ b/src/crispy/result.h
@@ -19,7 +19,8 @@ class failure
     constexpr failure(const failure&) = default;
     constexpr failure(failure&&) noexcept = default;
 
-    template <typename Err = E, typename = std::enable_if_t<std::is_constructible_v<E, Err&&>>>
+    template <typename Err = E>
+        requires std::is_constructible_v<E, Err&&>
     constexpr explicit failure(Err&& e): _value { std::forward<Err>(e) }
     {
     }
@@ -64,6 +65,10 @@ class failure
 template <typename T>
 failure(T) -> failure<T>;
 
+template <typename T, typename E>
+concept Result = !std::is_reference_v<T> && !std::is_same_v<T, std::remove_cv_t<std::in_place_t>>
+                 && !std::is_same_v<T, typename std::remove_cv_t<failure<E>>>;
+
 // TODO: Finish support for T = void (this is not so important for now, however)
 
 // result<T, E> is a type that represents either a value of type T or an error of type E.
@@ -75,6 +80,7 @@ failure(T) -> failure<T>;
 // The API is kept as close as possible to C++23's std::expected<T, E> type,
 // so that it can be easily replaced once C++23 is available.
 template <typename T, typename E = std::error_code>
+    requires Result<T, E>
 class result
 {
   private:
@@ -82,12 +88,9 @@ class result
     {
     };
 
-    static inline constexpr failure_t Failure {};
-
-    static_assert(!std::is_reference_v<T>, "T must not be a reference");
-    static_assert(!std::is_same_v<T, std::remove_cv_t<std::in_place_t>>, "T must not be in_place_t");
     static_assert(!std::is_same_v<T, std::remove_cv_t<failure_t>>, "T must not be failure_t");
-    static_assert(!std::is_same_v<T, typename std::remove_cv_t<failure<E>>>, "T must not be failure<E>");
+
+    static inline constexpr failure_t Failure {};
 
   public:
     using value_type = T;
@@ -111,13 +114,15 @@ class result
     {
     }
 
-    template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+    template <typename U = T>
+        requires(!std::is_void_v<U>)
     constexpr result(U&& value) noexcept(std::is_nothrow_move_constructible_v<value_type>):
         _data { T { std::forward<U>(value) } }
     {
     }
 
-    template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+    template <typename U = T>
+        requires(!std::is_void_v<U>)
     constexpr result(std::in_place_t, U&& value) noexcept(std::is_nothrow_move_constructible_v<T>):
         _data { std::forward<U>(value) }
     {
@@ -146,13 +151,13 @@ class result
 
     [[nodiscard]] constexpr const T* operator->() const noexcept { return &std::get<value_type>(_data); }
     [[nodiscard]] constexpr T* operator->() noexcept { return &std::get<value_type>(_data); }
-    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0>
+    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0> //NOLINT
     [[nodiscard]] constexpr const T& operator*() const& noexcept { return std::get<value_type>(_data); }
-    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0>
+    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0> //NOLINT
     [[nodiscard]] constexpr T& operator*() & noexcept { return std::get<value_type>(_data); }
-    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0>
+    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0> //NOLINT
     [[nodiscard]] constexpr const T&& operator*() const&& noexcept { return std::move(std::get<value_type>(_data)); }
-    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0>
+    template <std::enable_if_t<!std::is_same_v<T, void>, int> = 0> //NOLINT
     [[nodiscard]] constexpr T&& operator*() && noexcept { return std::move(std::get<value_type>(_data)); }
 
     [[nodiscard]] constexpr bool has_value() const noexcept { return std::holds_alternative<value_type>(_data); }
@@ -171,14 +176,16 @@ class result
     // clang-format on
 
     // {{{ emplace
-    template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+    template <typename U = T>
+        requires(!std::is_void_v<U>)
     constexpr U& emplace(value_type&& exp) noexcept(std::is_nothrow_move_constructible_v<value_type>)
     {
         _data = std::move(exp);
         return value();
     }
 
-    template <typename U = T, typename = std::enable_if_t<std::is_void_v<U>>>
+    template <typename U = T>
+        requires(!std::is_void_v<U>)
     constexpr void emplace() noexcept
     {
         _data = value_type {};

--- a/src/crispy/result_test.cpp
+++ b/src/crispy/result_test.cpp
@@ -12,7 +12,7 @@ using crispy::failure;
 namespace
 {
 
-enum class error_code
+enum class error_code : uint8_t
 {
     E0,
     E1,
@@ -22,7 +22,7 @@ enum class error_code
     E5
 };
 
-enum class another_error
+enum class another_error : uint8_t
 {
     E0,
     E1,

--- a/src/crispy/ring.h
+++ b/src/crispy/ring.h
@@ -14,9 +14,9 @@ namespace crispy
 {
 
 template <typename T, typename Vector>
-struct RingIterator;
+struct ring_iterator;
 template <typename T, typename Vector>
-struct RingReverseIterator;
+struct ring_reverse_iterator;
 
 /**
  * Implements an efficient ring buffer over type T
@@ -27,10 +27,10 @@ class basic_ring // NOLINT(readability-identifier-naming)
 {
   public:
     using value_type = T;
-    using iterator = RingIterator<value_type, Vector>;
-    using const_iterator = RingIterator<value_type const, Vector>;
-    using reverse_iterator = RingReverseIterator<value_type, Vector>;
-    using const_reverse_iterator = RingReverseIterator<value_type const, Vector>;
+    using iterator = ring_iterator<value_type, Vector>;
+    using const_iterator = ring_iterator<value_type const, Vector>;
+    using reverse_iterator = ring_reverse_iterator<value_type, Vector>;
+    using const_reverse_iterator = ring_reverse_iterator<value_type const, Vector>;
     using difference_type = long;
     using offset_type = long;
 
@@ -184,7 +184,7 @@ using fixed_size_ring = basic_ring<T, std::array<T, N>>;
 
 // {{{ iterator
 template <typename T, typename Vector>
-struct RingIterator
+struct ring_iterator
 {
     using iterator_category = std::random_access_iterator_tag;
     using value_type = T;
@@ -195,75 +195,76 @@ struct RingIterator
     basic_ring<T, Vector>* ring {};
     difference_type current {};
 
-    RingIterator(basic_ring<T, Vector>* aRing, difference_type aCurrent): ring { aRing }, current { aCurrent }
+    ring_iterator(basic_ring<T, Vector>* aRing, difference_type aCurrent):
+        ring { aRing }, current { aCurrent }
     {
     }
 
-    RingIterator() = default;
+    ring_iterator() = default;
 
-    RingIterator(RingIterator const&) = default;
-    RingIterator& operator=(RingIterator const&) = default;
+    ring_iterator(ring_iterator const&) = default;
+    ring_iterator& operator=(ring_iterator const&) = default;
 
-    RingIterator(RingIterator&&) noexcept = default;
-    RingIterator& operator=(RingIterator&&) noexcept = default;
+    ring_iterator(ring_iterator&&) noexcept = default;
+    ring_iterator& operator=(ring_iterator&&) noexcept = default;
 
-    RingIterator& operator++() noexcept
+    ring_iterator& operator++() noexcept
     {
         ++current;
         return *this;
     }
 
-    RingIterator operator++(int) noexcept
+    ring_iterator operator++(int) noexcept
     {
         auto old = *this;
         ++(*this);
         return old;
     }
 
-    RingIterator& operator--() noexcept
+    ring_iterator& operator--() noexcept
     {
         --current;
         return *this;
     }
 
-    RingIterator operator--(int) noexcept
+    ring_iterator operator--(int) noexcept
     {
         auto old = *this;
         --(*this);
         return old;
     }
 
-    RingIterator& operator+=(int n) noexcept
+    ring_iterator& operator+=(int n) noexcept
     {
         current += n;
         return *this;
     }
-    RingIterator& operator-=(int n) noexcept
+    ring_iterator& operator-=(int n) noexcept
     {
         current -= n;
         return *this;
     }
 
-    RingIterator operator+(difference_type n) noexcept { return RingIterator { ring, current + n }; }
-    RingIterator operator-(difference_type n) noexcept { return RingIterator { ring, current - n }; }
+    ring_iterator operator+(difference_type n) noexcept { return ring_iterator { ring, current + n }; }
+    ring_iterator operator-(difference_type n) noexcept { return ring_iterator { ring, current - n }; }
 
-    RingIterator operator+(RingIterator const& rhs) const noexcept
+    ring_iterator operator+(ring_iterator const& rhs) const noexcept
     {
-        return RingIterator { ring, current + rhs.current };
+        return ring_iterator { ring, current + rhs.current };
     }
-    difference_type operator-(RingIterator const& rhs) const noexcept { return current - rhs.current; }
+    difference_type operator-(ring_iterator const& rhs) const noexcept { return current - rhs.current; }
 
-    friend RingIterator operator+(difference_type n, RingIterator a)
+    friend ring_iterator operator+(difference_type n, ring_iterator a)
     {
-        return RingIterator { a.ring, n + a.current };
+        return ring_iterator { a.ring, n + a.current };
     }
-    friend RingIterator operator-(difference_type n, RingIterator a)
+    friend ring_iterator operator-(difference_type n, ring_iterator a)
     {
-        return RingIterator { a.ring, n - a.current };
+        return ring_iterator { a.ring, n - a.current };
     }
 
-    bool operator==(RingIterator const& rhs) const noexcept { return current == rhs.current; }
-    bool operator!=(RingIterator const& rhs) const noexcept { return current != rhs.current; }
+    bool operator==(ring_iterator const& rhs) const noexcept { return current == rhs.current; }
+    bool operator!=(ring_iterator const& rhs) const noexcept { return current != rhs.current; }
 
     T& operator*() noexcept { return (*ring)[current]; }
     T const& operator*() const noexcept { return (*ring)[current]; }
@@ -275,7 +276,7 @@ struct RingIterator
 
 // {{{ reverse iterator
 template <typename T, typename Vector>
-struct RingReverseIterator
+struct ring_reverse_iterator
 {
     using iterator_category = std::random_access_iterator_tag;
     using value_type = T;
@@ -286,68 +287,71 @@ struct RingReverseIterator
     basic_ring<T, Vector>* ring;
     difference_type current;
 
-    RingReverseIterator(basic_ring<T, Vector>* ring, difference_type current):
+    ring_reverse_iterator(basic_ring<T, Vector>* ring, difference_type current):
         ring { ring }, current { current }
     {
     }
 
-    RingReverseIterator(RingReverseIterator const&) = default;
-    RingReverseIterator& operator=(RingReverseIterator const&) = default;
+    ring_reverse_iterator(ring_reverse_iterator const&) = default;
+    ring_reverse_iterator& operator=(ring_reverse_iterator const&) = default;
 
-    RingReverseIterator(RingReverseIterator&&) noexcept = default;
-    RingReverseIterator& operator=(RingReverseIterator&&) noexcept = default;
+    ring_reverse_iterator(ring_reverse_iterator&&) noexcept = default;
+    ring_reverse_iterator& operator=(ring_reverse_iterator&&) noexcept = default;
 
-    RingReverseIterator& operator++() noexcept
+    ring_reverse_iterator& operator++() noexcept
     {
         ++current;
         return *this;
     }
-    RingReverseIterator& operator++(int) noexcept { return ++(*this); }
+    ring_reverse_iterator& operator++(int) noexcept { return ++(*this); }
 
-    RingReverseIterator& operator--() noexcept
+    ring_reverse_iterator& operator--() noexcept
     {
         --current;
         return *this;
     }
-    RingReverseIterator& operator--(int) noexcept { return --(*this); }
+    ring_reverse_iterator& operator--(int) noexcept { return --(*this); }
 
-    RingReverseIterator& operator+=(int n) noexcept
+    ring_reverse_iterator& operator+=(int n) noexcept
     {
         current += n;
         return *this;
     }
-    RingReverseIterator& operator-=(int n) noexcept
+    ring_reverse_iterator& operator-=(int n) noexcept
     {
         current -= n;
         return *this;
     }
 
-    RingReverseIterator operator+(difference_type n) noexcept
+    ring_reverse_iterator operator+(difference_type n) noexcept
     {
-        return RingReverseIterator { ring, current + n };
+        return ring_reverse_iterator { ring, current + n };
     }
-    RingReverseIterator operator-(difference_type n) noexcept
+    ring_reverse_iterator operator-(difference_type n) noexcept
     {
-        return RingReverseIterator { ring, current - n };
-    }
-
-    RingReverseIterator operator+(RingReverseIterator const& rhs) const noexcept
-    {
-        return RingReverseIterator { ring, current + rhs.current };
-    }
-    difference_type operator-(RingReverseIterator const& rhs) const noexcept { return current - rhs.current; }
-
-    friend RingReverseIterator operator+(difference_type n, RingReverseIterator a)
-    {
-        return RingReverseIterator { a.ring, n + a.current };
-    }
-    friend RingReverseIterator operator-(difference_type n, RingReverseIterator a)
-    {
-        return RingReverseIterator { a.ring, n - a.current };
+        return ring_reverse_iterator { ring, current - n };
     }
 
-    bool operator==(RingReverseIterator const& rhs) const noexcept { return current == rhs.current; }
-    bool operator!=(RingReverseIterator const& rhs) const noexcept { return current != rhs.current; }
+    ring_reverse_iterator operator+(ring_reverse_iterator const& rhs) const noexcept
+    {
+        return ring_reverse_iterator { ring, current + rhs.current };
+    }
+    difference_type operator-(ring_reverse_iterator const& rhs) const noexcept
+    {
+        return current - rhs.current;
+    }
+
+    friend ring_reverse_iterator operator+(difference_type n, ring_reverse_iterator a)
+    {
+        return ring_reverse_iterator { a.ring, n + a.current };
+    }
+    friend ring_reverse_iterator operator-(difference_type n, ring_reverse_iterator a)
+    {
+        return ring_reverse_iterator { a.ring, n - a.current };
+    }
+
+    bool operator==(ring_reverse_iterator const& rhs) const noexcept { return current == rhs.current; }
+    bool operator!=(ring_reverse_iterator const& rhs) const noexcept { return current != rhs.current; }
 
     T& operator*() noexcept { return (*ring)[ring->size() - current - 1]; }
     T const& operator*() const noexcept { return (*ring)[ring->size() - current - 1]; }

--- a/src/crispy/sort.h
+++ b/src/crispy/sort.h
@@ -56,9 +56,13 @@ constexpr void sort(Container& container)
     if (auto const count = std::size(container); count > 1)
         sort(
             container,
-            [](auto const& a, auto const& b) { return a < b   ? -1
-                                                      : a > b ? +1
-                                                              : 0; },
+            [](auto const& a, auto const& b) {
+                if (a < b)
+                    return -1;
+                if (a > b)
+                    return +1;
+                return 0;
+            },
             0,
             count - 1);
 }

--- a/src/crispy/times.h
+++ b/src/crispy/times.h
@@ -189,33 +189,26 @@ namespace detail
         return detail::times_2d<I, T1, T2> { std::move(a), std::move(b) };
     }
 
-    template <typename I,
-              typename T,
-              typename Callable,
-              typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T>, int> = 0>
-    constexpr void operator|(detail::times<I, T> times, Callable callable)
-    {
-        for (auto&& i: times)
-            callable(i);
-    }
-
-    template <typename I,
-              typename T,
-              typename Callable,
-              typename std::enable_if_t<std::is_invocable_r_v<void, Callable>, int> = 0>
+    template <typename I, typename T, typename Callable>
+        requires std::is_invocable_r_v<void, Callable>
     constexpr void operator|(detail::times<I, T> times, Callable callable)
     {
         for ([[maybe_unused]] auto&& i: times)
             callable();
     }
 
+    template <typename I, typename T, typename Callable>
+        requires std::is_invocable_r_v<void, Callable, T>
+    constexpr void operator|(detail::times<I, T> times, Callable callable)
+    {
+        for (auto&& i: times)
+            callable(i);
+    }
+
     // ---------------------------------------------------------------------------------------------------
 
-    template <typename I,
-              typename T1,
-              typename T2,
-              typename Callable,
-              typename std::enable_if_t<std::is_invocable_r_v<void, Callable, T1, T2>, int> = 0>
+    template <typename I, typename T1, typename T2, typename Callable>
+        requires std::is_invocable_v<Callable, T1, T2>
     constexpr void operator|(detail::times_2d<I, T1, T2> times, Callable callable)
     {
         for (auto&& [i, j]: times)
@@ -223,8 +216,6 @@ namespace detail
     }
 
 } // namespace detail
-
-// TODO: give random access hints to STL algorithms
 
 template <typename I, typename T>
 constexpr inline detail::times<I, T> times(T start, I count, T step = T(1))

--- a/src/crispy/utils_test.cpp
+++ b/src/crispy/utils_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("fromHexString")
     CHECK(!crispy::fromHexString("abc"sv));
     CHECK(!crispy::fromHexString("GX"sv));
 
-    CHECK(crispy::fromHexString(""sv).value() == ""sv);
+    CHECK(crispy::fromHexString(""sv).value().empty());
     CHECK(crispy::fromHexString("61"sv).value() == "a"sv);
     CHECK(crispy::fromHexString("4162"sv).value() == "Ab"sv);
 }
@@ -126,7 +126,7 @@ struct variable_collector
 TEST_CASE("replaceVariables")
 {
     // clang-format off
-    CHECK(""sv == crispy::replaceVariables("", variable_collector()));
+    CHECK(crispy::replaceVariables("", variable_collector()).empty());
     CHECK("()"sv == crispy::replaceVariables("${}", variable_collector()));
     CHECK("(Hello)"sv == crispy::replaceVariables("${Hello}", variable_collector()));
     CHECK("(Hello) World"sv == crispy::replaceVariables("${Hello} World", variable_collector()));

--- a/src/text_shaper/directwrite_shaper.cpp
+++ b/src/text_shaper/directwrite_shaper.cpp
@@ -78,7 +78,7 @@ namespace
                     float const redAlpha = a * srcR / 255.0;
                     float const greenAlpha = a * srcG / 255.0;
                     float const blueAlpha = a * srcB / 255.0;
-                    float const averageAlpha = (redAlpha + greenAlpha + blueAlpha) / 3.0;
+                    float const averageAlpha = (redAlpha + greenAlpha + blueAlpha) / 3.0f;
 
                     auto const currentR = *_it;
                     auto const currentG = *(_it + 1);
@@ -268,7 +268,7 @@ struct directwrite_shaper::Private
         return int(maxAdvance);
     }
 
-    float pixelPerDip() { return dpi_.x / 96.0; }
+    float pixelPerDip() { return static_cast<float>(dpi_.x) / 96.0f; }
 };
 
 directwrite_shaper::directwrite_shaper(DPI _dpi, font_locator& _locator):
@@ -464,7 +464,7 @@ std::optional<rasterized_glyph> directwrite_shaper::rasterize(glyph_key _glyph, 
 {
     DxFontInfo const& fontInfo = d->fonts.at(_glyph.font);
     IDWriteFontFace5* fontFace = fontInfo.fontFace;
-    float const fontEmSize = ptToEm(_glyph.size.pt);
+    float const fontEmSize = static_cast<float>(ptToEm(_glyph.size.pt));
 
     UINT16 const glyphIndex = static_cast<UINT16>(_glyph.index.value);
     DWRITE_GLYPH_OFFSET const glyphOffset {};

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -76,7 +76,7 @@ constexpr double average(DPI dpi) noexcept
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class font_weight
+enum class font_weight : uint8_t
 {
     thin,
     extra_light, // aka. ultralight
@@ -113,7 +113,7 @@ constexpr std::optional<font_weight> make_font_weight(std::string_view text)
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class font_slant
+enum class font_slant : uint8_t
 {
     normal,
     italic,
@@ -132,7 +132,7 @@ constexpr std::optional<font_slant> make_font_slant(std::string_view text)
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class font_spacing
+enum class font_spacing : uint8_t
 {
     proportional,
     mono
@@ -274,7 +274,7 @@ constexpr bool operator<(glyph_key const& a, glyph_key const& b) noexcept
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class render_mode
+enum class render_mode : uint8_t
 {
     bitmap, //!< bitmaps are preferred
     gray,   //!< gray-scale anti-aliasing

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -292,13 +292,13 @@ namespace std
 template <>
 struct hash<text::font_key>
 {
-    std::size_t operator()(text::font_key key) const noexcept { return key.value; }
+    std::size_t operator()(text::font_key key) const noexcept { return key.value; } // NOLINT
 };
 
 template <>
 struct hash<text::glyph_index>
 {
-    std::size_t operator()(text::glyph_index index) const noexcept { return index.value; }
+    std::size_t operator()(text::glyph_index index) const noexcept { return index.value; } //NOLINT
 };
 
 template <>

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -298,7 +298,7 @@ struct hash<text::font_key>
 template <>
 struct hash<text::glyph_index>
 {
-    std::size_t operator()(text::glyph_index index) const noexcept { return index.value; } //NOLINT
+    std::size_t operator()(text::glyph_index index) const noexcept { return index.value; } // NOLINT
 };
 
 template <>

--- a/src/text_shaper/fontconfig_locator.cpp
+++ b/src/text_shaper/fontconfig_locator.cpp
@@ -127,18 +127,18 @@ namespace
 
 } // namespace
 
-struct fontconfig_locator::Private
+struct fontconfig_locator::private_tag
 {
     // currently empty, maybe later something (such as caching)?
     FcConfig* ftConfig = nullptr;
 
-    Private()
+    private_tag()
     {
         FcInit();
         ftConfig = FcInitLoadConfigAndFonts(); // Most convenient of all the alternatives
     }
 
-    ~Private()
+    ~private_tag()
     {
         locatorLog()("~fontconfig_locator.dtor");
         FcConfigDestroy(ftConfig);
@@ -147,7 +147,7 @@ struct fontconfig_locator::Private
 };
 
 fontconfig_locator::fontconfig_locator():
-    _d { new Private(), [](Private* p) {
+    _d { new private_tag(), [](private_tag* p) {
             delete p;
         } }
 {

--- a/src/text_shaper/fontconfig_locator.h
+++ b/src/text_shaper/fontconfig_locator.h
@@ -24,8 +24,8 @@ class fontconfig_locator: public font_locator
     [[nodiscard]] font_source_list resolve(gsl::span<const char32_t> codepoints) override;
 
   private:
-    struct Private;
-    std::unique_ptr<Private, void (*)(Private*)> _d;
+    struct private_tag;
+    std::unique_ptr<private_tag, void (*)(private_tag*)> _d;
 };
 
 } // namespace text

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -394,7 +394,7 @@ namespace
     }
 } // namespace
 
-struct open_shaper::Private // {{{
+struct open_shaper::private_open_shaper // {{{
 {
     crispy::finally ftCleanup;
     FT_Library ft {};
@@ -477,7 +477,7 @@ struct open_shaper::Private // {{{
         return output;
     }
 
-    Private(DPI dpi, font_locator& locator):
+    private_open_shaper(DPI dpi, font_locator& locator):
         ftCleanup { [this]() {
             FT_Done_FreeType(ft);
         } },
@@ -552,7 +552,7 @@ struct open_shaper::Private // {{{
 }; // }}}
 
 open_shaper::open_shaper(DPI dpi, font_locator& locator):
-    _d(new Private(dpi, locator), [](Private* p) { delete p; })
+    _d(new private_open_shaper(dpi, locator), [](private_open_shaper* p) { delete p; })
 {
 }
 

--- a/src/text_shaper/open_shaper.h
+++ b/src/text_shaper/open_shaper.h
@@ -43,8 +43,8 @@ class open_shaper: public shaper
     [[nodiscard]] std::optional<rasterized_glyph> rasterize(glyph_key glyph, render_mode mode) override;
 
   private:
-    struct Private;
-    std::unique_ptr<Private, void (*)(Private*)> _d;
+    struct private_open_shaper;
+    std::unique_ptr<private_open_shaper, void (*)(private_open_shaper*)> _d;
 };
 
 } // namespace text

--- a/src/text_shaper/shaper.h
+++ b/src/text_shaper/shaper.h
@@ -33,7 +33,7 @@ auto const inline rasterizerLog = logstore::category("font.render", "Logs detail
 auto const inline textShapingLog = logstore::category("font.textshaping", "Logs details about text shaping.");
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class bitmap_format
+enum class bitmap_format : uint8_t
 {
     alpha_mask,
     rgb,

--- a/src/vtbackend/CellUtil.h
+++ b/src/vtbackend/CellUtil.h
@@ -19,9 +19,13 @@ namespace vtbackend::CellUtil
                                              bool blinkingState,
                                              bool rapidBlinkState) noexcept
 {
-    auto const fgMode = (cellFlags & CellFlag::Faint)                                    ? ColorMode::Dimmed
-                        : ((cellFlags & CellFlag::Bold) && colorPalette.useBrightColors) ? ColorMode::Bright
-                                                                                         : ColorMode::Normal;
+    auto const fgMode = [](CellFlags flags, ColorPalette const& colorPalette) {
+        if (flags & CellFlag::Faint)
+            return ColorMode::Dimmed;
+        if ((flags & CellFlag::Bold) && colorPalette.useBrightColors)
+            return ColorMode::Bright;
+        return ColorMode::Normal;
+    }(cellFlags, colorPalette);
 
     auto constexpr BgMode = ColorMode::Normal;
 
@@ -54,9 +58,13 @@ namespace vtbackend::CellUtil
     if (isDefaultColor(underlineColor))
         return defaultColor;
 
-    auto const mode = (cellFlags & CellFlag::Faint)                                    ? ColorMode::Dimmed
-                      : ((cellFlags & CellFlag::Bold) && colorPalette.useBrightColors) ? ColorMode::Bright
-                                                                                       : ColorMode::Normal;
+    auto const mode = [](CellFlags flags, ColorPalette const& colorPalette) {
+        if (flags & CellFlag::Faint)
+            return ColorMode::Dimmed;
+        if ((flags & CellFlag::Bold) && colorPalette.useBrightColors)
+            return ColorMode::Bright;
+        return ColorMode::Normal;
+    }(cellFlags, colorPalette);
 
     return apply(colorPalette, underlineColor, ColorTarget::Foreground, mode);
 }

--- a/src/vtbackend/Charset.h
+++ b/src/vtbackend/Charset.h
@@ -10,7 +10,7 @@ namespace vtbackend
 
 using CharsetMap = std::array<char32_t, 127>;
 
-enum class CharsetId
+enum class CharsetId : uint8_t
 {
     Special, // Special Character and Line Drawing Set
 
@@ -27,7 +27,7 @@ enum class CharsetId
     USASCII
 };
 
-enum class CharsetTable
+enum class CharsetTable : uint8_t
 {
     G0 = 0,
     G1 = 1,

--- a/src/vtbackend/Color.h
+++ b/src/vtbackend/Color.h
@@ -31,7 +31,7 @@ enum class IndexedColor : uint8_t
 };
 
 //! Bright colors. As introduced by aixterm, bright versions of standard 3bit colors.
-enum class BrightColor
+enum class BrightColor : uint8_t
 {
     Black = 0,
     Red = 1,

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -17,7 +17,7 @@
 namespace vtbackend
 {
 
-enum class ColorPreference
+enum class ColorPreference : uint8_t
 {
     Dark,
     Light,
@@ -130,13 +130,13 @@ struct ColorPalette
     RGBColorPair indicatorStatusLineInactive = { 0xFFFFFF_rgb, 0x0270c0_rgb };
 };
 
-enum class ColorTarget
+enum class ColorTarget : uint8_t
 {
     Foreground,
     Background,
 };
 
-enum class ColorMode
+enum class ColorMode : uint8_t
 {
     Dimmed,
     Normal,

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -42,7 +42,7 @@ struct BackgroundImage
     using Location = std::variant<std::filesystem::path, ImageDataPtr>;
 
     Location location;
-    crispy::strong_hash hash;
+    crispy::strong_hash hash {};
 
     // image configuration
     float opacity = 0.5; // normalized value

--- a/src/vtbackend/ControlCode.h
+++ b/src/vtbackend/ControlCode.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <string_view>
 
@@ -48,7 +49,7 @@ enum class C0 : char
 };
 
 // NOLINTBEGIN(readability-identifier-naming)
-enum class C1_7bit
+enum class C1_7bit : char
 {
     SCS_G0 = 0x28,       //!< Set Character Set (0)
     SCS_G1 = 0x29,       //!< Set Character Set (1)
@@ -90,7 +91,7 @@ enum class C1_7bit
     APC = 0x5f,          //!< Application Program Command
 };
 
-enum class C1_8bit
+enum class C1_8bit : uint8_t
 {
     PAD = 0x80,  //!< Padding Character
     HOP = 0x81,  //!< High Octet Preset

--- a/src/vtbackend/Grid_test.cpp
+++ b/src/vtbackend/Grid_test.cpp
@@ -134,6 +134,7 @@ Grid<Cell> setupGridForResizeTests2x3a3()
 
 } // namespace
 
+// NOLINTBEGIN(misc-const-correctness)
 TEST_CASE("Grid.setup", "[grid]")
 {
     auto grid = Grid<Cell>(PageSize { LineCount(2), ColumnCount(5) }, true, LineCount(0));
@@ -899,3 +900,4 @@ TEST_CASE("Grid resize", "[grid]")
 }
 
 // }}}
+// NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/Hyperlink.h
+++ b/src/vtbackend/Hyperlink.h
@@ -11,7 +11,7 @@
 namespace vtbackend
 {
 
-enum class HyperlinkState
+enum class HyperlinkState : uint8_t
 {
     /// Default hyperlink state.
     Inactive,

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -23,7 +23,7 @@ namespace vtbackend
 // Or do we want to deal with Image slices right away and just keep those?
 // The latter doesn't require reference counting.
 
-enum class ImageFormat
+enum class ImageFormat : uint8_t
 {
     RGB,
     RGBA,
@@ -88,7 +88,7 @@ class Image: public std::enable_shared_from_this<Image>
 };
 
 /// Image resize hints are used to properly fit/fill the area to place the image onto.
-enum class ImageResize
+enum class ImageResize : uint8_t
 {
     NoResize,
     ResizeToFit, // default
@@ -98,7 +98,7 @@ enum class ImageResize
 
 /// Image alignment policy are used to properly align the image to a given spot when not fully
 /// filling the area this image as to be placed to.
-enum class ImageAlignment
+enum class ImageAlignment : uint8_t
 {
     TopStart,
     TopCenter,

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -20,7 +20,7 @@ namespace vtbackend
 {
 
 /// Mutualy exclusive mouse protocls.
-enum class MouseProtocol
+enum class MouseProtocol : uint16_t
 {
     /// Old X10 mouse protocol
     X10 = 9,
@@ -35,7 +35,7 @@ enum class MouseProtocol
 };
 
 // {{{ Modifier
-enum Modifier : unsigned
+enum Modifier : uint8_t
 {
     // NB: These values MUST match the values of the corresponding
     // the bit positions in the modifier mask in CSIu keyboard protocol.
@@ -62,7 +62,7 @@ std::string to_string(Modifiers modifier);
 
 // }}}
 // {{{ KeyInputEvent, Key
-enum class Key
+enum class Key : uint8_t
 {
     // function keys
     F1,
@@ -180,14 +180,14 @@ enum class Key
 
 std::string to_string(Key key);
 
-enum class KeyMode
+enum class KeyMode : uint8_t
 {
     Normal,
     Application
 };
 // }}}
 // {{{ Mouse
-enum class MouseButton
+enum class MouseButton : uint8_t
 {
     Left,
     Right,
@@ -201,7 +201,7 @@ enum class MouseButton
 
 std::string to_string(MouseButton button);
 
-enum class MouseTransport
+enum class MouseTransport : uint8_t
 {
     // CSI M Cb Cx Cy, with Cb, Cx, Cy incremented by 0x20
     Default,
@@ -217,7 +217,7 @@ enum class MouseTransport
 };
 // }}}
 
-enum class KeyboardEventType
+enum class KeyboardEventType : uint8_t
 {
     Press = 1,
     Repeat = 2,
@@ -296,7 +296,7 @@ class StandardKeyboardInputGenerator: public KeyboardInputGenerator
     std::string _pendingSequence {};
 };
 
-enum class KeyboardEventFlag
+enum class KeyboardEventFlag : uint8_t
 {
     None = 0,
     DisambiguateEscapeCodes = 1,
@@ -401,7 +401,7 @@ class InputGenerator
     void setMouseTransport(MouseTransport mouseTransport);
     [[nodiscard]] MouseTransport mouseTransport() const noexcept { return _mouseTransport; }
 
-    enum class MouseWheelMode
+    enum class MouseWheelMode : uint8_t
     {
         // mouse wheel generates mouse wheel events as determined by mouse protocol + transport.
         Default,
@@ -472,7 +472,7 @@ class InputGenerator
         }
     }
 
-    enum class MouseEventType
+    enum class MouseEventType : uint8_t
     {
         Press,
         Drag,

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -43,7 +43,6 @@ TEST_CASE("InputGenerator.Modifier.encodings")
 
 TEST_CASE("InputGenerator.consume")
 {
-    auto received = string {};
     auto input = InputGenerator {};
     input.generateRaw("ABCDEF"sv);
     REQUIRE(input.peek() == "ABCDEF"sv);
@@ -55,7 +54,7 @@ TEST_CASE("InputGenerator.consume")
     input.generateRaw("abcdef"sv);
     REQUIRE(input.peek() == "Fabcdef"sv);
     input.consume(7);
-    REQUIRE(input.peek() == ""sv);
+    REQUIRE(input.peek().empty());
 }
 
 TEST_CASE("InputGenerator.Ctrl+Space", "[terminal,input]")

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -316,7 +316,6 @@ class Line
         }
         else
         {
-            auto const u8Text = unicode::convert_to<char>(text);
             InflatedBuffer const& cells = inflatedBuffer();
             if (text.size() > unbox<size_t>(size()) - unbox<size_t>(startColumn))
                 return false;

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -53,7 +53,7 @@ struct TrivialLineBuffer
     HyperlinkId hyperlink {};
 
     ColumnCount usedColumns {};
-    crispy::BufferFragment<char> text {};
+    crispy::buffer_fragment<char> text {};
 
     void reset(GraphicsAttributes attributes) noexcept
     {

--- a/src/vtbackend/Line_test.cpp
+++ b/src/vtbackend/Line_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Line.BufferFragment", "[Line]")
     auto const bufferFragment = bufferObject->ref(0, 10);
 
     auto const externalView = string_view(bufferObject->data(), 10);
-    auto const fragment = BufferFragment(bufferObject, externalView);
+    auto const fragment = buffer_fragment(bufferObject, externalView);
     CHECK(fragment.view() == externalView);
 }
 

--- a/src/vtbackend/MatchModes.h
+++ b/src/vtbackend/MatchModes.h
@@ -23,7 +23,7 @@ class MatchModes
         Trace = 0x40,
     };
 
-    enum class Status
+    enum class Status : uint8_t
     {
         Any,
         Enabled,

--- a/src/vtbackend/RenderBuffer.h
+++ b/src/vtbackend/RenderBuffer.h
@@ -99,7 +99,7 @@ struct RenderBufferRef
 
 /// Reflects the current state of a RenderDoubleBuffer object.
 ///
-enum class RenderBufferState
+enum class RenderBufferState : uint8_t
 {
     WaitingForRefresh,
     RefreshBuffersAndTrySwap,

--- a/src/vtbackend/RenderBufferBuilder.h
+++ b/src/vtbackend/RenderBufferBuilder.h
@@ -117,7 +117,7 @@ class RenderBufferBuilder
     [[nodiscard]] bool gridLineContainsCursor(LineOffset screenLineOffset) const noexcept;
 
     // clang-format off
-    enum class State { Gap, Sequence };
+    enum class State : uint8_t { Gap, Sequence };
     // clang-format on
 
     gsl::not_null<RenderBuffer*> _output;

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -1717,7 +1717,7 @@ void Screen<Cell>::setMark()
     currentLine().setMarked(true);
 }
 
-enum class ModeResponse
+enum class ModeResponse : uint8_t
 { // TODO: respect response 0, 3, 4.
     NotRecognized = 0,
     Set = 1,

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -1731,9 +1731,9 @@ template <CellConcept Cell>
 void Screen<Cell>::requestAnsiMode(unsigned int mode)
 {
     auto const modeResponse = [&](auto mode) -> ModeResponse {
-        if (isValidDECMode(mode))
+        if (isValidAnsiMode(mode))
         {
-            if (_terminal->isModeEnabled(static_cast<DECMode>(mode)))
+            if (_terminal->isModeEnabled(static_cast<AnsiMode>(mode)))
                 return ModeResponse::Set;
             else
                 return ModeResponse::Reset;

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -1730,10 +1730,16 @@ enum class ModeResponse : uint8_t
 template <CellConcept Cell>
 void Screen<Cell>::requestAnsiMode(unsigned int mode)
 {
-    ModeResponse const modeResponse =
-        isValidAnsiMode(mode)
-            ? _terminal->isModeEnabled(static_cast<AnsiMode>(mode)) ? ModeResponse::Set : ModeResponse::Reset
-            : ModeResponse::NotRecognized;
+    auto const modeResponse = [&](auto mode) -> ModeResponse {
+        if (isValidDECMode(mode))
+        {
+            if (_terminal->isModeEnabled(static_cast<DECMode>(mode)))
+                return ModeResponse::Set;
+            else
+                return ModeResponse::Reset;
+        }
+        return ModeResponse::NotRecognized;
+    }(mode);
 
     auto const code = toAnsiModeNum(static_cast<AnsiMode>(mode));
 
@@ -1743,10 +1749,16 @@ void Screen<Cell>::requestAnsiMode(unsigned int mode)
 template <CellConcept Cell>
 void Screen<Cell>::requestDECMode(unsigned int mode)
 {
-    ModeResponse const modeResponse =
-        isValidDECMode(mode)
-            ? _terminal->isModeEnabled(static_cast<DECMode>(mode)) ? ModeResponse::Set : ModeResponse::Reset
-            : ModeResponse::NotRecognized;
+    auto const modeResponse = [&](auto mode) -> ModeResponse {
+        if (isValidDECMode(mode))
+        {
+            if (_terminal->isModeEnabled(static_cast<DECMode>(mode)))
+                return ModeResponse::Set;
+            else
+                return ModeResponse::Reset;
+        }
+        return ModeResponse::NotRecognized;
+    }(mode);
 
     auto const code = toDECModeNum(static_cast<DECMode>(mode));
 

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -421,12 +421,13 @@ size_t Screen<Cell>::emplaceCharsIntoCurrentLine(string_view chars, size_t cellC
     {
         // Only use fastpath if the currently line hasn't been inflated already.
         // Because we might lose prior-written textual/SGR information otherwise.
-        line.setBuffer(TrivialLineBuffer { line.trivialBuffer().displayWidth,
-                                           _cursor.graphicsRendition,
-                                           line.trivialBuffer().fillAttributes,
-                                           _cursor.hyperlink,
-                                           ColumnCount::cast_from(cellCount),
-                                           crispy::BufferFragment { _terminal->currentPtyBuffer(), chars } });
+        line.setBuffer(
+            TrivialLineBuffer { line.trivialBuffer().displayWidth,
+                                _cursor.graphicsRendition,
+                                line.trivialBuffer().fillAttributes,
+                                _cursor.hyperlink,
+                                ColumnCount::cast_from(cellCount),
+                                crispy::buffer_fragment { _terminal->currentPtyBuffer(), chars } });
         advanceCursorAfterWrite(ColumnCount::cast_from(cellCount));
     }
     else

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -47,14 +47,14 @@ struct Settings;
 // CSI ? Pi ; Pa ; Pv S
 namespace XtSmGraphics
 {
-    enum class Item
+    enum class Item : uint8_t
     {
         NumberOfColorRegisters = 1,
         SixelGraphicsGeometry = 2,
         ReGISGraphicsGeometry = 3,
     };
 
-    enum class Action
+    enum class Action : uint8_t
     {
         Read = 1,
         ResetToDefault = 2,
@@ -68,7 +68,7 @@ namespace XtSmGraphics
 /// TBC - Tab Clear
 ///
 /// This control function clears tab stops.
-enum class HorizontalTabClear
+enum class HorizontalTabClear : uint8_t
 {
     /// Ps = 0 (default)
     AllTabs,
@@ -82,7 +82,7 @@ enum class HorizontalTabClear
 ///  Input: CSI 14 t (for text area size)
 ///  Input: CSI 14; 2 t (for full window size)
 /// Output: CSI 14 ; width ; height ; t
-enum class RequestPixelSize // TODO: rename RequestPixelSize to RequestArea?
+enum class RequestPixelSize : uint8_t // TODO: rename RequestPixelSize to RequestArea?
 {
     CellArea,
     TextArea,
@@ -90,7 +90,7 @@ enum class RequestPixelSize // TODO: rename RequestPixelSize to RequestArea?
 };
 
 /// DECRQSS - Request Status String
-enum class RequestStatusString
+enum class RequestStatusString : uint8_t
 {
     SGR,
     DECSCL,
@@ -114,7 +114,7 @@ inline std::string setDynamicColorValue(
     return fmt::format("rgb:{:04X}/{:04X}/{:04X}", r, g, b);
 }
 
-enum class ApplyResult
+enum class ApplyResult : uint8_t
 {
     Ok,
     Invalid,

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -793,7 +793,7 @@ TEST_CASE("DSR.Unsolicited_ColorPaletteUpdated", "[screen]")
     mock.terminal.resetColorPalette(lightModeColors);
 
     // This must not trigger an unsolicited DSR by default.
-    REQUIRE(escape(mock.replyData()) == ""sv);
+    REQUIRE(escape(mock.replyData()).empty());
 
     // Request unsolicited DSRs for color palette updates.
     mock.writeToScreen(DECSM(toDECModeNum(DECMode::ReportColorPaletteUpdated)));
@@ -2645,7 +2645,6 @@ TEST_CASE("peek into history", "[screen]")
     REQUIRE(screen.logicalCursorPosition() == CellLocation { LineOffset(1), ColumnOffset(2) });
 
     // first line in history
-    auto const m1 = screen.grid().lineText(LineOffset(-2));
     CHECK(screen.grid().lineText(LineOffset(-2)) == "123");
 
     // second line in history

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -135,6 +135,8 @@ MockTerm<vtpty::MockPty> screenForDECRA()
 } // namespace
 // }}}
 
+// NOLINTBEGIN(misc-const-correctness)
+
 // {{{ writeText
 // AutoWrap disabled: text length is less then available columns in line.
 TEST_CASE("writeText.bulk.A.1", "[screen]")
@@ -3780,3 +3782,8 @@ TEST_CASE("LS1 and LS0", "[screen]")
 // TODO: DeviceStatusReport
 // TODO: SendDeviceAttributes
 // TODO: SendTerminalId
+
+// NOLINTEND(misc-const-correctness)
+
+// NOLINTBEGIN(misc-const-correctness)
+// NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/Selector.h
+++ b/src/vtbackend/Selector.h
@@ -53,7 +53,7 @@ struct SelectionHelper
 class Selection
 {
   public:
-    enum class State
+    enum class State : uint8_t
     {
         /// Inactive, but waiting for the selection to be started (by moving the cursor).
         Waiting,

--- a/src/vtbackend/Selector.h
+++ b/src/vtbackend/Selector.h
@@ -205,16 +205,22 @@ struct fmt::formatter<vtbackend::Selection>: formatter<std::string>
     auto format(const vtbackend::Selection& selector, format_context& ctx) -> format_context::iterator
     {
         return formatter<std::string>::format(
-            fmt::format("{}({} from {} to {})",
-                        dynamic_cast<vtbackend::WordWiseSelection const*>(&selector)   ? "WordWiseSelection"
-                        : dynamic_cast<vtbackend::FullLineSelection const*>(&selector) ? "FullLineSelection"
-                        : dynamic_cast<vtbackend::RectangularSelection const*>(&selector)
-                            ? "RectangularSelection"
-                        : dynamic_cast<vtbackend::LinearSelection const*>(&selector) ? "LinearSelection"
-                                                                                     : "Selection",
-                        selector.state(),
-                        selector.from(),
-                        selector.to()),
+            fmt::format(
+                "{}({} from {} to {})",
+                [](auto const* selector) -> std::string_view {
+                    if (dynamic_cast<vtbackend::WordWiseSelection const*>(selector))
+                        return "WordWiseSelection";
+                    if (dynamic_cast<vtbackend::FullLineSelection const*>(selector))
+                        return "FullLineSelection";
+                    if (dynamic_cast<vtbackend::RectangularSelection const*>(selector))
+                        return "RectangularSelection";
+                    if (dynamic_cast<vtbackend::LinearSelection const*>(selector))
+                        return "LinearSelection";
+                    return "Selection";
+                }(&selector),
+                selector.state(),
+                selector.from(),
+                selector.to()),
             ctx);
     }
 };

--- a/src/vtbackend/Selector_test.cpp
+++ b/src/vtbackend/Selector_test.cpp
@@ -76,6 +76,7 @@ template <typename T>
 TextSelection(Screen<T> const&) -> TextSelection<T>;
 } // namespace
 
+// NOLINTBEGIN(misc-const-correctness)
 TEST_CASE("Selector.Linear", "[selector]")
 {
     auto screenEvents = ScreenEvents {};
@@ -254,3 +255,4 @@ TEST_CASE("Selector.Rectangular", "[selector]")
 {
     // TODO
 }
+// NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/SixelParser.h
+++ b/src/vtbackend/SixelParser.h
@@ -25,7 +25,7 @@ namespace vtbackend
 class SixelParser: public ParserExtension
 {
   public:
-    enum class State
+    enum class State : uint8_t
     {
         Ground,           // Sixel data
         RasterSettings,   // '"', configuring the raster
@@ -34,7 +34,7 @@ class SixelParser: public ParserExtension
         ColorParam        // color parameter
     };
 
-    enum class Colorspace
+    enum class Colorspace : uint8_t
     {
         RGB,
         HSL

--- a/src/vtbackend/SixelParser_test.cpp
+++ b/src/vtbackend/SixelParser_test.cpp
@@ -338,9 +338,14 @@ TEST_CASE("SixelParser.newline", "[sixel]")
     {
         for (int x = 0; x < ib.size().width.as<int>(); ++x)
         {
-            auto const expectedColor = y < 6 && x < 4    ? PinColors[1]
-                                       : y < 12 && x < 4 ? PinColors[2]
-                                                         : PinColors[0];
+            auto const expectedColor = [&](int x, int y) -> RGBAColor {
+                if (y < 6 && x < 4)
+                    return PinColors[1];
+                if (y < 12 && x < 4)
+                    return PinColors[2];
+                return PinColors[0];
+            }(x, y);
+
             auto const pos = CellLocation { LineOffset(y), ColumnOffset(x) };
             auto const actualColor = ib.at(pos);
 

--- a/src/vtbackend/StatusLineBuilder.h
+++ b/src/vtbackend/StatusLineBuilder.h
@@ -75,7 +75,7 @@ StatusLineDefinition parseStatusLineDefinition(std::string_view left,
                                                std::string_view middle,
                                                std::string_view right);
 
-enum class StatusLineStyling
+enum class StatusLineStyling : uint8_t
 {
     Disabled,
     Enabled

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1344,7 +1344,6 @@ string Terminal::extractLastMarkRange() const
 
     for (auto lineNum = firstLine; lineNum <= lastLine; ++lineNum)
     {
-        auto const lineText = _primaryScreen.grid().lineAt(lineNum).toUtf8Trimmed();
         text += _primaryScreen.grid().lineAt(lineNum).toUtf8Trimmed();
         text += '\n';
     }
@@ -1355,7 +1354,7 @@ string Terminal::extractLastMarkRange() const
 // {{{ ScreenEvents overrides
 void Terminal::requestCaptureBuffer(LineCount lines, bool logical)
 {
-    return _eventListener.requestCaptureBuffer(lines, logical);
+    _eventListener.requestCaptureBuffer(lines, logical);
 }
 
 void Terminal::requestShowHostWritableStatusLine()

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -147,7 +147,7 @@ struct Search
 
 // Mandates what execution mode the terminal will take to process VT sequences.
 //
-enum class ExecutionMode
+enum class ExecutionMode : uint8_t
 {
     // Normal execution mode, with no tracing enabled.
     Normal,
@@ -165,7 +165,7 @@ enum class ExecutionMode
     // TODO: BreakAtFrame,
 };
 
-enum class WrapPending
+enum class WrapPending : uint8_t
 {
     Yes,
     No,

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -215,6 +215,7 @@ class TraceHandler: public SequenceHandler
 /// gets updated according to the process' outputted text,
 /// whereas input to the process can be send high-level via the various
 /// send(...) member functions.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding) // TODO
 class Terminal
 {
   public:

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1166,7 +1166,10 @@ class Terminal
             terminal.sequenceHandler().writeText(codepoints, cellCount);
         }
         void writeTextEnd() { terminal.sequenceHandler().writeTextEnd(); }
-        size_t maxBulkTextSequenceWidth() const noexcept { return terminal.maxBulkTextSequenceWidth(); }
+        [[nodiscard]] size_t maxBulkTextSequenceWidth() const noexcept
+        {
+            return terminal.maxBulkTextSequenceWidth();
+        }
     };
 
     struct TerminalInstructionCounter

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -43,6 +43,7 @@ using namespace vtbackend::test;
 // TODO: Writing text, leading to page-scroll properly updates viewport.
 // TODO: Writing text, leading to page-scroll properly updates active selection.
 
+// NOLINTBEGIN(misc-const-correctness)
 TEST_CASE("Terminal.BlinkingCursor", "[terminal]")
 {
     auto mc = MockTerm { ColumnCount { 6 }, LineCount { 4 } };
@@ -422,3 +423,5 @@ TEST_CASE("Terminal.TextSelection", "[terminal]")
     mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
     CHECK(mock.terminal.extractSelectionText().empty());
 }
+
+// NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/VTType.h
+++ b/src/vtbackend/VTType.h
@@ -17,7 +17,7 @@ namespace vtbackend
  *
  * The integer representational values match the one for DA2's first response parameter.
  */
-enum class VTType
+enum class VTType : uint8_t
 {
     VT100 = 0,
     VT220 = 1,
@@ -31,7 +31,7 @@ enum class VTType
     VT525 = 65,
 };
 
-enum class VTExtension
+enum class VTExtension : uint8_t
 {
     None,
     Unknown,

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -43,7 +43,7 @@ namespace
                || (192 <= codepoint && codepoint <= 255);
     }
 
-    enum class WordSkipClass
+    enum class WordSkipClass : uint8_t
     {
         Word,
         Keyword,

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -12,7 +12,7 @@ namespace vtbackend
 
 class Terminal;
 
-enum class JumpOver
+enum class JumpOver : uint8_t
 {
     Yes,
     No

--- a/src/vtbackend/ViCommands_test.cpp
+++ b/src/vtbackend/ViCommands_test.cpp
@@ -65,6 +65,7 @@ auto setupMockTerminal(std::string_view text,
 } // namespace
 // }}}
 
+// NOLINTBEGIN(misc-const-correctness)
 TEST_CASE("vi.motions: |", "[vi]")
 {
     // The meaning of this code shall not be questioned. It's purely for testing.
@@ -206,3 +207,4 @@ TEST_CASE("ViCommands:modeChanged", "[vi]")
         REQUIRE(mock.terminal.search().pattern.empty());
     }
 }
+// NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -57,7 +57,7 @@ namespace vtbackend
  *   ya"       yank around "
  */
 
-enum class ViMotion
+enum class ViMotion : uint8_t
 {
     Explicit,              // <special one for explicit operators>
     Selection,             // <special one for v_ modes>
@@ -102,7 +102,7 @@ enum class ViMotion
     RepeatCharMoveReverse, // ,
 };
 
-enum class ViOperator
+enum class ViOperator : uint8_t
 {
     MoveCursor,
     Yank = 'y',
@@ -112,7 +112,7 @@ enum class ViOperator
     Open = 'o',
 };
 
-enum class TextObject
+enum class TextObject : uint8_t
 {
     AngleBrackets = '<',  // i<  a<
     CurlyBrackets = '{',  // i{  a{
@@ -127,7 +127,7 @@ enum class TextObject
     BigWord = 'W',        // iW  aW
 };
 
-enum class TextObjectScope
+enum class TextObjectScope : uint8_t
 {
     Inner = 'i',
     A = 'a'
@@ -140,7 +140,7 @@ struct RectangularHighlight { CellLocation from; CellLocation to; };
 
 using HighlightRange = std::variant<LinearHighlight, RectangularHighlight>;
 
-enum class SearchEditMode
+enum class SearchEditMode : uint8_t
 {
     Disabled,
     Enabled,
@@ -218,7 +218,7 @@ class ViInputHandler: public InputHandler
     void setSearchModeSwitch(bool enabled);
 
   private:
-    enum class ModeSelect
+    enum class ModeSelect : uint8_t
     {
         Normal,
         Visual

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -4,6 +4,7 @@
 #include <vtpty/ImageSize.h>
 #include <vtpty/PageSize.h>
 
+#include <cstdint>
 #include <limits>
 #include <ostream>
 #include <variant>
@@ -439,13 +440,13 @@ constexpr ColumnOffset& operator-=(ColumnOffset& a, ColumnCount b) noexcept
 }
 // }}}
 
-enum class HighlightSearchMatches
+enum class HighlightSearchMatches : uint8_t
 {
     No,
     Yes
 };
 
-enum class ScreenType
+enum class ScreenType : uint8_t
 {
     Primary = 0,
     Alternate = 1,
@@ -463,13 +464,13 @@ enum class ScreenType
 // - PhysicalCoordinate
 // - ScrollbackCoordinate
 
-enum class CursorDisplay
+enum class CursorDisplay : uint8_t
 {
     Steady,
     Blink
 };
 
-enum class CursorShape
+enum class CursorShape : uint8_t
 {
     Block,
     Rectangle,
@@ -479,13 +480,13 @@ enum class CursorShape
 
 CursorShape makeCursorShape(std::string const& name);
 
-enum class ControlTransmissionMode
+enum class ControlTransmissionMode : uint8_t
 {
     S7C1T, // 7-bit controls
     S8C1T, // 8-bit controls
 };
 
-enum class GraphicsRendition
+enum class GraphicsRendition : uint8_t
 {
     Reset = 0, //!< Reset any rendition (style as well as foreground / background coloring).
 
@@ -517,7 +518,7 @@ enum class GraphicsRendition
     NoOverline = 55,      //!< Reverses Overline.
 };
 
-enum class StatusDisplayType
+enum class StatusDisplayType : uint8_t
 {
     None,
     Indicator,
@@ -525,7 +526,7 @@ enum class StatusDisplayType
 };
 
 // Mandates the position to show the statusline at.
-enum class StatusDisplayPosition
+enum class StatusDisplayPosition : uint8_t
 {
     // The status line is classically shown at the bottom of the render target.
     Bottom,
@@ -535,7 +536,7 @@ enum class StatusDisplayPosition
 };
 
 // Selects whether the terminal sends data to the main display or the status line.
-enum class ActiveStatusDisplay
+enum class ActiveStatusDisplay : uint8_t
 {
     // Selects the main display. The terminal sends data to the main display only.
     Main,
@@ -546,7 +547,7 @@ enum class ActiveStatusDisplay
     IndicatorStatusLine,
 };
 
-enum class AnsiMode
+enum class AnsiMode : uint8_t
 {
     KeyboardAction = 2,    // KAM
     Insert = 4,            // IRM
@@ -554,7 +555,7 @@ enum class AnsiMode
     AutomaticNewLine = 20, // LNM
 };
 
-enum class DECMode
+enum class DECMode : std::uint16_t
 {
     UseApplicationCursorKeys,
     DesignateCharsetUSASCII,
@@ -669,7 +670,7 @@ enum class DECMode
 };
 
 /// OSC color-setting related commands that can be grouped into one
-enum class DynamicColorName
+enum class DynamicColorName : uint8_t
 {
     DefaultForegroundColor,
     DefaultBackgroundColor,
@@ -680,7 +681,7 @@ enum class DynamicColorName
     HighlightBackgroundColor,
 };
 
-enum class ViMode
+enum class ViMode : uint8_t
 {
     /// Vi-like normal-mode.
     Normal, // <Escape>, <C-[>

--- a/src/vtparser/Parser.h
+++ b/src/vtparser/Parser.h
@@ -198,7 +198,7 @@ enum class State : uint8_t
 // NOLINTEND(readability-identifier-naming)
 
 /// Actions can be invoked due to various reasons.
-enum class ActionClass
+enum class ActionClass : uint8_t
 {
     /// Action to be invoked because we enter a new state.
     Enter,
@@ -697,7 +697,7 @@ class Parser
     void printUtf8Byte(char ch);
 
   private:
-    enum class ProcessKind
+    enum class ProcessKind : uint8_t
     {
         /// Processing bulk-text in ground state succeed, keep on going.
         ContinueBulk,

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -96,7 +96,7 @@ class [[nodiscard]] Process: public Pty
     void waitForClosed() override;
     [[nodiscard]] bool isClosed() const noexcept override { return pty().isClosed(); }
     [[nodiscard]] std::optional<ReadResult> read(crispy::buffer_object<char>& storage, std::optional<std::chrono::milliseconds> timeout, size_t n) override { return pty().read(storage, timeout, n); }
-    void wakeupReader() override { return pty().wakeupReader(); }
+    void wakeupReader() override { pty().wakeupReader(); }
     [[nodiscard]] int write(std::string_view data) override { return pty().write(data); }
     [[nodiscard]] PageSize pageSize() const noexcept override { return pty().pageSize(); }
     void resizeScreen(PageSize cells, std::optional<ImageSize> pixels = std::nullopt) override { pty().resizeScreen(cells, pixels); }

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -78,7 +78,7 @@ class [[nodiscard]] Process: public Pty
 
     [[nodiscard]] std::string workingDirectory() const;
 
-    enum class TerminationHint
+    enum class TerminationHint : uint8_t
     {
         Normal,
         Hangup

--- a/src/vtpty/SshSession.h
+++ b/src/vtpty/SshSession.h
@@ -71,7 +71,7 @@ class SshSession final: public Pty
 
     [[nodiscard]] std::optional<ExitStatus> exitStatus() const;
 
-    enum class State
+    enum class State : uint8_t
     {
         Initial,                            // initial state
         Started,                            // start() has been called

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -12,6 +12,7 @@
 #include <range/v3/view/zip.hpp>
 
 #include <array>
+#include <cstdint>
 
 using namespace std::string_view_literals;
 
@@ -66,7 +67,7 @@ namespace detail
     namespace
     {
 
-        enum class Thickness
+        enum class Thickness : uint8_t
         {
             Light,
             Heavy
@@ -173,7 +174,7 @@ namespace detail
 
         struct ProgressBar
         {
-            enum class Part
+            enum class Part : uint8_t
             {
                 Left,
                 Middle,
@@ -595,7 +596,7 @@ namespace detail
 
         struct DiagonalMosaic
         {
-            enum class Body
+            enum class Body : uint8_t
             {
                 Lower,
                 Upper
@@ -729,7 +730,7 @@ namespace detail
             return pixmap.take();
         }
 
-        enum class UpperOrLower
+        enum class UpperOrLower : uint8_t
         {
             Upper,
             Lower

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -965,9 +965,10 @@ auto BoxDrawingRenderer::createTileData(char32_t codepoint, atlas::TileLocation 
     {
         auto const supersamplingFactor = []() {
             auto constexpr EnvName = "SSA_FACTOR";
-            if (!getenv(EnvName))
+            auto* const envValue = getenv(EnvName);
+            if (!envValue)
                 return 2;
-            auto const val = atoi(getenv(EnvName));
+            auto const val = atoi(envValue);
             if (!(val >= 1 && val <= 8))
                 return 1;
             return val;
@@ -1043,38 +1044,20 @@ optional<atlas::Buffer> BoxDrawingRenderer::buildElements(char32_t codepoint)
     auto const ld = [=](Ratio a, Ratio b) {
         return lowerDiagonalMosaic(size, a, b);
     };
-    auto const lineArt =
-#if __cplusplus > 201703L
-        [=, this]
-#else
-        [=]
-#endif
-        () {
-            auto b = blockElement<2>(size);
-            b.getlineThickness(_gridMetrics.underline.thickness);
-            return b;
-        };
-    auto const progressBar =
-#if __cplusplus > 201703L
-        [=, this]
-#else
-        [=]
-#endif
-        () {
-            return ProgressBar { size, _gridMetrics.underline.position };
-        };
-    auto const segmentArt =
-#if __cplusplus > 201703L
-        [=, this]
-#else
-        [=]
-#endif
-        () {
-            auto constexpr AntiAliasingSamplingFactor = 1;
-            return blockElement<AntiAliasingSamplingFactor>(size)
-                .getlineThickness(_gridMetrics.underline.thickness)
-                .baseline(_gridMetrics.baseline * AntiAliasingSamplingFactor);
-        };
+    auto const lineArt = [size, this]() {
+        auto b = blockElement<2>(size);
+        b.getlineThickness(_gridMetrics.underline.thickness);
+        return b;
+    };
+    auto const progressBar = [size, this]() {
+        return ProgressBar { size, _gridMetrics.underline.position };
+    };
+    auto const segmentArt = [size, this]() {
+        auto constexpr AntiAliasingSamplingFactor = 1;
+        return blockElement<AntiAliasingSamplingFactor>(size)
+            .getlineThickness(_gridMetrics.underline.thickness)
+            .baseline(_gridMetrics.baseline * AntiAliasingSamplingFactor);
+    };
 
     // TODO: just check notcurses-info to get an idea what may be missing
     // clang-format off

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -191,8 +191,9 @@ auto DecorationRenderer::createTileData(Decorator decoration,
                     auto const intensity = static_cast<uint8_t>(255 * fabs(y - y1));
                     // block.paintOver(x, yBase + y1, 255 - intensity);
                     // block.paintOver(x, yBase + y2, intensity);
-                    block.paintOverThick(x, yBase + y1, uint8_t(255 - intensity), thicknessHalf, 0);
-                    block.paintOverThick(x, yBase + y2, intensity, thicknessHalf, 0);
+                    block.paintOverThick(
+                        static_cast<int>(x), yBase + y1, uint8_t(255 - intensity), thicknessHalf, 0);
+                    block.paintOverThick(static_cast<int>(x), yBase + y2, intensity, thicknessHalf, 0);
                 }
                 return block.take();
             });

--- a/src/vtrasterizer/Decorator.h
+++ b/src/vtrasterizer/Decorator.h
@@ -14,7 +14,7 @@ namespace vtrasterizer
 /// Dectorator, to decorate a grid cell, eventually containing a character
 ///
 /// It should be possible to render multiple decoration onto the same coordinates.
-enum class Decorator
+enum class Decorator : uint8_t
 {
     /// Draws an underline
     Underline,

--- a/src/vtrasterizer/FontDescriptions.h
+++ b/src/vtrasterizer/FontDescriptions.h
@@ -7,14 +7,14 @@
 namespace vtrasterizer
 {
 
-enum class TextShapingEngine
+enum class TextShapingEngine : uint8_t
 {
     OpenShaper, //!< Uses open-source implementation: harfbuzz/freetype/fontconfig
     DWrite,     //!< native platform support: Windows
     CoreText,   //!< native platform support: macOS
 };
 
-enum class FontLocatorEngine
+enum class FontLocatorEngine : uint8_t
 {
     Mock,       //!< mock font locator API
     FontConfig, //!< platform independant font locator API
@@ -58,7 +58,7 @@ inline bool operator!=(FontDescriptions const& a, FontDescriptions const& b) noe
     return !(a == b);
 }
 
-enum class TextStyle
+enum class TextStyle : uint8_t
 {
     Invalid = 0x00,
     Regular = 0x10,

--- a/src/vtrasterizer/Pixmap.cpp
+++ b/src/vtrasterizer/Pixmap.cpp
@@ -17,7 +17,7 @@ namespace
     struct From { int value; };
     struct To { int value; };
     struct BaseOffset { int value; };
-    enum class Orientation { Horizontal, Vertical };
+    enum class Orientation: uint8_t { Horizontal, Vertical };
     // clang-format on
 
     Pixmap& segment_line(Pixmap& pixmap, Orientation orientation, BaseOffset base, From from, To to)

--- a/src/vtrasterizer/Pixmap.h
+++ b/src/vtrasterizer/Pixmap.h
@@ -12,6 +12,7 @@
 #include <range/v3/view/iota.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 
 namespace vtrasterizer
@@ -62,20 +63,20 @@ constexpr auto linearEq(crispy::point p1, crispy::point p2) noexcept
     };
 }
 
-enum class Dir
+enum class Dir : uint8_t
 {
     Top,
     Right,
     Bottom,
     Left
 };
-enum class Inverted
+enum class Inverted : uint8_t
 {
     No,
     Yes
 };
 
-enum Arc
+enum Arc : uint8_t
 {
     NoArc,
     TopLeft,

--- a/src/vtrasterizer/TextureAtlas.h
+++ b/src/vtrasterizer/TextureAtlas.h
@@ -10,6 +10,7 @@
 
 #include <fmt/format.h>
 
+#include <cstdint>
 #include <variant> // monostate
 #include <vector>
 
@@ -20,7 +21,7 @@ namespace vtrasterizer::atlas
 
 using Buffer = std::vector<uint8_t>;
 
-enum class Format
+enum class Format : uint8_t
 {
     Red = 1,
     RGB = 3,
@@ -152,7 +153,7 @@ struct RenderTile
     vtbackend::ImageSize bitmapSize {}; // bitmap size inside the tile (must not exceed the grid's tile size)
     vtbackend::ImageSize targetSize {}; // dimensions of the bitmap on the render target surface
     std::array<float, 4> color;         // optional; a color being associated with this texture
-    TileLocation tileLocation {};       // what tile to render from which texture atlas
+    TileLocation tileLocation;          // what tile to render from which texture atlas
 
     NormalizedTileLocation normalizedLocation {};
 

--- a/src/vtrasterizer/shared_defines.h
+++ b/src/vtrasterizer/shared_defines.h
@@ -1,3 +1,4 @@
+// NOLINTBEGIN(cppcoreguidelines-macro-to-enum)
 // NOLINTBEGIN(modernize-macro-to-enum)
 
 // Shared preprocessor definitions between C++ and GLSL.
@@ -17,3 +18,4 @@
 #define FRAGMENT_SELECTOR_GLYPH_LCD 3
 
 // NOLINTEND(modernize-macro-to-enum)
+// NOLINTEND(cppcoreguidelines-macro-to-enum)


### PR DESCRIPTION
Fix several clang-tidy checks:
* `performance-enum-size`
* `modernize-use-constraints`
* `readability-avoid-nested-conditional-operator`
* `bugprone-narrowing-conversions`
And made them error on warnings
