### PR TITLE
Further improvements to tabs handling (add MoveTabToLeft / MoveTabToRight / MoveTabTo actions)

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,7 +107,9 @@
     <release version="0.6.2" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
           <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>
+          <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
           <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>
+          <li>Adds `MoveTabTo` action to move tabs to a specific position (#1695)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
         </ul>
       </description>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.6.2" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -81,6 +81,8 @@ optional<Action> fromString(string const& name)
         mapAction<actions::WriteScreen>("WriteScreen"),
         mapAction<actions::CreateNewTab>("CreateNewTab"),
         mapAction<actions::CloseTab>("CloseTab"),
+        mapAction<actions::MoveTabToLeft>("MoveTabToLeft"),
+        mapAction<actions::MoveTabToRight>("MoveTabToRight"),
         mapAction<actions::SwitchToTab>("SwitchToTab"),
         mapAction<actions::SwitchToPreviousTab>("SwitchToPreviousTab"),
         mapAction<actions::SwitchToTabLeft>("SwitchToTabLeft"),

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -81,6 +81,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::WriteScreen>("WriteScreen"),
         mapAction<actions::CreateNewTab>("CreateNewTab"),
         mapAction<actions::CloseTab>("CloseTab"),
+        mapAction<actions::MoveTabTo>("MoveTabTo"),
         mapAction<actions::MoveTabToLeft>("MoveTabToLeft"),
         mapAction<actions::MoveTabToRight>("MoveTabToRight"),
         mapAction<actions::SwitchToTab>("SwitchToTab"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -81,6 +81,8 @@ struct ViNormalMode{};
 struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
 struct CreateNewTab{};
 struct CloseTab{};
+struct MoveTabToLeft{};
+struct MoveTabToRight{};
 struct SwitchToTab{ int position; };
 struct SwitchToPreviousTab{};
 struct SwitchToTabLeft{};
@@ -140,6 +142,8 @@ using Action = std::variant<CancelSelection,
                             WriteScreen,
                             CreateNewTab,
                             CloseTab,
+                            MoveTabToLeft,
+                            MoveTabToRight,
                             SwitchToTab,
                             SwitchToPreviousTab,
                             SwitchToTabLeft,
@@ -259,6 +263,8 @@ namespace documentation
     };
     constexpr inline std::string_view CreateNewTab { "Creates a new tab in the terminal emulator." };
     constexpr inline std::string_view CloseTab { "Closes current tab." };
+    constexpr inline std::string_view MoveTabToLeft { "Moves current tab to the left." };
+    constexpr inline std::string_view MoveTabToRight { "Moves current tab to the right." };
     constexpr inline std::string_view SwitchToTab {
         "Switch to absolute tab position (starting at number 1)"
     };
@@ -323,6 +329,8 @@ inline auto getDocumentation()
         std::tuple { Action { WriteScreen {} }, documentation::WriteScreen },
         std::tuple { Action { CreateNewTab {} }, documentation::CreateNewTab },
         std::tuple { Action { CloseTab {} }, documentation::CloseTab },
+        std::tuple { Action { MoveTabToLeft {} }, documentation::MoveTabToLeft },
+        std::tuple { Action { MoveTabToRight {} }, documentation::MoveTabToRight },
         std::tuple { Action { SwitchToTab {} }, documentation::SwitchToTab },
         std::tuple { Action { SwitchToPreviousTab {} }, documentation::SwitchToPreviousTab },
         std::tuple { Action { SwitchToTabLeft {} }, documentation::SwitchToTabLeft },
@@ -397,6 +405,8 @@ DECLARE_ACTION_FMT(ViNormalMode)
 DECLARE_ACTION_FMT(WriteScreen)
 DECLARE_ACTION_FMT(CreateNewTab)
 DECLARE_ACTION_FMT(CloseTab)
+DECLARE_ACTION_FMT(MoveTabToLeft)
+DECLARE_ACTION_FMT(MoveTabToRight)
 DECLARE_ACTION_FMT(SwitchToPreviousTab)
 DECLARE_ACTION_FMT(SwitchToTabLeft)
 DECLARE_ACTION_FMT(SwitchToTabRight)
@@ -476,6 +486,8 @@ struct std::formatter<contour::actions::Action>: std::formatter<std::string>
         HANDLE_ACTION(ViNormalMode);
         HANDLE_ACTION(CreateNewTab);
         HANDLE_ACTION(CloseTab);
+        HANDLE_ACTION(MoveTabToLeft);
+        HANDLE_ACTION(MoveTabToRight);
         HANDLE_ACTION(SwitchToPreviousTab);
         HANDLE_ACTION(SwitchToTabLeft);
         HANDLE_ACTION(SwitchToTabRight);

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -1827,6 +1827,14 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
                 return std::nullopt;
         }
 
