### PR TITLE
install-deps.sh: Flip curl/wget priority to favor curl over wget, because at least Fedora 40 Linux seems to complain on wget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
           docker cp contour_static:/contour/build/src/contour/contour contour
           docker container rm contour_static
       - name: "Uploading static executable"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "contour"
           path: "contour"
@@ -494,7 +494,7 @@ jobs:
           BASENAME="contour-${{ steps.set_vars.outputs.version }}-osx"
           mv -vf "build/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Darwin.dmg" "${BASENAME}.dmg"
       - name: upload to artifact store (DMG)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: "contour-${{ steps.set_vars.outputs.version }}-osx.dmg"
           path: "contour-${{ steps.set_vars.outputs.version }}-osx.dmg"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -42,10 +42,10 @@ fetch_and_unpack()
     FULL_DISTFILE="$SYSDEPS_DIST_DIR/$DISTFILE"
 
     if ! test -f "$FULL_DISTFILE"; then
-        if command -v wget > /tmp/word 2>&1; then
-            wget -O "$FULL_DISTFILE" "$URL"
-        elif command -v curl > /tmp/word 2>&1; then
+        if command -v curl > /tmp/word 2>&1; then
             curl -L -o "$FULL_DISTFILE" "$URL"
+        elif command -v wget > /tmp/word 2>&1; then
+            wget -O "$FULL_DISTFILE" "$URL"
         elif command -v fetch > /tmp/word 2>&1; then
             # FreeBSD
             fetch -o "$FULL_DISTFILE" "$URL"


### PR DESCRIPTION
at least my Fedora 40 on my new Linux laptop instantly started to complain on a fresh Fedora install. I sadly don't seem to remember what exactly the error message was ;(

Also, added a commit to streamline all upload-artifact actions to v4 (we had 2 at v3 and v2 still)