### PR TITLE
Instead of option_as_alt introduce command_as_alt and fix behaviour

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -398,6 +398,7 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "insert_after_yank", where.insertAfterYank);
         loadFromEntry(child, "bell", where.bell);
         loadFromEntry(child, "wm_class", where.wmClass);
+        loadFromEntry(child, "command_as_alt", where.commandKeyAsAlt);
         loadFromEntry(child, "margins", where.margins);
         loadFromEntry(child, "terminal_id", where.terminalId);
         loadFromEntry(child, "frozen_dec_modes", where.frozenModes);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -445,7 +445,7 @@ struct TerminalProfile
     ConfigEntry<HyperlinkDecorationConfig, documentation::HyperlinkDecoration> hyperlinkDecoration {};
 
     ConfigEntry<std::string, documentation::WMClass> wmClass { CONTOUR_APP_ID };
-    ConfigEntry<bool, documentation::OptionKeyAsAlt> optionKeyAsAlt { false };
+    ConfigEntry<bool, documentation::CommandKeyAsAlt> commandKeyAsAlt { true };
 };
 
 const InputMappings defaultInputMappings {

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -1631,22 +1631,22 @@ constexpr StringLiteral HyperlinkDecorationWeb {
 
 };
 
-constexpr StringLiteral OptionKeyAsAltConfig {
-    "{comment} Tells Contour how to handle Option-Key events on MacOS.\n"
+constexpr StringLiteral CommandKeyAsAltConfig {
+    "{comment} Tells Contour how to handle Command-Key events on MacOS.\n"
     "{comment} This value is ignored on other platforms.\n"
     "{comment}\n"
-    "{comment} Default: false\n"
-    "option_as_alt: {}\n"
+    "{comment} Default: true\n"
+    "command_as_alt: {}\n"
     "\n"
 };
 
-constexpr StringLiteral OptionKeyAsAltWeb {
-    "section tells Contour how to handle Option-Key events on MacOS.\n"
+constexpr StringLiteral CommandKeyAsAltWeb {
+    "section tells Contour how to handle Command-Key events on MacOS.\n"
     "This value is ignored on other platforms.\n"
     "``` yaml\n"
     "profiles:\n"
     "  profile_name:\n"
-    "    option_as_alt: false\n"
+    "    command_as_alt: false\n"
     "```\n"
     "\n"
 };
@@ -1753,7 +1753,7 @@ using TerminalId = DocumentationEntry<TerminalIdConfig, TerminalIdWeb>;
 using History = DocumentationEntry<HistoryConfig, HistoryWeb>;
 using Scrollbar = DocumentationEntry<ScrollbarConfig, ScrollbarWeb>;
 using StatusLine = DocumentationEntry<StatusLineConfig, StatusLineWeb>;
-using OptionKeyAsAlt = DocumentationEntry<OptionKeyAsAltConfig, OptionKeyAsAltWeb>;
+using CommandKeyAsAlt = DocumentationEntry<CommandKeyAsAltConfig, CommandKeyAsAltWeb>;
 using Fonts = DocumentationEntry<FontsConfig, FontsWeb>;
 using Permissions = DocumentationEntry<PermissionsConfig, PermissionsWeb>;
 using DrawBoldTextWithBrightColors =

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -246,7 +246,7 @@ profiles:
         # This value is ignored on other platforms.
         #
         # Default: false
-        option_as_alt: false
+        command_as_alt: false
 
         # Environment variables to be passed to the shell.
         # environment:

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -387,11 +387,11 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         return true;
     }
 
-#if defined(__apple__)
-    if (0x20 <= key && key < 0x80 && (modifiers.alt() && session.profile().optionKeyAsAlt.value()))
+#if defined(__APPLE__)
+    if (0x20 <= key && key < 0x80
+        && ((modifiers & Modifier::Super) && session.profile().commandKeyAsAlt.value()))
     {
-        auto const ch = static_cast<char32_t>(modifiers.shift() ? std::toupper(key) : std::tolower(key));
-        session.sendCharEvent(ch, physicalKey, modifiers, eventType, now);
+        session.sendCharEvent(key, physicalKey, Modifier::Alt, vtbackend::KeyboardEventType::Press, now);
         event->accept();
         return true;
     }


### PR DESCRIPTION
on my system macOS shows Sigma symbol when I press Option+W for example, same happening to other keybindings, maybe it is better to use command instead of option as an alt alternative on the macos then? @christianparpart 
Also, PR fixes option_as_alt behaviour since we need to check for __APPLE__ macro and send press event to trigger user key_mappings action

Closes #1607.