### PR TITLE
Fix line corruption on windows

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -132,6 +132,7 @@
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Do not export the `TERM` environment variable on Windows OS (when using ConPTY).</li>
+          <li>Fixes line corruption after resize (#883)</li>
           <li>Fixes resize of trivial line (#916)</li>
           <li>Fixes copying of wrapped line</li>
           <li>Fixes deletion of spaces on resize </li>

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -668,8 +668,15 @@ inline void Screen<Cell>::scrollUp(LineCount n, Margin margin)
 template <CellConcept Cell>
 inline bool Screen<Cell>::isContiguousToCurrentLine(std::string_view continuationChars) const noexcept
 {
+#if defined(_MSC_VER)
+    return false;
+#else
+    // MSVC does not like comparison of this iterator, most likely bug on msvc side since they are of the same
+    // type can be checked with std::equality_comparable_with<std::string_view::iterator,
+    // decltype(line.trivialBuffer().text.view())::iterator>
     auto const& line = currentLine();
     return line.isTrivialBuffer() && line.trivialBuffer().text.view().end() == continuationChars.begin();
+#endif
 }
 
 } // namespace vtbackend


### PR DESCRIPTION
MSVC was giving me runtime errors when i was opening julia, with the message that iterators can not be comparable
I beleive that this PR  closes https://github.com/contour-terminal/contour/issues/883