### PR TITLE
fix: delete duplicated CharInputMapping entry in defaultInputMappings

### DIFF
--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -536,12 +536,6 @@ const InputMappings defaultInputMappings {
                                                 | vtbackend::Modifiers { vtbackend::Modifier::Control } } },
             .input = 'V',
             .binding = { { actions::PasteClipboard { .strip = false } } } },
-        CharInputMapping {
-            .modes { vtbackend::MatchModes {} },
-            .modifiers { vtbackend::Modifiers { vtbackend::Modifiers { vtbackend::Modifier::Shift }
-                                                | vtbackend::Modifiers { vtbackend::Modifier::Control } } },
-            .input = 'V',
-            .binding = { { actions::PasteClipboard { .strip = false } } } },
         CharInputMapping { .modes { vtbackend::MatchModes {} },
                            .modifiers { vtbackend::Modifiers { vtbackend::Modifier::Alt }
                                         | vtbackend::Modifiers { vtbackend::Modifier::Control } },


### PR DESCRIPTION
## Description

Describe your changes in detail
Delete the duplicated CharInputMapping entry in defaultInputMappings

```markdown
Your issue description (body) goes here
https://github.com/contour-terminal/contour/issues/1635
```

## Motivation and Context

Why is this change required? What problem does it solve?
It fixes the problem that copied text will be pasted twice.
```markdown

```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x ] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] I have gone through all the steps, and have thoroughly read the instructions
