### PR TITLE
allow preset colors tweaks

### DIFF
--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -2,6 +2,9 @@ Color scheme configure colors that are used inside terminal. To specify which co
 
 ## Color scheme configuration
 
+Color configuration is set under `profiles` with `colors`.
+Then the scheme is defined under `color_schemes`.
+
 ### `default`
 section defines the default colors used in the terminal.
 ``` yaml
@@ -182,6 +185,20 @@ color_schemes:
           foreground: '#808080'
           background: '#000000'
 ```
+
+### Palette Presets 
+When choosing a palette from a preset as the color scheme  (in `profiles`) it is possible to tweak any configuration:
+``` yaml
+color_schemes:
+  one-light:
+      word_highlight_other:
+          foreground: CellForeground
+          background: CellBackground
+          foreground_alpha: 1.0
+          background_alpha: 1.0
+```
+ 
+
 Complete configuration looks like this:
 ``` yaml
 color_schemes:

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -112,6 +112,7 @@
           <li>Fixes `CancelSelection` default binding with escape (#1710)</li>
           <li>Fixes `CreateTab` to sometimes spawn more than one tab (#1695)</li>
           <li>Fixes crash using Chinese IME (#1707)</li>
+          <li>Enables customizing predefined color palette (#1763)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
           <li>Allow glyphs to underflow if they are not bigger than the cell size (#1603)</li>
           <li>Adds `MoveTabToLeft` and `MoveTabToRight` actions to move tabs around (#1695)</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -470,7 +470,6 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
     if (vtbackend::defaultColorPalettes(entry, where))
     {
         logger()("Loaded predefined color palette {}", entry);
-        return;
     }
 
     if (!child) // can not load directly from config file


### PR DESCRIPTION
## Description

Fall through when configuring preset palette.
Allows tweaking preset configuration later in the yaml

Enables, for example, under `color_schemes`:
```
    one-light:
        word_highlight_other:
            foreground: CellForeground
            background: CellBackground
            foreground_alpha: 1.0
            background_alpha: 1.0
```

## Motivation and Context

Enables tweaking preset color schemes.
It allows users to change part of the configuration when selecting a preset one.

## How Has This Been Tested?
I ran it locally

## Documentation
`docs/configuration/colors.md` was updated with the new ability

