### PR TITLE
Fix third-party dependency files leaking into install tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -26,7 +26,7 @@ endfunction(subproject_version)
 set(ContourThirdParties_SRCDIR ${PROJECT_SOURCE_DIR}/_deps/sources)
 if(EXISTS "${ContourThirdParties_SRCDIR}/CMakeLists.txt")
     message(STATUS "Embedding 3rdparty libraries: ${ContourThirdParties_SRCDIR}")
-    add_subdirectory(${ContourThirdParties_SRCDIR})
+    add_subdirectory(${ContourThirdParties_SRCDIR} EXCLUDE_FROM_ALL)
 else()
     message(STATUS "No 3rdparty libraries found at ${ContourThirdParties_SRCDIR}")
 endif()
@@ -85,6 +85,7 @@ else()
             NAME GSL
             GITHUB_REPOSITORY microsoft/GSL
             GIT_TAG v${GSL_VERSION}
+            EXCLUDE_FROM_ALL YES
             OPTIONS "GSL_TEST=OFF"
         )
         set(THIRDPARTY_BUILTIN_GSL "embedded (CPM)")
@@ -131,6 +132,7 @@ if(LIBTERMINAL_BUILD_BENCH_HEADLESS)
                 NAME termbench-pro
                 GITHUB_REPOSITORY contour-terminal/termbench-pro
                 GIT_TAG ${TERMBENCH_PRO_COMMIT_HASH}
+                EXCLUDE_FROM_ALL YES
             )
             set(THIRDPARTY_BUILTIN_termbench "embedded (CPM)")
         else()

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
       <description>
         <ul>
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>
+          <li>Fixes third-party dependency files (headers, libraries) leaking into install tree (#1788)</li>
           <li>Fixes Insert Replace Mode (IRM, CSI 4 h) not shifting text right on character insertion (#1877)</li>
           <li>Fixes Home/End key encoding in Kitty keyboard protocol (extended keyboard input generator)</li>
           <li>Fixes glyph scaling and vertical centering of colored emoji</li>


### PR DESCRIPTION
Fixes #1788

Add `EXCLUDE_FROM_ALL` to `add_subdirectory` and `CPMAddPackage` calls for third-party dependencies, preventing their `install()` rules from polluting the install prefix. Bumps `cmake_minimum_required` to 3.25 (presets already require 3.27).