### PR TITLE
Change `colors` terminfo entry from 256 up to 32767 colors

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -126,6 +126,7 @@
           <li>Fixes backtab (Shift+Tab) handling (#1685)</li>
           <li>Fixes various spelling typos across the codebase (#1688)</li>
           <li>Improve tab close handling to better select previously focused tab</li>
+          <li>Change `colors` terminfo entry from 256 up to 32767 colors</li>
           <li>Add action `SwitchToPreviousTab` to switch to the previously focused tab</li>
         </ul>
       </description>

--- a/src/vtbackend/Capabilities.cpp
+++ b/src/vtbackend/Capabilities.cpp
@@ -91,12 +91,14 @@ namespace
         Boolean { "Tc"_tcap, "Tc"sv, true }     // RGB color support (introduced by Tmux in 2016)
     );
 
+    constexpr inline auto Int16Max = std::numeric_limits<int16_t>::max();
+
     constexpr inline auto NumericalCaps = defineCapabilities(
-        Numeric { "co"_tcap, "cols"sv, 80 },     // number of columns in a line
-        Numeric { "it"_tcap, "it"sv, 8 },        // tabs initially every # spaces
-        Numeric { "Co"_tcap, "colors"sv, 256 },  // maximum number of colors on screen
-        Numeric { "pa"_tcap, "pairs"sv, 32767 }, // maximum number of color-pairs on the screen
-        Numeric { "li"_tcap, "lines"sv, 24 }     // default number of lines in a terminal
+        Numeric { "co"_tcap, "cols"sv, 80 },         // number of columns in a line
+        Numeric { "it"_tcap, "it"sv, 8 },            // tabs initially every # spaces
+        Numeric { "Co"_tcap, "colors"sv, Int16Max }, // maximum number of colors on screen
+        Numeric { "pa"_tcap, "pairs"sv, Int16Max },  // maximum number of color-pairs on the screen
+        Numeric { "li"_tcap, "lines"sv, 24 }         // default number of lines in a terminal
     );
 
     constexpr auto inline Undefined = Code {};

--- a/src/vtbackend/Capabilities_test.cpp
+++ b/src/vtbackend/Capabilities_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Capabilities.get")
     REQUIRE(rgb == "8/8/8");
 
     auto const colors = tcap.numericCapability("colors");
-    REQUIRE(colors == 256);
+    REQUIRE(colors == std::numeric_limits<int16_t>::max());
 
     auto const bce = tcap.numericCapability("bce");
     REQUIRE(bce);


### PR DESCRIPTION
With a little bit of help, I've got `msgcat --color=test` to output true colors in the "hue/saturation" section, which looks partly like this:

![image](https://github.com/user-attachments/assets/0cc9556d-73f1-42fb-9c4a-baed94765be7)

While this one better exposes the colors supported by Contour, we still have a remaining problem. gettext (the package providing `msgcat` executable) is heavily hardcoded down to xterm :vomiting_face:), so we need to make it pretend we are exterm by symlinking `c/contour` terminfo file to `x/xterm-contour`.

We should probably talk to the gettext guys to make their heuristic less xterm-centric.