### PR TITLE
feat: add input_method_editor profile configuration

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -139,7 +139,8 @@
           <li>Adds git graph drawing glyphs</li>
           <li>Adds new arc style for box drawing characters</li>
           <li>Adds multiple rendering options for braille characters</li>
-          <li>Adds configuration action ToggleInputMethodHandling to allow toggling IME (input method editor) handling (#1813)</li>
+          <li>Adds configuration action ToggleInputMethodHandling to allow toggling IME (Input Method Editor) handling (#1813)</li>
+          <li>Adds configuration option `input_method_editor` to profile settings to opt-out of IME (Input Method Editor) support (#1817)</li>
           <li>Drop Qt5 support</li>
         </ul>
       </description>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -417,6 +417,7 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "scrollbar", where.scrollbar);
         loadFromEntry(child, "mouse", where.mouse);
         loadFromEntry(child, "permissions", where.permissions);
+        loadFromEntry(child, "input_method_editor", where.inputMethodEditor);
         loadFromEntry(child, "highlight_word_and_matches_on_double_click", where.highlightDoubleClickedWord);
         loadFromEntry(child, "font", where.fonts);
         loadFromEntry(child, "draw_bold_text_with_bright_colors", where.drawBoldTextWithBrightColors);

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -422,6 +422,7 @@ struct TerminalProfile
     ConfigEntry<ScrollBarConfig, documentation::Scrollbar> scrollbar {};
     ConfigEntry<MouseConfig, documentation::Mouse> mouse { true };
     ConfigEntry<PermissionsConfig, documentation::Permissions> permissions {};
+    ConfigEntry<bool, documentation::InputMethodEditorSupport> inputMethodEditor { true };
     ConfigEntry<bool, documentation::HighlightDoubleClickerWord> highlightDoubleClickedWord { true };
     ConfigEntry<vtrasterizer::FontDescriptions, documentation::Fonts> fonts { defaultFont };
     ConfigEntry<bool, documentation::DrawBoldTextWithBrightColors> drawBoldTextWithBrightColors { false };

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -421,6 +421,13 @@ constexpr StringLiteral HighlightTimeoutConfig {
     "\n"
 };
 
+constexpr StringLiteral InputMethodEditorSupportConfig {
+    "{comment} Enables Input Method Editor (IME) support.\n"
+    "{comment} This is enabled by default.\n"
+    "input_method_editor: {}\n"
+    "\n"
+};
+
 constexpr StringLiteral HighlightDoubleClickerWordConfig {
     "{comment} If enabled, and you double-click on a word in the primary screen,\n"
     "{comment} all other words matching this word will be highlighted as well.\n"
@@ -1840,6 +1847,7 @@ using WordHighlightCurrent = DocumentationEntry<WordHighlightCurrentConfig, Dumm
 using WordHighlight = DocumentationEntry<WordHighlightConfig, Dummy>;
 using IndicatorStatusLine = DocumentationEntry<IndicatorStatusLineConfig, Dummy>;
 using InputMethodEditor = DocumentationEntry<InputMethodEditorConfig, Dummy>;
+using InputMethodEditorSupport = DocumentationEntry<InputMethodEditorSupportConfig, Dummy>;
 using NormalColors = DocumentationEntry<NormalColorsConfig, Dummy>;
 using BrightColors = DocumentationEntry<BrightColorsConfig, Dummy>;
 using DimColors = DocumentationEntry<DimColorsConfig, Dummy>;

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -306,6 +306,10 @@ void TerminalDisplay::setSession(TerminalSession* newSession)
 
     QObject::connect(newSession, &TerminalSession::titleChanged, this, &TerminalDisplay::titleChanged);
 
+    auto const imeEnabled = profile().inputMethodEditor.value();
+    setFlag(Flag::ItemAcceptsInputMethod, imeEnabled);
+    displayLog()("IME enabled: {}", imeEnabled);
+
     _session->start();
 
     window()->setFlag(Qt::FramelessWindowHint, !profile().showTitleBar.value());


### PR DESCRIPTION
This PR adds a new profile configuration \`input_method_editor\` (boolean, default true) to control IME support.

Changes:
- Added \`inputMethodEditor\` to \`TerminalProfile\` in \`Config.h\`.
- Updated \`ConfigDocumentation.h\` with documentation.
- Updated \`Config.cpp\` to parse the new option.
- Updated \`TerminalDisplay.cpp\` to initialize IME state from profile configuration.
- Added release note to \`metainfo.xml\`.

Note: Includes temporary debug logging in \`TerminalDisplay.cpp\` to assist with verification.

Closes #1817.