### PR TITLE
Do not crop underflow glyphs if they fit in cell size height

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -111,6 +111,7 @@
           <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
           <li>Fixes crash using Chinese IME (#1707)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
+          <li>Allow glyphs to underflow if they are not bigger than the cell size (#1603)</li>
           <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>
           <li>Adds `MoveTabTo` action to move tabs to a specific position (#1695)</li>
           <li>Adds handling of control codes for Ctrl+5|6|7|8 (#1701)</li>

--- a/src/vtrasterizer/TextRenderer.cpp
+++ b/src/vtrasterizer/TextRenderer.cpp
@@ -770,11 +770,8 @@ auto TextRenderer::createRasterizedGlyph(atlas::TileLocation tileLocation,
     // or 0 if not overflowing.
     auto const yOverflow = max(0, yMax - _gridMetrics.cellSize.height.as<int>());
 
-    // {{{ crop underflow if yMin < 0 and yMax > 0
-    // If the rasterized glyph is underflowing below the grid cell's minimum (0),
-    // and overlaps with grid cell, then cut off at grid cell's bottom.
-    // For underscore glyphs, ymin can be lower than 0 but ymax is zero, so we need to check for yMax > 0.
-    if (yMin < 0 && yMax > 0)
+    // {{{ crop underflow if glyph is larger than cell
+    if (yMax - yMin > _gridMetrics.cellSize.height.as<int>())
     {
         auto const rowCount = (unsigned) -yMin;
         Require(rowCount <= unbox(glyph.bitmapSize.height));


### PR DESCRIPTION
Closes https://github.com/contour-terminal/contour/issues/1603
Some fonts position characters to underflow, for example char `p` so we should not crop such characters as long as they are not exceeding cell size 