### PR TITLE
Fix error with wrong terminal size during tab switch

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
       <description>
         <ul>
           <li>Do not abort when failing to create `XDG_STATE_HOME/contour/crash` directory</li>
+          <li>Fixes tab switch crash after resize</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li>Do not abort when failing to create `XDG_STATE_HOME/contour/crash` directory</li>
           <li>Fixes tab switch crash after resize</li>
+          <li>Fixes tab shrinking after tab creation/switches when a non-zero horizontal window margin is configured</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -97,21 +97,27 @@ void TerminalSessionManager::setSession(size_t index)
     if (!isAllowedToChangeTabs())
         return;
 
+    Require(display != nullptr);
+    auto const pixels = display->pixelSize();
+    auto const totalPageSize = display->calculatePageSize() + _activeSession->terminal().statusLineHeight();
+
     auto* oldSession = _activeSession;
 
     if (index < _sessions.size())
+    {
         _activeSession = _sessions[index];
+        // Ensure that the existing session is resized to the display's size.
+        _activeSession->terminal().resizeScreen(totalPageSize, pixels);
+    }
     else
         createSession();
 
     if (oldSession == _activeSession)
         return;
 
-    Require(display != nullptr);
-    auto const pixels = display->pixelSize();
-    auto const totalPageSize = display->calculatePageSize() + _activeSession->terminal().statusLineHeight();
-
     display->setSession(_activeSession);
+    // Resize active session after display is attached to it
+    // to return a lost line
     _activeSession->terminal().resizeScreen(totalPageSize, pixels);
     updateStatusLine();
 

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1071,7 +1071,11 @@ bool TerminalDisplay::isFullScreen() const
 vtbackend::ImageSize TerminalDisplay::pixelSize() const
 {
     assert(_session);
-    return gridMetrics().cellSize * _session->terminal().pageSize();
+    auto const scaledWindowMargins = applyContentScale(_session->profile().margins.value(), contentScale());
+    auto const scaledWindowMarginsPixels =
+        vtbackend::ImageSize { Width::cast_from(unbox(scaledWindowMargins.horizontal) * 2),
+                               Height::cast_from(unbox(scaledWindowMargins.vertical) * 2) };
+    return gridMetrics().cellSize * _session->terminal().pageSize() + scaledWindowMarginsPixels;
 }
 
 vtbackend::ImageSize TerminalDisplay::cellSize() const


### PR DESCRIPTION
Fix crash with resize and tab switching, we notice this bug on systems with scaled UI (specifically macOS, but bug can appear on other systems as well)