+        if (holds_alternative<actions::MoveTabTo>(action))
+        {
+            if (auto position = node["position"]; position.IsScalar())
+                return actions::MoveTabTo { position.as<int>() };
+            else
+                return std::nullopt;
+        }
+
         if (holds_alternative<actions::SwitchToTab>(action))
         {
             if (auto position = node["position"]; position.IsScalar())

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -741,6 +741,8 @@ constexpr StringLiteral InputMappingsConfig {
     "position.\n"
     "{comment} - IncreaseFontSize  Increases the font size by 1 pixel.\n"
     "{comment} - IncreaseOpacity   Increases the default-background opacity by 5%.\n"
+    "{comment} - MoveTabToLeft     Moves the current tab to the left.\n"
+    "{comment} - MoveTabToRight    Moves the current tab to the right.\n"
     "{comment} - NewTerminal       Spawns a new terminal at the current terminals current working "
     "directory.\n"
     "{comment} - NoSearchHighlight Disables current search highlighting, if anything is still "

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -783,6 +783,7 @@ constexpr StringLiteral InputMappingsConfig {
     "{comment} - SendChars         Writes given characters in `chars` member to the applications input.\n"
     "{comment} - SwitchToTab       Switches to the tab position, given by extra parameter \"position\".\n"
     "{comment}                     The positions start at number 1.\n"
+    "{comment} - SwitchToPreviousTab Switches to the previously active tab.\n"
     "{comment} - SwitchToTabLeft   Switches to the tab left of the current tab.\n"
     "{comment} - SwitchToTabRight  Switches to the tab right of the current tab.\n"
     "{comment} - CreateNewTab      Creates a new tab.\n"

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <limits>
 
@@ -185,7 +186,10 @@ namespace
 
 } // namespace
 
-TerminalSession::TerminalSession(unique_ptr<vtpty::Pty> pty, ContourGuiApp& app):
+TerminalSession::TerminalSession(TerminalSessionManager* manager,
+                                 unique_ptr<vtpty::Pty> pty,
+                                 ContourGuiApp& app):
+    _manager { manager },
     _id { createSessionId() },
     _startTime { steady_clock::now() },
     _config { app.config() },
@@ -1437,6 +1441,18 @@ bool TerminalSession::operator()(actions::CreateNewTab)
 bool TerminalSession::operator()(actions::CloseTab)
 {
     emit closeTab();
+    return true;
+}
+
+bool TerminalSession::operator()(actions::MoveTabToLeft)
+{
+    _manager->moveTabToLeft(this);
+    return true;
+}
+
+bool TerminalSession::operator()(actions::MoveTabToRight)
+{
+    _manager->moveTabToRight(this);
     return true;
 }
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1444,6 +1444,12 @@ bool TerminalSession::operator()(actions::CloseTab)
     return true;
 }
 
+bool TerminalSession::operator()(actions::MoveTabTo event)
+{
+    _manager->moveTabTo(event.position);
+    return true;
+}
+
 bool TerminalSession::operator()(actions::MoveTabToLeft)
 {
     _manager->moveTabToLeft(this);

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1434,7 +1434,7 @@ bool TerminalSession::operator()(actions::WriteScreen const& event)
 
 bool TerminalSession::operator()(actions::CreateNewTab)
 {
-    emit createNewTab();
+    _manager->createSession();
     return true;
 }
 

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -32,6 +32,7 @@ namespace display
 }
 
 class ContourGuiApp;
+class TerminalSessionManager;
 
 /**
  * A set of user-facing activities that are guarded behind a permission-check wall.
@@ -215,7 +216,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
      * @param pty a PTY object (can be process, networked, mockup, ...)
      * @param display fronend display to render the terminal.
      */
-    TerminalSession(std::unique_ptr<vtpty::Pty> pty, ContourGuiApp& app);
+    TerminalSession(TerminalSessionManager* manager, std::unique_ptr<vtpty::Pty> pty, ContourGuiApp& app);
     ~TerminalSession() override;
 
     int id() const noexcept { return _id; }
@@ -356,6 +357,8 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::WriteScreen const& event);
     bool operator()(actions::CreateNewTab);
     bool operator()(actions::CloseTab);
+    bool operator()(actions::MoveTabToLeft);
+    bool operator()(actions::MoveTabToRight);
     bool operator()(actions::SwitchToTab const& event);
     bool operator()(actions::SwitchToPreviousTab);
     bool operator()(actions::SwitchToTabLeft);
@@ -437,6 +440,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
 
     // private data
     //
+    TerminalSessionManager* _manager;
     int _id;
     std::chrono::steady_clock::time_point _startTime;
     config::Config _config;

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -357,6 +357,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::WriteScreen const& event);
     bool operator()(actions::CreateNewTab);
     bool operator()(actions::CloseTab);
