### PR TITLE
Update libunicode to version 0.7.0, supporting Unicode 17.0.0

### DIFF
--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -53,7 +53,7 @@ endmacro()
 message(STATUS "==============================================================================")
 message(STATUS "    Contour ThirdParties: ${ContourThirdParties}")
 
-set(LIBUNICODE_MINIMAL_VERSION "0.6.0")
+set(LIBUNICODE_MINIMAL_VERSION "0.7.0")
 set(BOXED_CPP_MINIMAL_VERSION "1.4.3")
 set(TERMBENCH_PRO_COMMIT_HASH "f6c37988e6481b48a8b8acaf1575495e018e9747")
 set(CATCH_VERSION "3.4.0")

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -10,22 +10,22 @@ class ThirdParty {
     [string] $Macro
 }
 
-$libunicode_git_sha="817cb5900acdf6f60e2344a4c8f1f39262878a4b"
-$reflection_cpp_git_sha="02484cd9ec16d7efc252ab8fd1f85d7264192418"
+$libunicode_version="0.7.0"
+$reflection_cpp_version="0.4.0"
 
 # Take care, order matters, at least as much as dependencies are of concern.
 $ThirdParties =
 @(
     [ThirdParty]@{
-        Folder  = "reflection-cpp-${reflection_cpp_git_sha}";
-        Archive = "reflection-cpp-${reflection_cpp_git_sha}.zip";
-        URI     = "https://github.com/contour-terminal/reflection-cpp/archive/${reflection_cpp_git_sha}.zip";
+        Folder  = "reflection-cpp-${reflection_cpp_version}";
+        Archive = "reflection-cpp-${reflection_cpp_version}.zip";
+        URI     = "https://github.com/contour-terminal/reflection-cpp/archive/refs/tags/v${reflection_cpp_version}.zip";
         Macro   = "reflection_cpp"
     };
     [ThirdParty]@{
-        Folder  = "libunicode-${libunicode_git_sha}";
-        Archive = "libunicode-${libunicode_git_sha}.zip";
-        URI     = "https://github.com/contour-terminal/libunicode/archive/${libunicode_git_sha}.zip";
+        Folder  = "libunicode-${libunicode_version}";
+        Archive = "libunicode-${libunicode_version}.zip";
+        URI     = "https://github.com/contour-terminal/libunicode/archive/refs/tags/v${libunicode_version}.zip";
         Macro   = "libunicode"
     };
     [ThirdParty]@{

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -104,11 +104,11 @@ fetch_and_unpack_boxed() {
 
 fetch_and_unpack_libunicode() {
     if test x$LIBUNICODE_SRC_DIR = x; then
-        local libunicode_git_sha="817cb5900acdf6f60e2344a4c8f1f39262878a4b"
+        local libunicode_version="0.7.0"
         fetch_and_unpack \
-            libunicode-$libunicode_git_sha \
-            libunicode-$libunicode_git_sha.tar.gz \
-            https://github.com/contour-terminal/libunicode/archive/$libunicode_git_sha.tar.gz \
+            libunicode-$libunicode_version \
+            libunicode-$libunicode_version.tar.gz \
+            https://github.com/contour-terminal/libunicode/archive/refs/tags/v${libunicode_version}.tar.gz \
             libunicode
     else
         echo "Hard linking external libunicode source directory to: $LIBUNICODE_SRC_DIR"
@@ -120,11 +120,11 @@ fetch_and_unpack_libunicode() {
 }
 
 fetch_and_unpack_reflection_cpp() {
-    local reflection_cpp_git_sha="02484cd9ec16d7efc252ab8fd1f85d7264192418"
+    local reflection_cpp_version="0.4.0"
     fetch_and_unpack \
-        reflection-cpp-$reflection_cpp_git_sha \
-        reflection-cpp-$reflection_cpp_git_sha.tar.gz \
-        https://github.com/contour-terminal/reflection-cpp/archive/$reflection_cpp_git_sha.tar.gz \
+        reflection-cpp-$reflection_cpp_version \
+        reflection-cpp-$reflection_cpp_version.tar.gz \
+        https://github.com/contour-terminal/reflection-cpp/archive/refs/tags/v${reflection_cpp_version}.tar.gz \
         reflection_cpp
 }
 


### PR DESCRIPTION
This pull request updates the dependencies for `libunicode` and `reflection-cpp` to use their latest tagged releases instead of specific git commit hashes. The changes affect both the CMake configuration and the dependency installation scripts for Windows and Unix-like systems.

Dependency version updates:

* Updated the minimum required version of `libunicode` in `cmake/ContourThirdParties.cmake` from `0.6.0` to `0.7.0`.
* Updated the dependency installation scripts (`install-deps.ps1` and `install-deps.sh`) to fetch `libunicode` version `0.7.0` and `reflection-cpp` version `0.4.0` from their respective tagged releases, instead of using specific git commit hashes. [[1]](diffhunk://#diff-25031af30432b3e35de77f7ac1ab4827654940173e72c892c161de9d57e1a9c3L13-R28) [[2]](diffhunk://#diff-730bfa187055b10e83cb5b13c8431a299d1548d7617e875174ec33d85151de9bL107-R111) [[3]](diffhunk://#diff-730bfa187055b10e83cb5b13c8431a299d1548d7617e875174ec33d85151de9bL123-R127)

Download source updates:

* Changed the download URLs in the installation scripts to use the `/refs/tags/v<version>` format, ensuring the dependencies are fetched from official release tags rather than from arbitrary commits. [[1]](diffhunk://#diff-25031af30432b3e35de77f7ac1ab4827654940173e72c892c161de9d57e1a9c3L13-R28) [[2]](diffhunk://#diff-730bfa187055b10e83cb5b13c8431a299d1548d7617e875174ec33d85151de9bL107-R111) [[3]](diffhunk://#diff-730bfa187055b10e83cb5b13c8431a299d1548d7617e875174ec33d85151de9bL123-R127)