### PR TITLE
mark fmt::formatter<..>::format() const

### DIFF
--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -299,14 +299,14 @@ inline auto getDocumentation()
 } // namespace contour::actions
 
 // {{{ fmtlib custom formatters
-#define DECLARE_ACTION_FMT(T)                                                                    \
-    template <>                                                                                  \
-    struct fmt::formatter<contour::actions::T>: fmt::formatter<std::string_view>                 \
-    {                                                                                            \
-        auto format(contour::actions::T const&, format_context& ctx) -> format_context::iterator \
-        {                                                                                        \
-            return formatter<string_view>::format(#T, ctx);                                      \
-        }                                                                                        \
+#define DECLARE_ACTION_FMT(T)                                                                          \
+    template <>                                                                                        \
+    struct fmt::formatter<contour::actions::T>: fmt::formatter<std::string_view>                       \
+    {                                                                                                  \
+        auto format(contour::actions::T const&, format_context& ctx) const -> format_context::iterator \
+        {                                                                                              \
+            return formatter<string_view>::format(#T, ctx);                                            \
+        }                                                                                              \
     };
 
 // {{{ declare
@@ -371,7 +371,8 @@ DECLARE_ACTION_FMT(WriteScreen)
 template <>
 struct fmt::formatter<contour::actions::Action>: fmt::formatter<std::string>
 {
-    auto format(contour::actions::Action const& _action, format_context& ctx) -> format_context::iterator
+    auto format(contour::actions::Action const& _action,
+                format_context& ctx) const -> format_context::iterator
     {
         std::string name = "Unknown action";
         // {{{ handle
@@ -447,7 +448,7 @@ struct fmt::formatter<contour::actions::CopyFormat>
         return ctx.begin();
     }
     template <typename FormatContext>
-    auto format(contour::actions::CopyFormat value, FormatContext& ctx)
+    auto format(contour::actions::CopyFormat value, FormatContext& ctx) const
     {
         switch (value)
         {

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -1140,7 +1140,7 @@ std::string defaultConfigFilePath();
 template <>
 struct fmt::formatter<contour::config::Permission>: formatter<std::string_view>
 {
-    auto format(contour::config::Permission value, format_context& ctx)
+    auto format(contour::config::Permission value, format_context& ctx) const
     {
         string_view name;
         switch (value)
@@ -1156,7 +1156,7 @@ struct fmt::formatter<contour::config::Permission>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::Opacity>: formatter<float>
 {
-    auto format(vtbackend::Opacity value, format_context& ctx)
+    auto format(vtbackend::Opacity value, format_context& ctx) const
     {
         return formatter<float>::format(static_cast<float>(value) / std::numeric_limits<uint8_t>::max(), ctx);
     }
@@ -1165,7 +1165,7 @@ struct fmt::formatter<vtbackend::Opacity>: formatter<float>
 template <>
 struct fmt::formatter<crispy::strong_hashtable_size>: formatter<uint>
 {
-    auto format(crispy::strong_hashtable_size value, format_context& ctx)
+    auto format(crispy::strong_hashtable_size value, format_context& ctx) const
     {
         return formatter<uint>::format(value.value, ctx);
     }
@@ -1174,7 +1174,7 @@ struct fmt::formatter<crispy::strong_hashtable_size>: formatter<uint>
 template <>
 struct fmt::formatter<vtbackend::StatusDisplayPosition>: formatter<std::string_view>
 {
-    auto format(vtbackend::StatusDisplayPosition value, format_context& ctx)
+    auto format(vtbackend::StatusDisplayPosition value, format_context& ctx) const
     {
         string_view name;
         switch (value)
@@ -1189,7 +1189,7 @@ struct fmt::formatter<vtbackend::StatusDisplayPosition>: formatter<std::string_v
 template <>
 struct fmt::formatter<vtbackend::BackgroundImage>: formatter<std::string_view>
 {
-    auto format(vtbackend::BackgroundImage value, format_context& ctx)
+    auto format(vtbackend::BackgroundImage value, format_context& ctx) const
     {
         if (auto* loc = std::get_if<std::filesystem::path>(&value.location))
             return formatter<string_view>::format(loc->string(), ctx);
@@ -1200,7 +1200,7 @@ struct fmt::formatter<vtbackend::BackgroundImage>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::StatusDisplayType>: formatter<std::string_view>
 {
-    auto format(vtbackend::StatusDisplayType value, format_context& ctx)
+    auto format(vtbackend::StatusDisplayType value, format_context& ctx) const
     {
         string_view name;
         switch (value)
@@ -1216,7 +1216,7 @@ struct fmt::formatter<vtbackend::StatusDisplayType>: formatter<std::string_view>
 template <>
 struct fmt::formatter<crispy::lru_capacity>: formatter<uint>
 {
-    auto format(crispy::lru_capacity value, format_context& ctx)
+    auto format(crispy::lru_capacity value, format_context& ctx) const
     {
         return formatter<uint>::format(value.value, ctx);
     }
@@ -1225,7 +1225,7 @@ struct fmt::formatter<crispy::lru_capacity>: formatter<uint>
 template <>
 struct fmt::formatter<std::set<std::basic_string<char>>>: formatter<std::string_view>
 {
-    auto format(std::set<std::basic_string<char>> value, format_context& ctx)
+    auto format(std::set<std::basic_string<char>> value, format_context& ctx) const
     {
         auto result = std::string {};
         result.append(value | ranges::views::join(", ") | ranges::to<std::string>);
@@ -1236,7 +1236,7 @@ struct fmt::formatter<std::set<std::basic_string<char>>>: formatter<std::string_
 template <>
 struct fmt::formatter<contour::config::SelectionAction>: formatter<std::string_view>
 {
-    auto format(contour::config::SelectionAction value, format_context& ctx)
+    auto format(contour::config::SelectionAction value, format_context& ctx) const
     {
         std::string_view name;
         switch (value)
@@ -1254,7 +1254,7 @@ struct fmt::formatter<contour::config::SelectionAction>: formatter<std::string_v
 template <>
 struct fmt::formatter<contour::config::ScrollBarPosition>: formatter<std::string_view>
 {
-    auto format(contour::config::ScrollBarPosition value, format_context& ctx)
+    auto format(contour::config::ScrollBarPosition value, format_context& ctx) const
     {
         std::string_view name;
         switch (value)
@@ -1270,7 +1270,7 @@ struct fmt::formatter<contour::config::ScrollBarPosition>: formatter<std::string
 template <>
 struct fmt::formatter<contour::config::RenderingBackend>: formatter<std::string_view>
 {
-    auto format(contour::config::RenderingBackend const& val, fmt::format_context& ctx)
+    auto format(contour::config::RenderingBackend const& val, fmt::format_context& ctx) const
     {
         std::string_view name;
         switch (val)
@@ -1287,7 +1287,7 @@ template <>
 struct fmt::formatter<contour::config::WindowMargins>: public fmt::formatter<std::string>
 {
     using WindowMargins = contour::config::WindowMargins;
-    auto format(WindowMargins margins, format_context& ctx) -> format_context::iterator
+    auto format(WindowMargins margins, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}x+{}y", margins.horizontal, margins.vertical),
                                               ctx);
@@ -1297,7 +1297,7 @@ struct fmt::formatter<contour::config::WindowMargins>: public fmt::formatter<std
 template <typename T, contour::config::documentation::StringLiteral D>
 struct fmt::formatter<contour::config::ConfigEntry<T, D>>
 {
-    auto format(contour::config::ConfigEntry<T, D> const& c, fmt::format_context& ctx)
+    auto format(contour::config::ConfigEntry<T, D> const& c, fmt::format_context& ctx) const
     {
         return fmt::format_to(ctx.out(), "{}", c.value());
     }

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -485,7 +485,7 @@ struct formatter<contour::GuardedRole>
     }
 
     template <typename FormatContext>
-    auto format(contour::GuardedRole value, FormatContext& ctx)
+    auto format(contour::GuardedRole value, FormatContext& ctx) const
     {
         switch (value)
         {

--- a/src/crispy/StrongHash.h
+++ b/src/crispy/StrongHash.h
@@ -308,7 +308,7 @@ struct fmt::formatter<crispy::strong_hash>
         return ctx.begin();
     }
     template <typename FormatContext>
-    auto format(crispy::strong_hash const& hash, FormatContext& ctx)
+    auto format(crispy::strong_hash const& hash, FormatContext& ctx) const
     {
         return fmt::format_to(ctx.out(), "{}", to_structured_string(hash));
     }

--- a/src/crispy/StrongLRUHashtable.h
+++ b/src/crispy/StrongLRUHashtable.h
@@ -42,7 +42,7 @@ struct lru_hashtable_stats
 template <>
 struct fmt::formatter<crispy::lru_hashtable_stats>: fmt::formatter<std::string>
 {
-    auto format(crispy::lru_hashtable_stats stats, format_context& ctx) -> format_context::iterator
+    auto format(crispy::lru_hashtable_stats stats, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format(

--- a/src/crispy/file_descriptor.h
+++ b/src/crispy/file_descriptor.h
@@ -121,7 +121,7 @@ using file_descriptor = native_handle<int, -1>;
 template <>
 struct fmt::formatter<HANDLE>: fmt::formatter<std::string>
 {
-    auto format(HANDLE value, format_context& ctx) -> format_context::iterator
+    auto format(HANDLE value, format_context& ctx) const -> format_context::iterator
     {
         auto str = fmt::format("0x{:X}", (unsigned long long) (value));
         return fmt::formatter<std::string>::format(str, ctx);
@@ -132,7 +132,7 @@ struct fmt::formatter<HANDLE>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<crispy::file_descriptor>: fmt::formatter<crispy::file_descriptor::native_handle_type>
 {
-    auto format(crispy::file_descriptor const& fd, format_context& ctx) -> format_context::iterator
+    auto format(crispy::file_descriptor const& fd, format_context& ctx) const -> format_context::iterator
     {
         return fmt::formatter<crispy::file_descriptor::native_handle_type>::format(fd.get(), ctx);
     }

--- a/src/crispy/flags.h
+++ b/src/crispy/flags.h
@@ -144,7 +144,7 @@ class flags
 template <typename Enum>
 struct fmt::formatter<crispy::flags<Enum>>: public fmt::formatter<std::string>
 {
-    auto format(crispy::flags<Enum> const& flags, format_context& ctx) -> format_context::iterator
+    auto format(crispy::flags<Enum> const& flags, format_context& ctx) const -> format_context::iterator
     {
         std::string result;
         for (auto i = 0u; i < sizeof(Enum) * 8; ++i)

--- a/src/crispy/point.h
+++ b/src/crispy/point.h
@@ -89,7 +89,7 @@ constexpr inline bool operator!=(point const& a, point const& b) noexcept
 template <>
 struct fmt::formatter<crispy::point>: formatter<std::string>
 {
-    auto format(crispy::point coord, format_context& ctx) -> format_context::iterator
+    auto format(crispy::point coord, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}, {})", coord.x, coord.y), ctx);
     }

--- a/src/text_shaper/font.h
+++ b/src/text_shaper/font.h
@@ -331,7 +331,7 @@ struct hash<text::font_description>
 template <>
 struct fmt::formatter<text::DPI>: fmt::formatter<std::string>
 {
-    auto format(text::DPI dpi, format_context& ctx) -> format_context::iterator
+    auto format(text::DPI dpi, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}x{}", dpi.x, dpi.y), ctx);
     }
@@ -340,7 +340,7 @@ struct fmt::formatter<text::DPI>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_weight>: formatter<string_view>
 {
-    auto format(text::font_weight value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_weight value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -365,7 +365,7 @@ struct fmt::formatter<text::font_weight>: formatter<string_view>
 template <>
 struct fmt::formatter<text::font_slant>: formatter<string_view>
 {
-    auto format(text::font_slant value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_slant value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -381,7 +381,7 @@ struct fmt::formatter<text::font_slant>: formatter<string_view>
 template <>
 struct fmt::formatter<text::font_spacing>: formatter<string_view>
 {
-    auto format(text::font_spacing value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_spacing value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -396,7 +396,7 @@ struct fmt::formatter<text::font_spacing>: formatter<string_view>
 template <>
 struct fmt::formatter<text::font_description>: fmt::formatter<std::string>
 {
-    auto format(text::font_description const& desc, format_context& ctx) -> format_context::iterator
+    auto format(text::font_description const& desc, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format("(family={} weight={} slant={} spacing={}, strict_spacing={})",
@@ -412,7 +412,7 @@ struct fmt::formatter<text::font_description>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_metrics>: fmt::formatter<std::string>
 {
-    auto format(text::font_metrics const& metrics, format_context& ctx) -> format_context::iterator
+    auto format(text::font_metrics const& metrics, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}, {}, {}, {}, {}, {})",
                                                           metrics.lineHeight,
@@ -428,7 +428,7 @@ struct fmt::formatter<text::font_metrics>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_size>: fmt::formatter<std::string>
 {
-    auto format(text::font_size size, format_context& ctx) -> format_context::iterator
+    auto format(text::font_size size, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}pt", size.pt), ctx);
     }
@@ -437,7 +437,7 @@ struct fmt::formatter<text::font_size>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_key>: fmt::formatter<std::string>
 {
-    auto format(text::font_key key, format_context& ctx) -> format_context::iterator
+    auto format(text::font_key key, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}", key.value), ctx);
     }
@@ -446,7 +446,7 @@ struct fmt::formatter<text::font_key>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::glyph_index>: fmt::formatter<std::string>
 {
-    auto format(text::glyph_index value, format_context& ctx) -> format_context::iterator
+    auto format(text::glyph_index value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}", value.value), ctx);
     }
@@ -455,7 +455,7 @@ struct fmt::formatter<text::glyph_index>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::glyph_key>: fmt::formatter<std::string>
 {
-    auto format(text::glyph_key const& key, format_context& ctx) -> format_context::iterator
+    auto format(text::glyph_key const& key, format_context& ctx) const -> format_context::iterator
     {
 #if defined(GLYPH_KEY_DEBUG)
         return formatter<std::string>::format(
@@ -475,7 +475,7 @@ struct fmt::formatter<text::glyph_key>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_feature>: fmt::formatter<std::string>
 {
-    auto format(text::font_feature value, format_context& ctx) -> format_context::iterator
+    auto format(text::font_feature value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}{}{}{}{}",
                                                           value.enabled ? '+' : '-',
@@ -490,7 +490,7 @@ struct fmt::formatter<text::font_feature>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::render_mode>: fmt::formatter<std::string_view>
 {
-    auto format(text::render_mode value, format_context& ctx) -> format_context::iterator
+    auto format(text::render_mode value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)

--- a/src/text_shaper/font_locator.h
+++ b/src/text_shaper/font_locator.h
@@ -76,7 +76,7 @@ class font_locator
 template <>
 struct fmt::formatter<text::font_path>: fmt::formatter<std::string>
 {
-    auto format(text::font_path spec, format_context& ctx) -> format_context::iterator
+    auto format(text::font_path spec, format_context& ctx) const -> format_context::iterator
     {
         auto weightMod = spec.weight ? fmt::format(" {}", spec.weight.value()) : "";
         auto slantMod = spec.slant ? fmt::format(" {}", spec.slant.value()) : "";
@@ -88,7 +88,7 @@ struct fmt::formatter<text::font_path>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_memory_ref>: fmt::formatter<std::string>
 {
-    auto format(text::font_memory_ref ref, format_context& ctx) -> format_context::iterator
+    auto format(text::font_memory_ref ref, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("in-memory: {}", ref.identifier), ctx);
     }
@@ -97,7 +97,7 @@ struct fmt::formatter<text::font_memory_ref>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::font_source>: fmt::formatter<std::string>
 {
-    auto format(text::font_source source, format_context& ctx) -> format_context::iterator
+    auto format(text::font_source source, format_context& ctx) const -> format_context::iterator
     {
         std::string text;
         if (std::holds_alternative<text::font_path>(source))

--- a/src/text_shaper/shaper.h
+++ b/src/text_shaper/shaper.h
@@ -159,7 +159,7 @@ class shaper
 template <>
 struct fmt::formatter<text::bitmap_format>: fmt::formatter<std::string_view>
 {
-    auto format(text::bitmap_format value, format_context& ctx) -> format_context::iterator
+    auto format(text::bitmap_format value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -175,7 +175,7 @@ struct fmt::formatter<text::bitmap_format>: fmt::formatter<std::string_view>
 template <>
 struct fmt::formatter<text::glyph_position>: fmt::formatter<std::string>
 {
-    auto format(text::glyph_position const& gpos, format_context& ctx) -> format_context::iterator
+    auto format(text::glyph_position const& gpos, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}+{}+{}|{}+{})",
                                                           gpos.glyph.index.value,
@@ -190,7 +190,7 @@ struct fmt::formatter<text::glyph_position>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<text::rasterized_glyph>: fmt::formatter<std::string>
 {
-    auto format(text::rasterized_glyph const& glyph, format_context& ctx) -> format_context::iterator
+    auto format(text::rasterized_glyph const& glyph, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("rasterized_glyph({}, {}+{}, {})",
                                                           glyph.index.value,

--- a/src/vtbackend/Capabilities.h
+++ b/src/vtbackend/Capabilities.h
@@ -107,7 +107,7 @@ class StaticDatabase: public Database
 template <>
 struct fmt::formatter<vtbackend::capabilities::Code>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::capabilities::Code value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::capabilities::Code value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(value.hex(), ctx);
     }

--- a/src/vtbackend/CellFlags.h
+++ b/src/vtbackend/CellFlags.h
@@ -42,7 +42,7 @@ using CellFlags = crispy::flags<CellFlag>;
 template <>
 struct fmt::formatter<vtbackend::CellFlag>: fmt::formatter<std::string_view>
 {
-    auto format(const vtbackend::CellFlag value, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::CellFlag value, format_context& ctx) const -> format_context::iterator
     {
         string_view s;
 

--- a/src/vtbackend/Color.h
+++ b/src/vtbackend/Color.h
@@ -403,7 +403,7 @@ std::optional<RGBColor> parseColor(std::string_view const& value);
 template <>
 struct fmt::formatter<vtbackend::Color>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::Color value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::Color value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(to_string(value), ctx);
     }
@@ -412,7 +412,7 @@ struct fmt::formatter<vtbackend::Color>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::RGBColor>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::RGBColor value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::RGBColor value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(to_string(value), ctx);
     }
@@ -422,7 +422,7 @@ template <>
 struct fmt::formatter<vtbackend::RGBAColor>: fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(vtbackend::RGBAColor value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::RGBAColor value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(to_string(value), ctx);
     }
@@ -431,7 +431,7 @@ struct fmt::formatter<vtbackend::RGBAColor>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::CellRGBColor>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::CellRGBColor value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::CellRGBColor value, format_context& ctx) const -> format_context::iterator
     {
         if (std::holds_alternative<vtbackend::CellForegroundColor>(value))
             return formatter<std::string>::format("CellForeground", ctx);
@@ -445,7 +445,7 @@ struct fmt::formatter<vtbackend::CellRGBColor>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::RGBColorPair>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::RGBColorPair value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::RGBColorPair value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}/{}", value.foreground, value.background), ctx);
     }

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -153,7 +153,7 @@ RGBColor apply(ColorPalette const& colorPalette, Color color, ColorTarget target
 template <>
 struct fmt::formatter<vtbackend::ColorPreference>: fmt::formatter<std::string_view>
 {
-    auto format(vtbackend::ColorPreference value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ColorPreference value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -168,7 +168,7 @@ struct fmt::formatter<vtbackend::ColorPreference>: fmt::formatter<std::string_vi
 template <>
 struct fmt::formatter<vtbackend::ColorMode>: fmt::formatter<std::string_view>
 {
-    auto format(vtbackend::ColorMode value, fmt::format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ColorMode value, fmt::format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -184,7 +184,7 @@ struct fmt::formatter<vtbackend::ColorMode>: fmt::formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ColorTarget>: fmt::formatter<std::string_view>
 {
-    auto format(vtbackend::ColorTarget value, fmt::format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ColorTarget value, fmt::format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -929,7 +929,8 @@ struct std::hash<vtbackend::Function>
 template <>
 struct fmt::formatter<vtbackend::FunctionCategory>: fmt::formatter<std::string_view>
 {
-    auto format(const vtbackend::FunctionCategory value, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::FunctionCategory value,
+                format_context& ctx) const -> format_context::iterator
     {
         using vtbackend::FunctionCategory;
         string_view name;
@@ -963,7 +964,7 @@ struct fmt::formatter<vtbackend::FunctionCategory>: fmt::formatter<std::string_v
 template <>
 struct fmt::formatter<vtbackend::Function>: fmt::formatter<std::string>
 {
-    auto format(const vtbackend::Function f, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::Function f, format_context& ctx) const -> format_context::iterator
     {
         std::string value;
         switch (f.category)
@@ -1013,7 +1014,7 @@ struct fmt::formatter<vtbackend::Function>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::FunctionSelector>: fmt::formatter<std::string>
 {
-    auto format(const vtbackend::FunctionSelector f, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::FunctionSelector f, format_context& ctx) const -> format_context::iterator
     {
         std::string value;
         // clang-format off

--- a/src/vtbackend/Grid.h
+++ b/src/vtbackend/Grid.h
@@ -913,7 +913,8 @@ template <typename RendererT>
 template <>
 struct fmt::formatter<vtbackend::Margin::Horizontal>: fmt::formatter<std::string>
 {
-    auto format(const vtbackend::Margin::Horizontal range, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::Margin::Horizontal range,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}..{}", range.from, range.to), ctx);
     }
@@ -922,7 +923,8 @@ struct fmt::formatter<vtbackend::Margin::Horizontal>: fmt::formatter<std::string
 template <>
 struct fmt::formatter<vtbackend::Margin::Vertical>: fmt::formatter<std::string>
 {
-    auto format(const vtbackend::Margin::Vertical range, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::Margin::Vertical range,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}..{}", range.from, range.to), ctx);
     }

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -262,7 +262,7 @@ class ImagePool
 template <>
 struct fmt::formatter<vtbackend::ImageFormat>: formatter<std::string_view>
 {
-    auto format(vtbackend::ImageFormat value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ImageFormat value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -277,7 +277,7 @@ struct fmt::formatter<vtbackend::ImageFormat>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ImageStats>: formatter<std::string>
 {
-    auto format(vtbackend::ImageStats stats, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ImageStats stats, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format(
@@ -290,7 +290,7 @@ template <>
 struct fmt::formatter<std::shared_ptr<vtbackend::Image const>>: fmt::formatter<std::string>
 {
     auto format(std::shared_ptr<vtbackend::Image const> const& image,
-                format_context& ctx) -> format_context::iterator
+                format_context& ctx) const -> format_context::iterator
     {
         std::string text;
         if (!image)
@@ -310,7 +310,7 @@ struct fmt::formatter<std::shared_ptr<vtbackend::Image const>>: fmt::formatter<s
 template <>
 struct fmt::formatter<vtbackend::ImageResize>: formatter<std::string_view>
 {
-    auto format(vtbackend::ImageResize value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ImageResize value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -327,7 +327,7 @@ struct fmt::formatter<vtbackend::ImageResize>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ImageAlignment>: formatter<std::string_view>
 {
-    auto format(vtbackend::ImageAlignment value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ImageAlignment value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -349,7 +349,8 @@ struct fmt::formatter<vtbackend::ImageAlignment>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::RasterizedImage>: formatter<std::string>
 {
-    auto format(vtbackend::RasterizedImage const& image, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::RasterizedImage const& image,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("RasterizedImage<{}, {}, {}, {}, {}>",
                                                           image.weak_from_this().use_count(),
@@ -364,7 +365,8 @@ struct fmt::formatter<vtbackend::RasterizedImage>: formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::ImageFragment>: fmt::formatter<std::string>
 {
-    auto format(const vtbackend::ImageFragment& fragment, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::ImageFragment& fragment,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format("ImageFragment<offset={}, {}>", fragment.offset(), fragment.rasterizedImage()), ctx);

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -554,7 +554,7 @@ inline std::string to_string(InputGenerator::MouseEventType value)
 template <>
 struct fmt::formatter<vtbackend::KeyboardEventType>: formatter<std::string_view>
 {
-    auto format(vtbackend::KeyboardEventType value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::KeyboardEventType value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -570,7 +570,7 @@ struct fmt::formatter<vtbackend::KeyboardEventType>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::KeyboardEventFlag>: formatter<std::string_view>
 {
-    auto format(vtbackend::KeyboardEventFlag value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::KeyboardEventFlag value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -591,7 +591,7 @@ struct fmt::formatter<vtbackend::KeyboardEventFlag>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::MouseProtocol>: formatter<std::string_view>
 {
-    auto format(vtbackend::MouseProtocol value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::MouseProtocol value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -609,7 +609,7 @@ struct fmt::formatter<vtbackend::MouseProtocol>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::Modifier>: formatter<std::string_view>
 {
-    auto format(vtbackend::Modifier value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::Modifier value, format_context& ctx) const -> format_context::iterator
     {
         std::string_view name;
         switch (value)
@@ -632,7 +632,7 @@ template <>
 struct fmt::formatter<vtbackend::InputGenerator::MouseWheelMode>: formatter<std::string_view>
 {
     auto format(vtbackend::InputGenerator::MouseWheelMode value,
-                format_context& ctx) -> format_context::iterator
+                format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -652,7 +652,7 @@ struct fmt::formatter<vtbackend::InputGenerator::MouseWheelMode>: formatter<std:
 template <>
 struct fmt::formatter<vtbackend::KeyMode>: public formatter<std::string_view>
 {
-    auto format(vtbackend::KeyMode value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::KeyMode value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -667,7 +667,7 @@ struct fmt::formatter<vtbackend::KeyMode>: public formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::MouseButton>: formatter<std::string_view>
 {
-    auto format(vtbackend::MouseButton value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::MouseButton value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -688,7 +688,7 @@ struct fmt::formatter<vtbackend::MouseButton>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::MouseTransport>: formatter<std::string_view>
 {
-    auto format(vtbackend::MouseTransport value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::MouseTransport value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -706,7 +706,7 @@ struct fmt::formatter<vtbackend::MouseTransport>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::Key>: formatter<std::string_view>
 {
-    auto format(vtbackend::Key value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::Key value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)

--- a/src/vtbackend/MatchModes.h
+++ b/src/vtbackend/MatchModes.h
@@ -110,7 +110,7 @@ constexpr bool operator!=(MatchModes a, MatchModes b) noexcept
 template <>
 struct fmt::formatter<vtbackend::MatchModes>: formatter<std::string>
 {
-    auto format(vtbackend::MatchModes m, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::MatchModes m, format_context& ctx) const -> format_context::iterator
     {
         std::string s;
         auto const advance = [&](vtbackend::MatchModes::Flag cond, std::string_view text) {

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -679,7 +679,7 @@ template <>
 struct fmt::formatter<vtbackend::RequestStatusString>: formatter<std::string_view>
 {
     auto format(vtbackend::RequestStatusString value,
-                format_context& ctx) noexcept -> format_context::iterator
+                format_context& ctx) const noexcept -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -709,7 +709,7 @@ struct fmt::formatter<vtbackend::Sequence>
         return ctx.begin();
     }
     template <typename FormatContext>
-    auto format(vtbackend::Sequence const& seq, FormatContext& ctx)
+    auto format(vtbackend::Sequence const& seq, FormatContext& ctx) const
     {
         return fmt::format_to(ctx.out(), "{}", seq.text());
     }

--- a/src/vtbackend/Selector.h
+++ b/src/vtbackend/Selector.h
@@ -186,7 +186,7 @@ template <>
 struct fmt::formatter<vtbackend::Selection::State>: formatter<std::string_view>
 {
     using State = vtbackend::Selection::State;
-    auto format(State state, format_context& ctx) -> format_context::iterator
+    auto format(State state, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (state)
@@ -202,7 +202,7 @@ struct fmt::formatter<vtbackend::Selection::State>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::Selection>: formatter<std::string>
 {
-    auto format(const vtbackend::Selection& selector, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::Selection& selector, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format(

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1200,7 +1200,7 @@ template <>
 struct fmt::formatter<vtbackend::TraceHandler::PendingSequence>: fmt::formatter<std::string>
 {
     auto format(vtbackend::TraceHandler::PendingSequence const& pendingSequence,
-                format_context& ctx) -> format_context::iterator
+                format_context& ctx) const -> format_context::iterator
     {
         std::string value;
         if (auto const* p = std::get_if<vtbackend::Sequence>(&pendingSequence))
@@ -1219,7 +1219,7 @@ struct fmt::formatter<vtbackend::TraceHandler::PendingSequence>: fmt::formatter<
 template <>
 struct fmt::formatter<vtbackend::AnsiMode>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::AnsiMode mode, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::AnsiMode mode, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(to_string(mode), ctx);
     }
@@ -1228,7 +1228,7 @@ struct fmt::formatter<vtbackend::AnsiMode>: fmt::formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::DECMode>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::DECMode mode, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::DECMode mode, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(to_string(mode), ctx);
     }
@@ -1238,7 +1238,7 @@ template <>
 struct fmt::formatter<vtbackend::DynamicColorName>: formatter<std::string_view>
 {
     template <typename FormatContext>
-    auto format(vtbackend::DynamicColorName value, FormatContext& ctx)
+    auto format(vtbackend::DynamicColorName value, FormatContext& ctx) const
     {
         using vtbackend::DynamicColorName;
         string_view name;
@@ -1259,7 +1259,7 @@ struct fmt::formatter<vtbackend::DynamicColorName>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ExecutionMode>: formatter<std::string_view>
 {
-    auto format(vtbackend::ExecutionMode value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ExecutionMode value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)

--- a/src/vtbackend/VTType.h
+++ b/src/vtbackend/VTType.h
@@ -82,7 +82,7 @@ std::string to_params(DeviceAttributes v);
 template <>
 struct fmt::formatter<vtbackend::VTType>: fmt::formatter<std::string_view>
 {
-    auto format(const vtbackend::VTType id, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::VTType id, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (id)
@@ -104,7 +104,7 @@ struct fmt::formatter<vtbackend::VTType>: fmt::formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::VTExtension>: fmt::formatter<std::string_view>
 {
-    auto format(const vtbackend::VTExtension id, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::VTExtension id, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (id)

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -268,7 +268,7 @@ class ViInputHandler: public InputHandler
 template <>
 struct fmt::formatter<vtbackend::TextObjectScope>: formatter<std::string_view>
 {
-    auto format(vtbackend::TextObjectScope scope, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::TextObjectScope scope, format_context& ctx) const -> format_context::iterator
     {
         using TextObjectScope = vtbackend::TextObjectScope;
         string_view name;
@@ -284,7 +284,7 @@ struct fmt::formatter<vtbackend::TextObjectScope>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::TextObject>: formatter<std::string_view>
 {
-    auto format(vtbackend::TextObject textObject, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::TextObject textObject, format_context& ctx) const -> format_context::iterator
     {
         using TextObject = vtbackend::TextObject;
         string_view name;
@@ -309,7 +309,7 @@ struct fmt::formatter<vtbackend::TextObject>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ViOperator>: formatter<std::string_view>
 {
-    auto format(vtbackend::ViOperator op, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ViOperator op, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         using vtbackend::ViOperator;
@@ -329,7 +329,7 @@ struct fmt::formatter<vtbackend::ViOperator>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::ViMotion>: formatter<std::string_view>
 {
-    auto format(vtbackend::ViMotion motion, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ViMotion motion, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         using vtbackend::ViMotion;

--- a/src/vtbackend/cell/CompactCell.h
+++ b/src/vtbackend/cell/CompactCell.h
@@ -484,7 +484,7 @@ inline bool beginsWith(std::u32string_view text, CompactCell const& cell) noexce
 template <>
 struct fmt::formatter<vtbackend::CompactCell>: fmt::formatter<std::string>
 {
-    auto format(vtbackend::CompactCell const& cell, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::CompactCell const& cell, format_context& ctx) const -> format_context::iterator
     {
         std::string codepoints;
         for (auto const i: crispy::times(cell.codepointCount()))

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -888,7 +888,7 @@ struct numeric_limits<vtbackend::CursorShape>
 template <>
 struct fmt::formatter<vtbackend::CursorShape>: formatter<std::string_view>
 {
-    auto format(vtbackend::CursorShape value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::CursorShape value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -905,7 +905,7 @@ struct fmt::formatter<vtbackend::CursorShape>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::CellLocation>: formatter<std::string>
 {
-    auto format(vtbackend::CellLocation coord, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::CellLocation coord, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}, {})", coord.line, coord.column), ctx);
     }
@@ -914,7 +914,7 @@ struct fmt::formatter<vtbackend::CellLocation>: formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::PageSize>: formatter<std::string>
 {
-    auto format(vtbackend::PageSize value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::PageSize value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}x{}", value.columns, value.lines), ctx);
     }
@@ -923,7 +923,7 @@ struct fmt::formatter<vtbackend::PageSize>: formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::GridSize>: formatter<std::string>
 {
-    auto format(vtbackend::GridSize value, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::GridSize value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}x{}", value.columns, value.lines), ctx);
     }
@@ -932,7 +932,7 @@ struct fmt::formatter<vtbackend::GridSize>: formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::ScreenType>: formatter<std::string_view>
 {
-    auto format(const vtbackend::ScreenType value, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::ScreenType value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -947,7 +947,7 @@ struct fmt::formatter<vtbackend::ScreenType>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtbackend::PixelCoordinate>: formatter<std::string>
 {
-    auto format(const vtbackend::PixelCoordinate coord, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::PixelCoordinate coord, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}:{}", coord.x.value, coord.y.value), ctx);
     }
@@ -956,7 +956,7 @@ struct fmt::formatter<vtbackend::PixelCoordinate>: formatter<std::string>
 template <>
 struct fmt::formatter<vtbackend::ViMode>: formatter<std::string_view>
 {
-    auto format(vtbackend::ViMode mode, format_context& ctx) -> format_context::iterator
+    auto format(vtbackend::ViMode mode, format_context& ctx) const -> format_context::iterator
     {
         using vtbackend::ViMode;
         string_view name;

--- a/src/vtparser/Parser.h
+++ b/src/vtparser/Parser.h
@@ -468,7 +468,7 @@ struct numeric_limits<vtparser::Action>
 template <>
 struct fmt::formatter<vtparser::State>: formatter<std::string_view>
 {
-    auto format(vtparser::State state, format_context& ctx) -> format_context::iterator
+    auto format(vtparser::State state, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string_view>::format(vtparser::to_string(state), ctx);
     }
@@ -477,7 +477,7 @@ struct fmt::formatter<vtparser::State>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtparser::ActionClass>: formatter<std::string_view>
 {
-    auto format(vtparser::ActionClass value, format_context& ctx) -> format_context::iterator
+    auto format(vtparser::ActionClass value, format_context& ctx) const -> format_context::iterator
     {
         auto constexpr Mappings = std::array<std::string_view, 4> { "Enter", "Event", "Leave", "Transition" };
         return formatter<std::string_view>::format(Mappings.at(static_cast<unsigned>(value)), ctx);
@@ -487,7 +487,7 @@ struct fmt::formatter<vtparser::ActionClass>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtparser::Action>: formatter<std::string_view>
 {
-    auto format(vtparser::Action value, format_context& ctx) -> format_context::iterator
+    auto format(vtparser::Action value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string_view>::format(vtparser::to_string(value), ctx);
     }

--- a/src/vtpty/ImageSize.h
+++ b/src/vtpty/ImageSize.h
@@ -91,7 +91,7 @@ constexpr ImageSize max(ImageSize a, ImageSize b) noexcept
 template <>
 struct fmt::formatter<vtpty::ImageSize>: fmt::formatter<std::string>
 {
-    auto format(vtpty::ImageSize value, format_context& ctx) -> format_context::iterator
+    auto format(vtpty::ImageSize value, format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("{}x{}", value.width, value.height), ctx);
     }

--- a/src/vtpty/Process.h
+++ b/src/vtpty/Process.h
@@ -112,7 +112,8 @@ class [[nodiscard]] Process: public Pty
 template <>
 struct fmt::formatter<vtpty::Process::ExitStatus>: fmt::formatter<std::string>
 {
-    auto format(vtpty::Process::ExitStatus const& status, format_context& ctx) -> format_context::iterator
+    auto format(vtpty::Process::ExitStatus const& status,
+                format_context& ctx) const -> format_context::iterator
     {
         auto const text =
             std::visit(overloaded { [&](vtpty::Process::NormalExit exit) {

--- a/src/vtpty/SshSession.h
+++ b/src/vtpty/SshSession.h
@@ -169,7 +169,7 @@ class SshSession final: public Pty
 template <>
 struct fmt::formatter<vtpty::SshSession::State>: fmt::formatter<std::string_view>
 {
-    auto format(vtpty::SshSession::State const& state, format_context& ctx) -> format_context::iterator
+    auto format(vtpty::SshSession::State const& state, format_context& ctx) const -> format_context::iterator
     {
         std::string_view name;
         // clang-format off
@@ -206,7 +206,8 @@ struct fmt::formatter<vtpty::SshSession::State>: fmt::formatter<std::string_view
 template <>
 struct fmt::formatter<vtpty::SshSession::ExitStatus>: fmt::formatter<std::string>
 {
-    auto format(vtpty::SshSession::ExitStatus const& status, format_context& ctx) -> format_context::iterator
+    auto format(vtpty::SshSession::ExitStatus const& status,
+                format_context& ctx) const -> format_context::iterator
     {
         return std::visit(overloaded { [&](vtpty::SshSession::NormalExit exit) {
                                           return fmt::formatter<std::string>::format(

--- a/src/vtrasterizer/Decorator.h
+++ b/src/vtrasterizer/Decorator.h
@@ -82,7 +82,7 @@ struct std::numeric_limits<vtrasterizer::Decorator>
 template <>
 struct fmt::formatter<vtrasterizer::Decorator>: formatter<std::string_view>
 {
-    auto format(vtrasterizer::Decorator value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::Decorator value, format_context& ctx) const -> format_context::iterator
     {
         auto constexpr Mappings = std::array {
             "underline", "double-underline", "curly-underline", "dotted-underline", "dashed-underline",

--- a/src/vtrasterizer/FontDescriptions.h
+++ b/src/vtrasterizer/FontDescriptions.h
@@ -81,7 +81,7 @@ constexpr bool operator<(TextStyle a, TextStyle b) noexcept
 template <>
 struct fmt::formatter<vtrasterizer::TextStyle>: fmt::formatter<std::string_view>
 {
-    auto format(vtrasterizer::TextStyle value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::TextStyle value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -99,7 +99,7 @@ struct fmt::formatter<vtrasterizer::TextStyle>: fmt::formatter<std::string_view>
 template <>
 struct fmt::formatter<vtrasterizer::FontLocatorEngine>: fmt::formatter<std::string_view>
 {
-    auto format(vtrasterizer::FontLocatorEngine value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::FontLocatorEngine value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -114,7 +114,7 @@ struct fmt::formatter<vtrasterizer::FontLocatorEngine>: fmt::formatter<std::stri
 template <>
 struct fmt::formatter<vtrasterizer::TextShapingEngine>: fmt::formatter<std::string_view>
 {
-    auto format(vtrasterizer::TextShapingEngine value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::TextShapingEngine value, format_context& ctx) const -> format_context::iterator
     {
         string_view name;
         switch (value)
@@ -130,7 +130,8 @@ struct fmt::formatter<vtrasterizer::TextShapingEngine>: fmt::formatter<std::stri
 template <>
 struct fmt::formatter<vtrasterizer::FontDescriptions>: fmt::formatter<std::string>
 {
-    auto format(vtrasterizer::FontDescriptions const& fd, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::FontDescriptions const& fd,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("({}, {}, {}, {}, {}, {}, {}, {})",
                                                           fd.size,

--- a/src/vtrasterizer/GridMetrics.h
+++ b/src/vtrasterizer/GridMetrics.h
@@ -97,7 +97,8 @@ struct GridMetrics
 template <>
 struct fmt::formatter<vtrasterizer::GridMetrics>: formatter<std::string>
 {
-    auto format(vtrasterizer::GridMetrics const& v, fmt::format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::GridMetrics const& v,
+                fmt::format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format(

--- a/src/vtrasterizer/Pixmap.h
+++ b/src/vtrasterizer/Pixmap.h
@@ -302,7 +302,7 @@ Pixmap& Pixmap::segment_bar(int which, More... more)
 template <>
 struct fmt::formatter<vtrasterizer::Arc>: fmt::formatter<string_view>
 {
-    auto format(vtrasterizer::Arc value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::Arc value, format_context& ctx) const -> format_context::iterator
     {
         using vtrasterizer::Arc;
         string_view name;

--- a/src/vtrasterizer/RenderTarget.h
+++ b/src/vtrasterizer/RenderTarget.h
@@ -221,7 +221,8 @@ inline Renderable::TextureAtlas::TileCreateData Renderable::createTileData(atlas
 template <>
 struct fmt::formatter<vtrasterizer::RenderTileAttributes>: fmt::formatter<std::string>
 {
-    auto format(vtrasterizer::RenderTileAttributes value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::RenderTileAttributes value,
+                format_context& ctx) const -> format_context::iterator
     {
         return fmt::formatter<std::string>::format(
             fmt::format("tile +{}x +{}y", value.x.value, value.y.value), ctx);
@@ -233,7 +234,7 @@ struct fmt::formatter<vtrasterizer::atlas::TileAttributes<vtrasterizer::RenderTi
     fmt::formatter<std::string>
 {
     auto format(vtrasterizer::atlas::TileAttributes<vtrasterizer::RenderTileAttributes> const& value,
-                format_context& ctx) -> format_context::iterator
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format("(location {}; bitmap {}; {})", value.location, value.bitmapSize, value.metadata),

--- a/src/vtrasterizer/TextClusterGrouper_test.cpp
+++ b/src/vtrasterizer/TextClusterGrouper_test.cpp
@@ -103,7 +103,7 @@ template <>
 struct fmt::formatter<TextClusterGroup>: formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(TextClusterGroup const& group, FormatContext& ctx)
+    auto format(TextClusterGroup const& group, FormatContext& ctx) const
     {
         return formatter<std::string>::format(
             fmt::format("TextClusterGroup {{ codepoints: \"{}\", @{}, clusters={}, style: {}, color: {} }}",
@@ -120,7 +120,7 @@ template <>
 struct fmt::formatter<BoxDrawingCell>: formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(BoxDrawingCell const& cell, FormatContext& ctx)
+    auto format(BoxDrawingCell const& cell, FormatContext& ctx) const
     {
         return formatter<std::string>::format(
             fmt::format("BoxDrawingCell {{ position: {}, codepoint: U+{:04X}, color: {} }}",
@@ -135,7 +135,7 @@ template <>
 struct fmt::formatter<Event>: formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(Event const& event, FormatContext& ctx)
+    auto format(Event const& event, FormatContext& ctx) const
     {
         if (std::holds_alternative<TextClusterGroup>(event))
             return formatter<std::string>::format(fmt::format("{}", std::get<TextClusterGroup>(event)), ctx);

--- a/src/vtrasterizer/TextureAtlas.h
+++ b/src/vtrasterizer/TextureAtlas.h
@@ -684,7 +684,7 @@ void TextureAtlas<Metadata>::inspect(std::ostream& output) const
 template <>
 struct fmt::formatter<vtrasterizer::atlas::Format>: formatter<std::string_view>
 {
-    auto format(vtrasterizer::atlas::Format value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::atlas::Format value, format_context& ctx) const -> format_context::iterator
     {
         std::string_view name;
         switch (value)
@@ -700,7 +700,8 @@ struct fmt::formatter<vtrasterizer::atlas::Format>: formatter<std::string_view>
 template <>
 struct fmt::formatter<vtrasterizer::atlas::TileLocation>: fmt::formatter<std::string>
 {
-    auto format(vtrasterizer::atlas::TileLocation value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::atlas::TileLocation value,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("Tile {}x+{}y", value.x.value, value.y.value), ctx);
     }
@@ -709,7 +710,8 @@ struct fmt::formatter<vtrasterizer::atlas::TileLocation>: fmt::formatter<std::st
 template <>
 struct fmt::formatter<vtrasterizer::atlas::RenderTile>: fmt::formatter<std::string>
 {
-    auto format(vtrasterizer::atlas::RenderTile const& value, format_context& ctx) -> format_context::iterator
+    auto format(vtrasterizer::atlas::RenderTile const& value,
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(
             fmt::format("RenderTile({}x + {}y, {})", value.x.value, value.y.value, value.tileLocation), ctx);
@@ -720,7 +722,7 @@ template <>
 struct fmt::formatter<vtrasterizer::atlas::AtlasProperties>: fmt::formatter<std::string>
 {
     auto format(vtrasterizer::atlas::AtlasProperties const& value,
-                format_context& ctx) -> format_context::iterator
+                format_context& ctx) const -> format_context::iterator
     {
         return formatter<std::string>::format(fmt::format("tile size {}, format {}, direct-mapped {}",
                                                           value.tileSize,


### PR DESCRIPTION
otherwise the tree does not build with fmt 11, like:

```
/usr/include/fmt/base.h: In instantiation of ‘static void fmt::v11::detail::value<Context>::format_custom_arg(void*, typename Context::parse_context_type&, Context&) [with T = crispy::native_handle<int, -1>; Formatter = fmt::v11::formatter<crispy::native_handle<int, -1> >; Context = fmt::v11::context; typename Context::parse_context_type = fmt::v11::basic_format_parse_context<char>]’:
/usr/include/fmt/base.h:1373:19:   required from ‘constexpr fmt::v11::detail::value<Context>::value(T&) [with T = const crispy::native_handle<int, -1>; Context = fmt::v11::context]’
 1373 |     custom.format = format_custom_arg<
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 1374 |         value_type, typename Context::template formatter_type<value_type>>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1631:41:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {const crispy::native_handle<int, -1>}; long unsigned int NUM_ARGS = 1; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 15; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
 1631 |   return {arg_mapper<Context>().map(val)};
      |                                         ^
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-0.4.3.6442/src/crispy/logstore.h:111:59:   required from ‘logstore::message_builder& logstore::message_builder::operator()(std::string_view, const Ts& ...) [with Ts = {crispy::native_handle<int, -1>}; std::string_view = std::basic_string_view<char>]’
  111 |         _buffer += fmt::vformat(fmt, fmt::make_format_args(args...));
      |                                      ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-0.4.3.6442/src/vtpty/UnixPty.cpp:215:13:   required from here
  215 |     ptyLog()("PTY destroying master (file descriptor {}).", _masterFd);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1392:29: error: passing ‘const fmt::v11::formatter<crispy::native_handle<int, -1> >’ as ‘this’ argument discards qualifiers [-fpermissive]
 1392 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-0.4.3.6442/src/vtpty/UnixPty.h:8:
```

## Description

Describe your changes in detail

```markdown
Your issue description (body) goes here
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown

```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
