### PR TITLE
Add styling-capability for active tab in Tabs view in statusline

### DIFF
--- a/docs/configuration/indicator-statusline.md
+++ b/docs/configuration/indicator-statusline.md
@@ -73,3 +73,13 @@ These parameters apply to all variables above.
 
 The `Command` variable is the only one that requires a special attribute, `Program` whose value
 is the command to execute.
+
+### Tabs formatting extensions
+
+The `Tabs` key allows additional styling through the following attributes:
+
+Parameter                 | Description
+--------------------------|--------------------------------------------------------------------
+`ActiveColor`             | color of the active tab
+`ActiveBackground`        | background color of the active tab
+

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -351,7 +351,7 @@ struct TerminalProfile
         statusDisplayPosition { vtbackend::StatusDisplayPosition::Bottom };
     ConfigEntry<std::string, documentation::IndicatorStatusLineLeft> indicatorStatusLineLeft {
         " {InputMode:Bold,Color=#FFFF00}"
-        "{Tabs:Left= │ }"
+        "{Tabs:ActiveColor=#FFFF00,Left= │ }"
         "{SearchPrompt:Left= │ }"
         "{TraceMode:Bold,Color=#FFFF00,Left= │ }"
         "{ProtectedMode:Bold,Left= │ }"

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -64,20 +64,10 @@ class TerminalSessionManager: public QAbstractListModel
         if (!_activeSession)
             return;
 
-        _activeSession->terminal().setGuiTabInfoForStatusLine(
-            [this, currentSessionIndex = getCurrentSessionIndex()]() {
-                std::string tabInfo;
-                for (size_t i = 0; i < _sessions.size(); ++i)
-                {
-                    if (std::cmp_equal(i, currentSessionIndex))
-                        tabInfo += "[";
-                    tabInfo += std::to_string(i + 1);
-                    if (std::cmp_equal(i, currentSessionIndex))
-                        tabInfo += "]";
-                    tabInfo += " ";
-                }
-                return tabInfo;
-            }());
+        _activeSession->terminal().setGuiTabInfoForStatusLine(vtbackend::TabsInfo {
+            .tabCount = _sessions.size(),
+            .activeTabPosition = _sessions.empty() ? 0 : static_cast<size_t>(1 + getCurrentSessionIndex()),
+        });
     }
 
     bool isAllowedToChangeTabs()

--- a/src/vtbackend/StatusLineBuilder.h
+++ b/src/vtbackend/StatusLineBuilder.h
@@ -38,7 +38,12 @@ namespace StatusLineDefinitions
     struct Text: Styles { std::string text; };
     struct TraceMode: Styles {};
     struct VTType: Styles {};
-    struct Tabs: Styles {};
+
+    struct Tabs: Styles
+    {
+        std::optional<RGBColor> activeColor;
+        std::optional<RGBColor> activeBackground;
+    };
 
     using Item = std::variant<
         CellSGR,

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -207,6 +207,12 @@ class TraceHandler: public SequenceHandler
     PendingSequenceQueue _pendingSequences = {};
 };
 
+struct TabsInfo
+{
+    size_t tabCount = 1;
+    size_t activeTabPosition = 1;
+};
+
 /// Terminal API to manage input and output devices of a pseudo terminal, such as keyboard, mouse, and screen.
 ///
 /// With a terminal being attached to a Process, the terminal's screen
@@ -955,8 +961,8 @@ class Terminal
     void setStatusLineDefinition(StatusLineDefinition&& definition);
     void resetStatusLineDefinition();
 
-    std::string_view guiTabInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
-    void setGuiTabInfoForStatusLine(std::string value) { _guiTabInfoForStatusLine = std::move(value); }
+    TabsInfo guiTabsInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
+    void setGuiTabInfoForStatusLine(TabsInfo info) { _guiTabInfoForStatusLine = info; }
 
   private:
     void mainLoop();
@@ -1070,7 +1076,7 @@ class Terminal
     Viewport _viewport;
     StatusLineDefinition _indicatorStatusLineDefinition;
 
-    std::string _guiTabInfoForStatusLine;
+    TabsInfo _guiTabInfoForStatusLine;
 
     // {{{ selection states
     std::unique_ptr<Selection> _selection;


### PR DESCRIPTION
Improve UI/UX a bit of tabs feature's statusline:

- have the active tab's color customizable
- teh tabs textual representation in the statusline must not jump around in spacing, based on what tab is active (due to ` [N] ` vs ` N `.


- refs: #1634 (would benefit from it)