### PR TITLE
Revert indicator status-line back to showing tabs left

### DIFF
--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -184,10 +184,11 @@ struct MouseConfig
 struct IndicatorConfig
 {
     std::string left { " {InputMode:Bold,Color=#FFFF00}"
-                       "{SearchPrompt:Left= │ }"
                        "{TraceMode:Bold,Color=#FFFF00,Left= │ }"
-                       "{ProtectedMode:Bold,Left= │ }" };
-    std::string middle { "{Tabs:ActiveColor=#FFFF00}" };
+                       "{Tabs:ActiveColor=#FFFF00,Left= │ }"
+                       "{ProtectedMode:Bold,Left= │ }"
+                       "{SearchPrompt:Left= │ }" };
+    std::string middle { "« {Title} »" };
     std::string right { "{HistoryLineCount:Faint,Color=#c0c0c0} │ {Clock:Bold}" };
 };
 


### PR DESCRIPTION
This is especially to how other terminals and applications show tabs by default. The user is free to configure to deviate from that default.

