### PR TITLE
Fix build for fmt 11

### DIFF
--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -465,7 +465,7 @@ inline typename Line<Cell>::InflatedBuffer const& Line<Cell>::inflatedBuffer() c
 template <>
 struct fmt::formatter<vtbackend::LineFlags>: formatter<std::string>
 {
-    auto format(const vtbackend::LineFlags flags, format_context& ctx) -> format_context::iterator
+    auto format(const vtbackend::LineFlags flags, format_context& ctx) const -> format_context::iterator
     {
         static const std::array<std::pair<vtbackend::LineFlags, std::string_view>, 3> nameMap = {
             std::pair { vtbackend::LineFlag::Wrappable, std::string_view("Wrappable") },


### PR DESCRIPTION
## Description

Without this, it built failed.

```
[31/124] /usr/bin/g++ -DCONTOUR_STACKTRACE_ADDR2LINE=1 -DFMT_HEADER_ONLY=1 -DHAVE_BACKTRACE -DHAVE_BACKTRACE_SYMBOLS -DHAVE_CXXABI_H -DHAVE_DLADDR -DHAVE_DLFCN_H -DHAVE_DLSYM -DHAVE_EXECINFO_H -DHAVE_SYS_SELECT_H -DHAVE_UNWIND_H -DLIBTERMINAL_LOG_TRACE=1 -DLIBTERMINAL_NAME=\"contour\" -DLIBTERMINAL_VERSION_MAJOR=0 -DLIBTERMINAL_VERSION_MINOR=4 -DLIBTERMINAL_VERSION_PATCH=4 -DLIBTERMINAL_VERSION_STRING=\"0.4.4\" -DVTPTY_LIBSSH2=1 -I/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=c++20 -fdiagnostics-color=always -fdiagnostics-color=always -maes -MD -MT src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o -MF src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o.d -o src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o -c /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp
FAILED: src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o 
/usr/bin/g++ -DCONTOUR_STACKTRACE_ADDR2LINE=1 -DFMT_HEADER_ONLY=1 -DHAVE_BACKTRACE -DHAVE_BACKTRACE_SYMBOLS -DHAVE_CXXABI_H -DHAVE_DLADDR -DHAVE_DLFCN_H -DHAVE_DLSYM -DHAVE_EXECINFO_H -DHAVE_SYS_SELECT_H -DHAVE_UNWIND_H -DLIBTERMINAL_LOG_TRACE=1 -DLIBTERMINAL_NAME=\"contour\" -DLIBTERMINAL_VERSION_MAJOR=0 -DLIBTERMINAL_VERSION_MINOR=4 -DLIBTERMINAL_VERSION_PATCH=4 -DLIBTERMINAL_VERSION_STRING=\"0.4.4\" -DVTPTY_LIBSSH2=1 -I/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=c++20 -fdiagnostics-color=always -fdiagnostics-color=always -maes -MD -MT src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o -MF src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o.d -o src/vtbackend/CMakeFiles/vtbackend.dir/Grid.cpp.o -c /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp
In file included from /usr/include/fmt/format.h:41,
                 from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/crispy/flags.h:4,
                 from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/CellFlags.h:4,
                 from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/GraphicsAttributes.h:4,
                 from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.h:4,
                 from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp:2:
/usr/include/fmt/base.h: In instantiation of â€˜static void fmt::v11::detail::value<Context>::format_custom_arg(void*, typename Context::parse_context_type&, Context&) [with T = crispy::flags<vtbackend::LineFlag>; Formatter = fmt::v11::formatter<crispy::flags<vtbackend::LineFlag> >; Context = fmt::v11::context; typename Context::parse_context_type = fmt::v11::basic_format_parse_context<char>]â€™:
/usr/include/fmt/base.h:1383:19:   required from â€˜constexpr fmt::v11::detail::value<Context>::value(T&) [with T = crispy::flags<vtbackend::LineFlag>; Context = fmt::v11::context]â€™
 1383 |     custom.format = format_custom_arg<
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 1384 |         value_type, typename Context::template formatter_type<value_type>>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1647:41:   required from â€˜constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {const int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, crispy::flags<vtbackend::LineFlag>}; long unsigned int NUM_ARGS = 3; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 4049; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]â€™
 1647 |   return {arg_mapper<Context>().map(val)};
      |                                         ^
/usr/include/fmt/format.h:4365:44:   required from â€˜std::string fmt::v11::format(format_string<T ...>, T&& ...) [with T = {const int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, crispy::flags<vtbackend::LineFlag>}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, const int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, crispy::flags<vtbackend::LineFlag> >]â€™
 4365 |   return vformat(fmt, fmt::make_format_args(args...));
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp:1009:26:   required from â€˜std::ostream& vtbackend::dumpGrid(std::ostream&, const Grid<Cell>&) [with Cell = CompactCell; std::ostream = std::basic_ostream<char>]â€™
 1009 |         os << fmt::format("[{:>2}] \"{}\" | {}\n",
      |               ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
 1010 |                           lineOffset,
      |                           ~~~~~~~~~~~
 1011 |                           grid.lineText(LineOffset::cast_from(lineOffset)),
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1012 |                           lineAttribs.flags());
      |                           ~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp:1022:13:   required from â€˜std::string vtbackend::dumpGrid(const Grid<Cell>&) [with Cell = CompactCell; std::string = std::__cxx11::basic_string<char>]â€™
 1022 |     dumpGrid(sstr, grid);
      |     ~~~~~~~~^~~~~~~~~~~~
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.cpp:1159:51:   required from here
 1159 |     vtbackend::Grid<vtbackend::CompactCell> const&);
      |                                                   ^
/usr/include/fmt/base.h:1402:29: error: passing â€˜const fmt::v11::formatter<crispy::flags<vtbackend::LineFlag> >â€™ as â€˜thisâ€™ argument discards qualifiers [-fpermissive]
 1402 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Grid.h:5:
/builddir/build/BUILD/contour-terminal-0.4.3.6442-build/contour-c895cde8b29f1c6a4dc9db3ca1c670e34d0337f1/src/vtbackend/Line.h:468:10: note:   in call to â€˜fmt::v11::context::iterator fmt::v11::formatter<crispy::flags<vtbackend::LineFlag> >::format(vtbackend::LineFlags, fmt::v11::format_context&)â€™
  468 |     auto format(const vtbackend::LineFlags flags, format_context& ctx) -> format_context::iterator
      |          ^~~~~~
```

The change was tested and built successfully on Fedora 41 [1, 2].

[1] https://src.fedoraproject.org/rpms/contour-terminal/c/ac43e10c98f46e5571456a4971f0e4a01261b82c?branch=rawhide
[2] https://koji.fedoraproject.org/koji/taskinfo?taskID=121381786

## Motivation and Context



## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
