### PR TITLE
Get list of entries that are missing in config file

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -130,6 +130,7 @@
           <li>Add option PasteSelection to paste text as a shell input (#1549)</li>
           <li>Add case-insensitive smart search (#1410)</li>
           <li>Add OpenBSD support</li>
+          <li>Add new CLI command: `contour info config` to list missing entries from config file (#1125).</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Do not export the `TERM` environment variable on Windows OS (when using ConPTY).</li>

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -1134,6 +1134,7 @@ std::optional<std::string> readConfigFile(std::string const& filename);
 void loadConfigFromFile(Config& config, std::filesystem::path const& fileName);
 Config loadConfigFromFile(std::filesystem::path const& fileName);
 Config loadConfig();
+void compareEntries(Config& config, auto const& output);
 
 std::string defaultConfigString();
 std::error_code createDefaultConfig(std::filesystem::path const& path);

--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -385,6 +385,7 @@ crispy::cli::command ContourApp::parameterDefinition() const
                 CLI::option_list {},
                 CLI::command_list {
                     CLI::command { "vt", "Prints general information about supported VT sequences." },
+                    CLI::command { "config", "Prints missing entries from user config file." },
                 } },
             CLI::command { "documentation",
                            "Generate documentation for web page",

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -55,6 +55,7 @@ ContourGuiApp::ContourGuiApp(): _sessionManager(*this)
 {
     link("contour.terminal", bind(&ContourGuiApp::terminalGuiAction, this));
     link("contour.font-locator", bind(&ContourGuiApp::fontConfigAction, this));
+    link("contour.info.config", bind(&ContourGuiApp::checkConfig, this));
 }
 
 int ContourGuiApp::run(int argc, char const* argv[])
@@ -209,6 +210,20 @@ QUrl ContourGuiApp::resolveResource(std::string_view path)
 #endif
 
     return QUrl("qrc:/contour/" + QString::fromLatin1(path.data(), static_cast<int>(path.size())));
+}
+
+int ContourGuiApp::checkConfig()
+{
+    auto const& flags = parameters();
+    auto const configPath = QString::fromStdString(flags.get<string>("contour.terminal.config"));
+
+    _config = configPath.isEmpty() ? contour::config::loadConfig()
+                                   : contour::config::loadConfigFromFile(configPath.toStdString());
+
+    contour::config::compareEntries(
+        _config, logstore::category("", "Console Logger", logstore::category::state::Enabled));
+
+    return EXIT_SUCCESS;
 }
 
 bool ContourGuiApp::loadConfig(string const& target)

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -80,6 +80,7 @@ class ContourGuiApp: public QObject, public ContourApp
     bool loadConfig(std::string const& target);
     int terminalGuiAction();
     int fontConfigAction();
+    int checkConfig();
 
     config::Config _config;
     TerminalSessionManager _sessionManager;

--- a/src/crispy/times.h
+++ b/src/crispy/times.h
@@ -130,7 +130,7 @@ namespace detail
             return *this;
         }
 
-        constexpr times_2d_iterator<I, T1, T2>& operator++(int) noexcept { return *++this; }
+        constexpr times_2d_iterator<I, T1, T2>& operator++(int) noexcept { return ++*this; }
 
         constexpr bool operator==(times_2d_iterator<I, T1, T2> const& other) const noexcept
         {


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1125
Now user can query list of entries that are missing from the config file via
`contour info config`, i am not sure what will be the better place for this action, so i am open for suggestions @christianparpart 