### PR TITLE
Add mode dependent configuration for indicator statusline colors

### DIFF
--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -172,37 +172,33 @@ color_schemes:
 
 
 ### `indicator_statusline`
-Defines the colors to be used for the Indicator status line.
+Defines the colors to be used for the Indicator status line. Configuration entry consist of following sections, namely `default`, `inactive`, `insert_mode`, `normal_mode`, `visual_mode`. Each section have `foreground` and `background` options. You can specify only the sections you want to customize after configuring the `default` section.
+Minimal configuration looks like this:
 ``` yaml
 color_schemes:
   default:
     indicator_statusline:
-      foreground: '#808080'
-      background: '#000000'
+        default:
+          foreground: '#808080'
+          background: '#000000'
 ```
-
-
-
-### `indicator_statusline_inactive`
-Alternate colors to be used for the indicator status line when this terminal is currently not in focus.
+Complete configuration looks like this:
 ``` yaml
 color_schemes:
   default:
-    indicator_statusline_inactive:
-      foreground: '#808080'
-      background: '#000000'
-```
-
-
-
-### `input_method_editor`
-Colors for the IME (Input Method Editor) area.
-``` yaml
-color_schemes:
-  default:
-    indicator_statusline_inactive:
-      foreground: '#808080'
-      background: '#000000'
+    indicator_statusline:
+        default:
+          foreground: '#FFFFFF'
+          background: '#0270C0'
+        inactive:
+          foreground: '#FFFFFF'
+          background: '#0270C0'
+        normal_mode:
+          foreground: '#0f0002'
+          background: '#0270C0'
+        visual_mode:
+          foreground: '#ffffff'
+          background: '#0270C0'
 ```
 
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -125,6 +125,7 @@
           <li>Add handling of different input commands (#629)</li>
           <li>Add key bindings disabled indicator for status line (#783)</li>
           <li>When switching to normal mode screen will stay in same position (#808)</li>
+          <li>Add customizable per-input-mode default text/background coloring for indicator statusline (#1528)</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Fixes forwarding of input while in normal mode (#1468)</li>

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -943,19 +943,16 @@ constexpr StringLiteral WordHighlight {
 constexpr StringLiteral IndicatorStatusLine {
     "\n"
     "{comment} Defines the colors to be used for the Indicator status line.\n"
-    "{comment} Values must be in RGB form.\n"
+    "{comment} Configuration consist of different sections: default, inactive, insert_mode, normal_mode, "
+    "visual_mode.\n"
+    "{comment} Each section customize status line colors for corresponding mode.\n"
     "indicator_statusline:\n"
-    "    foreground: {}\n"
-    "    background: {}\n"
-};
-
-constexpr StringLiteral IndicatorStatusLineInactive {
-    "\n"
-    "{comment} Alternate colors to be used for the indicator status line when\n"
-    "{comment} this terminal is currently not in focus.\n"
-    "indicator_statusline_inactive:\n"
-    "    foreground: {}\n"
-    "    background: {}\n"
+    "    default:\n"
+    "        foreground: {}\n"
+    "        background: {}\n"
+    "    inactive:\n"
+    "        foreground: {}\n"
+    "        background: {}\n"
 };
 
 constexpr StringLiteral InputMethodEditor { "\n"

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -126,8 +126,10 @@ struct ColorPalette
     CellRGBColorAndAlphaPair normalModeCursorline = { 0xFFFFFF_rgb, 0.2f, 0x808080_rgb, 0.4f };
     // clang-format on
 
-    RGBColorPair indicatorStatusLine = { 0xFFFFFF_rgb, 0x0270c0_rgb };
     RGBColorPair indicatorStatusLineInactive = { 0xFFFFFF_rgb, 0x0270c0_rgb };
+    RGBColorPair indicatorStatusLineInsertMode = { 0xFFFFFF_rgb, 0x0270c0_rgb };
+    RGBColorPair indicatorStatusLineNormalMode = { 0xFFFFFF_rgb, 0x0270c0_rgb };
+    RGBColorPair indicatorStatusLineVisualMode = { 0xFFFFFF_rgb, 0x0270c0_rgb };
 };
 
 enum class ColorTarget : uint8_t

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -539,8 +539,24 @@ void Terminal::updateIndicatorStatusLine()
 {
     Require(_activeStatusDisplay != ActiveStatusDisplay::IndicatorStatusLine);
 
-    auto const colors =
-        _focused ? colorPalette().indicatorStatusLine : colorPalette().indicatorStatusLineInactive;
+    auto const colors = [&]() {
+        if (!_focused)
+        {
+            return colorPalette().indicatorStatusLineInactive;
+        }
+        else
+        {
+            switch (_inputHandler.mode())
+            {
+                case ViMode::Insert: return colorPalette().indicatorStatusLineInsertMode;
+                case ViMode::Normal: return colorPalette().indicatorStatusLineNormalMode;
+                case ViMode::Visual:
+                case ViMode::VisualLine:
+                case ViMode::VisualBlock: return colorPalette().indicatorStatusLineVisualMode;
+            }
+        }
+        crispy::unreachable();
+    }();
 
     auto const backupForeground = _colorPalette.defaultForeground;
     auto const backupBackground = _colorPalette.defaultBackground;


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1528

This PR adds customization of indicator status line colors for different modes.
Unfortunately it breaks present configuration for inactive status line 