### PR TITLE
docs(spelling): fix typos in documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ You can also see some live development on [Twitch](https://www.twitch.tv/christi
 - Always work on a branch based off the master branch, if it is a feature or a bugfix.
 - Please have a look at the [coding style guidelines](internals/CODING_STYLE.md).
 - When creating a pull request, please see if you can keep the commits as atomic as possible.
-  That is, a single reasonabily sized feature or functionality should be committed as
+  That is, a single reasonably sized feature or functionality should be committed as
   one single commit. If you can branch out a some functionality, let it be a more generalized API or
   refactor of something that can stand on their own, then those deserve their own commits.
 - Every new feature should ideally be unit-testable, this isn't always possible or easy for pure GUI

--- a/docs/configuration/advanced/renderer.md
+++ b/docs/configuration/advanced/renderer.md
@@ -46,7 +46,7 @@ renderer:
 Enables/disables the use of direct-mapped texture atlas tiles for
 the most often used ones (US-ASCII, cursor shapes, underline styles)
 
-You most likely do not wnat to touch this and leave it enabled.
+You most likely do not want to touch this and leave it enabled.
 
 Default: true
 

--- a/docs/configuration/key-mapping.md
+++ b/docs/configuration/key-mapping.md
@@ -19,7 +19,7 @@ Modifiers:
 * Alt
 * Control
 * Shift
-* Meta (this is the Windows key on Windows OS, ans the Command key on macOS, and Meta on anything else)<br />Keys can be expressed case-insensitively symbolic.
+* Meta (this is the Windows key on Windows OS, and the Command key on macOS, and Meta on anything else)<br />Keys can be expressed case-insensitively symbolic.
 
 Keys can be expressed case-insensitively symbolic:
 

--- a/docs/demo/size_indicator.md
+++ b/docs/demo/size_indicator.md
@@ -1,5 +1,5 @@
 # Size indicator
 
-On resize window with current terminal size will apear
+On resize window with current terminal size will appear
 
 ![type:video](../videos/size-indicator.mp4)

--- a/docs/drafts/daemon-mode.md
+++ b/docs/drafts/daemon-mode.md
@@ -9,7 +9,7 @@ Let's implement a terminal multiplexing server that `Contour` can connect to.
 - support for handling multiple sessions
 - support concurrent clients to the same sessions
 - a session has one or more terminals, with a server managed layout (stacked, tabbed, tiled, ...)
-- connected clients to the same terminal can independantly scroll in history.
+- connected clients to the same terminal can independently scroll in history.
 - communication via `AF_UNIX` and `AF_INET`.
 - attached clients to a terminal receive:
   - An initial fullscreen redraw event,

--- a/docs/drafts/grid-redesign.md
+++ b/docs/drafts/grid-redesign.md
@@ -20,7 +20,7 @@
 - because of the meaning of the scroll-offset, reflow can be O(1) implemented
   with a `Line()` being arbitrary long(!) and the top screen line being
   computed by subtracting `(PageLineCount - 1) * PageColumnCount)`,
-  then *just* lineary walking forward until the bottom right.
+  then *just* linearly walking forward until the bottom right.
   - this enables relative jumps (`CUU` etc) to jump up logical lines.
   - we could make the cursor jump behavior configurable, via DEC mode.
 - On char write overflow
@@ -33,7 +33,7 @@
 
 ### Notes
 
-Suppose only a single overly long line is written and ocupies the full screen
+Suppose only a single overly long line is written and occupies the full screen
 (many page counts).
 
 ```

--- a/docs/input-modes.md
+++ b/docs/input-modes.md
@@ -69,7 +69,7 @@ the terminal to scroll the view to make that target line visible.
 Contour currently only supports OSC-8 hyperlinks as well as explicitly opening selected text.
 
 In normal mode, you can open links by moving the cursor onto a resource (URL or local file) and
-then press `oiW` (open in (space sperated) word) or use any of the other supported text objects
+then press `oiW` (open in (space separated) word) or use any of the other supported text objects
 to denote what to open.
 
 You may as well type `oo` to open the URL under the current line. This works if no other information

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,7 +61,7 @@ by default contour will be compiler with Qt 6, to change Qt version use `QTVER=5
 ```
 
 This script *might* ask you for the administrator password if a package dependency
-can be insalled via the system package manager.
+can be installed via the system package manager.
 
 #### Compile
 

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -13,7 +13,7 @@ src/              - Contour source code
   vtbackend/      - core terminal library
   vtparser/       - VT parser library
   vtpty/          - PTY library
-  vtrasterizer/   - frontend independant Terminal rendering library
+  vtrasterizer/   - frontend independent Terminal rendering library
 test/             - Contains a set of test scripts.
 ```
 
@@ -25,7 +25,7 @@ are too small to be their own library and ease general development.
 ### `text_shaper` library
 
 This library abstracts font location service, text shaping, as well as
-glyph rasterization into a platform independant API.
+glyph rasterization into a platform independent API.
 
 ### `vtpty` library
 

--- a/docs/internals/text-stack.md
+++ b/docs/internals/text-stack.md
@@ -4,7 +4,7 @@ A terminal emulator's text stack.
 TL;DR
 -----
 
-This document describes how rendering text is architectually implemented
+This document describes how rendering text is architecturally implemented
 in Contour, an in-early-development virtual terminal emulator, in order to
 support complex unicode as well as (and especially) complex colored emoji.
 
@@ -100,7 +100,7 @@ text along with some latin and Kanji or Emoji in between or a font style change
 for obvious reasons.
 Each segment (usually called run) must be shaped individually with its own set
 of fallback fonts. Emoji are using a different font and font fallback
-list than regular text which uses a different font and font falback list then
+list than regular text which uses a different font and font fallback list then
 bold, italic, or bold itaic fonts.
 Emoji also have two different presentation styles, the one
 that everybody expects and is named Emoji emoji presentation
@@ -155,7 +155,7 @@ to introduce feature detection and mode switching on how to process
 grapheme clusters and their width, if legacy apps are of concern.
 
 Algorithmic wise, implementing grapheme cluster segmentation isn't too hard
-but in execution very expensive. Also grapheme cluster width compuation
+but in execution very expensive. Also grapheme cluster width computation
 is expensive. But luckily, in the context of terminal emulators,
 both can be optimized for the general case in terminal emulatoors, which is
 mostly US-ASCII, and yields almost no penalty with optimizations or a
@@ -170,7 +170,7 @@ without caching without hurting user experience.
 After investigating into the above optimization possibilities however, I do
 not see why a terminal emulator should *not* do provide support for
 complex unicode, as the performance I have achieved so far is above average at
-least, and therefore should be suffient for everyday use.
+least, and therefore should be sufficient for everyday use.
 
 Bidirectional text was not addressed in this document nor in the implementation
 in the Contour terminal yet, as this imposes a new set of challenges

--- a/docs/vt-extensions/save-and-restore-sgr-attributes.md
+++ b/docs/vt-extensions/save-and-restore-sgr-attributes.md
@@ -8,7 +8,7 @@ and `SGRRESTORE` (`CSI # }`) to restore the previously saved SGR attributes.
 ## Relation to xterm's XTPUSHSGR / XTPOPSGR
 
 Both, `XTPUSHSGR` and `XTPOPSGR` are in its most basic form equivalent to `SGRSAVE` and `SGRRESTORE`,
-but the xterm extenions push and pop using a stack rather than save and restore using a simple 
+but the xterm extensions push and pop using a stack rather than save and restore using a simple
 storage location, and the xterm equivalent does allow pushing/popping only certain SGR attributes.
 
 This is needless functionality that should not be implemented by a terminal but rather in the applications itself.

--- a/docs/vt-extensions/synchronized-output.md
+++ b/docs/vt-extensions/synchronized-output.md
@@ -57,7 +57,7 @@ than having no synchronized output at all.
 
 ## Adoption State
 
-| Support | Terminal/Tookit/App   | Notes  |
+| Support | Terminal/Toolkit/App   | Notes  |
 |---------|------------|--------|
 | n/a     | xterm.js   | see tracker [xterm.js#3375](https://github.com/xtermjs/xterm.js/issues/3375) |
 | not yet | Windows Terminal | Proof-of-concept implementation by @j4james exists; tracker: [wt#8331](https://github.com/microsoft/terminal/issues/8331)  |


### PR DESCRIPTION
## Description

Spelling fixes in `docs` directory.

## Motivation and Context

Pedantic change: fixing spelling in MkDocs documentation.

## How Has This Been Tested?

- [x] changes verified visually in local MkDocs

## Checklist:

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [x] I have added tests to cover my changes. *not applicable*
- [x] I have gone through all the steps, and have thoroughly read the instructions
