### PR TITLE
docs(fix): update old wiki links to point to the MkDocs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ for everyday use. It is aiming for power users with a modern feature mindset.
 - ✅ Key binding customization
 - ✅ Color Schemes
 - ✅ Profiles (grouped customization of: color scheme, login shell, and related behaviours)
-- ✅ [Synchronized rendering](https://github.com/contour-terminal/contour/wiki/VTExtensions#synchronized-output) (via `SM ? 2026` / `RM ? 2026`)
+- ✅ [Synchronized rendering](https://contour-terminal.org/vt-extensions/synchronized-output/) (via `SM ? 2026` / `RM ? 2026`)
 - ✅ Text reflow (configurable via `SM ? 2028` / `RM ? 2028`)
 - ✅ Clickable hyperlinks via [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
 - ✅ Clipboard setting via OSC 52
 - ✅ Sixel inline images
-- ✅ Terminal page [buffer capture VT extension](https://github.com/contour-terminal/contour/wiki/VTExtensions#buffer-capture) to quickly extract contents.
+- ✅ Terminal page [buffer capture VT extension](https://contour-terminal.org/vt-extensions/buffer-capture/) to quickly extract contents.
 - ✅ Builtin [Fira Code inspired progress bar](https://github.com/contour-terminal/contour/issues/521) support.
 - ✅ Read-only mode, protecting against accidental user-input to the running application, such as <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 - ✅ VT320 Host-programmable and Indicator status line support.

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,12 +17,12 @@
 :material-check-bold:{.check-mark}  Key binding customization <br/>
 :material-check-bold:{.check-mark}  Color Schemes <br/>
 :material-check-bold:{.check-mark}  Profiles (grouped customization of: color scheme, login shell, and related behaviours) <br/>
-:material-check-bold:{.check-mark}  [Synchronized rendering](https://github.com/contour-terminal/contour/wiki/VTExtensions#synchronized-output) (via `SM ? 2026` / `RM ? 2026`) <br/>
+:material-check-bold:{.check-mark}  [Synchronized rendering](vt-extensions/synchronized-output.md) (via `SM ? 2026` / `RM ? 2026`) <br/>
 :material-check-bold:{.check-mark}  Text reflow (configurable via `SM ? 2028` / `RM ? 2028`) <br/>
 :material-check-bold:{.check-mark}  Clickable hyperlinks via [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) <br/>
 :material-check-bold:{.check-mark}  Clipboard setting via OSC 52 <br/>
 :material-check-bold:{.check-mark}  [Sixel Image support](demo/images.md) <br/>
-:material-check-bold:{.check-mark}  Terminal page [buffer capture VT extension](https://github.com/contour-terminal/contour/wiki/VTExtensions#buffer-capture) to quickly extract contents. <br/>
+:material-check-bold:{.check-mark}  Terminal page [buffer capture VT extension](vt-extensions/buffer-capture.md) to quickly extract contents. <br/>
 :material-check-bold:{.check-mark}  Builtin [Fira Code inspired progress bar](https://github.com/contour-terminal/contour/issues/521) support. <br/>
 :material-check-bold:{.check-mark}  Read-only mode, protecting against accidental user-input to the running application, such as <kbd>Ctrl</kbd>+<kbd>C</kbd>. <br/>
 :material-check-bold:{.check-mark}  [VT320 Host-programmable and Indicator statusline support](demo/statusline.md) <br/>


### PR DESCRIPTION
## Description

Update links for synchronized rendering and buffer capture in `README.md` and adjust links in `MkDocs` documentation to match `*.md` syntax used by other links.

## Motivation and Context

Current links as of now simply redirect to the repository's main GitHub page/README. + Remove hard-coded domain in MkDocs links.

## How Has This Been Tested?

- [x] Tested website changes locally.

## Checklist:

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [x] I have added tests to cover my changes. *(not applicable here)*
- [x] I have gone through all the steps, and have thoroughly read the instructions
