### PR TITLE
Fix hint mode highlight offset with non-ASCII characters

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -12,6 +12,7 @@ DDDDD
 ellips
 emtpy
 FFFFF
+fullwidth
 GGGGG
 gitbranch
 gitgraph
@@ -23,3 +24,4 @@ rbong
 ULval
 unscroll
 URval
+xad


### PR DESCRIPTION
Fixes #1870

- Converts regex byte offsets to codepoint indices when computing hint overlay column positions, fixing rightward shift on lines with multi-byte UTF-8 characters before a match (#1870)
- Adds 5 test cases covering Unicode prompts, CJK chars, multiple non-ASCII segments, ASCII regression, and match-at-line-start
