### PR TITLE
Fix CancelSelection consuming ESC key when no selection exists

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -108,6 +108,7 @@
       <description>
         <ul>
           <li>Fixes keyboard input being swallowed in programs like less and bat due to empty-string terminfo capabilities (#1861)</li>
+          <li>Fixes ESC key not being sent to the application when CancelSelection input mapping has no mode restriction (#1839)</li>
           <li>Fixes F3 key not reaching PTY applications when a keybinding matches but its action does not execute, by falling through to the terminal instead of silently consuming the key event</li>
           <li>Fixes F3/Shift+F3 search navigation keybindings firing in any mode instead of only when Search mode is active</li>
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1224,6 +1224,8 @@ void TerminalSession::cursorPositionChanged()
 // {{{ Actions
 bool TerminalSession::operator()(actions::CancelSelection)
 {
+    if (!_terminal.selectionAvailable())
+        return false;
     _terminal.clearSelection();
     return true;
 }


### PR DESCRIPTION
Fixes #1839

## Summary
- `CancelSelection` handler unconditionally returned `true`, consuming the ESC key event even when no selection was active — preventing `\x1b` from reaching PTY applications for users whose config lacked a mode restriction on the binding (e.g. configs predating PR #1714)
- Guard with `selectionAvailable()` so the handler returns `false` when no selection exists, allowing the key event to propagate to the terminal (follows the pattern used by `FollowHyperlink`, `SearchReverse`, and `SearchNext`)
- Adds three vtbackend-level tests validating the preconditions the fix relies on