### PR TITLE
Add hint mode for keyboard-driven selection of URLs, file paths, and more

### DIFF
--- a/.github/actions/spelling/allow/terminal-terms.txt
+++ b/.github/actions/spelling/allow/terminal-terms.txt
@@ -158,6 +158,7 @@ cuu
 dcl
 dcs
 fbterm
+githash
 stty
 undercurl
 zellij

--- a/.github/actions/spelling/allow/uncategorized.txt
+++ b/.github/actions/spelling/allow/uncategorized.txt
@@ -25,6 +25,7 @@ CInclude
 CLEARTYPE
 CODEHALTH
 CONOUT
+COPYANDPASTE
 COPYTOCLIPBOARD
 COPYTOSELECTIONCLIPBOARD
 Crafters
@@ -51,6 +52,7 @@ DUSE
 Danich
 ERRORDEF
 Extrawurst
+FFCC
 FFFDu
 FFFFFFFFu
 FFu
@@ -464,6 +466,7 @@ hendrikmuhs
 hewbrew
 highcon
 highp
+hintmode
 histcontrol
 hla
 hori
@@ -1010,6 +1013,7 @@ versionsuffix
 vfork
 vgetq
 viewn
+vimium
 vimspector
 visibile
 visiblity

--- a/docs/demo/hint-mode.md
+++ b/docs/demo/hint-mode.md
@@ -1,0 +1,159 @@
+# Hint Mode
+
+Hint mode lets you quickly act on clickable elements visible in the terminal —
+URLs, file paths, git commit hashes, IP addresses — using only the keyboard.
+When activated, Contour scans the visible screen for recognized patterns,
+overlays a short alphabetic label on each match, and waits for you to type a
+label to perform an action on that match.
+
+Think of it like [Vimium](https://vimium.github.io/) for your terminal.
+
+![hint-mode-overview](../screenshots/hint-mode-overview.png "Hint mode with labels overlaid on detected patterns")
+
+## Activating Hint Mode
+
+There are two ways to enter hint mode:
+
+### Via Key Binding (from any mode)
+
+The default key binding activates hint mode for URLs:
+
+```yaml
+input_mapping:
+    - { mods: [Control, Shift], key: U, action: HintMode, patterns: url, hint_action: Open }
+```
+
+Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> to scan for URLs
+and open the selected one in your browser.
+
+### Via Vi Normal Mode
+
+When in [normal mode](../input-modes.md), you can use:
+
+- `gh` — activate hint mode with **Copy** action (yank the match to clipboard)
+- `gH` — activate hint mode with **Open** action (open the match, e.g. URL in browser)
+
+These commands scan for all builtin patterns (URLs, file paths, git hashes, IPs).
+
+## Using Hint Mode
+
+Once hint mode is active:
+
+1. **Labels appear** — Each detected match gets a short label (`a`, `b`, ..., `z`; or two-character labels `aa`, `ab`, ... for more than 26 matches).
+2. **Type the label** — Type the label characters to select a match. Labels are case-insensitive.
+3. **Auto-select** — As soon as your typed characters uniquely identify a match, the action is performed automatically.
+4. **Cancel** — Press <kbd>Escape</kbd> to exit hint mode without selecting anything.
+5. **Backspace** — Press <kbd>Backspace</kbd> to undo the last typed label character.
+
+## Recognized Patterns
+
+Contour ships with the following builtin pattern detectors:
+
+| Pattern     | Examples                                     | Description                        |
+|-------------|----------------------------------------------|------------------------------------|
+| `url`       | `https://example.com`, `http://localhost:8080` | HTTP and HTTPS URLs              |
+| `filepath`  | `/home/user/file.txt`, `./src/main.cpp`, `lib/utils.h` | Absolute, relative, and home-relative (`~/...`) file paths |
+| `githash`   | `a1b2c3d`, `abc1234567890def1234567890abcdef12345678` | 7–40 character hex strings (git commit SHAs) |
+| `ipv4`      | `192.168.1.1`, `10.0.0.1:8080`               | IPv4 addresses, optionally with port |
+| `ipv6`      | `::1`, `fe80::1`, `2001:0db8:85a3:0000:0000:8a2e:0370:7334` | IPv6 addresses |
+
+### Smart File Path Detection
+
+When the terminal knows the current working directory (via
+[shell integration](../vt-extensions/osc-133-shell-integration.md)), Contour
+broadens its file path detection to also match:
+
+- **Bare filenames with extensions** — `main.cpp`, `README.md`
+- **Extensionless files** — `Makefile`, `LICENSE`, `Dockerfile`, `CHANGELOG`
+- **Directory names** — `src`, `build`, `docs`
+
+These bare names are validated against the filesystem: only entries that actually
+exist in the current working directory are shown as hints. This means you can
+look at `ls` output, compiler errors, or `git status` and jump directly to the
+referenced files.
+
+![hint-mode-bare-filenames](../screenshots/hint-mode-bare-filenames.png "Bare filenames and directories detected in compiler output")
+
+## Actions
+
+The `hint_action` parameter controls what happens when you select a match:
+
+| Action         | Description                                                  |
+|----------------|--------------------------------------------------------------|
+| `Copy`         | Copy the matched text to the system clipboard (default)      |
+| `Open`         | Open the match — URLs open in the browser, files open in the configured editor |
+| `Paste`        | Paste the matched text into the terminal input               |
+| `CopyAndPaste` | Copy to clipboard **and** paste into the terminal            |
+| `Select`       | Copy the matched text to clipboard (visual mode pre-selection is planned) |
+
+## Configuration
+
+### Key Bindings
+
+You can create multiple hint mode bindings for different pattern sets and actions:
+
+```yaml
+input_mapping:
+    # Open URLs in browser
+    - { mods: [Control, Shift], key: U, action: HintMode, patterns: url, hint_action: Open }
+
+    # Copy file paths to clipboard
+    - { mods: [Control, Shift], key: F, action: HintMode, patterns: filepath, hint_action: Copy }
+
+    # Copy git hashes to clipboard
+    - { mods: [Control, Shift], key: G, action: HintMode, patterns: githash, hint_action: Copy }
+
+    # Scan for all patterns and copy
+    - { mods: [Control, Shift], key: H, action: HintMode, patterns: all, hint_action: Copy }
+```
+
+The `patterns` parameter accepts:
+
+- A pattern name: `url`, `filepath`, `githash`, `ipv4`, `ipv6`
+- `all` or empty: scan for all builtin patterns at once
+
+### Colors
+
+Hint mode label and match colors are configured in the color scheme section of
+your configuration:
+
+```yaml
+color_schemes:
+    default:
+        # Colors for the short alphabetic labels overlaid on matches.
+        hint_label:
+            foreground: '#000000'
+            foreground_alpha: 1.0
+            background: '#E5C07B'
+            background_alpha: 1.0
+
+        # Colors for the matched text behind the labels.
+        hint_match:
+            foreground: '#ABB2BF'
+            foreground_alpha: 1.0
+            background: '#3E4452'
+            background_alpha: 0.8
+```
+
+## Tips and Tricks
+
+- **Shell integration matters** — Ensure your shell reports the current working
+  directory via [OSC 133](../vt-extensions/osc-133-shell-integration.md) for the
+  best file path detection. Without it, only paths containing a `/` separator are
+  matched.
+
+- **Combine with Vi mode** — In normal mode, `gh` (copy) and `gH` (open) are
+  quick ways to enter hint mode without reaching for modifier keys.
+
+- **Works with scrollback** — Hint mode scans the currently visible viewport.
+  Scroll to the area of interest first, then activate hint mode.
+
+- **Compiler errors** — When viewing build output with file paths like
+  `src/main.cpp:42:10: error: ...`, hint mode detects the file path portion,
+  making it easy to copy or open the referenced file.
+
+## Related
+
+- [Input Modes](../input-modes.md) — Vi-like input modes including normal mode, where `gh`/`gH` trigger hint mode
+- [Key Mapping](../configuration/key-mapping.md) — How to customize key bindings
+- [Shell Integration](../vt-extensions/osc-133-shell-integration.md) — Enables smart bare filename detection

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,6 +9,7 @@
 :material-check-bold:{.check-mark}  Bold and italic fonts <br/>
 :material-check-bold:{.check-mark}  High-DPI support. <br/>
 :material-check-bold:{.check-mark}  [Vi-like input modes](input-modes.md) for improved navigation, selection and copy'n'paste experience <br/>
+:material-check-bold:{.check-mark}  [Hint mode](demo/hint-mode.md) for keyboard-driven selection of URLs, file paths, git hashes, and more <br/>
 :material-check-bold:{.check-mark}  [Vertical Line Markers](demo/line-marks.md) (quickly jump to markers in your history!) <br/>
 :material-check-bold:{.check-mark}  Blurred behind transparent background when using Windows 10 or KDE window manager on Linux. <br/>
 :material-check-bold:{.check-mark}  Blurrable Background image support. <br/>

--- a/docs/input-modes.md
+++ b/docs/input-modes.md
@@ -16,6 +16,7 @@ using vim motion keys and then start selecting.
 - **visual mode**: Linear selection, use motion keys to alter the selection.
 - **visual line mode**: Line based selection, use motion keys to alter the selection.
 - **visual block mode**: Block based selection, use motion keys to alter the selection.
+- **[hint mode](demo/hint-mode.md)**: Overlay alphabetic labels on detected patterns (URLs, file paths, etc.) and type a label to act on it.
 
 ### Supported operators (Normal Mode)
 
@@ -31,6 +32,8 @@ using vim motion keys and then start selecting.
 - Normal: `o {motion}` (opens resource by given `motion`, this can be a URL or local file)
 - Normal: `o {TextObject}` (opens resource by given `textObject`, such as `oiw`, `oaw`, `oiW`, ...)
 - Visual: `o` (open current selection into primary clipboard)
+- Normal: `gh` (enter [hint mode](demo/hint-mode.md) — copy selected match to clipboard)
+- Normal: `gH` (enter [hint mode](demo/hint-mode.md) — open selected match)
 
 ### Supported motions
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -121,6 +121,7 @@
           <li>Adds pixel-perfect builtin rendering for mathematical bracket and symbol characters (U+239B–U+23B3), including parenthesis pieces, curly bracket pieces, integral extensions, horizontal line extension, bracket sections, and summation symbols</li>
           <li>Adds pixel-perfect builtin rendering for shade characters (U+2591–U+2593): light shade, medium shade, and dark shade</li>
           <li>Adds snap-to-grid window resizing via WM size-increment hints (X11/macOS) and client-side snapping (Wayland, where xdg-shell has no size-increment hint)</li>
+          <li>Adds hint mode for keyboard-driven selection of URLs, file paths, git hashes, and IP addresses with configurable actions (Copy, Open, Paste, Select), activatable via key binding or Vi normal mode (gh/gH)</li>
         </ul>
       </description>
     </release>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
     - Input method editor (IME): demo/ime.md
     - Line marks: demo/line-marks.md
     - Status line: demo/statusline.md
+    - Hint mode: demo/hint-mode.md
     - Input modes: input-modes.md
     - Size indicator: demo/size_indicator.md
     - Git branch drawings: demo/git-branch-drawings.md

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -40,6 +40,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::FocusNextSearchMatch>("FocusNextSearchMatch"),
         mapAction<actions::FocusPreviousSearchMatch>("FocusPreviousSearchMatch"),
         mapAction<actions::FollowHyperlink>("FollowHyperlink"),
+        mapAction<actions::HintMode>("HintMode"),
         mapAction<actions::IncreaseFontSize>("IncreaseFontSize"),
         mapAction<actions::IncreaseOpacity>("IncreaseOpacity"),
         mapAction<actions::NewTerminal>("NewTerminal"),

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -714,6 +714,12 @@ const InputMappings defaultInputMappings {
                                         | vtbackend::Modifiers { vtbackend::Modifier::Control } },
                            .input = 'H',
                            .binding = { { actions::NoSearchHighlight {} } } },
