### PR TITLE
Fix: add <cstdint> header to fix build

### DIFF
--- a/src/crispy/TrieMap.h
+++ b/src/crispy/TrieMap.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <variant>


### PR DESCRIPTION
## Description

Fix: add <cstdint> header to fix build

Ref: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

## Motivation and Context

Why is this change required? What problem does it solve?

```markdown

```

## How Has This Been Tested?

- [ ] Please describe how you tested your changes.
- [ ] see how your change affects other areas of the code, etc.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] I have read the [**`CONTRIBUTING`**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) document in my spoken language, and understand the terms
- [ ] I have updated (or added) the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have gone through all the steps, and have thoroughly read the instructions
