### PR TITLE
Stop scroll when switching to normal mode

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -121,6 +121,7 @@
           <li>Add better bell sound (#1378)</li>
           <li>Add config entry to configure behaviour on exit from search mode</li>
           <li>Add handling of different input commands (#629)</li>
+          <li>When switching to normal mode screen will stay in same position (#808)</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Fixes forwarding of input while in normal mode (#1468)</li>

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -252,6 +252,7 @@ void ViCommands::modeChanged(ViMode mode)
                 _terminal->clearSelection();
             _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
             _terminal->screenUpdated();
+            _terminal->viewport().makeVisibleWithinSafeArea(LineOffset { 0 });
             break;
         case ViMode::Visual:
             _terminal->setSelector(make_unique<LinearSelection>(


### PR DESCRIPTION
I think this is a sane default behavior that allows you to investigate the output from the command
Closes https://github.com/contour-terminal/contour/issues/808