### PR TITLE
[vtrasterizer] Fixes U+E0B6 PUA (half filled circle right)

### DIFF
--- a/src/vtrasterizer/Pixmap.cpp
+++ b/src/vtrasterizer/Pixmap.cpp
@@ -91,7 +91,7 @@ Pixmap& Pixmap::halfFilledCircleLeft()
         putpixel(x, y + (h / 2));
     };
     auto const radius = crispy::point { .x = w, .y = h / 2 };
-    drawEllipseArc(putAbove, size, radius, Arc::UL);
+    drawEllipseArc(putAbove, size, radius, Arc::UR);
     drawEllipseArc(putBelow, size, radius, Arc::BR);
     return *this;
 }


### PR DESCRIPTION
check the image of swapped vs correct :)

<img width="553" height="462" alt="image" src="https://github.com/user-attachments/assets/c1c310bd-809e-4a0b-9e5e-c7a906dfbfb1" />

