### PR TITLE
Fix copy of multi-line selection

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -133,6 +133,7 @@
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Do not export the `TERM` environment variable on Windows OS (when using ConPTY).</li>
           <li>Fixes resize of trivial line (#916)</li>
+          <li>Fixes copying of wrapped line</li>
           <li>Fixes forwarding of input while in normal mode (#1468)</li>
           <li>Fixes OSC-8 link id collision (#1499)</li>
           <li>Fixed overlap of glyphs for long codepoints (#1349)</li>

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1317,8 +1317,7 @@ namespace
         void operator()(CellLocation pos, Cell const& cell)
         {
             auto const isNewLine = pos.column < lastColumn || (pos.column == lastColumn && !text.empty());
-            bool const touchesRightPage = term->isSelected({ pos.line, rightPage });
-            if (isNewLine && (!term->isLineWrapped(pos.line) || !touchesRightPage))
+            if (isNewLine && (!term->isLineWrapped(pos.line)))
             {
                 // TODO: handle logical line in word-selection (don't include LF in wrapped lines)
                 trimSpaceRight(currentLine);


### PR DESCRIPTION
PR fixes a bug when copying a selection of a wrapped line. 
Previously new-line was inserted without the need when copying the selection span across few grid-line, when they represent  one logical lines that is wrapped due to terminal size 