### PR TITLE
Send backtab as a key

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -152,6 +152,7 @@
           <li>Fixes missing keymapping for numpad (#1325)</li>
           <li>Improves handling of constant bell sound spawning</li>
           <li>Fixes yW (yank WORD) not working properly in normal mode (#1448)</li>
+          <li>Fixes key mapping Shift+Tab (#1578)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1438,9 +1438,9 @@ std::optional<std::variant<vtbackend::Key, char32_t>> YAMLConfigReader::parseKey
                      std::pair { "SLASH"sv, '/' },         std::pair { "SUBTRACT"sv, '-' },
                      std::pair { "SPACE"sv, ' ' } };
 
-    auto const lowerName = crispy::toUpper(name);
+    auto const upperName = crispy::toUpper(name);
     for (auto const& mapping: NamedChars)
-        if (lowerName == mapping.first)
+        if (upperName == mapping.first)
             return static_cast<char32_t>(mapping.second);
 
     return std::nullopt;

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -383,7 +383,7 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
 
     if (key == Qt::Key_Backtab)
     {
-        session.sendCharEvent(U'\t', physicalKey, modifiers.with(Modifier::Shift), eventType, now);
+        session.sendKeyEvent(Key::Tab, modifiers.with(Modifier::Shift), eventType, now);
         event->accept();
         return true;
     }


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1578
Shift+Tab is Qt::Key_Backtab (https://doc.qt.io/qt-5/qt.html#Key-enum) we should send it as a key, not as a character 