### PR TITLE
Add few BSD specific locations during terminfo loading

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -120,6 +120,10 @@ namespace
 
         locations.emplace_back("/usr/share/terminfo");
 
+        // BSD locations
+        locations.emplace_back("/usr/local/share/terminfo");
+        locations.emplace_back("/usr/local/share/site-terminfo");
+
         return locations;
     }
 


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1599
@herrhotzenplotz  I hove this is sufficient to find terminfo files on freebsd