### PR TITLE
Since v0.5 requires macOS 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Click the following button to install Contour from the Flathub store.
 
 ## Requirements
 
-- **operating system**: A *recent* operating system (macOS 12, Windows 10+, an up-to-date Linux, FreeBSD or OpenBSD)
+- **operating system**: A *recent* operating system (macOS 14, Windows 10+, an up-to-date Linux, FreeBSD or OpenBSD)
 - **GPU**: driver must support at least OpenGL 3.3 hardware accelerated or as software rasterizer.
 - **CPU**: x86-64 AMD or Intel with AES-NI instruction set or ARMv8 with crypto extensions.
 


### PR DESCRIPTION
This is based on trying the recent releases, see #1649

## Description

Update minimum version of macOS in the README file requirements section.

## Motivation and Context

Avoids false hope in users with older Apple Mac that they can run the latest release.

## How Has This Been Tested?

Tested recent releases under macOS 12.7.6 "Monterey" to determine the minimum version of macOS reported as required, see #1649.

## Checklist:

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
