### PR TITLE
Fixed compilation error by spliting to an if statement

### DIFF
--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -315,7 +315,13 @@ bool ContourGuiApp::loadConfig(string const& target)
     }
 
     if (auto const wmClass = flags.get<string>("contour.terminal.class"); !wmClass.empty())
-        _config.profile(profileName())->wmClass = wmClass;
+    {
+        auto profile = _config.profile(profileName());
+        if (profile)
+        {
+            profile->wmClass = wmClass;
+        }
+    }
 
     return true;
 }


### PR DESCRIPTION
## Description

Added an if staement to support constexpr usage
Fixes: https://github.com/contour-terminal/contour/issues/1774

## Motivation and Context

Without it pedentic does not work

## How Has This Been Tested?

compiled

