### PR TITLE
Fix CMake configuration for CONTOUR_FRONTEND_GUI=OFF to still build contour binary, but without GUI.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,4 @@ add_subdirectory(vtparser)
 add_subdirectory(vtbackend)
 add_subdirectory(vtrasterizer)
 
-if(CONTOUR_FRONTEND_GUI)
-    add_subdirectory(contour)
-endif()
+add_subdirectory(contour)

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -24,7 +24,9 @@ message(STATUS "Qt components: ${QT_COMPONENTS}")
 
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 
-add_subdirectory(display)
+if(CONTOUR_FRONTEND_GUI)
+    add_subdirectory(display)
+endif()
 
 if(APPLE)
     #set(CMAKE_INSTALL_RPATH "@executable_path")
@@ -35,29 +37,32 @@ if(APPLE)
     find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 endif()
 
+set(_header_files
+    Actions.h
+    CaptureScreen.h
+    Config.h
+    ContourApp.h
+)
 set(_source_files
-    CaptureScreen.cpp CaptureScreen.h
+    Actions.cpp
+    CaptureScreen.cpp
+    Config.cpp
+    ContourApp.cpp
     main.cpp
 )
 
 if(CONTOUR_FRONTEND_GUI)
     list(APPEND _header_files
-        Actions.h
         Audio.h
         BlurBehind.h
-        Config.h
-        ContourApp.h
         ContourGuiApp.h
         TerminalSession.h
         TerminalSessionManager.h
         helper.h
     )
     list(APPEND _source_files
-        Actions.cpp
         Audio.cpp
         BlurBehind.cpp
-        Config.cpp
-        ContourApp.cpp
         ContourGuiApp.cpp
         TerminalSession.cpp
         TerminalSessionManager.cpp
@@ -167,10 +172,9 @@ endif()
 
 target_link_libraries(contour
     PRIVATE
-    ContourTerminalDisplay
     crispy::core
     vtbackend
-    vtrasterizer
+    Qt6::Core
     ${YAML_CPP_LIBRARIES}
 )
 
@@ -181,7 +185,8 @@ if(CONTOUR_FRONTEND_GUI)
     endif()
     target_link_libraries(contour
         PRIVATE
-        Qt6::Core
+        vtrasterizer
+        ContourTerminalDisplay
         Qt6::Core5Compat
         Qt6::Multimedia
         Qt6::Network

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -361,11 +361,13 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("mouse_block_selection_modifier", c.mouseBlockSelectionModifiers);
         loadFromEntry("profiles", c.profiles, c.defaultProfileName.value());
         loadFromEntry("git_drawings", c.gitDrawings);
+#if defined(CONTOUR_FRONTEND_GUI)
         vtrasterizer::BoxDrawingRenderer::setGitDrawingsStyle(c.gitDrawings.value());
         loadFromEntry("box_arc_style", c.boxArcStyle);
         vtrasterizer::BoxDrawingRenderer::setArcStyle(c.boxArcStyle.value());
         loadFromEntry("braile_style", c.braileStyle);
         vtrasterizer::BoxDrawingRenderer::setBraileStyle(c.braileStyle.value());
+#endif
 
         // loadFromEntry("color_schemes", c.colorschemes); // NB: This is always loaded lazily
         loadFromEntry("input_mapping", c.inputMappings);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -3,7 +3,10 @@
 
 #include <contour/Actions.h>
 #include <contour/ConfigDocumentation.h>
-#include <contour/display/ShaderConfig.h>
+
+#if defined(CONTOUR_FRONTEND_GUI)
+    #include <contour/display/ShaderConfig.h>
+#endif
 
 #include <vtbackend/Color.h>
 #include <vtbackend/ColorPalette.h>
@@ -1566,11 +1569,11 @@ struct std::formatter<vtbackend::Opacity>: formatter<float>
 };
 
 template <>
-struct std::formatter<crispy::strong_hashtable_size>: formatter<uint>
+struct std::formatter<crispy::strong_hashtable_size>: formatter<unsigned>
 {
     auto format(crispy::strong_hashtable_size value, auto& ctx) const
     {
-        return formatter<uint>::format(value.value, ctx);
+        return formatter<unsigned>::format(value.value, ctx);
     }
 };
 
@@ -1617,11 +1620,11 @@ struct std::formatter<vtbackend::StatusDisplayType>: formatter<std::string_view>
 };
 
 template <>
-struct std::formatter<crispy::lru_capacity>: formatter<uint>
+struct std::formatter<crispy::lru_capacity>: formatter<unsigned>
 {
     auto format(crispy::lru_capacity value, auto& ctx) const
     {
-        return formatter<uint>::format(value.value, ctx);
+        return formatter<unsigned>::format(value.value, ctx);
     }
 };
 

--- a/src/contour/display/CMakeLists.txt
+++ b/src/contour/display/CMakeLists.txt
@@ -30,5 +30,12 @@ endif()
 
 target_include_directories(ContourTerminalDisplay PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../..")
 target_link_libraries(ContourTerminalDisplay vtrasterizer)
-target_link_libraries(ContourTerminalDisplay Qt6::Core Qt6::Gui Qt6::OpenGL Qt6::Multimedia Qt6::Quick Qt6::QuickControls2)
+target_link_libraries(ContourTerminalDisplay
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Multimedia
+    Qt6::OpenGL
+    Qt6::Quick
+    Qt6::QuickControls2
+)
 set_target_properties(ContourTerminalDisplay PROPERTIES AUTOMOC ON)

--- a/src/contour/main.cpp
+++ b/src/contour/main.cpp
@@ -1,5 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <contour/ContourGuiApp.h>
+
+#if defined(CONTOUR_FRONTEND_GUI)
+    #include <contour/ContourGuiApp.h>
+#else
+    #include <contour/ContourApp.h>
+#endif
+
+#include <QtCore/QByteArray>
+#include <QtCore/QString>
+
+#if __has_include(<QtCore/QtLogging>)
+    #include <QtCore/QtLogging>
+#endif
 
 #if defined(_WIN32)
     #include <cstdio>


### PR DESCRIPTION
Closes #1780.