### PR TITLE
[contour] Fixes option_as_alt configuration option not working on macOS

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -126,6 +126,7 @@
           <li>Fixes Precondition failure when rendering vertically overflowing glyphs (#1805)</li>
           <li>Fixes fish-shell keyboard input protocol behavior; acting as if it would be broken on e.g. control keys (weird handling of CSIu input protocol)</li>
           <li>Fixes `ssh.known_hosts` configuration loading incorrectly mapping to `ssh.public_key_file`</li>
+          <li>Fixes `option_as_alt` configuration option not working (#1812)</li>
           <li>Enables customizing predefined color palette (#1763)</li>
           <li>Ensure inserting new tabs happens right next to the currently active tab (#1695)</li>
           <li>Allow glyphs to underflow if they are not bigger than the cell size (#1603)</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -407,6 +407,7 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "insert_after_yank", where.insertAfterYank);
         loadFromEntry(child, "bell", where.bell);
         loadFromEntry(child, "wm_class", where.wmClass);
+        loadFromEntry(child, "option_as_alt", where.optionKeyAsAlt);
         loadFromEntry(child, "margins", where.margins);
         loadFromEntry(child, "terminal_id", where.terminalId);
         loadFromEntry(child, "frozen_dec_modes", where.frozenModes);

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -379,10 +379,12 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         return true;
     }
 
-#if defined(__apple__)
-    if (0x20 <= key && key < 0x80 && (modifiers.alt() && session.profile().optionKeyAsAlt.value()))
+#if defined(__APPLE__)
+    if (0x20 <= key && key < 0x80
+        && (modifiers.test(Modifier::Alt) && session.profile().optionKeyAsAlt.value()))
     {
-        auto const ch = static_cast<char32_t>(modifiers.shift() ? std::toupper(key) : std::tolower(key));
+        bool const shiftPressed = modifiers.test(Modifier::Shift) ^ modifiers.test(Modifier::CapsLock);
+        auto const ch = static_cast<char32_t>(shiftPressed ? std::toupper(key) : std::tolower(key));
         session.sendCharEvent(ch, physicalKey, modifiers, eventType, now);
         event->accept();
         return true;


### PR DESCRIPTION
closes #1812.