### PR TITLE
[contour] Slightly improve mouse/touchpad scroll sensitivity.

### DIFF
--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -175,11 +175,11 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
 
     int getScrollX() const noexcept { return _accumulatedScrollX; }
     void addScrollX(int v) noexcept { _accumulatedScrollX += v; }
-    void resetScrollX() noexcept { _accumulatedScrollX = 0; }
+    void resetScrollX(int value) noexcept { _accumulatedScrollX = value; }
 
     int getScrollY() const noexcept { return _accumulatedScrollY; }
     void addScrollY(int v) noexcept { _accumulatedScrollY += v; }
-    void resetScrollY() noexcept { _accumulatedScrollY = 0; }
+    void resetScrollY(int value) noexcept { _accumulatedScrollY = value; }
 
     QString title() const;
     void setTitle(QString const& value) { terminal().setWindowTitle(value.toStdString()); }


### PR DESCRIPTION
This is (sadly) not yet worth a changelog, because the improvement is minimal.
But the implementation is at least more correct in not losing mouse/touchpad scroll pixel distances.

I was expecting that we forgot to apply UI scaling. But we do this. And yet, it feels like scrolling is not quite fast.
However, some other TEs also suffer from this, but KDE konsole at least doesn't. I assume that they simply don't use pixel data but angle data to scroll. :thinking: 
