### PR TITLE
ContourThirdParties.cmake: fix boxed-cpp detection

### DIFF
--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -127,7 +127,7 @@ if(COMMAND ContourThirdParties_Embed_boxed_cpp)
     endif()
     set(THIRDPARTY_BUILTIN_boxed_cpp "embedded")
 else()
-    HandleThirdparty(boxed_cpp "gh:contour-terminal/boxed-cpp#v${BOXED_CPP_MINIMAL_VERSION}")
+    HandleThirdparty(boxed-cpp "gh:contour-terminal/boxed-cpp#v${BOXED_CPP_MINIMAL_VERSION}")
 endif()
 
 


### PR DESCRIPTION
## Description

fix following error

```
CMake Warning at cmake/ContourThirdParties.cmake:38 (find_package):
  By not providing "Findboxed_cpp.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "boxed_cpp", but CMake did not find one.

  Could not find a package configuration file provided by "boxed_cpp" with
  any of the following names:

    boxed_cppConfig.cmake
    boxed_cpp-config.cmake

  Add the installation prefix of "boxed_cpp" to CMAKE_PREFIX_PATH or set
  "boxed_cpp_DIR" to a directory containing one of the above files.  If
  "boxed_cpp" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  cmake/ContourThirdParties.cmake:130 (HandleThirdparty)
  CMakeLists.txt:129 (include)
```

## Motivation and Context

Cannot compile on OpenBSD.
Previous commit (4c71d0c) has no problem.

## How Has This Been Tested?

simply `cmake ..` on build directory.

