### PR TITLE
Do not crop symbol that is completely below cell

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Add binding to exit normal mode with `Esc` (#1604)</li>
           <li>Add config option to switch into insert mode after yank (#1604)</li>
           <li>Improves window size/resize handling on HiDPI monitor settings (#1628)</li>
+          <li>Fixes cropping of underscore character for some fonts (#1603)</li>
         </ul>
       </description>
     </release>

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -770,10 +770,11 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
     // or 0 if not overflowing.
     auto const yOverflow = max(0, yMax - _gridMetrics.cellSize.height.as<int>());
 
-    // {{{ crop underflow if yMin < 0
+    // {{{ crop underflow if yMin < 0 and yMax > 0
     // If the rasterized glyph is underflowing below the grid cell's minimum (0),
-    // then cut off at grid cell's bottom.
-    if (yMin < 0)
+    // and overlaps with grid cell, then cut off at grid cell's bottom.
+    // For underscore glyphs, ymin can be lower than 0 but ymax is zero, so we need to check for yMax > 0.
+    if (yMin < 0 && yMax > 0)
     {
         auto const rowCount = (unsigned) -yMin;
         Require(rowCount <= unbox(glyph.bitmapSize.height));


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1603

Some fonts want underscore character to be below grid cell completely, we can allow