### PR TITLE
Fix unchecked or unused QFile open status

### DIFF
--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -427,7 +427,7 @@ int ContourApp::integrationAction()
                                      shell);
             return EXIT_FAILURE;
         }
-        file.open(QFile::ReadOnly);
+        Require(file.open(QFile::ReadOnly));
         auto const contents = file.readAll();
         stream.write(contents.constData(), contents.size());
         return EXIT_SUCCESS;

--- a/src/contour/display/Blur.cpp
+++ b/src/contour/display/Blur.cpp
@@ -29,8 +29,7 @@ namespace
             QString::fromStdString(std::format("#version {}\n", useOpenGLES() ? "300 es" : "330"));
 
         QFile file(shaderFilePath);
-        file.open(QFile::ReadOnly);
-        Require(file.isOpen());
+        Require(file.open(QFile::ReadOnly));
         auto const fileContents = file.readAll();
         return versionHeader + "#line 1\n" + fileContents;
     }

--- a/src/contour/display/ShaderConfig.cpp
+++ b/src/contour/display/ShaderConfig.cpp
@@ -68,16 +68,14 @@ ShaderConfig builtinShaderConfig(ShaderClass shaderClass)
     auto const makeConfig = [](ShaderClass shaderClass) -> ShaderConfig {
         auto const makeSource = [](QString const& filename) -> ShaderSource {
             QFile sharedDefinesFile(":/contour/vtrasterizer/shared_defines.h");
-            sharedDefinesFile.open(QFile::ReadOnly);
-            Require(sharedDefinesFile.isOpen());
+            Require(sharedDefinesFile.open(QFile::ReadOnly));
             auto const sharedDefines = sharedDefinesFile.readAll().toStdString() + "\n#line 1\n";
             auto const versionHeader = std::format("#version {}\n", useOpenGLES() ? "300 es" : "330");
 
             auto const shaderFilePath = ":/contour/display/shaders/" + filename;
 
             QFile file(shaderFilePath);
-            file.open(QFile::ReadOnly);
-            Require(file.isOpen());
+            Require(file.open(QFile::ReadOnly));
             auto const fileContents = file.readAll().toStdString();
 
             auto const fileHeader = versionHeader + sharedDefines;


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
Fix several QFile::open() return values that are not checked or used.  
Previously, some call sites subsequently checked by Require(file.isopen()) which can be made redundant. 
One other call site missed the check.
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown
Improves the file open status check.
```

## How Has This Been Tested?

- [x] Please describe how you tested your changes.
- [x] see how your change affects other areas of the code, etc.

Regression test by running the test target.   As far as I can tell, the test covers the the change.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have gone through all the steps, and have thoroughly read the instructions
