### PR TITLE
Fix forceScrollToBottom() not resetting pixel offset

### DIFF
--- a/src/vtbackend/Viewport.cpp
+++ b/src/vtbackend/Viewport.cpp
@@ -43,7 +43,15 @@ bool Viewport::scrollToBottom()
 bool Viewport::forceScrollToBottom()
 {
     viewportLog()("force ScrollToBottom");
-    return scrollTo(ScrollOffset(0));
+    bool changed = scrollTo(ScrollOffset(0));
+    if (_pixelOffset != 0.0f)
+    {
+        resetPixelOffset();
+        if (!changed)
+            _modified();
+        changed = true;
+    }
+    return changed;
 }
 
 bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset)


### PR DESCRIPTION
forceScrollToBottom() only reset the line-level scroll offset via scrollTo() but did not clear the sub-line pixel offset used for smooth scrolling. This could leave a residual pixel offset after snapping to the bottom, causing visual misalignment.

Reset _pixelOffset and fire the _modified() callback when needed.
