### PR TITLE
[CMake] Bump default Qt search path to C:/Qt/6.10.0 (from 6.6.1)

### DIFF
--- a/cmake/presets/os-windows.json
+++ b/cmake/presets/os-windows.json
@@ -16,7 +16,7 @@
             },
             "cacheVariables": {
                 "VCPKG_TARGET_TRIPLET": "x64-windows",
-                "CMAKE_PREFIX_PATH": "C:/Qt/6.6.1/msvc2019_64",
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.10.0/msvc2022_64",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
                 "CMAKE_SYSTEM_VERSION": "10",
                 "CMAKE_VERBOSE_MAKEFILE": "ON",


### PR DESCRIPTION
Jumping Qt (Cmake) module search path to look for Qt version 6.10.0 instead of 6.6.1.
I am assuming that this won't break CI. It at least helps me not updating this var on windows dev box though ;)