### PR TITLE
Add predefined color palettes

### DIFF
--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -414,7 +414,9 @@ profiles:
 
 
 ### `colors`
-section in the configuration file allows you to specify the colorscheme to use for the terminal.
+section in the configuration file allows you to specify the colorscheme to use for the terminal. You can use one of the predefined color palettes as a setting for colors entry. 
+List of predefined colorschemes: `contour`(default colors), `monokai`, `one-light`, `one-dark`, `gruvbox-light`, `gruvbox-dark`, `solarized-light`, `solarized-dark`, `papercolor-light`, `papercolor-dark`.
+
 ``` yaml
 profiles:
   profile_name:

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -133,6 +133,7 @@
           <li>Add OpenBSD support</li>
           <li>Add new CLI command: `contour info config` to list missing entries from config file (#1125).</li>
           <li>Add xdg-terminal-exec support (#1570).</li>
+          <li>Add predefined color palettes (monokai, gruvbox-light/dark, solarized-light/dark, papercolor-light/dark, one-light, one-dark) (#1285).</li>
           <li>Update of contour.desktop file (#1423)</li>
           <li>Changed configuration entry values for `font_locator` down to `native` and `mock` only (#1538).</li>
           <li>Do not export the `TERM` environment variable on Windows OS (when using ConPTY).</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -2,6 +2,8 @@
 #include <contour/Actions.h>
 #include <contour/Config.h>
 
+#include <vtbackend/ColorPalette.h>
+
 #include <text_shaper/font.h>
 
 #include <crispy/StrongHash.h>
@@ -487,6 +489,12 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
 {
     logger()("color palette loading {}", entry);
     auto child = node[entry];
+
+    if (vtbackend::defaultColorPalettes(entry, where))
+    {
+        logger()("Loaded predefined color palette {}", entry);
+        return;
+    }
 
     if (!child) // can not load directly from config file
     {

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -334,6 +334,9 @@ constexpr StringLiteral DrawBoldTextWithBrightColors {
 
 constexpr StringLiteral Colors {
     "{comment} Specifies a colorscheme to use (alternatively the colors can be inlined).\n"
+    "{comment} Or choose from existing default palettes:\n"
+    "{comment} contour, monokai, one-dark, one-light, gruvbox-light, gruvbox-dark,\n"
+    "{comment} solarized-light, solarized-dark, papercolor-light, papercolor-dark.\n"
     "{comment}\n"
     "{comment} This can be either the name to a single colorscheme to always use,\n"
     "{comment} or a map with two keys (dark and light) to determine the color scheme to use for each.\n"

--- a/src/vtbackend/ColorPalette.cpp
+++ b/src/vtbackend/ColorPalette.cpp
@@ -5,6 +5,7 @@
 #include <crispy/overloaded.h>
 
 #include <cstdio>
+#include <map>
 
 using namespace std;
 
@@ -75,6 +76,269 @@ ColorPalette::Palette const ColorPalette::defaultColorPalette = []() constexpr {
 
     return colors;
 }();
+
+bool defaultColorPalettes(std::string const& colorPaletteName, ColorPalette& palette) noexcept
+{
+
+    // TODO add dim colors, do we need to adapt them to each of color palettes?
+    std::map<std::string, std::function<void()>> const definedColorPalettes = {
+        { "contour",
+          [&]() {
+          } },
+        { "monokai",
+          [&]() {
+              // Monokai dark colors
+              // normal colors
+              palette.palette[0] = 0x272822_rgb; // black
+              palette.palette[1] = 0xf92672_rgb; // red
+              palette.palette[2] = 0xa6e22e_rgb; // green
+              palette.palette[3] = 0xf4bf75_rgb; // yellow
+              palette.palette[4] = 0x66d9ef_rgb; // blue
+              palette.palette[5] = 0xae81ff_rgb; // magenta
+              palette.palette[6] = 0xa1efe4_rgb; // cyan
+              palette.palette[7] = 0xf8f8f2_rgb; // white
+              // bright colors
+              palette.palette[8] = 0x75715e_rgb;  // bright black (dark gray)
+              palette.palette[9] = 0xf92672_rgb;  // bright red
+              palette.palette[10] = 0xa6e22e_rgb; // bright green
+              palette.palette[11] = 0xf4bf75_rgb; // bright yellow
+              palette.palette[12] = 0x66d9ef_rgb; // bright blue
+              palette.palette[13] = 0xae81ff_rgb; // bright magenta
+              palette.palette[14] = 0xa1efe4_rgb; // bright blue
+              palette.palette[15] = 0xf8f8f2_rgb; // bright white
+
+              palette.defaultForeground = 0xf8f8f2_rgb;
+              palette.defaultBackground = 0x272822_rgb;
+              palette.defaultForegroundBright = 0xf8f8f2_rgb;
+              palette.defaultForegroundDimmed = 0x75715e_rgb;
+              palette.mouseForeground = 0xf8f8f2_rgb;
+              palette.mouseBackground = 0x272822_rgb;
+              palette.cursor.color = 0xf8f8f2_rgb;
+          } },
+        { "one-light",
+          [&]() {
+              // One Light colors
+              // normal colors
+              palette.palette[0] = 0x000000_rgb; // black
+              palette.palette[1] = 0xda3e39_rgb; // red
+              palette.palette[2] = 0x41933e_rgb; // green
+              palette.palette[3] = 0x855504_rgb; // yellow
+              palette.palette[4] = 0x315eee_rgb; // blue
+              palette.palette[5] = 0x930092_rgb; // magenta
+              palette.palette[6] = 0x0e6fad_rgb; // cyan
+              palette.palette[7] = 0x8e8f96_rgb; // white
+
+              // bright colors
+              palette.palette[8] = 0x2a2b32_rgb;  // bright black (dark gray)
+              palette.palette[9] = 0xda3e39_rgb;  // bright red
+              palette.palette[10] = 0x41933e_rgb; // bright green
+              palette.palette[11] = 0x855504_rgb; // bright yellow
+              palette.palette[12] = 0x315eee_rgb; // bright blue
+              palette.palette[13] = 0x930092_rgb; // bright magenta
+              palette.palette[14] = 0x0e6fad_rgb; // bright cuan
+              palette.palette[15] = 0xfffefe_rgb; // bright white
+
+              palette.defaultForeground = 0x2a2b32_rgb;
+              palette.defaultBackground = 0xf8f8f8_rgb;
+              palette.cursor.color = 0x2a2b32_rgb;
+          } },
+        { "one-dark",
+          [&]() {
+              // One Dark colors
+              // normal colors
+              palette.palette[0] = 0x000000_rgb; // black
+              palette.palette[1] = 0xe06c75_rgb; // red
+              palette.palette[2] = 0x98c379_rgb; // green
+              palette.palette[3] = 0xe5c07b_rgb; // yellow
+              palette.palette[4] = 0x61afef_rgb; // blue
+              palette.palette[5] = 0xc678dd_rgb; // magenta
+              palette.palette[6] = 0x56b6c2_rgb; // cyan
+              palette.palette[7] = 0xabb2bf_rgb; // white
+
+              // bright colors
+              palette.palette[8] = 0x5c6370_rgb;  // bright black (dark gray)
+              palette.palette[9] = 0xe06c75_rgb;  // bright red
+              palette.palette[10] = 0x98c379_rgb; // bright green
+              palette.palette[11] = 0xd19a66_rgb; // bright yellow
+              palette.palette[12] = 0x61afef_rgb; // bright blue
+              palette.palette[13] = 0xc678dd_rgb; // bright magenta
+              palette.palette[14] = 0x56b6c2_rgb; // bright cuan
+              palette.palette[15] = 0xfffefe_rgb; // bright white
+
+              palette.defaultForeground = 0x5c6370_rgb;
+              palette.defaultBackground = 0x1e2127_rgb;
+              palette.defaultForegroundBright = 0x5c6370_rgb;
+              palette.defaultForegroundDimmed = 0x545862_rgb;
+              palette.mouseForeground = 0xabb2bf_rgb;
+              palette.mouseBackground = 0x282c34_rgb;
+              palette.cursor.color = 0x5c6370_rgb;
+          } },
+        { "gruvbox-light",
+          [&]() {
+              // Gruvbox colors
+              // normal colors
+              palette.palette[0] = 0xfbf1c7_rgb; // black
+              palette.palette[1] = 0xcc241d_rgb; // red
+              palette.palette[2] = 0x98971a_rgb; // green
+              palette.palette[3] = 0xd79921_rgb; // yellow
+              palette.palette[4] = 0x458588_rgb; // blue
+              palette.palette[5] = 0xb16286_rgb; // magenta
+              palette.palette[6] = 0x689d6a_rgb; // cyan
+              palette.palette[7] = 0x7c6f64_rgb; // white
+              // bright colors
+              palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
+              palette.palette[9] = 0x9d0006_rgb;  // bright red
+              palette.palette[10] = 0x79740e_rgb; // bright green
+              palette.palette[11] = 0xb57614_rgb; // bright yellow
+              palette.palette[12] = 0x076678_rgb; // bright blue
+              palette.palette[13] = 0x8f3f71_rgb; // bright magenta
+              palette.palette[14] = 0x427b58_rgb; // bright cuan
+              palette.palette[15] = 0x3c3836_rgb; // bright white
+
+              palette.defaultForeground = 0x3c3836_rgb;
+              palette.defaultBackground = 0xfbf1c7_rgb;
+              palette.cursor.color = 0x3c3836_rgb;
+          } },
+        { "gruvbox-dark",
+          [&]() {
+              // Gruvbox colors
+              // normal colors
+              palette.palette[0] = 0x282828_rgb; // black
+              palette.palette[1] = 0xcc241d_rgb; // red
+              palette.palette[2] = 0x98971a_rgb; // green
+              palette.palette[3] = 0xd79921_rgb; // yellow
+              palette.palette[4] = 0x458588_rgb; // blue
+              palette.palette[5] = 0xb16286_rgb; // magenta
+              palette.palette[6] = 0x689d6a_rgb; // cyan
+              palette.palette[7] = 0xa89984_rgb; // white
+              // bright colors
+              palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
+              palette.palette[9] = 0xfb4934_rgb;  // bright red
+              palette.palette[10] = 0xb8bb26_rgb; // bright green
+              palette.palette[11] = 0xfabd2f_rgb; // bright yellow
+              palette.palette[12] = 0x83a598_rgb; // bright blue
+              palette.palette[13] = 0xd3869b_rgb; // bright magenta
+              palette.palette[14] = 0x8ec07c_rgb; // bright cuan
+              palette.palette[15] = 0xebdbb2_rgb; // bright white
+
+              palette.defaultForeground = 0xebdbb2_rgb;
+              palette.defaultBackground = 0x292929_rgb;
+              palette.cursor.color = 0xebdbb2_rgb;
+          } },
+        { "solarized-light",
+          [&]() {
+              // Solarized colors
+              // normal colors
+              palette.palette[0] = 0xeee8d5_rgb; // black
+              palette.palette[1] = 0xdc322f_rgb; // red
+              palette.palette[2] = 0x859900_rgb; // green
+              palette.palette[3] = 0xb58900_rgb; // yellow
+              palette.palette[4] = 0x268bd2_rgb; // blue
+              palette.palette[5] = 0xd33682_rgb; // magenta
+              palette.palette[6] = 0x2aa198_rgb; // cyan
+              palette.palette[7] = 0x002b36_rgb; // white
+              // bright colors
+              palette.palette[8] = 0x657b83_rgb;  // bright black
+              palette.palette[9] = 0xcb4b16_rgb;  // bright red
+              palette.palette[10] = 0x859900_rgb; // bright green
+              palette.palette[11] = 0xb58900_rgb; // bright yellow
+              palette.palette[12] = 0x6c71c4_rgb; // bright blue
+              palette.palette[13] = 0xd33682_rgb; // bright magenta
+              palette.palette[14] = 0x2aa198_rgb; // bright cyan
+              palette.palette[15] = 0x073642_rgb; // bright white
+
+              palette.defaultForeground = 0x657b83_rgb;
+              palette.defaultBackground = 0xfdf6e3_rgb;
+              palette.cursor.color = 0x657b83_rgb;
+          } },
+        { "solarized-dark",
+          [&]() {
+              // solarized colors
+              // normal colors
+              palette.palette[0] = 0x073642_rgb; // black
+              palette.palette[1] = 0xdc322f_rgb; // red
+              palette.palette[2] = 0x859900_rgb; // green
+              palette.palette[3] = 0xcf9a6b_rgb; // yellow
+              palette.palette[4] = 0x268bd2_rgb; // blue
+              palette.palette[5] = 0xd33682_rgb; // magenta
+              palette.palette[6] = 0x2aa198_rgb; // cyan
+              palette.palette[7] = 0xeee8d5_rgb; // white
+              // bright color
+              palette.palette[8] = 0x657b83_rgb;  // bright black
+              palette.palette[9] = 0xcb4b16_rgb;  // bright red
+              palette.palette[10] = 0x859900_rgb; // bright green
+              palette.palette[11] = 0xcf9a6b_rgb; // bright yellow
+              palette.palette[12] = 0x6c71c4_rgb; // bright blue
+              palette.palette[13] = 0xd33682_rgb; // bright magenta
+              palette.palette[14] = 0x2aa198_rgb; // bright cyan
+              palette.palette[15] = 0xfdf6e3_rgb; // bright white
+
+              palette.defaultForeground = 0x839496_rgb;
+              palette.defaultBackground = 0x002b36_rgb;
+              palette.cursor.color = 0x839496_rgb;
+          } },
+        { "papercolor-light",
+          [&]() {
+              // papercolor light colors
+              // normal colors
+              palette.palette[0] = 0xeeeeee_rgb; // black
+              palette.palette[1] = 0xaf0000_rgb; // red
+              palette.palette[2] = 0x008700_rgb; // green
+              palette.palette[3] = 0x5f8700_rgb; // yellow
+              palette.palette[4] = 0x0087af_rgb; // blue
+              palette.palette[5] = 0x878787_rgb; // magenta
+              palette.palette[6] = 0x005f87_rgb; // cyan
+              palette.palette[7] = 0x444444_rgb; // white
+              // bright colors
+              palette.palette[8] = 0xbcbcbc_rgb;  // bright black
+              palette.palette[9] = 0xd70000_rgb;  // bright red
+              palette.palette[10] = 0xd70087_rgb; // bright green
+              palette.palette[11] = 0x8700af_rgb; // bright yellow
+              palette.palette[12] = 0xd75f00_rgb; // bright blue
+              palette.palette[13] = 0xd75f00_rgb; // bright magenta
+              palette.palette[14] = 0x005faf_rgb; // bright cyan
+              palette.palette[15] = 0x005f87_rgb; // bright white
+
+              palette.defaultForeground = 0x444444_rgb;
+              palette.defaultBackground = 0xeeeeee_rgb;
+              palette.cursor.color = 0x444444_rgb;
+          } },
+        { "papercolor-dark",
+          [&]() {
+              // papercolor dark colors
+              // normal colors
+              palette.palette[0] = 0x1C1C1C_rgb; // Black (Host)
+              palette.palette[1] = 0xAF005F_rgb; // Red (Syntax string)
+              palette.palette[2] = 0x5FAF00_rgb; // Green (Command)
+              palette.palette[3] = 0xD7AF5F_rgb; // Yellow (Command second)
+              palette.palette[4] = 0x5FAFD7_rgb; // Blue (Path)
+              palette.palette[5] = 0x808080_rgb; // Magenta (Syntax var)
+              palette.palette[6] = 0xD7875F_rgb; // Cyan (Prompt)
+              palette.palette[7] = 0xD0D0D0_rgb; // White
+
+              palette.palette[8] = 0x585858_rgb;  // Bright Black
+              palette.palette[9] = 0x5FAF5F_rgb;  // Bright Red (Command error)
+              palette.palette[10] = 0xAFD700_rgb; // Bright Green (Exec)
+              palette.palette[11] = 0xAF87D7_rgb; // Bright Yellow
+              palette.palette[12] = 0xFFAF00_rgb; // Bright Blue (Folder)
+              palette.palette[13] = 0xFF5FAF_rgb; // Bright Magenta
+              palette.palette[14] = 0x00AFAF_rgb; // Bright Cyan
+              palette.palette[15] = 0x5F8787_rgb; // Bright White
+
+              palette.defaultForeground = 0xd0d0d0_rgb;
+              palette.defaultBackground = 0x1c1c1c_rgb;
+              palette.cursor.color = 0xd0d0d0_rgb;
+          } },
+    };
+    // find if colorPaletteName is a known color palette
+    auto const it = definedColorPalettes.find(colorPaletteName);
+    if (it != definedColorPalettes.end())
+    {
+        it->second();
+        return true;
+    }
+    return false;
+}
 
 void ImageData::updateHash() noexcept
 {

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -132,6 +132,8 @@ struct ColorPalette
     RGBColorPair indicatorStatusLineVisualMode = { 0xFFFFFF_rgb, 0x0270c0_rgb };
 };
 
+bool defaultColorPalettes(std::string const& colorPaletteName, ColorPalette& palette) noexcept;
+
 enum class ColorTarget : uint8_t
 {
     Foreground,

--- a/src/vtbackend/Line.cpp
+++ b/src/vtbackend/Line.cpp
@@ -182,7 +182,7 @@ InflatedLineBuffer<Cell> inflate(TrivialLineBuffer const& input)
                                      input.hyperlink);
                 --gapPending;
             }
-            auto const charWidth = unicode::width(nextChar);
+            auto const charWidth = static_cast<int>(unicode::width(nextChar));
             columns.emplace_back(Cell {});
             columns.back().setHyperlink(input.hyperlink);
             columns.back().write(input.textAttributes, nextChar, static_cast<uint8_t>(charWidth));


### PR DESCRIPTION
Refs https://github.com/contour-terminal/contour/issues/1285

PR adds few predefined color palettes, values are taken from https://github.com/Gogh-Co/Gogh/tree/master/themes
and supported themes are:
contour, monokai, one-dark, one-light, gruvbox-light, gruvbox-dark, solarized-light, solarized-dark, papercolor-light, papercolor-dark.

in config user can specify both single colorscheme or as a map like:
```
colors: contour
```
or 
```
colors:
    light: monokai
    dark: contour
 ```