### PR TITLE
fix error, "" is an invalid MIME type ("" does not contain a subtype)

### DIFF
--- a/src/contour/contour.desktop
+++ b/src/contour/contour.desktop
@@ -8,7 +8,7 @@ Categories=Qt;System;TerminalEmulator;
 Actions=NewWindow;
 X-KDE-AuthorizeAction=shell_access
 StartupWMClass=contour
-MimeType=application/x-executable;;
+MimeType=application/x-executable;
 
 Name=Contour
 


### PR DESCRIPTION
## Description

fix `Error in file "/usr/local/share/applications/org.contourterminal.Contour.desktop": "" is an invalid MIME type ("" does not contain a subtype)` at install

