### PR TITLE
Fix indicator statusline default and insert mode loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1120,7 +1120,7 @@ jobs:
     - name: "configure cmake"
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX=~/opt/notcurses \
+              -DCMAKE_INSTALL_PREFIX=~/home/runner/opt/notcurses \
               -DUSE_CPP=OFF \
               -DUSE_DEFLATE=OFF \
               -DUSE_MULTIMEDIA=ffmpeg \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1120,7 +1120,7 @@ jobs:
     - name: "configure cmake"
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX=~/home/runner/opt/notcurses \
+              -DCMAKE_INSTALL_PREFIX=/home/runner/opt/notcurses \
               -DUSE_CPP=OFF \
               -DUSE_DEFLATE=OFF \
               -DUSE_MULTIMEDIA=ffmpeg \

--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -193,11 +193,14 @@ color_schemes:
         inactive:
           foreground: '#FFFFFF'
           background: '#0270C0'
+        insert_mode:
+          foreground: '#FFFFFF'
+          background: '#0270C0'
         normal_mode:
-          foreground: '#0f0002'
+          foreground: '#0F0002'
           background: '#0270C0'
         visual_mode:
-          foreground: '#ffffff'
+          foreground: '#FFFFFF'
           background: '#0270C0'
 ```
 
@@ -291,11 +294,21 @@ color_schemes:
             foreground_alpha: 1.0
             background_alpha: 0.5
         indicator_statusline:
-            foreground: '#808080'
-            background: '#000000'
-        indicator_statusline_inactive:
-            foreground: '#808080'
-            background: '#000000'
+            default:
+              foreground: '#FFFFFF'
+              background: '#0270C0'
+            inactive:
+              foreground: '#FFFFFF'
+              background: '#0270C0'
+            insert_mode:
+              foreground: '#FFFFFF'
+              background: '#0270C0'
+            normal_mode:
+              foreground: '#FFFFFF'
+              background: '#0270C0'
+            visual_mode:
+              foreground: '#FFFFFF'
+              background: '#0270C0'
         input_method_editor:
             foreground: '#FFFFFF'
             background: '#FF0000'

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.6.2" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Fixes insert mode / default status line colorscheme loading (#1737)</li>
           <li>Fixes `CancelSelection` default binding with escape (#1710)</li>
           <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
           <li>Fixes crash using Chinese IME (#1707)</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -550,11 +550,13 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, vtbackend::ColorPal
             vtbackend::RGBColorPair defaultIndicatorStatusLine;
             loadFromEntry(child["indicator_statusline"], "default", defaultIndicatorStatusLine);
             where.indicatorStatusLineInactive = defaultIndicatorStatusLine;
+            where.indicatorStatusLineInsertMode = defaultIndicatorStatusLine;
             where.indicatorStatusLineNormalMode = defaultIndicatorStatusLine;
             where.indicatorStatusLineVisualMode = defaultIndicatorStatusLine;
         }
         for (auto const& [name, defaultColor]:
              { pair { "inactive", &where.indicatorStatusLineInactive },
+               pair { "insert_mode", &where.indicatorStatusLineInsertMode },
                pair { "normal_mode", &where.indicatorStatusLineNormalMode },
                pair { "visual_mode", &where.indicatorStatusLineVisualMode } })
         {


### PR DESCRIPTION
## Description
- Adapted from #1743.
- Fixes the colorscheme config loading for the indicator status line to include `default` and `insert_mode` sections.
- Updates the examples in the docs to include all 5 sections, as well as removing the unused `indicator_statusline_inactive` section.

## Motivation and Context
- Closes #1737.
- The docs (currently) state that 5 sections may be configured under the `indicator_statusline` section of the config: `default`, `inactive`, `insert_mode`, `normal_mode`, and `visual_mode`. These changes reflect that claim.
- See https://github.com/contour-terminal/contour/pull/1743#issuecomment-2770891575 for further context.

## How Has This Been Tested?
- Built locally and verified by removing portions of the config to see changes.
- Before: ![Before](https://github.com/user-attachments/assets/724ccaaf-46e7-4b12-9224-613398e3cd20)
- After: ![After](https://github.com/user-attachments/assets/dd6696b4-20bd-474d-aae6-cb0549eed5d0)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [x] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
	- Not entirely sure how to implement tests for this, open to suggestions.
- [x] I have gone through all the steps, and have thoroughly read the instructions