### PR TITLE
simplify, cleanup, and improve window size/resize handling

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Add terminal tabs (#90)</li>
           <li>Add binding to exit normal mode with `Esc` (#1604)</li>
           <li>Add config option to switch into insert mode after yank (#1604)</li>
+          <li>Improves window size/resize handling on HiDPI monitor settings (#1628)</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,9 @@
     <release version="0.5.2" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Add terminal tabs (#90)</li>
+          <li>Add binding to exit normal mode with `Esc` (#1604)</li>
+          <li>Add config option to switch into insert mode after yank (#1604)</li>
         </ul>
       </description>
     </release>
@@ -114,9 +117,6 @@
     <release version="0.5.1" urgency="medium" date="2024-09-30">
       <description>
         <ul>
-          <li>Add terminal tabs (#90)</li>
-          <li>Add binding to exit normal mode with `Esc` (#1604)</li>
-          <li>Add config option to switch into insert mode after yank (#1604)</li>
           <li>Fixes vi-mode motions like `viW`, `yiW`, `oiW` as well as `B` and `W`</li>
           <li>Fixes rendered backend loading from config</li>
           <li>Fixes mouse wheel scrolling on High-DPI screens feeling too slow</li>

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -206,6 +206,13 @@ struct WindowMargins
     VerticalMargin vertical { 0 };
 };
 
+constexpr WindowMargins operator*(WindowMargins const& margin, double factor) noexcept
+{
+    return WindowMargins {
+        .horizontal = HorizontalMargin { static_cast<unsigned>(*margin.horizontal * factor) },
+    };
+}
+
 template <typename T, documentation::StringLiteral doc>
 struct ConfigEntry
 {

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -228,9 +228,6 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     config::Config const& config() const noexcept { return _config; }
     config::TerminalProfile const& profile() const noexcept { return _profile; }
 
-    double contentScale() const noexcept { return _contentScale; }
-    void setContentScale(double value) noexcept { _contentScale = value; }
-
     vtpty::Pty& pty() noexcept { return _terminal.device(); }
     vtbackend::Terminal& terminal() noexcept { return _terminal; }
     vtbackend::Terminal const& terminal() const noexcept { return _terminal; }
@@ -245,7 +242,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     Q_INVOKABLE void applyPendingFontChange(bool allow, bool remember);
     Q_INVOKABLE void executePendingBufferCapture(bool allow, bool remember);
     Q_INVOKABLE void executeShowHostWritableStatusLine(bool allow, bool remember);
-    Q_INVOKABLE void adaptToWidgetSize();
+    Q_INVOKABLE void resizeTerminalToDisplaySize();
 
     void updateColorPreference(vtbackend::ColorPreference preference);
 
@@ -438,7 +435,6 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     config::Config _config;
     std::string _profileName;
     config::TerminalProfile _profile;
-    double _contentScale = 1.0;
     ContourGuiApp& _app;
     vtbackend::ColorPreference _currentColorPreference;
 

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -65,14 +65,17 @@ void TerminalSessionManager::setSession(size_t index)
     if (!isAllowedToChangeTabs())
         return;
 
-    auto const pixels = display->pixelSize();
-    auto const totalPageSize = display->calculatePageSize() + _activeSession->terminal().statusLineHeight();
+    if (_activeSession)
+        _activeSession->detachDisplay(*display);
 
-    _activeSession->detachDisplay(*display);
     if (index < _sessions.size())
         _activeSession = _sessions[index];
     else
         _activeSession = createSession();
+
+    Require(display != nullptr);
+    auto const pixels = display->pixelSize();
+    auto const totalPageSize = display->calculatePageSize() + _activeSession->terminal().statusLineHeight();
 
     display->setSession(_activeSession);
     _activeSession->terminal().resizeScreen(totalPageSize, pixels);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -60,18 +60,23 @@ TerminalSession* TerminalSessionManager::createSession()
 
 void TerminalSessionManager::setSession(size_t index)
 {
-
+    Require(index <= _sessions.size());
     managerLog()(std::format("SET SESSION: index: {}, _sessions.size(): {}", index, _sessions.size()));
     if (!isAllowedToChangeTabs())
         return;
 
-    if (_activeSession)
-        _activeSession->detachDisplay(*display);
+    auto* oldSession = _activeSession;
 
     if (index < _sessions.size())
         _activeSession = _sessions[index];
     else
         _activeSession = createSession();
+
+    if (oldSession == _activeSession)
+        return;
+
+    if (oldSession)
+        oldSession->detachDisplay(*display);
 
     Require(display != nullptr);
     auto const pixels = display->pixelSize();

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -53,7 +53,6 @@ TerminalSession* TerminalSessionManager::createSession()
     // sessions. This will work around it, by explicitly claiming ownership of the object.
     QQmlEngine::setObjectOwnership(session, QQmlEngine::CppOwnership);
 
-    _activeSession = session;
     // we can close application right after session has been created
     _lastTabChange = std::chrono::steady_clock::now() - std::chrono::seconds(1);
     return session;
@@ -71,14 +70,9 @@ void TerminalSessionManager::setSession(size_t index)
 
     _activeSession->detachDisplay(*display);
     if (index < _sessions.size())
-    {
         _activeSession = _sessions[index];
-    }
     else
-    {
-        createSession();
-        _activeSession->terminal().resizeScreen(totalPageSize, pixels);
-    }
+        _activeSession = createSession();
 
     display->setSession(_activeSession);
     _activeSession->terminal().resizeScreen(totalPageSize, pixels);

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -64,20 +64,20 @@ class TerminalSessionManager: public QAbstractListModel
         if (!_activeSession)
             return;
 
-        const auto currentSessionIndex = getCurrentSessionIndex();
-        _activeSession->terminal().setGuiTabInfoForStatusLine([&]() {
-            std::string tabInfo;
-            for (size_t i = 0; i < _sessions.size(); ++i)
-            {
-                if (std::cmp_equal(i, currentSessionIndex))
-                    tabInfo += "[";
-                tabInfo += std::to_string(i + 1);
-                if (std::cmp_equal(i, currentSessionIndex))
-                    tabInfo += "]";
-                tabInfo += " ";
-            }
-            return tabInfo;
-        }());
+        _activeSession->terminal().setGuiTabInfoForStatusLine(
+            [this, currentSessionIndex = getCurrentSessionIndex()]() {
+                std::string tabInfo;
+                for (size_t i = 0; i < _sessions.size(); ++i)
+                {
+                    if (std::cmp_equal(i, currentSessionIndex))
+                        tabInfo += "[";
+                    tabInfo += std::to_string(i + 1);
+                    if (std::cmp_equal(i, currentSessionIndex))
+                        tabInfo += "]";
+                    tabInfo += " ";
+                }
+                return tabInfo;
+            }());
     }
 
     bool isAllowedToChangeTabs()

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -61,6 +61,9 @@ class TerminalSessionManager: public QAbstractListModel
 
     void updateStatusLine()
     {
+        if (!_activeSession)
+            return;
+
         const auto currentSessionIndex = getCurrentSessionIndex();
         _activeSession->terminal().setGuiTabInfoForStatusLine([&]() {
             std::string tabInfo;

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -23,13 +23,13 @@
 #include <QtQuick/QQuickItem>
 
 #include <QtQml>
-#include <atomic>
-#include <fstream>
+
+#if defined(CONTOUR_PERF_STATS)
+    #include <atomic>
+#endif
+
 #include <memory>
 #include <optional>
-#include <vector>
-
-#include <qqml.h>
 
 namespace contour::display
 {
@@ -124,8 +124,7 @@ class TerminalDisplay: public QQuickItem
     [[nodiscard]] vtbackend::ImageSize pixelSize() const;
     [[nodiscard]] vtbackend::ImageSize cellSize() const;
 
-    // general events
-    void adaptToWidgetSize();
+    void resizeTerminalToDisplaySize();
 
     // (user requested) actions
     vtbackend::FontDef getFontDef();
@@ -212,10 +211,9 @@ class TerminalDisplay: public QQuickItem
 
         // auto const availablePixels = gridMetrics().cellSize * _session->terminal().pageSize();
         auto const availablePixels = pixelSize();
-        return pageSizeForPixels(
-            availablePixels,
-            _renderer->gridMetrics().cellSize,
-            applyContentScale(_session->profile().margins.value(), _session->contentScale()));
+        return pageSizeForPixels(availablePixels,
+                                 _renderer->gridMetrics().cellSize,
+                                 applyContentScale(_session->profile().margins.value(), contentScale()));
     }
 
   private:
@@ -229,6 +227,11 @@ class TerminalDisplay: public QQuickItem
     [[nodiscard]] float uptime() const noexcept;
 
     void updateMinimumSize();
+
+    // Updates the recommended size in (virtual pixels) based on:
+    // - the grid cell size (based on the current font size and DPI),
+    // - configured window margins, and
+    // - the terminal's screen size.
     void updateImplicitSize();
 
     void statsSummary();

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -57,7 +57,7 @@ namespace
     {
         auto const pageSize = session.terminal().totalPageSize();
         auto const cellSize = session.display()->cellSize();
-        auto const dpr = session.contentScale();
+        auto const dpr = session.display()->contentScale();
 
         auto const marginTop = static_cast<int>(unbox(session.profile().margins.value().vertical) * dpr);
         auto const marginLeft = static_cast<int>(unbox(session.profile().margins.value().horizontal) * dpr);
@@ -443,7 +443,7 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
         ((modifiers & Modifier::Alt) ? transposed(event->angleDelta()) : event->angleDelta()) / 8;
 
     auto const pixelPosition =
-        makeMousePixelPosition(event, session.profile().margins.value(), session.contentScale());
+        makeMousePixelPosition(event, session.profile().margins.value(), session.display()->contentScale());
 
     if (!pixelDelta.isNull())
     {
@@ -468,7 +468,7 @@ void sendMousePressEvent(QMouseEvent* event, TerminalSession& session)
     session.sendMousePressEvent(
         makeModifiers(event->modifiers()),
         makeMouseButton(event->button()),
-        makeMousePixelPosition(event, session.profile().margins.value(), session.contentScale()));
+        makeMousePixelPosition(event, session.profile().margins.value(), session.display()->contentScale()));
     event->accept();
 }
 
@@ -477,7 +477,7 @@ void sendMouseReleaseEvent(QMouseEvent* event, TerminalSession& session)
     session.sendMouseReleaseEvent(
         makeModifiers(event->modifiers()),
         makeMouseButton(event->button()),
-        makeMousePixelPosition(event, session.profile().margins.value(), session.contentScale()));
+        makeMousePixelPosition(event, session.profile().margins.value(), session.display()->contentScale()));
     event->accept();
 }
 
@@ -486,7 +486,7 @@ void sendMouseMoveEvent(QMouseEvent* event, TerminalSession& session)
     session.sendMouseMoveEvent(
         makeModifiers(event->modifiers()),
         makeMouseCellLocation(event->pos().x(), event->pos().y(), session),
-        makeMousePixelPosition(event, session.profile().margins.value(), session.contentScale()));
+        makeMousePixelPosition(event, session.profile().margins.value(), session.display()->contentScale()));
     event->accept();
 }
 
@@ -500,7 +500,7 @@ void sendMouseMoveEvent(QHoverEvent* event, TerminalSession& session)
     session.sendMouseMoveEvent(
         makeModifiers(event->modifiers()),
         makeMouseCellLocation(position.x(), position.y(), session),
-        makeMousePixelPosition(event, session.profile().margins.value(), session.contentScale()));
+        makeMousePixelPosition(event, session.profile().margins.value(), session.display()->contentScale()));
     event->accept();
 }
 
@@ -612,21 +612,21 @@ void applyResize(vtbackend::ImageSize newPixelSize,
         return;
 
     auto const oldPageSize = session.terminal().pageSize();
-    auto const newPageSize =
-        pageSizeForPixels(newPixelSize,
-                          renderer.gridMetrics().cellSize,
-                          applyContentScale(session.profile().margins.value(), session.contentScale()));
+    auto const newPageSize = pageSizeForPixels(
+        newPixelSize,
+        renderer.gridMetrics().cellSize,
+        applyContentScale(session.profile().margins.value(), session.display()->contentScale()));
     vtbackend::Terminal& terminal = session.terminal();
     vtbackend::ImageSize const cellSize = renderer.gridMetrics().cellSize;
 
     if (renderer.hasRenderTarget())
         renderer.renderTarget().setRenderSize(newPixelSize);
     renderer.setPageSize(newPageSize);
-    renderer.setMargin(
-        computeMargin(renderer.gridMetrics().cellSize,
-                      newPageSize,
-                      newPixelSize,
-                      applyContentScale(session.profile().margins.value(), session.contentScale())));
+    renderer.setMargin(computeMargin(
+        renderer.gridMetrics().cellSize,
+        newPageSize,
+        newPixelSize,
+        applyContentScale(session.profile().margins.value(), session.display()->contentScale())));
 
     if (oldPageSize.lines != newPageSize.lines)
         emit session.lineCountChanged(newPageSize.lines.as<int>());

--- a/src/contour/ui.template/main.qml.in
+++ b/src/contour/ui.template/main.qml.in
@@ -38,13 +38,11 @@ ApplicationWindow
 
     onWidthChanged : function() {
         vtui.width = width
-        vtui.session.adaptToWidgetSize()
         vtui.updateSizeWidget()
     }
 
     onHeightChanged: function() {
         vtui.height = height
-        vtui.session.adaptToWidgetSize()
         vtui.updateSizeWidget()
     }
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -956,7 +956,7 @@ class Terminal
     void resetStatusLineDefinition();
 
     std::string_view guiTabInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
-    void setGuiTabInfoForStatusLine(std::string_view value) { _guiTabInfoForStatusLine = value; }
+    void setGuiTabInfoForStatusLine(std::string value) { _guiTabInfoForStatusLine = std::move(value); }
 
   private:
     void mainLoop();


### PR DESCRIPTION
it took me a while to figure out that fraction scaling on KDE Plasma (probably due to Wayland) is problematic. However, this PR still cleans up a lot and reliably produces the expected columns x lines page size on initial window spawn.

Fractional scaling on at least Wayland (KDE?) should be fixed later on its own.