### PR TITLE
Relax condition for codepoints size for IME

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li>Fixes `CancelSelection` default binding with escape (#1710)</li>
           <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
+          <li>Fixes crash using Chinese IME (#1707)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
           <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>
           <li>Adds `MoveTabTo` action to move tabs to a specific position (#1695)</li>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -407,7 +407,7 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
     if (!event->text().isEmpty())
     {
         auto const codepoints = event->text().toUcs4();
-        assert(codepoints.size() == 1);
+        assert(codepoints.size() >= 1);
 #if defined(__APPLE__)
         // On macOS the Alt-modifier does not seem to be passed to the terminal apps
         // but rather remapped to whatever macOS is mapping them to.


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1707
We need to relax the condition on the number of codepoints that can be inserted at once, since IME allows inserting more than one  glyph at a time.