### PR TITLE
Adapts CSIu input protocol to match how recent fish shell implementation transmits it.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -120,6 +120,7 @@
           <li>Fixes double line box drawing characters</li>
           <li>Fixes DECRQM (DEC Request Mode) response (#1797)</li>
           <li>Fixes Precondition failure when rendering vertically overflowing glyphs (#1805)</li>
+          <li>Fixes fish-shell keyboard input protocol behaviour; acting as if it would be broken on e.g. control keys (weird handling of CSIu input protocol)</li>
           <li>Enables customizing predefined color palette (#1763)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
           <li>Allow glyphs to underflow if they are not bigger than the cell size (#1603)</li>

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -517,7 +517,7 @@ constexpr inline auto CHA         = detail::CSI(std::nullopt, 0, 1, std::nullopt
 constexpr inline auto CHT         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'I', VTType::VT100, documentation::CHT);
 constexpr inline auto CNL         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'E', VTType::VT100, documentation::CNL);
 constexpr inline auto CPL         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'F', VTType::VT100, documentation::CPL);
-constexpr inline auto CSIUENHCE   = detail::CSI('=', 1, 2, std::nullopt, 'u', VTExtension::Unknown, documentation::CSIUENHCE);
+constexpr inline auto CSIUENHCE   = detail::CSI('=', 0, 2, std::nullopt, 'u', VTExtension::Unknown, documentation::CSIUENHCE);
 constexpr inline auto CSIUENTER   = detail::CSI('>', 0, 1, std::nullopt, 'u', VTExtension::Unknown, documentation::CSIUENTER);
 constexpr inline auto CSIULEAVE   = detail::CSI('<', 0, 1, std::nullopt, 'u', VTExtension::Unknown, documentation::CSIULEAVE);
 constexpr inline auto CSIUQUERY   = detail::CSI('?', 0, 0, std::nullopt, 'u', VTExtension::Unknown, documentation::CSIUQUERY);

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -3636,10 +3636,9 @@ ApplyResult Screen<Cell>::apply(Function const& function, Sequence const& seq)
             return ApplyResult::Ok;
         }
         case CSIUENHCE: {
-            auto const flags = KeyboardEventFlags::from_value(seq.param_or(0, 1));
+            // Defaulting flags to 0. (Seems not to be documented by the spec, but Fish shell is doing that!)
+            auto const flags = KeyboardEventFlags::from_value(seq.param_or(0, 0));
             auto const mode = seq.param_or(1, 1);
-            if (_terminal->keyboardProtocol().stackDepth() <= 1)
-                return ApplyResult::Invalid;
             switch (mode)
             {
                 case 1: _terminal->keyboardProtocol().flags() = flags; return ApplyResult::Ok;


### PR DESCRIPTION

However, I cannot really read that behaviour from https://sw.kovidgoyal.net/kitty/keyboard-protocol/

There was no example showing `CSI = u` nor `CSI = 5 u` without first entering CSIu mode.

It seems like fish shell is tweaking CSIu mode by setting/resetting without entering/leaving.

The given spec however also does not mention flags to default to 0 neither.


--

It *MAY* be that other CLI applications may also not enter/leave and just set/reset flags, so I think it MAY be good to have in anyways.

This may also relate to #1776. @mrdgo, if it is possible at all, maybe you want to give this branch a try?