### PR TITLE
Fix build for clang19 with libstdc++-13

### DIFF
--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -4,9 +4,11 @@
 #include <crispy/assert.h>
 #include <crispy/utils.h>
 
+#include <array>
 #include <format>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <variant>
 
 namespace contour::actions
@@ -290,10 +292,7 @@ namespace documentation
     constexpr inline std::string_view SetTabName { "Set the name of the current tab" };
 } // namespace documentation
 
-#if defined(__clang__) && __clang_major__ >= 19
-constexpr
-#endif
-    inline auto getDocumentation()
+constexpr inline auto getDocumentation()
 {
     return std::array {
         std::tuple { Action { CancelSelection {} }, documentation::CancelSelection },
@@ -362,7 +361,7 @@ constexpr
 }
 
 #if defined(__clang__) && __clang_major__ >= 19
-static_assert(getDocumentation().size() == std::variant_size_v<Action>);
+static_assert(std::tuple_size_v<decltype(getDocumentation())> == std::variant_size_v<Action>);
 #endif
 
 } // namespace contour::actions


### PR DESCRIPTION
## Description

Describe your changes in detail

```markdown
In file included from /home/deepin/contour/src/contour/display/TerminalDisplay.cpp:2:
/home/deepin/contour/src/contour/Actions.h:365:15: error: static assertion expression is not an integral constant expression
  365 | static_assert(getDocumentation().size() == std::variant_size_v<Action>);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_construct.h:97:14: note: construction of subobject of member '_M_local_buf' of union with no active member is not allowed in a constant expression
   97 |     { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
      |              ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/char_traits.h:272:6: note: in call to 'construct_at<char, const char &>(&Action{ChangeProfile{}}._Variant_storage::_M_u._Variant_storage::_M_rest._Variant_storage::_M_first._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/variant:273:7)._Variant_storage::_M_storage._Variant_storage::name._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._Variant_storage::_M_local_buf[0], ChangeProfile{}.name.union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._M_local_buf[0])'
  272 |             std::construct_at(__s1 + __i, __s2[__i]);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/char_traits.h:443:11: note: in call to 'copy(&Action{ChangeProfile{}}._Variant_storage::_M_u._Variant_storage::_M_rest._Variant_storage::_M_first._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/variant:273:7)._Variant_storage::_M_storage._Variant_storage::name._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._Variant_storage::_M_local_buf[0], &ChangeProfile{}.name.union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._M_local_buf[0], 1)'
  443 |           return __gnu_cxx::char_traits<char_type>::copy(__s1, __s2, __n);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:672:6: note: in call to 'copy(&Action{ChangeProfile{}}._Variant_storage::_M_u._Variant_storage::_M_rest._Variant_storage::_M_first._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/variant:273:7)._Variant_storage::_M_storage._Variant_storage::name._Variant_storage::union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._Variant_storage::_M_local_buf[0], &ChangeProfile{}.name.union (anonymous union at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:204:7)._M_local_buf[0], 1)'
  672 |             traits_type::copy(_M_local_buf, __str._M_local_buf,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  673 |                               __str.length() + 1);
      |                               ~~~~~~~~~~~~~~~~~~~
/home/deepin/contour/src/contour/Actions.h:33:8: note: in call to 'basic_string(ChangeProfile{}.name)'
   33 | struct ChangeProfile{ std::string name; };
      |        ^~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/variant:249:4: note: in call to 'ChangeProfile(ChangeProfile{})'
  249 |         : _M_storage(std::forward<_Args>(__args)...)
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/variant:384:4: note: (skipping 7 calls in backtrace; use -fconstexpr-backtrace-limit=0 to see all)
  384 |         : _M_first(in_place_index<0>, std::forward<_Args>(__args)...)
      |           ^
```

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown

```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