+        CharInputMapping { .modes { vtbackend::MatchModes {} },
+                           .modifiers { vtbackend::Modifiers { vtbackend::Modifier::Shift }
+                                        | vtbackend::Modifiers { vtbackend::Modifier::Control } },
+                           .input = 'U',
+                           .binding = { { actions::HintMode {
+                               .patterns = "url", .hintAction = vtbackend::HintAction::Open } } } },
     },
     .mouseMappings {
         MouseInputMapping { .modes { vtbackend::MatchModes {} },

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -1004,6 +1004,28 @@ constexpr StringLiteral WordHighlightConfig {
     "    background_alpha: {}\n"
 };
 
+constexpr StringLiteral HintLabelConfig {
+    "\n"
+    "{comment} Colors for hint mode labels (the short alphabetic tags shown on matches).\n"
+    "{comment} The format is equivalent to selection/search highlighting.\n"
+    "hint_label:\n"
+    "    foreground: {}\n"
+    "    foreground_alpha: {}\n"
+    "    background: {}\n"
+    "    background_alpha: {}\n"
+};
+
+constexpr StringLiteral HintMatchConfig {
+    "\n"
+    "{comment} Colors for hint mode match bodies (the text behind the labels).\n"
+    "{comment} The format is equivalent to selection/search highlighting.\n"
+    "hint_match:\n"
+    "    foreground: {}\n"
+    "    foreground_alpha: {}\n"
+    "    background: {}\n"
+    "    background_alpha: {}\n"
+};
+
 constexpr StringLiteral IndicatorStatusLineConfig {
     "\n"
     "{comment} Defines the colors to be used for the Indicator status line.\n"
@@ -1973,6 +1995,8 @@ using SearchHighlight = DocumentationEntry<SearchHighlightConfig, Dummy>;
 using SearchHighlightFocused = DocumentationEntry<SearchHighlightFocusedConfig, Dummy>;
 using WordHighlightCurrent = DocumentationEntry<WordHighlightCurrentConfig, Dummy>;
 using WordHighlight = DocumentationEntry<WordHighlightConfig, Dummy>;
+using HintLabel = DocumentationEntry<HintLabelConfig, Dummy>;
+using HintMatch = DocumentationEntry<HintMatchConfig, Dummy>;
 using IndicatorStatusLine = DocumentationEntry<IndicatorStatusLineConfig, Dummy>;
 using InputMethodEditor = DocumentationEntry<InputMethodEditorConfig, Dummy>;
 using InputMethodEditorSupport = DocumentationEntry<InputMethodEditorSupportConfig, Dummy>;

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -320,6 +320,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::DecreaseFontSize);
     bool operator()(actions::DecreaseOpacity);
     bool operator()(actions::FollowHyperlink);
+    bool operator()(actions::HintMode const&);
     bool operator()(actions::FocusNextSearchMatch);
     bool operator()(actions::FocusPreviousSearchMatch);
     bool operator()(actions::IncreaseFontSize);

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -25,6 +25,7 @@ set(vtbackend_HEADERS
     Functions.h
     GraphicsAttributes.h
     Grid.h
+    HintModeHandler.h
     Hyperlink.h
     Image.h
     InputBinding.h
@@ -58,6 +59,7 @@ set(vtbackend_SOURCES
     ColorPalette.cpp
     Functions.cpp
     Grid.cpp
+    HintModeHandler.cpp
     Image.cpp
     InputBinding.cpp
     InputGenerator.cpp
@@ -127,6 +129,7 @@ if(LIBTERMINAL_TESTING)
         Selector_test.cpp
         Functions_test.cpp
         Grid_test.cpp
+        HintModeHandler_test.cpp
         Line_test.cpp
         Screen_test.cpp
         Image_test.cpp

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -123,6 +123,9 @@ struct ColorPalette
     CellRGBColorAndAlphaPair selection { .foreground=CellForegroundColor {}, .foregroundAlpha=1.0f, .background=0x4040f0_rgb , .backgroundAlpha=0.5f };
 
     CellRGBColorAndAlphaPair normalModeCursorline = { .foreground=0xFFFFFF_rgb, .foregroundAlpha=0.2f, .background=0x808080_rgb, .backgroundAlpha=0.4f };
+
+    CellRGBColorAndAlphaPair hintLabel = { .foreground=0x1a1716_rgb, .foregroundAlpha=1.0f, .background=0xFFCC00_rgb, .backgroundAlpha=1.0f };
+    CellRGBColorAndAlphaPair hintMatch = { .foreground=CellForegroundColor {}, .foregroundAlpha=1.0f, .background=0x4488CC_rgb, .backgroundAlpha=0.35f };
     // clang-format on
 
     RGBColorPair indicatorStatusLineInactive = { .foreground = 0xFFFFFF_rgb, .background = 0x0270c0_rgb };

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/HintModeHandler.h>
+
+#include <algorithm>
+#include <ranges>
+
+using namespace std;
+
+namespace vtbackend
+{
+
+HintModeHandler::HintModeHandler(Executor& executor): _executor { executor }
+{
+}
+
+void HintModeHandler::rescanLines(vector<string> const& visibleLines, PageSize pageSize)
+{
+    _filter.clear();
+    _allMatches.clear();
+    _filteredMatches.clear();
+
+    // Scan each visible line for regex matches.
+    auto const lineCount = std::min(visibleLines.size(), static_cast<size_t>(unbox<int>(pageSize.lines)));
+    for (auto const lineIdx: std::views::iota(size_t { 0 }, lineCount))
+    {
+        auto const& lineText = visibleLines[lineIdx];
+        auto const lineOffset = LineOffset(static_cast<int>(lineIdx));
+
+        for (auto const& pattern: _patterns)
+        {
+            auto matchIter = sregex_iterator(lineText.begin(), lineText.end(), pattern.regex);
+            auto const matchEnd = sregex_iterator();
+
+            for (; matchIter != matchEnd; ++matchIter)
+            {
+                auto const& match = *matchIter;
+                if (match.empty())
+                    continue;
+
+                auto const matchStr = match.str();
+
+                // Apply pattern-specific validator (e.g. filesystem existence check).
+                if (pattern.validator && !pattern.validator(matchStr))
+                    continue;
+
+                auto const startCol = ColumnOffset(static_cast<int>(match.position()));
+                auto const endCol = ColumnOffset(static_cast<int>(match.position() + match.length() - 1));
+
+                _allMatches.push_back(HintMatch {
+                    .label = {},
+                    .matchedText = matchStr,
+                    .start = CellLocation { .line = lineOffset, .column = startCol },
+                    .end = CellLocation { .line = lineOffset, .column = endCol },
+                });
+            }
+        }
+    }
+
+    // Sort matches top-to-bottom, left-to-right, longer matches first at same start.
+    ranges::sort(_allMatches, [](auto const& a, auto const& b) {
+        if (a.start.line != b.start.line)
+            return a.start.line < b.start.line;
+        if (a.start.column != b.start.column)
+            return a.start.column < b.start.column;
+        return a.end.column > b.end.column; // Longer match first at same start position.
+    });
+
+    // Remove duplicate matches (same text at same position).
+    auto const [eraseBegin, eraseEnd] = ranges::unique(
+        _allMatches, [](auto const& a, auto const& b) { return a.start == b.start && a.end == b.end; });
+    _allMatches.erase(eraseBegin, eraseEnd);
+
+    // Remove overlapping matches — keep the longer (earlier) match at each position.
+    {
+        auto kept = vector<HintMatch>();
+        kept.reserve(_allMatches.size());
+        for (auto& match: _allMatches)
+        {
+            if (!kept.empty() && kept.back().start.line == match.start.line
+                && match.start.column <= kept.back().end.column)
+                continue; // Overlap detected — skip the shorter/later match.
+            kept.push_back(std::move(match));
+        }
+        _allMatches = std::move(kept);
+    }
+
+    assignLabels();
+    _filteredMatches = _allMatches;
+}
+
+void HintModeHandler::activate(vector<string> const& visibleLines,
+                               PageSize pageSize,
+                               vector<HintPattern> const& patterns,
+                               HintAction action)
+{
+    _action = action;
+    _patterns = patterns;
+    rescanLines(visibleLines, pageSize);
+
+    _active = true;
+    _executor.onHintModeEntered();
+    _executor.requestRedraw();
+}
+
+void HintModeHandler::refresh(vector<string> const& visibleLines, PageSize pageSize)
+{
+    rescanLines(visibleLines, pageSize);
+    _executor.requestRedraw();
+}
+
+void HintModeHandler::deactivate()
+{
+    if (!_active)
+        return;
+
+    _active = false;
+    _filter.clear();
+    _allMatches.clear();
+    _filteredMatches.clear();
+    _executor.onHintModeExited();
+    _executor.requestRedraw();
+}
+
+bool HintModeHandler::processInput(char32_t ch)
+{
+    if (!_active)
+        return false;
+
+    // Escape cancels hint mode.
+    if (ch == U'\x1B')
+    {
+        deactivate();
+        return true;
+    }
+
+    // Backspace removes last filter character.
+    if (ch == U'\x08' || ch == U'\x7F')
+    {
+        if (!_filter.empty())
+        {
+            _filter.pop_back();
+            updateFilteredMatches();
+            _executor.requestRedraw();
+        }
+        return true;
+    }
+
+    // Only accept lowercase alphabetic characters for label typing.
+    if (ch >= U'A' && ch <= U'Z')
+        ch = ch - U'A' + U'a'; // Normalize to lowercase.
+
+    if (ch < U'a' || ch > U'z')
+        return true; // Ignore non-alphabetic input.
+
+    _filter += static_cast<char>(ch);
+    updateFilteredMatches();
+
+    // Auto-select when exactly one match remains.
+    if (_filteredMatches.size() == 1 && _filteredMatches[0].label == _filter)
+    {
+        auto const matchedText = _filteredMatches[0].matchedText;
+        auto const action = _action;
+        deactivate();
+        _executor.onHintSelected(matchedText, action);
+        return true;
+    }
+
+    // If no matches remain, deactivate.
+    if (_filteredMatches.empty())
+    {
+        deactivate();
+        return true;
+    }
+
+    _executor.requestRedraw();
+    return true;
+}
+
+void HintModeHandler::assignLabels()
+{
+    auto const matchCount = _allMatches.size();
+    if (matchCount == 0)
+        return;
+
+    auto const useTwoChar = matchCount > 26;
+
+    for (auto const i: std::views::iota(size_t { 0 }, matchCount))
+    {
+        if (useTwoChar)
+        {
+            auto const first = static_cast<char>('a' + static_cast<int>(i / 26));
+            auto const second = static_cast<char>('a' + static_cast<int>(i % 26));
+            _allMatches[i].label = string { first, second };
+        }
+        else
+        {
+            _allMatches[i].label = string { static_cast<char>('a' + static_cast<int>(i)) };
+        }
+    }
+}
+
+void HintModeHandler::updateFilteredMatches()
+{
+    _filteredMatches.clear();
+    std::ranges::copy_if(_allMatches, std::back_inserter(_filteredMatches), [this](auto const& m) {
+        return m.label.starts_with(_filter);
+    });
+}
+
+vector<HintPattern> HintModeHandler::builtinPatterns()
+{
+    static auto const cached = vector<HintPattern> {
+        HintPattern { .name = "url",
+                      .regex = regex(R"(https?://[^\s<>\"'\])\}]+)",
+                                     regex_constants::ECMAScript | regex_constants::optimize),
+                      .validator = {} },
+        HintPattern { .name = "filepath",
+                      .regex = regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w][\w.-]*/[\w./-]+))",
+                                     regex_constants::ECMAScript | regex_constants::optimize),
+                      .validator = {} },
+        HintPattern {
+            .name = "githash",
+            .regex = regex(R"(\b[0-9a-f]{7,40}\b)", regex_constants::ECMAScript | regex_constants::optimize),
+            .validator = {} },
+        HintPattern { .name = "ipv4",
+                      .regex = regex(R"(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d+)?\b)",
+                                     regex_constants::ECMAScript | regex_constants::optimize),
+                      .validator = {} },
+        HintPattern {
+            .name = "ipv6",
+            .regex =
+                regex(R"((?:)"
+                      R"(\b[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){7}\b)"
+                      R"(|\b(?:[0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}::(?:[0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}\b)"
+                      R"(|::(?:[0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}\b)"
+                      R"(|\b(?:[0-9a-fA-F]{1,4}:)+:(?![0-9a-fA-F:]))"
+                      R"())",
+                      regex_constants::ECMAScript | regex_constants::optimize),
+            .validator = {} },
+    };
+    return cached;
+}
+
+auto extractPathFromFileUrl(std::string const& url) -> std::string
+{
+    constexpr auto Prefix = std::string_view("file://");
+    if (!url.starts_with(Prefix))
+        return url;
+    auto remainder = url.substr(Prefix.size());
+    // file:///path → /path  ;  file://host/path → /path
+    if (!remainder.empty() && remainder[0] != '/')
+    {
+        if (auto const pos = remainder.find('/'); pos != std::string::npos)
+            return std::string(remainder.substr(pos));
+        return {};
+    }
+    return std::string(remainder);
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/HintModeHandler.h
+++ b/src/vtbackend/HintModeHandler.h
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/primitives.h>
+
+#include <functional>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace vtbackend
+{
+
+/// Defines the action to perform when a hint is selected.
+enum class HintAction : uint8_t
+{
+    Copy,         ///< Copy matched text to clipboard.
+    Open,         ///< Open matched text (e.g. URL in browser).
+    Paste,        ///< Paste matched text into the terminal input.
+    CopyAndPaste, ///< Copy to clipboard and paste into terminal.
+    Select,       ///< Pre-select the match range in visual mode.
+};
+
+/// A named regex pattern used for hint scanning.
+struct HintPattern
+{
+    std::string name;
+    std::regex regex;
+    /// Optional post-match validator. When set, only matches for which
+    /// this returns true are kept. Used e.g. to check filesystem existence.
+    std::function<bool(std::string const&)> validator;
+};
+
+/// A single match found during hint scanning, with its label and grid positions.
+struct HintMatch
+{
+    std::string label;       ///< The label shown on the overlay (e.g. "a", "bc").
+    std::string matchedText; ///< The actual matched text.
+    CellLocation start;      ///< Start position in the grid.
+    CellLocation end;        ///< End position in the grid (inclusive).
+};
+
+/// Handles hint mode logic: scanning visible text for regex matches,
+/// assigning alphabetic labels, and progressively filtering by typed input.
+class HintModeHandler
+{
+  public:
+    /// Interface for the handler to communicate with the terminal.
+    class Executor
+    {
+      public:
+        virtual ~Executor() = default;
+
+        /// Called when a hint has been selected by the user.
+        virtual void onHintSelected(std::string const& matchedText, HintAction action) = 0;
+
+        /// Called when hint mode is entered.
+        virtual void onHintModeEntered() = 0;
+
+        /// Called when hint mode is exited.
+        virtual void onHintModeExited() = 0;
+
+        /// Requests a screen redraw.
+        virtual void requestRedraw() = 0;
+    };
+
+    explicit HintModeHandler(Executor& executor);
+
+    /// Activates hint mode by scanning visible lines for matches.
+    ///
+    /// @param visibleLines   Text of each visible line, indexed by line offset.
+    /// @param pageSize       The terminal page size.
+    /// @param patterns       The regex patterns to scan for.
+    /// @param action         The action to perform on selection.
+    void activate(std::vector<std::string> const& visibleLines,
+                  PageSize pageSize,
+                  std::vector<HintPattern> const& patterns,
+                  HintAction action);
+
+    /// Re-scans visible lines using previously stored patterns and action.
+    /// Called on viewport scroll to update hints without re-entering hint mode.
+    void refresh(std::vector<std::string> const& visibleLines, PageSize pageSize);
+
+    /// Deactivates hint mode.
+    void deactivate();
+
+    /// Returns true if hint mode is currently active.
+    [[nodiscard]] bool isActive() const noexcept { return _active; }
+
+    /// Processes a single character input for progressive label filtering.
+    /// Returns true if the input was consumed.
+    bool processInput(char32_t ch);
+
+    /// Returns the currently filtered matches.
+    [[nodiscard]] std::vector<HintMatch> const& matches() const noexcept { return _filteredMatches; }
+
+    /// Returns the typed filter prefix.
+    [[nodiscard]] std::string const& currentFilter() const noexcept { return _filter; }
+
+    /// Returns the hint action for the current session.
+    [[nodiscard]] HintAction action() const noexcept { return _action; }
+
+    /// Returns built-in default hint patterns (URLs, file paths, git hashes).
+    [[nodiscard]] static std::vector<HintPattern> builtinPatterns();
+
+  private:
+    /// Core scanning logic shared by activate() and refresh().
+    /// Clears existing matches, scans visible lines, sorts, deduplicates, and assigns labels.
+    void rescanLines(std::vector<std::string> const& visibleLines, PageSize pageSize);
+
+    /// Assigns labels to all matches.
+    void assignLabels();
+
+    /// Updates the filtered matches based on the current filter prefix.
+    void updateFilteredMatches();
+
+    Executor& _executor;
+    bool _active = false;
+    HintAction _action = HintAction::Copy;
+    std::vector<HintPattern> _patterns; ///< Stored on activate for refresh on scroll.
+    std::vector<HintMatch> _allMatches;
+    std::vector<HintMatch> _filteredMatches;
+    std::string _filter;
+};
+
+/// Extracts a local filesystem path from a file:// URL (as set by OSC 7).
+/// Returns the URL unchanged if it does not start with "file://".
+[[nodiscard]] auto extractPathFromFileUrl(std::string const& url) -> std::string;
+
+} // namespace vtbackend

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -1,0 +1,772 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/HintModeHandler.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <ranges>
+
+using namespace vtbackend;
+
+namespace
+{
+
+/// Test executor that records callbacks.
+class MockExecutor: public HintModeHandler::Executor
+{
+  public:
+    std::string lastSelectedText;
+    HintAction lastAction = HintAction::Copy;
+    int hintSelectedCount = 0;
+    int hintEnteredCount = 0;
+    int hintExitedCount = 0;
+    int redrawCount = 0;
+
+    void onHintSelected(std::string const& matchedText, HintAction action) override
+    {
+        lastSelectedText = matchedText;
+        lastAction = action;
+        ++hintSelectedCount;
+    }
+
+    void onHintModeEntered() override { ++hintEnteredCount; }
+    void onHintModeExited() override { ++hintExitedCount; }
+    void requestRedraw() override { ++redrawCount; }
+};
+
+auto const allPatterns = HintModeHandler::builtinPatterns();
+
+/// Returns only the URL pattern for precise count-based test assertions.
+auto urlOnlyPatterns() -> std::vector<HintPattern>
+{
+    auto result = std::vector<HintPattern>();
+    for (auto& p: HintModeHandler::builtinPatterns())
+        if (p.name == "url")
+            result.push_back(std::move(p));
+    return result;
+}
+
+/// Returns only the IPv6 pattern for precise test assertions.
+auto ipv6OnlyPatterns() -> std::vector<HintPattern>
+{
+    auto result = std::vector<HintPattern>();
+    for (auto& p: HintModeHandler::builtinPatterns())
+        if (p.name == "ipv6")
+            result.push_back(std::move(p));
+    return result;
+}
+
+/// Returns only the filepath pattern for precise test assertions.
+auto filepathOnlyPatterns() -> std::vector<HintPattern>
+{
+    auto result = std::vector<HintPattern>();
+    for (auto& p: HintModeHandler::builtinPatterns())
+        if (p.name == "filepath")
+            result.push_back(std::move(p));
+    return result;
+}
+
+} // namespace
+
+TEST_CASE("HintModeHandler.LabelAssignment.SingleChar", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> {
+        "visit https://example.com for more",
+        "also https://test.org and https://other.net",
+    };
+
+    handler.activate(lines, PageSize { LineCount(2), ColumnCount(50) }, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    auto const& matches = handler.matches();
+    REQUIRE(matches.size() == 3);
+
+    // Single-char labels for <=26 matches.
+    CHECK(matches[0].label == "a");
+    CHECK(matches[1].label == "b");
+    CHECK(matches[2].label == "c");
+
+    // Check matched text.
+    CHECK(matches[0].matchedText == "https://example.com");
+    CHECK(matches[1].matchedText == "https://test.org");
+    CHECK(matches[2].matchedText == "https://other.net");
+
+    // Check positions.
+    CHECK(matches[0].start.line == LineOffset(0));
+    CHECK(matches[0].start.column == ColumnOffset(6));
+}
+
+TEST_CASE("HintModeHandler.LabelAssignment.TwoChar", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Create 27 URLs to trigger two-char labels.
+    auto lines = std::vector<std::string>();
+    auto line = std::string {};
+    for (auto const i: std::views::iota(0, 27))
+    {
+        line += std::format("https://site{}.com ", i);
+        if (i % 5 == 4)
+        {
+            lines.push_back(line);
+            line.clear();
+        }
+    }
+    if (!line.empty())
+        lines.push_back(line);
+
+    handler.activate(lines,
+                     PageSize { LineCount(static_cast<int>(lines.size())), ColumnCount(200) },
+                     urlOnlyPatterns(),
+                     HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 27);
+
+    // Two-char labels.
+    CHECK(handler.matches()[0].label == "aa");
+    CHECK(handler.matches()[1].label == "ab");
+    CHECK(handler.matches()[25].label == "az");
+    CHECK(handler.matches()[26].label == "ba");
+}
+
+TEST_CASE("HintModeHandler.ProgressiveFiltering", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> {
+        "https://alpha.com https://beta.com https://gamma.com",
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 3);
+    CHECK(handler.matches()[0].label == "a");
+    CHECK(handler.matches()[1].label == "b");
+    CHECK(handler.matches()[2].label == "c");
+
+    // Type 'b' — should filter to only match 'b' and auto-select.
+    handler.processInput(U'b');
+
+    CHECK(executor.hintSelectedCount == 1);
+    CHECK(executor.lastSelectedText == "https://beta.com");
+    CHECK(!handler.isActive()); // Should have deactivated after selection.
+}
+
+TEST_CASE("HintModeHandler.EscapeCancels", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "https://example.com" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+
+    handler.processInput(U'\x1B');
+
+    CHECK(!handler.isActive());
+    CHECK(executor.hintExitedCount == 1);
+    CHECK(executor.hintSelectedCount == 0); // No selection made.
+}
+
+TEST_CASE("HintModeHandler.NoMatches", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "no urls or hashes here" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("HintModeHandler.FilePathPattern", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "edit /home/user/file.txt and ./local/path" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, allPatterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+    // Should find file paths.
+    auto foundHome = false;
+    auto foundLocal = false;
+    for (auto const& m: handler.matches())
+    {
+        if (m.matchedText.find("/home/user/file.txt") != std::string::npos)
+            foundHome = true;
+        if (m.matchedText.find("./local/path") != std::string::npos)
+            foundLocal = true;
+    }
+    CHECK(foundHome);
+    CHECK(foundLocal);
+}
+
+TEST_CASE("HintModeHandler.GitHashPattern", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "commit a1b2c3d some message" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, allPatterns, HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    auto foundHash = false;
+    for (auto const& m: handler.matches())
+    {
+        if (m.matchedText == "a1b2c3d")
+            foundHash = true;
+    }
+    CHECK(foundHash);
+}
+
+TEST_CASE("HintModeHandler.BackspaceRemovesFilter", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> {
+        "https://alpha.com https://beta.com https://gamma.com",
+    };
+
+    auto const patterns = urlOnlyPatterns();
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 3);
+
+    // Start typing but then backspace.
+    handler.processInput(U'a');
+    CHECK(!handler.isActive()); // 'a' is unique label -> auto-selected.
+
+    // Reactivate for backspace test.
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+
+    // Test backspace on empty filter is a no-op.
+    handler.processInput(U'\x08'); // Backspace on empty filter.
+    CHECK(handler.isActive());     // Should still be active.
+    CHECK(handler.currentFilter().empty());
+}
+
+TEST_CASE("HintModeHandler.CaseInsensitive", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "https://example.com" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].label == "a");
+
+    // Type uppercase 'A' — should be normalized to 'a'.
+    handler.processInput(U'A');
+    CHECK(executor.hintSelectedCount == 1);
+    CHECK(executor.lastSelectedText == "https://example.com");
+}
+
+TEST_CASE("HintModeHandler.ActionDispatch", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "https://example.com" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Open);
+
+    handler.processInput(U'a');
+
+    CHECK(executor.hintSelectedCount == 1);
+    CHECK(executor.lastAction == HintAction::Open);
+}
+
+TEST_CASE("HintModeHandler.OverlappingPatterns", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // URL "https://example.com/path" also matches filepath "/example.com/path".
+    // The overlap removal should keep only the longer URL match.
+    auto lines = std::vector<std::string> { "visit https://example.com/path for info" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, allPatterns, HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+
+    // Check that no two matches overlap.
+    auto const& matches = handler.matches();
+    for (auto const i: std::views::iota(size_t { 1 }, matches.size()))
+    {
+        if (matches[i].start.line == matches[i - 1].start.line)
+        {
+            CHECK(matches[i].start.column > matches[i - 1].end.column);
+        }
+    }
+
+    // The URL match should be present (it's the longer one).
+    auto foundUrl = false;
+    for (auto const& m: matches)
+    {
+        if (m.matchedText == "https://example.com/path")
+            foundUrl = true;
+    }
+    CHECK(foundUrl);
+}
+
+TEST_CASE("HintModeHandler.BareRelativeFilePath", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Bare relative paths like those from git status or compiler output.
+    auto lines = std::vector<std::string> {
+        "modified: src/vtbackend/Terminal.cpp",
+        "error in lib/utils/helpers.h:42",
+    };
+
+    handler.activate(
+        lines, PageSize { LineCount(2), ColumnCount(50) }, filepathOnlyPatterns(), HintAction::Open);
+
+    REQUIRE(handler.isActive());
+
+    auto foundTerminal = false;
+    auto foundHelpers = false;
+    for (auto const& m: handler.matches())
+    {
+        if (m.matchedText == "src/vtbackend/Terminal.cpp")
+            foundTerminal = true;
+        if (m.matchedText.find("lib/utils/helpers.h") != std::string::npos)
+            foundHelpers = true;
+    }
+    CHECK(foundTerminal);
+    CHECK(foundHelpers);
+}
+
+TEST_CASE("HintModeHandler.BareRelativeDoesNotMatchPlainWords", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Plain words without slashes must NOT match the filepath pattern.
+    auto lines = std::vector<std::string> { "hello world foo bar" };
+
+    handler.activate(
+        lines, PageSize { LineCount(1), ColumnCount(30) }, filepathOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("HintModeHandler.ValidatorFiltersMatches", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "open /accept/path and /reject/path" };
+
+    // Create a filepath pattern with a validator that only accepts "/accept/path".
+    auto patterns = filepathOnlyPatterns();
+    for (auto& p: patterns)
+    {
+        p.validator = [](std::string const& matchStr) -> bool {
+            return matchStr.find("accept") != std::string::npos;
+        };
+    }
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, patterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "/accept/path");
+}
+
+TEST_CASE("HintModeHandler.NoValidatorPassesAll", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "see /foo/bar and /baz/qux" };
+
+    // No validator set — both paths should pass through.
+    handler.activate(
+        lines, PageSize { LineCount(1), ColumnCount(40) }, filepathOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+
+    auto foundFoo = false;
+    auto foundBaz = false;
+    for (auto const& m: handler.matches())
+    {
+        if (m.matchedText == "/foo/bar")
+            foundFoo = true;
+        if (m.matchedText == "/baz/qux")
+            foundBaz = true;
+    }
+    CHECK(foundFoo);
+    CHECK(foundBaz);
+}
+
+TEST_CASE("HintModeHandler.BareFilenameWithValidatedPattern", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Simulate bare filenames, extensionless files, and directories.
+    auto lines = std::vector<std::string> { "error in main.cpp and README.md also Makefile and src" };
+
+    // Create a filepath pattern with the broader regex (includes bare name branch)
+    // and a validator that accepts specific names.
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [](std::string const& matchStr) -> bool {
+                // Simulate: these entries exist on disk, anything else doesn't.
+                return matchStr == "main.cpp" || matchStr == "README.md" || matchStr == "Makefile"
+                       || matchStr == "src";
+            },
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 4);
+    CHECK(handler.matches()[0].matchedText == "main.cpp");
+    CHECK(handler.matches()[1].matchedText == "README.md");
+    CHECK(handler.matches()[2].matchedText == "Makefile");
+    CHECK(handler.matches()[3].matchedText == "src");
+}
+
+TEST_CASE("HintModeHandler.BareFilenameFilteredByValidator", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Version numbers, domain names, and non-existent bare words should be filtered
+    // when the validator confirms they don't exist on disk.
+    auto lines = std::vector<std::string> { "version v0.6.3 and example.com and real.txt also build" };
+
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [](std::string const& matchStr) -> bool {
+                // Only real.txt "exists".
+                return matchStr == "real.txt";
+            },
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "real.txt");
+}
+
+TEST_CASE("HintModeHandler.SingleCharTokensNotMatched", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Single-character tokens are below the 2-char minimum of the broad regex branch.
+    auto lines = std::vector<std::string> { "a b c d" };
+
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [](std::string const&) -> bool { return true; }, // Accept everything.
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, patterns, HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("HintModeHandler.BuiltinRegexDoesNotMatchBareFilenames", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // With the default builtin patterns (no validator, no broad regex),
+    // bare filenames must NOT be matched — they need a path separator.
+    auto lines = std::vector<std::string> { "edit main.cpp and README.md" };
+
+    handler.activate(
+        lines, PageSize { LineCount(1), ColumnCount(40) }, filepathOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    // No filepath matches because there are no slashes.
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("extractPathFromFileUrl.NonFileUrl", "[hintmode]")
+{
+    CHECK(extractPathFromFileUrl("https://example.com") == "https://example.com");
+    CHECK(extractPathFromFileUrl("ftp://server/file") == "ftp://server/file");
+    CHECK(extractPathFromFileUrl("") == "");
+    CHECK(extractPathFromFileUrl("/plain/path") == "/plain/path");
+}
+
+TEST_CASE("extractPathFromFileUrl.FileUrlWithLocalPath", "[hintmode]")
+{
+    CHECK(extractPathFromFileUrl("file:///home/user/file.txt") == "/home/user/file.txt");
+    CHECK(extractPathFromFileUrl("file:///") == "/");
+}
+
+TEST_CASE("extractPathFromFileUrl.FileUrlWithHost", "[hintmode]")
+{
+    CHECK(extractPathFromFileUrl("file://hostname/home/user/file.txt") == "/home/user/file.txt");
+    CHECK(extractPathFromFileUrl("file://hostname") == "");
+}
+
+TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")
+{
+    namespace fs = std::filesystem;
+
+    // Create a temporary directory with real filesystem entries.
+    auto const tmpDir = fs::temp_directory_path() / "contour-hintmode-test";
+    fs::create_directories(tmpDir / "src");
+    std::ofstream(tmpDir / "Makefile").put('\n');
+    std::ofstream(tmpDir / "main.cpp").put('\n');
+    std::ofstream(tmpDir / "README.md").put('\n');
+    std::ofstream(tmpDir / ".hidden").put('\n');
+
+    auto const cwd = tmpDir.string();
+
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Simulate terminal output containing a mix of existing and non-existing bare names.
+    auto lines = std::vector<std::string> {
+        "edit main.cpp and README.md also Makefile and src and .hidden but not bogus or phantom.xyz",
+    };
+
+    // Mirror the production validator from Terminal::activateHintMode:
+    // resolve bare names relative to CWD, then check filesystem existence.
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [cwd](std::string const& matchStr) -> bool {
+                auto resolved = std::string {};
+                if (matchStr.starts_with("/"))
+                    resolved = matchStr;
+                else
+                    resolved = cwd + "/" + matchStr;
+                return fs::exists(resolved);
+            },
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(100) }, patterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+
+    // Collect matched text for easy assertion.
+    auto matchedTexts = std::vector<std::string>();
+    for (auto const& m: handler.matches())
+        matchedTexts.push_back(m.matchedText);
+
+    // Files and directories that exist in the temp CWD must be matched.
+    CHECK(std::ranges::find(matchedTexts, "main.cpp") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, "README.md") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, "Makefile") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, "src") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, ".hidden") != matchedTexts.end());
+
+    // Non-existent names must be filtered out by the validator.
+    CHECK(std::ranges::find(matchedTexts, "bogus") == matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, "phantom.xyz") == matchedTexts.end());
+
+    // Clean up.
+    fs::remove_all(tmpDir);
+}
+
+TEST_CASE("HintModeHandler.HiddenFilesWithValidatedPattern", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Bare dotfiles like .gitignore, .bashrc, .config should be matched.
+    auto lines = std::vector<std::string> {
+        "check .gitignore and .bashrc also .config and README.md",
+    };
+
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [](std::string const& matchStr) -> bool {
+                // Simulate: all dotfiles and README.md exist on disk.
+                return matchStr == ".gitignore" || matchStr == ".bashrc" || matchStr == ".config"
+                       || matchStr == "README.md";
+            },
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+
+    auto matchedTexts = std::vector<std::string>();
+    for (auto const& m: handler.matches())
+        matchedTexts.push_back(m.matchedText);
+
+    CHECK(std::ranges::find(matchedTexts, ".gitignore") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, ".bashrc") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, ".config") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, "README.md") != matchedTexts.end());
+}
+
+TEST_CASE("HintModeHandler.DotPrefixedRelativePath", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Dot-prefixed relative paths like .config/settings and .local/bin/tool
+    // should be matched via alternative 3 of the broadened regex.
+    auto lines = std::vector<std::string> {
+        "open .config/settings and .local/bin/tool",
+    };
+
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "filepath",
+            .regex = std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                                std::regex_constants::ECMAScript | std::regex_constants::optimize),
+            .validator = [](std::string const&) -> bool { return true; }, // Accept everything.
+        },
+    };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, patterns, HintAction::Open);
+
+    REQUIRE(handler.isActive());
+
+    auto matchedTexts = std::vector<std::string>();
+    for (auto const& m: handler.matches())
+        matchedTexts.push_back(m.matchedText);
+
+    CHECK(std::ranges::find(matchedTexts, ".config/settings") != matchedTexts.end());
+    CHECK(std::ranges::find(matchedTexts, ".local/bin/tool") != matchedTexts.end());
+}
+
+TEST_CASE("HintModeHandler.IPv6FullAddress", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "address 2001:0db8:85a3:0000:0000:8a2e:0370:7334 here" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+}
+
+TEST_CASE("HintModeHandler.IPv6CompressedMiddle", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "link-local fe80::4117:f059:6f05:b06 on eth0" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "fe80::4117:f059:6f05:b06");
+}
+
+TEST_CASE("HintModeHandler.IPv6CompressedStart", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "loopback ::1 and ::ffff:abcd more" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 2);
+    CHECK(handler.matches()[0].matchedText == "::1");
+    CHECK(handler.matches()[1].matchedText == "::ffff:abcd");
+}
+
+TEST_CASE("HintModeHandler.IPv6CompressedEnd", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "prefix fe80:: in use" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "fe80::");
+}
+
+TEST_CASE("HintModeHandler.IPv6ShortCompressed", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "dns 2001:db8::1 server" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "2001:db8::1");
+}
+
+TEST_CASE("HintModeHandler.IPv6DoesNotMatchCppScope", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "std::vector and boost::asio and Foo::Bar" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("HintModeHandler.IPv6DoesNotMatchPlainHex", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "hash abcdef0123 and word deadbeef" };
+
+    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, ipv6OnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.isActive());
+    CHECK(handler.matches().empty());
+}

