### PR TITLE
add missing separators

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -119,6 +119,7 @@
       <description>
         <ul>
           <li>Do not abort when failing to create `XDG_STATE_HOME/contour/crash` directory</li>
+          <li>Fixes DECRQSS for SGR (#1696)</li>
           <li>Fixes tab switch crash after resize</li>
           <li>Fixes tab shrinking after tab creation/switches when a non-zero horizontal window margin is configured</li>
           <li>Fixes startup crash when window is not yet fully initialized</li>

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -142,6 +142,7 @@ namespace // {{{ helper
             output += value;
         };
         auto const sgrAddSub = [&](unsigned value) {
+            sgrSep();
             output += std::to_string(value);
         };
 


### PR DESCRIPTION
fixes broken replies to decrqss (and possibly more, but i only noticed while testing that)

tested by calling decrqss