### PR TITLE
Refactor: Unify vector declaration style in files with 'using namespace std"

### DIFF
--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -108,9 +108,9 @@ namespace
                     "Could not create directory {}. {}", path.parent_path().string(), ec.message()) };
     }
 
-    vector<fs::path> getTermInfoDirs(optional<fs::path> const& appTerminfoDir)
+    std::vector<fs::path> getTermInfoDirs(optional<fs::path> const& appTerminfoDir)
     {
-        auto locations = vector<fs::path>();
+        auto locations = std::vector<fs::path>();
 
         if (appTerminfoDir.has_value())
             locations.emplace_back(appTerminfoDir.value().string());
@@ -140,7 +140,7 @@ namespace
             return "contour";
 
         auto locations = getTermInfoDirs(appTerminfoDir);
-        auto const terms = vector<string> {
+        auto const terms = std::vector<string> {
             "contour", "xterm-256color", "xterm", "vt340", "vt220",
         };
 

--- a/src/vtbackend/Selector.cpp
+++ b/src/vtbackend/Selector.cpp
@@ -85,7 +85,7 @@ bool Selection::intersects(Rect area) const noexcept
     return false;
 }
 
-std::vector<Selection::Range> Selection::ranges() const
+vector<Selection::Range> Selection::ranges() const
 {
     auto [result, from, to] = prepare(*this);
 

--- a/src/vtpty/Process_unix.cpp
+++ b/src/vtpty/Process_unix.cpp
@@ -58,9 +58,7 @@ namespace
         return strerror(errno);
     }
 
-    [[nodiscard]] char** createArgv(string const& arg0,
-                                    std::vector<string> const& args,
-                                    size_t startIndex = 0)
+    [[nodiscard]] char** createArgv(string const& arg0, vector<string> const& args, size_t startIndex = 0)
     {
         // Factor out in order to avoid false-positive by static analysers.
         auto const argCount = args.size() - startIndex;
@@ -172,7 +170,7 @@ void Process::start()
 
                 // Prepend flatpak to jump out of sandbox:
                 // flatpak-spawn --host --watch-bus --env=TERM=$TERM /bin/zsh
-                auto realArgs = std::vector<string> {};
+                auto realArgs = vector<string> {};
                 realArgs.emplace_back("--host");
                 realArgs.emplace_back("--watch-bus");
                 realArgs.emplace_back(

--- a/src/vtpty/Process_win32.cpp
+++ b/src/vtpty/Process_win32.cpp
@@ -137,7 +137,7 @@ namespace
         return hr;
     }
 
-    char** createArgv(string const& arg0, std::vector<string> const& args, size_t i = 0)
+    char** createArgv(string const& arg0, vector<string> const& args, size_t i = 0)
     {
         auto const argCount = args.size(); // factor out in order to avoid false-positive by static analysers.
         char** argv = new char*[argCount + 2 - i];

--- a/src/vtrasterizer/RenderTarget.cpp
+++ b/src/vtrasterizer/RenderTarget.cpp
@@ -18,7 +18,7 @@ void Renderable::setRenderTarget(RenderTarget& renderTarget, DirectMappingAlloca
 }
 
 auto Renderable::createTileData(atlas::TileLocation tileLocation,
-                                std::vector<uint8_t> bitmap,
+                                vector<uint8_t> bitmap,
                                 atlas::Format bitmapFormat,
                                 ImageSize bitmapSize,
                                 ImageSize renderBitmapSize,

--- a/src/vtrasterizer/utils.cpp
+++ b/src/vtrasterizer/utils.cpp
@@ -23,7 +23,7 @@ vector<uint8_t> downsampleRGBA(vector<uint8_t> const& bitmap,
     auto const ratio = max(ratioX, ratioY);
     auto const factor = static_cast<unsigned>(ceil(ratio));
 
-    std::vector<uint8_t> dest;
+    vector<uint8_t> dest;
     dest.resize(*newSize.height * *newSize.width * 4);
 
     // RasterizerLog()("scaling from {} to {}, ratio {}x{} ({}), factor {}",
@@ -79,7 +79,7 @@ vector<uint8_t> downsample(vector<uint8_t> const& bitmap,
     auto const ratio = max(ratioX, ratioY);
     auto const factor = static_cast<unsigned>(ceil(ratio));
 
-    std::vector<uint8_t> dest(*newSize.width * *newSize.height * numComponents, 0);
+    vector<uint8_t> dest(*newSize.width * *newSize.height * numComponents, 0);
 
     rasterizerLog()("downsample from {} to {}, ratio {}x{} ({}), factor {}",
                     size,


### PR DESCRIPTION
- Standardize vector declarations to either `vector` or `std::vector` per-file
- For each file containing 'using namespace std':
  - Analyze existing usage patterns of std types
  - Convert all vector declarations to match the prevalent style:
    * Use unqualified `vector` if majority usage omits std::
    * Use fully qualified `std::vector` if majority explicitly scopes types
- Maintains internal consistency within each file
- Preserves existing coding patterns and style preferences
- No functional changes - purely stylistic refactoring