### PR TITLE
Fix path to key-mapping docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - configuration/profiles.md
     - configuration/colors.md
     - configuration/indicator-statusline.md
+    - configuration/key-mapping.md
     #- Images (Advanced) : configuration/advanced/images.md
     #- Mouse (Advanced) : configuration/advanced/images.md
     #- Misc (Advanced) : configuration/advanced/mouse.md


### PR DESCRIPTION
Add path to generated key-mapping.md file inside mkdocs 