### PR TITLE
Fixes mouse wheel scrolling on High-DPI screens feeling too slow

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -119,6 +119,7 @@
           <li>Add config option to switch into insert mode after yank (#1604)</li>
           <li>Fixes vi-mode motions like `viW`, `yiW`, `oiW` as well as `B` and `W`</li>
           <li>Fixes rendered backend loading from config</li>
+          <li>Fixes mouse wheel scrolling on High-DPI screens feeling too slow</li>
           <li>Enable support for Unicode version 16.0.0 (#1606)</li>
           <li>Port to C++20's `std::format()` (#1598)</li>
           <li>Drop support for Ubuntu 23.10 and older. In order to have less burdain of maintencne, we only support the latest LTS of Ubuntu, which currently is 24.04 (#1607)</li>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -436,8 +436,8 @@ void sendWheelEvent(QWheelEvent* event, TerminalSession& session)
     //       it will send horizontal wheel events instead of vertical ones. We need to compensate
     //       for that here.
 
-    auto const pixelDelta =
-        (modifiers & Modifier::Alt) ? transposed(event->pixelDelta()) : event->pixelDelta();
+    auto const scaledPixelDelta = session.display()->contentScale() * event->pixelDelta();
+    auto const pixelDelta = (modifiers & Modifier::Alt) ? transposed(scaledPixelDelta) : scaledPixelDelta;
 
     auto const numDegrees =
         ((modifiers & Modifier::Alt) ? transposed(event->angleDelta()) : event->angleDelta()) / 8;


### PR DESCRIPTION
funny enough, mouse wheel pixel data depends on High DPI setting of your monitor. Well... May make sense.