### PR TITLE
Fix minor MSVC compiler warnings

### DIFF
--- a/src/crispy/App.cpp
+++ b/src/crispy/App.cpp
@@ -164,12 +164,12 @@ int app::licenseAction()
 {
     auto const& store = crispy::cli::about::store();
     auto const titleWidth = std::accumulate(
-        store.begin(), store.end(), 0u, [](size_t a, auto const& b) { return std::max(a, b.title.size()); });
-    auto const licenseWidth = std::accumulate(store.begin(), store.end(), 0u, [](size_t a, auto const& b) {
+        store.begin(), store.end(), 0zu, [](size_t a, auto const& b) { return std::max(a, b.title.size()); });
+    auto const licenseWidth = std::accumulate(store.begin(), store.end(), 0zu, [](size_t a, auto const& b) {
         return std::max(a, b.license.size());
     });
     auto const urlWidth = std::accumulate(
-        store.begin(), store.end(), 0u, [](size_t a, auto const& b) { return std::max(a, b.url.size()); });
+        store.begin(), store.end(), 0zu, [](size_t a, auto const& b) { return std::max(a, b.url.size()); });
 
     constexpr auto Horiz = "\u2550"sv;
     constexpr auto Vert = "\u2502"sv;

--- a/src/text_shaper/shaper.cpp
+++ b/src/text_shaper/shaper.cpp
@@ -116,7 +116,7 @@ tuple<rasterized_glyph, float> scale(rasterized_glyph const& bitmap, vtbackend::
     output.position.y =
         unbox<int>(output.bitmapSize.height) + unbox<int>(boundingBox.height - output.bitmapSize.height) / 4;
 
-    return { output, factor };
+    return { output, static_cast<float>(factor) };
 }
 
 } // namespace text

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -126,9 +126,9 @@ namespace
         for (auto const& pair: Pairs)
         {
             if (input == pair.first)
-                return { { pair.second, true } };
+                return { { static_cast<char>(pair.second), true } };
             if (input == pair.second)
-                return { { pair.first, false } };
+                return { { static_cast<char>(pair.first), false } };
         }
 
         return std::nullopt;


### PR DESCRIPTION
This pull request makes small type-safety improvements and clarifies type conversions in several parts of the codebase. The changes mainly ensure that initial values and returned types use explicit and appropriate types, which can help prevent subtle bugs and improve code readability.

Type conversions and initial value updates:

* Updated initial values in calls to `std::accumulate` in `src/crispy/App.cpp` to use `0zu` instead of `0u`, clarifying the intended type for size calculations.
* Changed the return value in the `scale` function in `src/text_shaper/shaper.cpp` to explicitly cast `factor` to `float`, ensuring the tuple contains the correct type.
* Added explicit `static_cast<char>` conversions for values returned in the command pair matching logic in `src/vtbackend/ViCommands.cpp`, making the returned types more predictable.