### PR TITLE
Improves handling of constant bell sound spawning

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -141,6 +141,7 @@
           <li>Fixes bell sound in spawned window in same process (#1515)</li>
           <li>Fixes status line crush (#1511)</li>
           <li>Fixes application window icon on (KDE) Wayland</li>
+          <li>Improves handling of constant bell sound spawning</li>
         </ul>
       </description>
     </release>

--- a/src/contour/ui.template/Terminal.qml.in
+++ b/src/contour/ui.template/Terminal.qml.in
@@ -185,7 +185,7 @@ ContourTerminal
 
     function playBell(volume) {
         if (bellSoundEffect.playbackState === MediaPlayer.PlayingState)
-            bellSoundEffect.stop();
+           return;
 
         if (bellSoundEffect.audioOutput)
             // Qt 6 solution to set the volume


### PR DESCRIPTION
Do not spawn bell sound when bell is playing, it allows to handle bell signals much faster in the case when the bell is constantly spawning