--- a/src/vtbackend/StatusLineBuilder.cpp
+++ b/src/vtbackend/StatusLineBuilder.cpp
@@ -35,6 +35,7 @@ namespace // helper functions
             case ViMode::Visual: return "VISUAL"sv;
             case ViMode::VisualLine: return "VISUAL LINE"sv;
             case ViMode::VisualBlock: return "VISUAL BLOCK"sv;
+            case ViMode::Hint: return "HINT"sv;
         }
         crispy::unreachable();
     }

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -297,6 +297,10 @@ void ViCommands::modeChanged(ViMode mode)
             (void) _terminal->selector()->extend(cursorPosition);
             _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
             break;
+        case ViMode::Hint:
+            // Keep cursor visible and status indicator, similar to Normal mode.
+            _terminal->pushStatusDisplay(StatusDisplayType::Indicator);
+            break;
     }
 
     _terminal->screenUpdated();
@@ -328,6 +332,12 @@ void ViCommands::searchCurrentWord()
     cursorPosition = range.second;
     updateSearchTerm(wordUnderCursor);
     jumpToNextMatch(1);
+}
+
+void ViCommands::enterHintMode(HintAction action)
+{
+    auto const patterns = HintModeHandler::builtinPatterns();
+    _terminal->activateHintMode(patterns, action);
 }
 
 void ViCommands::executeYank(ViMotion motion, unsigned count)