+    bool operator()(actions::MoveTabTo);
     bool operator()(actions::MoveTabToLeft);
     bool operator()(actions::MoveTabToRight);
     bool operator()(actions::SwitchToTab const& event);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -112,6 +112,9 @@ void TerminalSessionManager::setSession(size_t index)
 
 TerminalSession* TerminalSessionManager::activateSession(TerminalSession* session, bool isNewSession)
 {
+    if (!session)
+        return nullptr;
+
     managerLog()(
         "Activating session ID {} at index {}", session->id(), getSessionIndexOf(session).value_or(-1));
 

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -79,7 +79,11 @@ TerminalSession* TerminalSessionManager::createSessionInBackground()
     auto* session = new TerminalSession(this, createPty(ptyPath), _app);
     managerLog()("Create new session with ID {} at index {}", session->id(), _sessions.size());
 
-    _sessions.push_back(session);
+    auto const currentSessionIterator = std::ranges::find(_sessions, _activeSession);
+    auto const insertPoint = currentSessionIterator != _sessions.end() ? std::next(currentSessionIterator)
+                                                                       : currentSessionIterator;
+
+    _sessions.insert(insertPoint, session);
 
     connect(session, &TerminalSession::sessionClosed, [this, session]() { removeSession(*session); });
 

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -220,6 +220,21 @@ void TerminalSessionManager::closeTab()
     removeSession(*_activeSession);
 }
 
+void TerminalSessionManager::moveTabTo(int position)
+{
+    auto const currentIndexOpt = getSessionIndexOf(_activeSession);
+    if (!currentIndexOpt)
+        return;
+
+    if (position < 1 || position > static_cast<int>(_sessions.size()))
+        return;
+
+    auto const index = static_cast<size_t>(position - 1);
+
+    std::swap(_sessions[currentIndexOpt.value()], _sessions[index]);
+    updateStatusLine();
+}
+
 void TerminalSessionManager::moveTabToLeft(TerminalSession* session)
 {
     auto const maybeIndex = getSessionIndexOf(session);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -76,7 +76,7 @@ TerminalSession* TerminalSessionManager::createSessionInBackground()
     }
 #endif
 
-    auto* session = new TerminalSession(createPty(ptyPath), _app);
+    auto* session = new TerminalSession(this, createPty(ptyPath), _app);
     managerLog()("Create new session with ID {} at index {}", session->id(), _sessions.size());
 
     _sessions.push_back(session);
@@ -214,6 +214,36 @@ void TerminalSessionManager::closeTab()
                  _activeSession->id());
 
     removeSession(*_activeSession);
+}
+
+void TerminalSessionManager::moveTabToLeft(TerminalSession* session)
+{
+    auto const maybeIndex = getSessionIndexOf(session);
+    if (!maybeIndex)
+        return;
+
+    auto const index = maybeIndex.value();
+
+    if (index > 0)
+    {
+        std::swap(_sessions[index], _sessions[index - 1]);
+        updateStatusLine();
+    }
+}
+
+void TerminalSessionManager::moveTabToRight(TerminalSession* session)
+{
+    auto const maybeIndex = getSessionIndexOf(session);
+    if (!maybeIndex)
+        return;
+
+    auto const index = maybeIndex.value();
+
+    if (index + 1 < _sessions.size())
+    {
+        std::swap(_sessions[index], _sessions[index + 1]);
+        updateStatusLine();
+    }
 }
 
 void TerminalSessionManager::removeSession(TerminalSession& thatSession)

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -38,6 +38,7 @@ class TerminalSessionManager: public QAbstractListModel
     Q_INVOKABLE void switchToTabRight();
     Q_INVOKABLE void switchToTab(int position);
     Q_INVOKABLE void closeTab();
+    Q_INVOKABLE void moveTabTo(int position);
     Q_INVOKABLE void moveTabToLeft(TerminalSession* session);
     Q_INVOKABLE void moveTabToRight(TerminalSession* session);
 

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -38,6 +38,8 @@ class TerminalSessionManager: public QAbstractListModel
     Q_INVOKABLE void switchToTabRight();
     Q_INVOKABLE void switchToTab(int position);
     Q_INVOKABLE void closeTab();
+    Q_INVOKABLE void moveTabToLeft(TerminalSession* session);
+    Q_INVOKABLE void moveTabToRight(TerminalSession* session);
 
     void setSession(size_t index);
 

--- a/src/contour/ui.template/Terminal.qml.in
+++ b/src/contour/ui.template/Terminal.qml.in
@@ -241,9 +241,10 @@ ContourTerminal
     }
 
     function delay(duration) { // In milliseconds
-    var timeStart = new Date().getTime();
+        var timeStart = new Date().getTime();
         while (new Date().getTime() - timeStart < duration) {
-    }
+            // Do nothing
+        }
     }
 
 


### PR DESCRIPTION
initial support of moving tabs

@Yaraslaut I think we should give `TerminalSession` access to its owning list of tabs (`TerminalSessionManager` currently).

Maybe the name isn't the best, when thinking of tabs alone. In the long term, we might think of a tree data structure in order to implement tiling-like splits/pane views.

So whatever the DS / API will be, a leaf node (like a terminal session) should always have access to its parent node. What do you think? IMHO, this could also simplify the logic in the QML side (something I failed to revive in my head today)

### Update

Changes:

- [x] add MoveTabToLeft / MoveTabToRight, MoveTabTo actions
- [x] ensure inserting new tab happens right next to the currently active tab
- [x] fixes `CreateTab` to sometimes not spawn more than one tab (fixed implicitly)

closes #1692
closes #1691 