### PR TITLE
[GitHub] Fix bug report template drop-down selection elements

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -11,7 +11,7 @@ body:
 - type: input
   attributes:
     label: Contour Terminal version
-    placeholder: "0.2.3"
+    placeholder: "0.1.2.9999"
     description: |
       Contour terminal version. Try running `contour version` at the commandline to find out.
       Please copy'n'paste the full version line.
@@ -25,11 +25,11 @@ body:
     description: |
       Where did you get the software from.
     options:
-    - "Github: source code cloned"
-    - "Github: CI actions"
-    - "GitHub: release page"
+    - "GitHub: Source code"
+    - "GitHub: CI (Actions) artifact"
+    - "GitHub: Release page attachment"
     - "Ubuntu: PPA"
-    - "something else (please specify below)"
+    - "Something else (please specify below)"
   validations:
     required: true
 
@@ -57,11 +57,10 @@ body:
       What hardware architecture is Contour and your OS running on.
       In most cases, this is usually x86-64, but may vary.
     options:
-    - "x86-64"
-    - "x86"
-    - "ARM64"
-    - "AArch64"
-    - "something else (please specify below)"
+    - "x86 / i386"
+    - "x86-64 / amd64"
+    - "AArch64 / ARM64"
+    - "Something else (please specify below)"
   validations:
     required: true
 


### PR DESCRIPTION
ARM64 and AArch64 are the same thing. Some platforms and tools prefer using this or that name for it. Similarly, in many cases especially on Linux, different distributions and ecosystems use `amd64` instead of `x86-64` or `x86_64` to refer to what is essentially the same thing.

For example, Ubuntu uses `amd64`, `arm64`, and `i386` in the package names; see for example: https://launchpad.net/ubuntu/noble/+package/gcc-12-base.

Running the stock util command `arch` on Mac says `arm64` or `i386` (even for 64-bit Mac Intel builds: try running `arch -x86_64 zsh` to spawn an emulated version of the shell and then call `arch` inside, it will still say `i386`!), but the Linux `arch` command (and, by that logic, `uname`) reports `aarch64` and `x86_64` for the ARM vs. PC line.