### PR TITLE
Do not export TERM env var when using ConPTY (on Windows)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,6 +469,8 @@ jobs:
   windows:
     name: "Windows"
     runs-on: windows-latest
+    env:
+      VCPKG_ROOT: "${{ runner.workspace }}/vcpkg"
     steps:
       - uses: actions/checkout@v4
       - name: Run sccache-cache
@@ -494,7 +496,7 @@ jobs:
         uses: lukka/run-vcpkg@v11.1
         id: runvcpkg
         with:
-          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg
           vcpkgGitCommitId: 80403036a665cb8fcc1a1b3e17593d20b03b2489
       - name: "Generate build files"
         run: cmake --preset windows-cl-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,8 +469,6 @@ jobs:
   windows:
     name: "Windows"
     runs-on: windows-latest
-    env:
-      VCPKG_ROOT: "${{ runner.workspace }}/vcpkg"
     steps:
       - uses: actions/checkout@v4
       - name: Run sccache-cache
@@ -500,6 +498,8 @@ jobs:
           vcpkgGitCommitId: 80403036a665cb8fcc1a1b3e17593d20b03b2489
       - name: "Generate build files"
         run: cmake --preset windows-cl-release
+        env:
+          VCPKG_ROOT: "${{ runner.workspace }}/vcpkg"
       - name: "Build"
         run: cmake --build --preset windows-cl-release
       - name: "Test"

--- a/cmake/presets/os-windows.json
+++ b/cmake/presets/os-windows.json
@@ -20,7 +20,7 @@
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
                 "CMAKE_SYSTEM_VERSION": "10",
                 "CMAKE_VERBOSE_MAKEFILE": "ON",
-                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake"
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
             }
         },
         { "name": "windows-cl-debug", "inherits": ["windows-common", "debug"], "displayName": "Windows (MSVC) Debug", "description": "Using MSVC compiler (64-bit)" },

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -128,6 +128,7 @@
           <li>Add customizable per-input-mode default text/background coloring for indicator statusline (#1528)</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
+          <li>Do not export the `TERM` environment variable on Windows OS (when using ConPTY).</li>
           <li>Fixes forwarding of input while in normal mode (#1468)</li>
           <li>Fixes OSC-8 link id collision (#1499)</li>
           <li>Fixed overlap of glyphs for long codepoints (#1349)</li>

--- a/src/vtpty/Process_win32.cpp
+++ b/src/vtpty/Process_win32.cpp
@@ -66,6 +66,15 @@ namespace
         {
             for (auto const& env: newValues)
             {
+                if (env.first == "TERM")
+                {
+                    // Do not pass TERM to child process, as it might cause problems with some applications
+                    // (e.g. git diff) We are currently only using ConPTY here which does not require TERM to
+                    // be set.
+                    errorLog()("Ignoring TERM environment variable for child process.");
+                    continue;
+                }
+
                 if (auto len = GetEnvironmentVariable(env.first.c_str(), nullptr, 0); len != 0)
                 {
                     vector<char> buf;


### PR DESCRIPTION
Some apps on Windows can't handle a TERM variable that they do not know about. There is also no way to resolve terminfo db entries on Windows neither. So simply don't export it, such that apps won't get confused.