### PR TITLE
Disable fedora github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,97 +175,97 @@ jobs:
           retention-days: 1
   # }}}
   # {{{ Fedora
-  fedora:
-    strategy:
-      fail-fast: false
-      matrix:
-        os_version: [40]
-        arch:
-          [
-            "linux/amd64 x86_64"
-          ]
-    name: "Fedora ${{ matrix.os_version }} ${{ matrix.arch }}"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-      - name: Read matrix info
-        id: tags
-        shell: bash
-        run: |
-          arch="${{ matrix.arch }}"
-          echo "PLATFORM=${arch%% *}" >> "$GITHUB_OUTPUT"
-          echo "ARCH=${arch##* }" >> "$GITHUB_OUTPUT"
-      - name: "update APT database"
-        run: sudo apt -q update
-      - name: Installing xmllint for ci-set-vars
-        run: sudo apt -qy install libxml2-utils
-      - name: set environment variables
-        id: set_vars
-        run: ./scripts/ci-set-vars.sh
-        env:
-          REPOSITORY: ${{ github.event.repository.name }}
-      - name: Fetch and unpack embeds
-        run: ./scripts/install-deps.sh
-        env:
-          PREPARE_ONLY_EMBEDS: 'ON'
-          SYSDEP_ASSUME_YES: 'ON'
-          OS_OVERRIDE: 'fedora'
-      - name: "Post-fix embedded dependency permissions."
-        run: sudo find _deps/sources -exec chown $UID {} \;
-      - name: prepare distfile
-        run: |
-          set -x
-          PKGNAME="contour-${{ steps.set_vars.outputs.VERSION }}"
-          DISTDIR="/tmp/dist/${PKGNAME}"
-          mkdir -p ${DISTDIR}
-          cp -rvp . ${DISTDIR}
-          tar czpf ${PKGNAME}.tar.gz -C "/tmp/dist" .
-      - name: disable pedantic compiler on certain OS versions
-        # Generally disable -Werror.
-        #if: ${{ matrix.os_version == 38 || matrix.os_version == 39 }}
-        run: |
-          set -ex
-          #sed -i -e "s/PEDANTIC_COMPILER=ON/PEDANTIC_COMPILER=OFF/" .github/fedora/contour.spec
-          sed -i -e "s/PEDANTIC_COMPILER_WERROR=ON/PEDANTIC_COMPILER_WERROR=OFF/" .github/fedora/contour.spec
-      - name: Build ${{ matrix.arch }} release
-        shell: bash
-        run: |
-          set -x
-          ARCH="${{ steps.tags.outputs.ARCH }}"
-          VERSION="${{ steps.set_vars.outputs.VERSION }}"
-          OS_VERSION="${{ matrix.os_version }}"
-          sed -i -e "s/fedora:35/fedora:${{ matrix.os_version }}/" .github/fedora/Dockerfile
-          docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
-                  --tag contour:${ARCH} \
-                  --build-arg VERSION=${VERSION} \
-                  --build-arg VERSION_STRING=${VERSION} \
-                  -f .github/fedora/Dockerfile \
-                  --load \
-                  .
-          docker create --name contour-${ARCH} contour:${ARCH}
-          docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
-                    contour-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
-          docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-debuginfo-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
-                    contour-debuginfo-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
-          docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-debugsource-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
-                    contour-debugsource-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
-          docker container rm contour-${{ steps.tags.outputs.ARCH }}
-          echo "pwd: `pwd`" && ls -hla
-      - name: "Uploading Fedora RPM package"
-        uses: actions/upload-artifact@v4
-        with:
-          name: "contour-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm"
-          path: |
-            contour-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
-            contour-debuginfo-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
-            contour-debugsource-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
-          if-no-files-found: error
-          retention-days: 7
+  # fedora:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os_version: [40]
+  #       arch:
+  #         [
+  #           "linux/amd64 x86_64"
+  #         ]
+  #   name: "Fedora ${{ matrix.os_version }} ${{ matrix.arch }}"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@v2
+  #       with:
+  #         version: latest
+  #     - name: Read matrix info
+  #       id: tags
+  #       shell: bash
+  #       run: |
+  #         arch="${{ matrix.arch }}"
+  #         echo "PLATFORM=${arch%% *}" >> "$GITHUB_OUTPUT"
+  #         echo "ARCH=${arch##* }" >> "$GITHUB_OUTPUT"
+  #     - name: "update APT database"
+  #       run: sudo apt -q update
+  #     - name: Installing xmllint for ci-set-vars
+  #       run: sudo apt -qy install libxml2-utils
+  #     - name: set environment variables
+  #       id: set_vars
+  #       run: ./scripts/ci-set-vars.sh
+  #       env:
+  #         REPOSITORY: ${{ github.event.repository.name }}
+  #     - name: Fetch and unpack embeds
+  #       run: ./scripts/install-deps.sh
+  #       env:
+  #         PREPARE_ONLY_EMBEDS: 'ON'
+  #         SYSDEP_ASSUME_YES: 'ON'
+  #         OS_OVERRIDE: 'fedora'
+  #     - name: "Post-fix embedded dependency permissions."
+  #       run: sudo find _deps/sources -exec chown $UID {} \;
+  #     - name: prepare distfile
+  #       run: |
+  #         set -x
+  #         PKGNAME="contour-${{ steps.set_vars.outputs.VERSION }}"
+  #         DISTDIR="/tmp/dist/${PKGNAME}"
+  #         mkdir -p ${DISTDIR}
+  #         cp -rvp . ${DISTDIR}
+  #         tar czpf ${PKGNAME}.tar.gz -C "/tmp/dist" .
+  #     - name: disable pedantic compiler on certain OS versions
+  #       # Generally disable -Werror.
+  #       #if: ${{ matrix.os_version == 38 || matrix.os_version == 39 }}
+  #       run: |
+  #         set -ex
+  #         #sed -i -e "s/PEDANTIC_COMPILER=ON/PEDANTIC_COMPILER=OFF/" .github/fedora/contour.spec
+  #         sed -i -e "s/PEDANTIC_COMPILER_WERROR=ON/PEDANTIC_COMPILER_WERROR=OFF/" .github/fedora/contour.spec
+  #     - name: Build ${{ matrix.arch }} release
+  #       shell: bash
+  #       run: |
+  #         set -x
+  #         ARCH="${{ steps.tags.outputs.ARCH }}"
+  #         VERSION="${{ steps.set_vars.outputs.VERSION }}"
+  #         OS_VERSION="${{ matrix.os_version }}"
+  #         sed -i -e "s/fedora:35/fedora:${{ matrix.os_version }}/" .github/fedora/Dockerfile
+  #         docker buildx build --platform ${{ steps.tags.outputs.PLATFORM }} \
+  #                 --tag contour:${ARCH} \
+  #                 --build-arg VERSION=${VERSION} \
+  #                 --build-arg VERSION_STRING=${VERSION} \
+  #                 -f .github/fedora/Dockerfile \
+  #                 --load \
+  #                 .
+  #         docker create --name contour-${ARCH} contour:${ARCH}
+  #         docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
+  #                   contour-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
+  #         docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-debuginfo-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
+  #                   contour-debuginfo-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
+  #         docker cp contour-${ARCH}:/app/rpmbuild/RPMS/${ARCH}/contour-debugsource-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm \
+  #                   contour-debugsource-${VERSION}-1.fc${OS_VERSION}.${ARCH}.rpm
+  #         docker container rm contour-${{ steps.tags.outputs.ARCH }}
+  #         echo "pwd: `pwd`" && ls -hla
+  #     - name: "Uploading Fedora RPM package"
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: "contour-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm"
+  #         path: |
+  #           contour-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
+  #           contour-debuginfo-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
+  #           contour-debugsource-${{ steps.set_vars.outputs.VERSION }}-1.fc${{ matrix.os_version }}.${{ steps.tags.outputs.ARCH }}.rpm
+  #         if-no-files-found: error
+  #         retention-days: 7
   # }}}
   # {{{ FreeBSD
   freebsd:


### PR DESCRIPTION
Disable github action for fedora since they are failing outside of compilation and we build we recent compilers in another actions