### PR TITLE
Update libunicode to support Unicode 16.0.0

### DIFF
--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -53,7 +53,7 @@ endmacro()
 message(STATUS "==============================================================================")
 message(STATUS "    Contour ThirdParties: ${ContourThirdParties}")
 
-set(LIBUNICODE_MINIMAL_VERSION "0.4.0")
+set(LIBUNICODE_MINIMAL_VERSION "0.6.0")
 set(BOXED_CPP_MINIMAL_VERSION "1.4.3")
 set(TERMBENCH_PRO_COMMIT_HASH "f6c37988e6481b48a8b8acaf1575495e018e9747")
 set(CATCH_VERSION "3.4.0")

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
       <description>
         <ul>
           <li>Port to C++20's `std::format()` (#1598)</li>
+          <li>Enable support for Unicode version 16.0.0 (#1606)</li>
         </ul>
       </description>
     </release>

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -10,7 +10,7 @@ class ThirdParty {
     [string] $Macro
 }
 
-$libunicode_git_sha="6f8e210d1e50fc0db5c977ca9fd58555d23010ac"
+$libunicode_git_sha="817cb5900acdf6f60e2344a4c8f1f39262878a4b"
 
 # Take care, order matters, at least as much as dependencies are of concern.
 $ThirdParties =

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -112,7 +112,7 @@ fetch_and_unpack_boxed()
 fetch_and_unpack_libunicode()
 {
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="6f8e210d1e50fc0db5c977ca9fd58555d23010ac"
+        local libunicode_git_sha="817cb5900acdf6f60e2344a4c8f1f39262878a4b"
         fetch_and_unpack \
             libunicode-$libunicode_git_sha \
             libunicode-$libunicode_git_sha.tar.gz \


### PR DESCRIPTION
checklist

- [x] use latest libunicode release as dependency
- [x] update `LIBUNICODE_MINIMAL_VERSION`