### PR TITLE
Adds configuration action ToggleInputMethodHandling to allow toggling IME (input method editor) handling

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -139,6 +139,7 @@
           <li>Adds git graph drawing glyphs</li>
           <li>Adds new arc style for box drawing characters</li>
           <li>Adds multiple rendering options for braille characters</li>
+          <li>Adds configuration action ToggleInputMethodHandling to allow toggling IME (input method editor) handling (#1813)</li>
           <li>Drop Qt5 support</li>
         </ul>
       </description>

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -70,6 +70,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::SendChars>("SendChars"),
         mapAction<actions::ToggleAllKeyMaps>("ToggleAllKeyMaps"),
         mapAction<actions::ToggleFullscreen>("ToggleFullscreen"),
+        mapAction<actions::ToggleInputMethodHandling>("ToggleInputMethodHandling"),
         mapAction<actions::ToggleInputProtection>("ToggleInputProtection"),
         mapAction<actions::ToggleStatusLine>("ToggleStatusLine"),
         mapAction<actions::ToggleTitleBar>("ToggleTitleBar"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -71,6 +71,7 @@ struct SearchReverse{};
 struct SendChars{ std::string chars; };
 struct ToggleAllKeyMaps{};
 struct ToggleFullscreen{};
+struct ToggleInputMethodHandling {};
 struct ToggleInputProtection{};
 struct ToggleStatusLine{};
 struct ToggleTitleBar{};
@@ -134,6 +135,7 @@ using Action = std::variant<CancelSelection,
                             SendChars,
                             ToggleAllKeyMaps,
                             ToggleFullscreen,
+                            ToggleInputMethodHandling,
                             ToggleInputProtection,
                             ToggleStatusLine,
                             ToggleTitleBar,
@@ -245,6 +247,9 @@ namespace documentation
                                                          "keybind will be preserved when disabling all "
                                                          "others)." };
     constexpr inline std::string_view ToggleFullscreen { "Enables/disables full screen mode." };
+    constexpr inline std::string_view ToggleInputMethodHandling {
+        "Enables/disables IME (input method editor) handling."
+    };
     constexpr inline std::string_view ToggleInputProtection { "Enables/disables terminal input protection." };
     constexpr inline std::string_view ToggleStatusLine {
         "Shows/hides the VT320 compatible Indicator status line."
@@ -333,6 +338,7 @@ constexpr
         std::tuple { Action { SendChars {} }, documentation::SendChars },
         std::tuple { Action { ToggleAllKeyMaps {} }, documentation::ToggleAllKeyMaps },
         std::tuple { Action { ToggleFullscreen {} }, documentation::ToggleFullscreen },
+        std::tuple { Action { ToggleInputMethodHandling {} }, documentation::ToggleInputMethodHandling },
         std::tuple { Action { ToggleInputProtection {} }, documentation::ToggleInputProtection },
         std::tuple { Action { ToggleStatusLine {} }, documentation::ToggleStatusLine },
         std::tuple { Action { ToggleTitleBar {} }, documentation::ToggleTitleBar },
@@ -415,6 +421,7 @@ DECLARE_ACTION_FMT(SearchReverse)
 DECLARE_ACTION_FMT(SendChars)
 DECLARE_ACTION_FMT(ToggleAllKeyMaps)
 DECLARE_ACTION_FMT(ToggleFullscreen)
+DECLARE_ACTION_FMT(ToggleInputMethodHandling)
 DECLARE_ACTION_FMT(ToggleInputProtection)
 DECLARE_ACTION_FMT(ToggleStatusLine)
 DECLARE_ACTION_FMT(ToggleTitleBar)
@@ -507,6 +514,7 @@ struct std::formatter<contour::actions::Action>: std::formatter<std::string>
         HANDLE_ACTION(SendChars);
         HANDLE_ACTION(ToggleAllKeyMaps);
         HANDLE_ACTION(ToggleFullscreen);
+        HANDLE_ACTION(ToggleInputMethodHandling);
         HANDLE_ACTION(ToggleInputProtection);
         HANDLE_ACTION(ToggleStatusLine);
         HANDLE_ACTION(ToggleTitleBar);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -519,6 +519,12 @@ const InputMappings defaultInputMappings {
     .charMappings {
         CharInputMapping {
             .modes { vtbackend::MatchModes {} },
+            .modifiers { vtbackend::Modifiers { vtbackend::Modifiers { vtbackend::Modifier::Alt }
+                                                | vtbackend::Modifiers { vtbackend::Modifier::Control } } },
+            .input = ',',
+            .binding = { { actions::ToggleInputMethodHandling {} } } },
+        CharInputMapping {
+            .modes { vtbackend::MatchModes {} },
             .modifiers { vtbackend::Modifiers { vtbackend::Modifiers { vtbackend::Modifier::Shift }
                                                 | vtbackend::Modifiers { vtbackend::Modifier::Control } } },
             .input = '-',

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -792,6 +792,7 @@ constexpr StringLiteral InputMappingsConfig {
     "preserved "
     "when disabling all others).\n"
     "{comment} - ToggleFullScreen  Enables/disables full screen mode.\n"
+    "{comment} - ToggleInputMethodHandling Enables/disables IME (input method editor) handling.\n"
     "{comment} - ToggleInputProtection Enables/disables terminal input protection.\n"
     "{comment} - ToggleStatusLine  Shows/hides the VT320 compatible Indicator status line.\n"
     "{comment} - ToggleTitleBar    Shows/Hides titlebar\n"

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1466,6 +1466,13 @@ bool TerminalSession::operator()(actions::ToggleFullscreen)
     return true;
 }
 
+bool TerminalSession::operator()(actions::ToggleInputMethodHandling)
+{
+    if (_display)
+        _display->toggleInputMethodEditorHandling();
+    return true;
+}
+
 bool TerminalSession::operator()(actions::ToggleInputProtection)
 {
     terminal().setAllowInput(!terminal().allowInput());

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -351,6 +351,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::SendChars const& event);
     bool operator()(actions::ToggleAllKeyMaps);
     bool operator()(actions::ToggleFullscreen);
+    bool operator()(actions::ToggleInputMethodHandling);
     bool operator()(actions::ToggleInputProtection);
     bool operator()(actions::ToggleStatusLine);
     bool operator()(actions::ToggleTitleBar);

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1366,6 +1366,13 @@ void TerminalDisplay::toggleTitleBar()
     window()->setFlag(Qt::FramelessWindowHint, !currentlyFrameless);
 }
 
+void TerminalDisplay::toggleInputMethodEditorHandling()
+{
+    auto const enabled = !static_cast<bool>(flags() & Flag::ItemAcceptsInputMethod);
+    displayLog()("{} IME (input method editor) handling", enabled ? "Enabling" : "Disabling");
+    setFlag(Flag::ItemAcceptsInputMethod, enabled);
+}
+
 void TerminalDisplay::setHyperlinkDecoration(vtrasterizer::Decorator normal, vtrasterizer::Decorator hover)
 {
     _renderer->setHyperlinkDecoration(normal, hover);

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -141,6 +141,7 @@ class TerminalDisplay: public QQuickItem
     void setBlurBehind(bool enable);
     void toggleFullScreen();
     void toggleTitleBar();
+    void toggleInputMethodEditorHandling();
     void setHyperlinkDecoration(vtrasterizer::Decorator normal, vtrasterizer::Decorator hover);
 
     // terminal events


### PR DESCRIPTION
Closes #1813.

This is most useful on macOS, since there you can trigger ime by simply pressing e.g. `k` and that breaks UX for vim-like users in the terminal, when using vim motions to move around quickly. So quickly turning it off or on is actually useful.