### PR TITLE
Fix selectiveEraseLine erasing wrong line and add DECSCA tests

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li>Fixes keyboard input being swallowed in programs like less and bat due to empty-string terminfo capabilities (#1861)</li>
           <li>Fixes ESC key not being sent to the application when CancelSelection input mapping has no mode restriction (#1839)</li>
+          <li>Fixes selective erase (DECSED/DECSEL) incorrectly erasing the cursor line instead of the target line when erasing lines without protected characters (#28)</li>
           <li>Fixes F3 key not reaching PTY applications when a keybinding matches but its action does not execute, by falling through to the terminal instead of silently consuming the key event</li>
           <li>Fixes F3/Shift+F3 search navigation keybindings firing in any mode instead of only when Search mode is active</li>
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -1089,7 +1089,8 @@ void Screen<Cell>::selectiveEraseLine(LineOffset line)
         return;
     }
 
-    currentLine().reset(currentLine().flags(), _cursor.graphicsRendition);
+    auto& targetLine = _grid.lineAt(line);
+    targetLine.reset(targetLine.flags(), _cursor.graphicsRendition);
 
     auto const left = ColumnOffset(0);
     auto const right = boxed_cast<ColumnOffset>(pageSize().columns - 1);

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2499,7 +2499,7 @@ void Terminal::softReset()
     setMode(DECMode::ApplicationKeypad, false); // DECNKM
     setMode(DECMode::AutoRepeat, true);         // DECARM
     setMode(DECMode::BackarrowKey, false);      // DECBKM
-    // TODO: DECSCA (Select character attribute)
+    // DECSCA is reset by setGraphicsRendition(GraphicsRendition::Reset) above.
     // TODO: DECNRCM (National replacement character set)
     // TODO: GL, GR (G0, G1, G2, G3)
     // TODO: DECAUPSS (Assign user preference supplemental set)


### PR DESCRIPTION
- Fix bug in `selectiveEraseLine` where the optimization path (no protected characters on the line) used `currentLine()` instead of `_grid.lineAt(line)`, causing DECSED to erase the cursor's line rather than the target line
- Add 5 dedicated test cases: 4 for DECSCA (enable/disable, default param, SGR independence, save/restore cursor) and 1 regression test for the bug exposing DECSED-2 with lines having no protected characters
- Replace stale `TODO: DECSCA` comment in `softReset()` with clarifying note that DECSCA is already reset via `setGraphicsRendition(GraphicsRendition::Reset)`

Fixes #28