### PR TITLE
Fix `crispy::fnv` to build with libc++ on FreeBSD

### DIFF
--- a/src/crispy/FNV.h
+++ b/src/crispy/FNV.h
@@ -48,14 +48,10 @@ class fnv
     /// which are handled by dedicated overloads.
     template <typename V>
     constexpr U operator()(U memory, V const& value) const noexcept
-    requires(
-        std::is_trivially_copyable_v<V> &&
-        !std::same_as<V, std::string> &&
-        !std::same_as<V, std::string_view>
-    )
+        requires(std::is_trivially_copyable_v<V> && !std::same_as<V, std::string>
+                 && !std::same_as<V, std::string_view>)
     {
-        auto const* bytes =
-            reinterpret_cast<unsigned char const*>(&value);
+        auto const* bytes = reinterpret_cast<unsigned char const*>(&value);
         for (std::size_t i = 0; i < sizeof(V); ++i)
             memory = (*this)(memory, bytes[i]);
         return memory;
@@ -66,10 +62,8 @@ class fnv
     /// Each character in @p str is hashed sequentially before applying
     /// the remaining values in @p moreValues.
     template <typename... V>
-    constexpr U operator()(U memory,
-                           std::string_view str,
-                           V... moreValues) const noexcept
-    requires(std::same_as<T, char>)
+    constexpr U operator()(U memory, std::string_view str, V... moreValues) const noexcept
+        requires(std::same_as<T, char>)
     {
         for (auto const ch: str)
             memory = (*this)(memory, ch);
@@ -81,7 +75,7 @@ class fnv
     ///
     /// Hashes all characters in @p str starting from the given memory value.
     constexpr U operator()(U memory, std::string_view str) const noexcept
-    requires(std::same_as<T, char>)
+        requires(std::same_as<T, char>)
     {
         for (auto const ch: str)
             memory = (*this)(memory, ch);
@@ -105,7 +99,7 @@ class fnv
     ///
     /// Hashes the string's character data sequentially.
     constexpr U operator()(std::string const& str) const noexcept
-    requires(std::same_as<T, char>)
+        requires(std::same_as<T, char>)
     {
         return (*this)(str.data(), str.data() + str.size());
     }


### PR DESCRIPTION
## Description

This PR makes the following adjustments to `crispy::fnv`:

1. Restrict string-related overloads to char only
    - Replace `std::basic_string<T>` / `std::basic_string_view<T>` with
`std::string` / `std::string_view`
    - Guard these overloads using SFINAE so they are only enabled when `T == char`
2. Add a generic hashing overload for trivially copyable types
    - Allows hashing arbitrary trivially copyable values by hashing their byte representation
    - Explicitly excludes `std::string` and `std::string_view`, which have dedicated overloads

## Motivation and Context

### Background

While building contour on FreeBSD using libc++, compilation fails in `crispy::fnv` due to the use of `std::basic_string<T>` / `std::basic_string_view<T>` with non-character template parameters.

libc++ intentionally provides `std::char_traits` specializations only for character types (e.g. `char`, `wchar_t`). As a result, instantiating `std::basic_string_view<T>` / `std::basic_string<T>` for arbitrary `T` leads to compilation errors.

### Problem Description

The original implementation allowed the following patterns:

- `std::basic_string_view<T>` where `T` is not a character type
- `std::basic_string<T>` where `T` is not a character type

This causes issues on libc++ because:

- `std::char_traits<T>` is undefined for non-character types
- these errors occur at template instantiation time, not at overload resolution time
- as a result, valid uses such as `fnv<uint32_t>` fail to compile

## How Has This Been Tested?

- [x] Please describe how you tested your changes.
    - Built and tested on FreeBSD (libc++, clang) via the official FreeBSD ports framework.
    - Verified that the project builds successfully without compilation errors.
- [x] see how your change affects other areas of the code, etc.
    - No functional behavior changes are introduced.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
    - No documentation changes are needed.
- [ ] I have added tests to cover my changes.
    - No functional changes intended. So no tests are added.
- [x] I have gone through all the steps, and have thoroughly read the instructions
