### PR TITLE
Implement Shell Integration Framework (OSC 133)

### DIFF
--- a/docs/vt-extensions/osc-133-shell-integration.md
+++ b/docs/vt-extensions/osc-133-shell-integration.md
@@ -1,0 +1,103 @@
+# OSC 133 - Shell Integration
+
+This documentation describes the OSC 133 sequence used for shell integration, often referred to as FinalTerm or VSCode shell integration.
+
+**Proposal:** [VSCode Shell Integration](https://code.visualstudio.com/docs/terminal/shell-integration)
+
+## Sequence Specification
+
+**Format:** `OSC 133 ; <Command> [; <Parameters>...] ST`
+
+Where:
+
+* `OSC` is `\033]`.
+* `ST` (String Terminator) is `\033\` (or BEL `\007`).
+* `<Command>` is a single character identifier (A, B, C, D).
+
+### Commands
+
+#### A - Prompt Start
+
+Sent before the shell prompt starts printing.
+
+**Format:** `OSC 133 ; A [; <Key>=<Value>...] ST`
+
+**Parameters:**
+
+* `click_events=1`: Optional. If present (e.g., `OSC 133;A;click_events=1;ST`), indicates that the terminal should enable mouse click reporting for the prompt area.
+
+**Behavior:**
+
+* Marks the current line as a prompt line (conceptually similar to setting a "mark").
+* Notifies the terminal that the prompt is beginning.
+
+#### B - Prompt End
+
+Sent after the shell prompt has finished printing and before user input begins.
+
+**Format:** `OSC 133 ; B ST`
+
+**Behavior:**
+
+* Notifies the terminal that the prompt has ended.
+
+#### C - Command Output Start
+
+Sent after the user has finished typing the command (usually on Enter press) and before the command output begins.
+
+**Format:** `OSC 133 ; C [; <Key>=<Value>...] ST`
+
+**Parameters:**
+
+* `cmdline_url=<EncodedURL>`: Optional. Defines the command line being executed. The URL is percent-encoded.
+
+**Behavior:**
+
+* Notifies the terminal that command execution is starting and output will follow.
+* The `cmdline_url` parameter allows the terminal to know exactly what command is being run (useful for features like "Run Recent Command").
+
+#### D - Command Finished
+
+Sent after the command has finished executing and before the next prompt starts.
+
+**Format:** `OSC 133 ; D [; <ExitCode>] ST`
+
+**Parameters:**
+
+* `<ExitCode>`: The integer exit code of the command (e.g., `0` for success).
+
+**Behavior:**
+
+* Notifies the terminal that the command has finished.
+* Reports the exit code of the command.
+
+---
+
+## Example Flow
+
+```bash
+# Prompt Start
+printf "\033]133;A\033\\"
+
+# ... print prompt ...
+printf "user@host:~$ "
+
+# Prompt End
+printf "\033]133;B\033\\"
+
+# ... user types command (e.g., 'ls') ...
+
+# Command Output Start
+printf "\033]133;C\033\\"
+
+# ... command output ...
+ls
+
+# Command Finished (exit code 0)
+printf "\033]133;D;0\033\\"
+```
+
+## Related Extensions
+
+* **SETMARK (CSI > M)**: This extension is deprecated in favor of OSC 133.
+It is however similar to `OSC 133 ; A` by triggering `promptStart` and marking the line.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -147,6 +147,7 @@
           <li>Adds configuration option `input_method_editor` to profile settings to opt-out of IME (Input Method Editor) support (#1817)</li>
           <li>Adds background blur support for KDE Plasma on Wayland (for Qt 6.5.0 and newer)</li>
           <li>Adds VT sequences for double width / double height lines, `DECDHL`, `DECDWL`, `DECSWL` (#137)</li>
+          <li>Adds VT sequence extension OSC 133 shell integration (#793)</li>
           <li>Drop Qt5 support</li>
         </ul>
       </description>

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -130,6 +130,7 @@ if(LIBTERMINAL_TESTING)
         Image_test.cpp
         Sequence_test.cpp
         Terminal_test.cpp
+        ShellIntegration_test.cpp
         SixelParser_test.cpp
         ViCommands_test.cpp
     )

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -200,6 +200,7 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void clearToBeginOfScreen();
     void clearToEndOfScreen();
     void clearScreen();
+    void setMark();
 
     // DECSEL
     void selectiveEraseToBeginOfLine();
@@ -257,7 +258,6 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     void index();        // IND
     void reverseIndex(); // RI
 
-    void setMark();
     void setScrollSpeed(int speed);      // DECSSCLS
     void deviceStatusReport();           // DSR
     void reportCursorPosition();         // CPR
@@ -641,6 +641,8 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] std::unique_ptr<ParserExtension> hookSixel(Sequence const& seq);
     [[nodiscard]] std::unique_ptr<ParserExtension> hookDECRQSS(Sequence const& seq);
     [[nodiscard]] std::unique_ptr<ParserExtension> hookXTGETTCAP(Sequence const& seq);
+
+    void processShellIntegration(Sequence const& seq);
 
     gsl::not_null<Terminal*> _terminal;
     gsl::not_null<Settings*> _settings;

--- a/src/vtbackend/ShellIntegration.h
+++ b/src/vtbackend/ShellIntegration.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace vtbackend
+{
+
+class ShellIntegration
+{
+  public:
+    virtual ~ShellIntegration() = default;
+
+    /**
+     * Triggered when the shell starts printing the prompt.
+     *
+     * This roughly maps to OSC 133 ; A.
+     *
+     * @param clickEvents boolean indicating if the prompt is clickable/interactive.
+     */
+    virtual void promptStart(bool clickEvents = false) = 0;
+
+    /**
+     * Triggered when the shell finished printing the prompt.
+     *
+     * This roughly maps to OSC 133 ; B.
+     */
+    virtual void promptEnd() = 0;
+
+    /**
+     * Triggered when the shell is about to execute a command (and thus potential output starts).
+     *
+     * This roughly maps to OSC 133 ; C.
+     *
+     * @param commandLine The command line that is being executed.
+     */
+    virtual void commandOutputStart(std::optional<std::string> const& commandLine = std::nullopt) = 0;
+
+    /**
+     * Triggered when the executed command has finished.
+     *
+     * This roughly maps to OSC 133 ; D.
+     *
+     * @param exitCode The exit code of the executed command.
+     */
+    virtual void commandFinished(int exitCode) = 0;
+};
+
+class NullShellIntegration: public ShellIntegration
+{
+  public:
+    void promptStart(bool) override {}
+    void promptEnd() override {}
+    void commandOutputStart(std::optional<std::string> const&) override {}
+    void commandFinished(int) override {}
+};
+
+} // namespace vtbackend

--- a/src/vtbackend/ShellIntegration_test.cpp
+++ b/src/vtbackend/ShellIntegration_test.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/MockTerm.h>
+#include <vtbackend/ShellIntegration.h>
+#include <vtbackend/Terminal.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vtbackend;
+using namespace std::string_view_literals;
+
+namespace
+{
+
+class MockShellIntegration: public ShellIntegration
+{
+  public:
+    int promptStartCount = 0;
+    bool lastPromptStartClickEvents = false;
+    int promptEndCount = 0;
+    int commandOutputStartCount = 0;
+    std::optional<std::string> lastCommandOutputStartUrl;
+    int commandFinishedCount = 0;
+    int lastCommandFinishedExitCode = -1;
+
+    void promptStart(bool clickEvents) override
+    {
+        promptStartCount++;
+        lastPromptStartClickEvents = clickEvents;
+    }
+
+    void promptEnd() override { promptEndCount++; }
+
+    void commandOutputStart(std::optional<std::string> const& commandLineUrl) override
+    {
+        commandOutputStartCount++;
+        lastCommandOutputStartUrl = commandLineUrl;
+    }
+
+    void commandFinished(int exitCode) override
+    {
+        commandFinishedCount++;
+        lastCommandFinishedExitCode = exitCode;
+    }
+};
+
+} // namespace
+
+TEST_CASE("ShellIntegration.OSC_133")
+{
+    auto mockUnique = std::make_unique<MockShellIntegration>();
+    auto* mock = mockUnique.get();
+
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+    mc.terminal.setShellIntegration(std::move(mockUnique));
+
+    SECTION("A: Prompt Start")
+    {
+        mc.writeToScreen("\033]133;A\033\\");
+        CHECK(mock->promptStartCount == 1);
+        CHECK(mock->lastPromptStartClickEvents == false);
+    }
+
+    SECTION("A: Prompt Start with click_events")
+    {
+        mc.writeToScreen("\033]133;A;click_events=1\033\\");
+        CHECK(mock->promptStartCount == 1);
+        CHECK(mock->lastPromptStartClickEvents == true);
+        CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::Marked));
+    }
+
+    SECTION("B: Prompt End")
+    {
+        mc.writeToScreen("\033]133;B\033\\");
+        CHECK(mock->promptEndCount == 1);
+    }
+
+    SECTION("C: Command Output Start")
+    {
+        mc.writeToScreen("\033]133;C\033\\");
+        CHECK(mock->commandOutputStartCount == 1);
+        CHECK(mock->lastCommandOutputStartUrl == std::nullopt);
+    }
+
+    SECTION("C: Command Output Start with cmdline_url")
+    {
+        // "foo%20bar" unescapes to "foo bar"
+        mc.writeToScreen("\033]133;C;cmdline_url=foo%20bar\033\\");
+        CHECK(mock->commandOutputStartCount == 1);
+        REQUIRE(mock->lastCommandOutputStartUrl.has_value());
+        CHECK(mock->lastCommandOutputStartUrl.value() == "foo bar");
+    }
+
+    SECTION("D: Command Finished")
+    {
+        mc.writeToScreen("\033]133;D\033\\");
+        CHECK(mock->commandFinishedCount == 1);
+        CHECK(mock->lastCommandFinishedExitCode == 0);
+    }
+
+    SECTION("D: Command Finished with exit code")
+    {
+        mc.writeToScreen("\033]133;D;123\033\\");
+        CHECK(mock->commandFinishedCount == 1);
+        CHECK(mock->lastCommandFinishedExitCode == 123);
+    }
+}
+
+TEST_CASE("ShellIntegration.SETMARK")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    SECTION("SETMARK triggers promptStart")
+    {
+        mc.writeToScreen("\033[>M");
+        CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::Marked));
+    }
+}

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -162,7 +162,8 @@ Terminal::Terminal(Events& eventListener,
     _sequenceBuilder { ModeDependantSequenceHandler { *this }, TerminalInstructionCounter { *this } },
     _parser { std::ref(_sequenceBuilder) },
     _viCommands { *this },
-    _inputHandler { _viCommands, ViMode::Insert }
+    _inputHandler { _viCommands, ViMode::Insert },
+    _shellIntegration { std::make_unique<NullShellIntegration>() }
 {
     _savedColorPalettes.reserve(MaxColorPaletteSaveStackSize);
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -12,6 +12,7 @@
 #include <vtbackend/Sequence.h>
 #include <vtbackend/SequenceBuilder.h>
 #include <vtbackend/Settings.h>
+#include <vtbackend/ShellIntegration.h>
 #include <vtbackend/StatusLineBuilder.h>
 #include <vtbackend/ViCommands.h>
 #include <vtbackend/ViInputHandler.h>
@@ -561,6 +562,13 @@ class Terminal
     void pushColorPalette(size_t slot);
     void popColorPalette(size_t slot);
     void reportColorPaletteStack();
+
+    [[nodiscard]] ShellIntegration& shellIntegration() noexcept { return *_shellIntegration; }
+    [[nodiscard]] ShellIntegration const& shellIntegration() const noexcept { return *_shellIntegration; }
+    void setShellIntegration(std::unique_ptr<ShellIntegration> newShellIntegration)
+    {
+        _shellIntegration = std::move(newShellIntegration);
+    }
 
     [[nodiscard]] ScreenBase& currentScreen() noexcept { return *_currentScreen; }
     [[nodiscard]] ScreenBase const& currentScreen() const noexcept { return *_currentScreen; }
@@ -1231,6 +1239,8 @@ class Terminal
 
     ViCommands _viCommands;
     ViInputHandler _inputHandler;
+
+    std::unique_ptr<ShellIntegration> _shellIntegration;
 };
 
 } // namespace vtbackend


### PR DESCRIPTION
Closes #793

This pull request adds support for the OSC 133 shell integration VT sequence extension, enabling advanced shell prompt and command tracking features similar to those found in VSCode and FinalTerm. The implementation includes parsing and handling of OSC 133 sequences, a new shell integration interface, and comprehensive unit tests. It also introduces utility functions for URL unescaping and key-value parsing to support the new protocol.

The most important changes are:

**OSC 133 Shell Integration Support:**

* Added a new `ShellIntegration` interface and a default `NullShellIntegration` implementation in `src/vtbackend/ShellIntegration.h`, allowing the terminal to react to shell lifecycle events such as prompt start/end and command execution.
* Implemented OSC 133 sequence parsing and dispatch in `Screen`, with support for commands A (Prompt Start), B (Prompt End), C (Command Output Start), and D (Command Finished). This includes marking prompt lines and passing parameters like `click_events` and `cmdline_url`. [[1]](diffhunk://#diff-8bb49673341eeebf817e69f1da719fd39002d237baee26daa993c9d7c0129d6bR3223-R3281) [[2]](diffhunk://#diff-8bb49673341eeebf817e69f1da719fd39002d237baee26daa993c9d7c0129d6bL3704-R3761) [[3]](diffhunk://#diff-d766e4bddf12ece367d71001b6bcb7272c267168f2ff6cc6627d176e4468aebcR645-R646) [[4]](diffhunk://#diff-d766e4bddf12ece367d71001b6bcb7272c267168f2ff6cc6627d176e4468aebcR203) [[5]](diffhunk://#diff-a343eb9a54637693f11df8508a69f7d1ed126a0395460a5eb083746d7c601d30R566-R572) [[6]](diffhunk://#diff-a343eb9a54637693f11df8508a69f7d1ed126a0395460a5eb083746d7c601d30R1242-R1243) [[7]](diffhunk://#diff-d857f426295a317a92b0d94ed20c9fab3a3ca72d5e2e11732f8da08190014f10L165-R166) [[8]](diffhunk://#diff-a343eb9a54637693f11df8508a69f7d1ed126a0395460a5eb083746d7c601d30R15)
* Updated the deprecated `SETMARK` (CSI > M) handler to log a warning and direct users to migrate to OSC 133.

**Utility Functions:**

* Added `unescapeURL` and `for_each_key_value` helpers in `src/crispy/utils.h` for decoding percent-encoded URLs and parsing key-value parameter lists, respectively.
* Updated the `split` utility function for improved callback exception safety.

**Testing:**

* Added comprehensive unit tests for OSC 133 shell integration in `ShellIntegration_test.cpp`, including prompt and command lifecycle events, parameter parsing, and line marking. [[1]](diffhunk://#diff-6cfc8614c301b6f4fcbf4b7b8f464deef6728acd8ecf3edcbc1b439c2bbb7f23R1-R117) [[2]](diffhunk://#diff-9d57b06e9d9c27c9765a46d760a688d460110f55f34c92a866b44f0973e34fdeR133)
* Added tests for the new utility functions in `utils_test.cpp`. [[1]](diffhunk://#diff-5af880a261ba5e81bd3d276b47039f7ee862fcf5dab6f5c33e5f797741a7c0edL142-R189) [[2]](diffhunk://#diff-5af880a261ba5e81bd3d276b47039f7ee862fcf5dab6f5c33e5f797741a7c0edR6-R7)

**Documentation and Metadata:**

* Added documentation for the OSC 133 shell integration protocol in `docs/vt-extensions/osc-133-shell-integration.md`.
* Updated `metainfo.xml` to announce support for OSC 133 shell integration.