### PR TITLE
Fix macOS specific key handling

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -114,6 +114,7 @@
           <li>Add binding to exit normal mode with `Esc` (#1604)</li>
           <li>Add config option to switch into insert mode after yank (#1604)</li>
           <li>Improves window size/resize handling on HiDPI monitor settings (#1628)</li>
+          <li>Improves macOS key handling for Option+Left|Right keys to jump between words in the shell</li>
           <li>Fixes cropping of underscore character for some fonts (#1603)</li>
         </ul>
       </description>

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -54,6 +54,12 @@ using Modifiers = crispy::flags<Modifier>;
 /// @returns CSI parameter for given function key modifier
 constexpr size_t makeVirtualTerminalParam(Modifiers modifier) noexcept
 {
+#if defined(__APPLE__)
+    // Use option key as a control modifier to use
+    // Ctrl-Left[Right]Arrow for word navigation.
+    if (modifier == Modifier::Alt)
+        return 1 + Modifier::Control;
+#endif
     return 1 + modifier.value();
 }
 

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -144,10 +144,17 @@ TEST_CASE("InputGenerator.Modifier+ArrowKeys", "[terminal,input]")
         Mapping { Shift, Key::DownArrow, "\033[1;2B"sv },
         Mapping { Shift, Key::RightArrow, "\033[1;2C"sv },
         Mapping { Shift, Key::LeftArrow, "\033[1;2D"sv },
+#ifdef __APPLE__
+        Mapping { Alt, Key::UpArrow, "\033[1;5A"sv },
+        Mapping { Alt, Key::DownArrow, "\033[1;5B"sv },
+        Mapping { Alt, Key::RightArrow, "\033[1;5C"sv },
+        Mapping { Alt, Key::LeftArrow, "\033[1;5D"sv },
+#else
         Mapping { Alt, Key::UpArrow, "\033[1;3A"sv },
         Mapping { Alt, Key::DownArrow, "\033[1;3B"sv },
         Mapping { Alt, Key::RightArrow, "\033[1;3C"sv },
         Mapping { Alt, Key::LeftArrow, "\033[1;3D"sv },
+#endif
         Mapping { Control, Key::UpArrow, "\033[1;5A"sv },
         Mapping { Control, Key::DownArrow, "\033[1;5B"sv },
         Mapping { Control, Key::RightArrow, "\033[1;5C"sv },


### PR DESCRIPTION
Fixes macOS specific handling of the input
 -  Option used as a Control modifier, to allow Option-Left[Right] jumps between words in the shell