### PR TITLE
Fixes crash on full screen scrolling

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -125,6 +125,7 @@
           <li>Adds ability to name tabs (#1690)</li>
           <li>Adds dynamic loading of conpty.dll to allow mouse mode on Windows 10</li>
           <li>Fix empty history jump (#1781)</li>
+          <li>Fixes crash on full screen scrolling</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -525,8 +525,8 @@ void Grid<Cell>::scrollDown(LineCount vN, GraphicsAttributes const& defaultAttri
 
         rotateBuffersRight(n);
 
-        for (Line<Cell>& line: mainPage().subspan(0, unbox<size_t>(n)))
-            line.reset(defaultLineFlags(), defaultAttributes);
+        for (auto const i: ranges::views::iota(0, *n))
+            _lines[i].reset(defaultLineFlags(), defaultAttributes);
         return;
     }
 


### PR DESCRIPTION
When using Kakoune(Vim-like editor) to open a file, repeatedly pressing Page Up and Page Down can lead to crashes randomly.
The issue occurs within the  fullscreen scrolling branch of vtbackend::Grid::scrollDown.
```
backtrace:
std::__throw_bad_variant_access (__n=<optimized out>) at /usr/include/c++/15/variant:1420
std::get<...> (__v=std::variant [no contained value]) at /usr/include/c++/15/variant:1153
vtbackend::Line<vtbackend::CompactCell>::inflatedBuffer (this=0x1fa7d50) at contour/src/vtbackend/Line.h:456
vtbackend::Line<vtbackend::CompactCell>::reset (this=0x1fa7d50, flags=..., attributes=...) at contour/src/vtbackend/Line.h:113
                 HERE: "this=0x1fa7d50" is an illegal address!
vtbackend::Grid<vtbackend::CompactCell>::scrollDown (this=this@entry=0x1876448, vN=..., defaultAttributes=..., margin=...) at contour/src/vtbackend/Grid.cpp:529
vtbackend::Screen<vtbackend::CompactCell>::scrollDown (this=this@entry=0x1876380, n=..., margin=...) at contour/src/vtbackend/Screen.cpp:768
```

**Reason:**
Grid::rotateBuffersRight(n) performs a rotation on the ring buffer. gsl::span::subspan() cannot correctly handle the ring buffer, so leading to an out-of-bounds access for _lines[].

**Solution:**
Directly reset the corresponding line.