@@ -1190,7 +1200,8 @@ void ViCommands::moveCursorTo(CellLocation position)
     switch (_terminal->inputHandler().mode())
     {
         case ViMode::Normal:
-        case ViMode::Insert: break;
+        case ViMode::Insert:
+        case ViMode::Hint: break;
         case ViMode::Visual:
         case ViMode::VisualLine:
         case ViMode::VisualBlock:

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -34,6 +34,7 @@ class ViCommands: public ViInputHandler::Executor
     void reverseSearchCurrentWord() override;
     void toggleLineMark() override;
     void searchCurrentWord() override;
+    void enterHintMode(HintAction action) override;
     void execute(ViOperator op, ViMotion motion, unsigned count, char32_t lastChar = U'\0') override;
     void moveCursor(ViMotion motion, unsigned count, char32_t lastChar = U'\0') override;
     void select(TextObjectScope scope, TextObject textObject) override;

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -14,6 +14,12 @@
 
 namespace vtbackend
 {
+// Forward declaration (defined in HintModeHandler.h).
+enum class HintAction : uint8_t;
+} // namespace vtbackend
+
+namespace vtbackend
+{
 
 /*
  * ViInput emulates vi very basic in order to support
@@ -193,6 +199,9 @@ class ViInputHandler: public InputHandler
 
         // Similar to reverse search, but searching forward.
         virtual void searchCurrentWord() = 0;
+
+        /// Enters hint mode with the given action.
+        virtual void enterHintMode(HintAction action) = 0;
     };
 
     ViInputHandler(Executor& theExecutor, ViMode initialMode);
@@ -209,7 +218,8 @@ class ViInputHandler: public InputHandler
         switch (_viMode)
         {
             case ViMode::Insert:
-            case ViMode::Normal: return false;
+            case ViMode::Normal:
+            case ViMode::Hint: return false;
             case ViMode::Visual:
             case ViMode::VisualBlock:
             case ViMode::VisualLine: return true;

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -750,6 +750,9 @@ enum class ViMode : uint8_t
 
     /// Vi-like visual block-select mode.
     VisualBlock, // <C-V>
+
+    /// Hint overlay mode (keyboard-driven link following).
+    Hint,
 };
 
 std::string to_string(GraphicsRendition s);
@@ -1053,6 +1056,7 @@ struct std::formatter<vtbackend::ViMode>: formatter<std::string_view>
             case ViMode::Visual: name = "Visual"; break;
             case ViMode::VisualLine: name = "VisualLine"; break;
             case ViMode::VisualBlock: name = "VisualBlock"; break;
+            case ViMode::Hint: name = "Hint"; break;
         }
         return formatter<string_view>::format(name, ctx);
     }


### PR DESCRIPTION
Introduce a Vimium-style hint mode that scans the visible terminal for regex-matched patterns (URLs, file paths, git hashes, IPv4/IPv6 addresses), overlays short alphabetic labels on each match, and lets the user type a label to act on that match (copy, open, paste, select).

Key highlights:
- Activate via Ctrl+Shift+U (URLs), `gh`/`gH` in Vi normal mode (all patterns)
- Five actions: `Copy`, `Open`, `Paste`, `CopyAndPaste`, `Select`
- Progressive label filtering with auto-select on unique match
- Smart file path detection: when CWD is known via shell integration, bare filenames (main.cpp), extensionless files (Makefile), and directories (src) are matched and validated against the filesystem
- Configurable hint_label and hint_match colors in color schemes
