### PR TITLE
docs: Add adoption state for dark/light mode notifications

### DIFF
--- a/docs/vt-extensions/color-palette-update-notifications.md
+++ b/docs/vt-extensions/color-palette-update-notifications.md
@@ -43,3 +43,14 @@ e.g. by configuration.
 
 Please have a look at our example C++ [source code](https://github.com/contour-terminal/contour/blob/master/examples/detect-dark-light-mode.cpp)
 in order to see how to implement this in your own application.
+
+## Adoption State
+| Support  | Terminal/Toolkit/App | Notes                                                                                               |
+|----------|----------------------|-----------------------------------------------------------------------------------------------------|
+| ✅       | Contour              |                                                                                                     |
+| ✅       | Ghostty              | since `1.0.0`                                                                                       |
+| ✅       | Kitty                | since [`0.38.1`](https://sw.kovidgoyal.net/kitty/changelog/#detailed-list-of-changes)               |
+| ✅ (tui) | Neovim               | since [`d460928`](https://github.com/neovim/neovim/commit/d460928263d0ff53283f301dfcb85f5b6e17d2ac) |
+| not yet  | tmux                 | see tracker: [tmux#4269](https://github.com/tmux/tmux/issues/4269)                                  |
+| not yet  | WezTerm              | see tracker: [wezterm#6454](https://github.com/wez/wezterm/issues/6454)                             |
+| not yet  | Zellij               | see tracker: [zellij#3831](https://github.com/zellij-org/zellij/issues/3831)                        |


### PR DESCRIPTION
I noticed that contour is no longer the only terminal supporting dark/light mode notifications:
both Ghostty and Kitty also support it.

Adoption is also documented for synchronized output so it seems very natural
to also add it for this.

## How Has This Been Tested?

* [x] I ran `mkdocs` locally and looked at the result. 

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- `n/a` I have updated (or added) the documentation accordingly.
- `n/a` I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
