### PR TITLE
Fix backtab pty.output generation

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -110,6 +110,7 @@
           <li>Do not abort when failing to create `XDG_STATE_HOME/contour/crash` directory</li>
           <li>Fixes tab switch crash after resize</li>
           <li>Fixes tab shrinking after tab creation/switches when a non-zero horizontal window margin is configured</li>
+          <li>Fixes backtab (Shift+Tab) handling (#1685)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -68,6 +68,7 @@ bool StandardKeyboardInputGenerator::generateChar(char32_t characterEvent,
         return true;
     }
 
+    // Backtab handling, 0x09 is Tab
     if (modifiers == Modifier::Shift && characterEvent == 0x09)
     {
         append("\033[Z"); // introduced by linux_console in 1995, adopted by xterm in 2002
@@ -175,7 +176,7 @@ bool StandardKeyboardInputGenerator::generateKey(Key key, Modifiers modifiers, K
         case Key::F35: append(select(modifiers, { .std = CSI "49~", .mods = CSI "49;{}~" })); break;
         case Key::Escape: append("\033"); break;
         case Key::Enter: append(select(modifiers, { .std = "\r" })); break;
-        case Key::Tab: append(select(modifiers, { .std = "\t" })); break;
+        case Key::Tab: generateChar('\t', 0, modifiers, eventType); break;
         case Key::Backspace:
             // Well accepted hack to distinguish between Backspace nad Ctrl+Backspace,
             // - Backspace is emitting 0x7f,


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1685 
Solution is somewhat ugly, I am open for better one @christianparpart  :) 
but we need to preserve behavior for sending it as a key for https://github.com/contour-terminal/contour/issues/1578