### PR TITLE
Transform camelCase into snake_case for docs

### DIFF
--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -1382,10 +1382,23 @@ struct DocumentationWriter: Writer
     template <typename... T>
     std::string process(std::string_view doc, std::string_view name, T... val)
     {
-        return format("### `{}`\n"
-                      "{}\n",
-                      name,
-                      format(replaceCommentPlaceholder(std::string { doc }), val...));
+        return format(
+            "### `{}`\n"
+            "{}\n",
+            [](std::string_view name) -> std::string {
+                // camelCase into snake_case
+                auto result = std::string { name };
+                for (auto i = 0u; i < result.size(); ++i)
+                {
+                    if (std::isupper(result[i]))
+                    {
+                        result.insert(i, 1, '_');
+                        result[i + 1] = static_cast<char>(std::tolower(result[i + 1]));
+                    }
+                }
+                return result;
+            }(name),
+            format(replaceCommentPlaceholder(std::string { doc }), val...));
     }
 
     template <typename T, documentation::StringLiteral ConfigDoc, documentation::StringLiteral WebDoc>


### PR DESCRIPTION
Transform camelCase of names  inside c++ structures to snake_case that is used inside config files 
Refs https://github.com/contour-terminal/contour/issues/1622