### PR TITLE
Fix a couple of typos

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The website is living directly in the project's main repository.
 We are using [MkDocs](https://squidfunk.github.io/mkdocs-material/) to create the website
 and have the project well documented.
 
-Please bare with us, we just started developing this website, it is incomplete and far from perfect.
+Please bear with us, we just started developing this website, it is incomplete and far from perfect.
 This is why documentation and website development needs the most love and probably external contributions.
 
 ## Running the website locally

--- a/docs/vt-extensions/vertical-line-marks.md
+++ b/docs/vt-extensions/vertical-line-marks.md
@@ -24,7 +24,7 @@ have automatic markers set.
 
 ## Integration into ZSH:
 
-zsh is way to configurable to give a fully generic answer here, but to show how you can integrate vertical line markers when using the [powerlevel9k](https://github.com/Powerlevel9k/powerlevel9k), this is what your `~/.zshrc` config could contain:
+zsh is way too configurable to give a fully generic answer here, but to show how you can integrate vertical line markers when using [powerlevel9k](https://github.com/Powerlevel9k/powerlevel9k), this is what your `~/.zshrc` config could contain:
 
 ```sh
 prompt_setmark() {


### PR DESCRIPTION
Noticed the first when reading the terminal extensions documentation, and
noticed the second when reading the contributing guide.

## Description

Describe your changes in detail

```markdown
- **vertical-line-marks.md: Fix typos in ZSH integration docs**
- **CONTRIBUTING.md: Fix typo: s/bare with us/bear with us/**: https://www.merriam-webster.com/dictionary/bear%20with#phrases
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Fixes two typos.
```

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
  - N/A
- [x] I have gone through all the steps, and have thoroughly read the instructions
