### PR TITLE
Fix underline style reset

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -118,6 +118,7 @@
           <li>Improves macOS key handling for Option+Left|Right keys to jump between words in the shell</li>
           <li>Fixes cropping of underscore character for some fonts (#1603)</li>
           <li>Fixes DECFRA limits (#1664)</li>
+          <li>Fixes underline styles not being reset on switching to a new style (#1365)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/CellUtil.h
+++ b/src/vtbackend/CellUtil.h
@@ -154,7 +154,13 @@ template <typename Cell>
         case GraphicsRendition::Bold: flags |= CellFlag::Bold; break;
         case GraphicsRendition::Faint: flags |= CellFlag::Faint; break;
         case GraphicsRendition::Italic: flags |= CellFlag::Italic; break;
-        case GraphicsRendition::Underline: flags |= CellFlag::Underline; break;
+        case GraphicsRendition::Underline:
+            flags = flags.without({ CellFlag::DoublyUnderlined,
+                                    CellFlag::CurlyUnderlined,
+                                    CellFlag::DottedUnderline,
+                                    CellFlag::DashedUnderline });
+            flags |= CellFlag::Underline;
+            break;
         case GraphicsRendition::Blinking:
             flags.disable(CellFlag::RapidBlinking);
             flags.enable(CellFlag::Blinking);
@@ -166,10 +172,34 @@ template <typename Cell>
         case GraphicsRendition::Inverse: flags |= CellFlag::Inverse; break;
         case GraphicsRendition::Hidden: flags |= CellFlag::Hidden; break;
         case GraphicsRendition::CrossedOut: flags |= CellFlag::CrossedOut; break;
-        case GraphicsRendition::DoublyUnderlined: flags |= CellFlag::DoublyUnderlined; break;
-        case GraphicsRendition::CurlyUnderlined: flags |= CellFlag::CurlyUnderlined; break;
-        case GraphicsRendition::DottedUnderline: flags |= CellFlag::DottedUnderline; break;
-        case GraphicsRendition::DashedUnderline: flags |= CellFlag::DashedUnderline; break;
+        case GraphicsRendition::DoublyUnderlined:
+            flags = flags.without({ CellFlag::Underline,
+                                    CellFlag::CurlyUnderlined,
+                                    CellFlag::DottedUnderline,
+                                    CellFlag::DashedUnderline });
+            flags |= CellFlag::DoublyUnderlined;
+            break;
+        case GraphicsRendition::CurlyUnderlined:
+            flags = flags.without({ CellFlag::Underline,
+                                    CellFlag::DoublyUnderlined,
+                                    CellFlag::DottedUnderline,
+                                    CellFlag::DashedUnderline });
+            flags |= CellFlag::CurlyUnderlined;
+            break;
+        case GraphicsRendition::DottedUnderline:
+            flags = flags.without({ CellFlag::Underline,
+                                    CellFlag::DoublyUnderlined,
+                                    CellFlag::CurlyUnderlined,
+                                    CellFlag::DashedUnderline });
+            flags |= CellFlag::DottedUnderline;
+            break;
+        case GraphicsRendition::DashedUnderline:
+            flags = flags.without({ CellFlag::Underline,
+                                    CellFlag::DoublyUnderlined,
+                                    CellFlag::CurlyUnderlined,
+                                    CellFlag::DottedUnderline });
+            flags |= CellFlag::DashedUnderline;
+            break;
         case GraphicsRendition::Framed: flags |= CellFlag::Framed; break;
         case GraphicsRendition::Overline: flags |= CellFlag::Overline; break;
         case GraphicsRendition::Normal: flags = flags.without({ CellFlag::Bold, CellFlag::Faint }); break;

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -338,6 +338,73 @@ TEST_CASE("Terminal.XTPUSHCOLORS_and_XTPOPCOLORS", "[terminal]")
     }
 }
 
+TEST_CASE("Terminal.UnderlineStyleClearing", "[terminal]")
+{
+    // Each subsequent underline style should clear the former if present.
+
+    auto const now = chrono::steady_clock::now();
+    auto mc = MockTerm { ColumnCount(20), LineCount(1) };
+
+    mc.writeToScreen("\033[4:1mAB\033[21mCD\033[4:3mEF\033[24mGH\033[4:2mIJ\033[mKL");
+    mc.terminal.tick(now);
+    mc.terminal.ensureFreshRenderBuffer();
+    CHECK("ABCDEFGHIJKL" == trimmedTextScreenshot(mc));
+
+    auto& screen = mc.terminal.primaryScreen();
+
+    CHECK(screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::Underline));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(4)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(5)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(6)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(7)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(8)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(9)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(10)).isFlagEnabled(CellFlag::Underline));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(11)).isFlagEnabled(CellFlag::Underline));
+
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(4)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(5)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(6)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(7)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(8)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(9)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(10)).isFlagEnabled(CellFlag::DoublyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(11)).isFlagEnabled(CellFlag::DoublyUnderlined));
+
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(4)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(screen.at(LineOffset(0), ColumnOffset(5)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(6)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(7)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(8)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(9)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(10)).isFlagEnabled(CellFlag::CurlyUnderlined));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(11)).isFlagEnabled(CellFlag::CurlyUnderlined));
+
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(0)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(1)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(2)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(3)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(4)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(5)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(6)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(7)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(8)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(9)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(10)).isFlagEnabled(CellFlag::Italic));
+    CHECK(!screen.at(LineOffset(0), ColumnOffset(11)).isFlagEnabled(CellFlag::Italic));
+}
+
 TEST_CASE("Terminal.CurlyUnderline", "[terminal]")
 {
     auto const now = chrono::steady_clock::now();


### PR DESCRIPTION
## Description

Change the cell logic to reset underline style flags on a new style being applied to match the behavior of other terminals.

Example of the change affecting output:

```sh
printf '\033[4:3mAB\033[4:2mCD\033[4:1mEF\033[0mGH\n'
```

Before change:
![Screenshot_20241216_082626](https://github.com/user-attachments/assets/fc759102-725d-40fe-b0d4-042712a4f0fa)

After change:
![Screenshot_20241216_081554](https://github.com/user-attachments/assets/5a35c41d-73d6-44d4-a37c-abf9dbf9139a)

## Motivation and Context

Change behavior to match other terminal emulators like libvte, KDE Konsole, and WezTerm.

Example of Gnome Terminal on Ubuntu 24:
![Screenshot_20241216_083244](https://github.com/user-attachments/assets/d74044ef-2686-493c-8e65-8853199112f7)

## How Has This Been Tested?

- [x] Manual tests using recompiled terminal.
- [x] Added relevant checks to `vtbackend_test` and executed:

   ```sh
   $ ./build/linux-clang-release/src/vtbackend/vtbackend_test
   Randomness seeded to: 3112360726
   Starting resize to 3x2
   ===============================================================================
   All tests passed (3703 assertions in 198 test cases)
   ```

## Checklist:

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
