### PR TITLE
Add Semantic Block Protocol (DEC Mode 2034) with SBQUERY

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -10,7 +10,11 @@ circleval
 ctrled
 dcx
 DDDDD
+Decset
+DECRST
+DECSET
 ellips
+emantic
 emtpy
 FFFFF
 GGGGG
@@ -19,8 +23,12 @@ gitgraph
 HHHHH
 HTP
 isakbm
+NCommands
+ndrwxr
+nfile
 pseudoconsole
 rbong
+SBQUERY
 ULval
 unscroll
 URval

--- a/docs/vt-extensions/semantic-block-query.md
+++ b/docs/vt-extensions/semantic-block-query.md
@@ -1,0 +1,211 @@
+# Semantic Block Query (DEC Mode 2034)
+
+This extension provides a discoverable, machine-readable query mechanism that returns structured
+JSON blocks of semantic command data from the terminal. It is designed for programmatic consumers
+such as AI agents, accessibility tools, and automation scripts.
+
+## Prerequisites
+
+This feature requires [OSC 133 shell integration](osc-133-shell-integration.md) to be active
+in the running shell. The shell must emit OSC 133 sequences (A, B, C, D) to mark prompt boundaries,
+command output regions, and command completion.
+
+## Feature Discovery
+
+### DEC Private Mode 2034
+
+```
+Enable:  CSI ? 2034 h       (DECSM)
+Disable: CSI ? 2034 l       (DECRM)
+Query:   CSI ? 2034 $ p     (DECRQM)  ->  CSI ? 2034 ; Ps $ y
+```
+
+Where `Ps` in the DECRQM response is:
+- `0` = not recognized (terminal does not support this mode)
+- `1` = set (enabled)
+- `2` = reset (disabled)
+
+When enabled:
+- The terminal tracks semantic zones from OSC 133 sequences using line flags and internal metadata.
+- The terminal generates a session token and replies with a DCS containing the token (see Authentication below).
+- The query sequence `CSI > Ps ; Pn ; T1 ; T2 ; T3 ; T4 b` becomes available.
+
+When disabled:
+- All tracked semantic block data is discarded.
+- The session token is invalidated.
+- The query sequence returns an error response.
+
+## Authentication
+
+When mode 2034 is enabled via DECSM, the terminal generates a 64-bit session token and replies with:
+
+```
+DCS > 2034 ; 1 b T1 ; T2 ; T3 ; T4 ST
+```
+
+That is: `ESC P > 2034 ; 1 b T1 ; T2 ; T3 ; T4 ESC \`
+
+The 4 integer values (`T1`..`T4`) are the session token. These same values must be included
+in every SBQUERY request as additional CSI parameters (see Query Syntax below). No conversion
+is needed — the values from the DCS reply are used directly.
+
+### Token Lifecycle
+
+1. **On DECSET 2034**: Terminal generates a fresh token and replies with the DCS token response.
+2. **On SBQUERY**: The token must be included as parameters T1..T4. Missing or invalid tokens produce error responses.
+3. **On DECRST 2034**: The token is invalidated along with all tracked data.
+4. **On re-enable**: A new token is generated; previous tokens are no longer valid.
+
+### Security Note
+
+DECSET normally does not produce a reply. Some terminal multiplexers (e.g. tmux, screen)
+may not forward the DCS token response to the application. In such environments, token-based
+authentication may not be usable. This is a known limitation.
+
+## Query Syntax — SBQUERY
+
+```
+CSI > Ps ; Pn ; T1 ; T2 ; T3 ; T4 b
+```
+
+**Mnemonic:** SBQUERY — **S**emantic **B**lock **QUERY**
+
+CSI with `>` leader, final character `b` (for "blocks").
+
+| Parameter | Meaning                                              |
+|-----------|------------------------------------------------------|
+| Ps        | Query type (see table below)                         |
+| Pn        | Count parameter (default 1)                          |
+| T1..T4    | Session token as 4 × uint16 values (from DECSET reply) |
+
+| Ps | Meaning                         | Pn                  |
+|----|-------------------------------- |---------------------|
+| 1  | Last completed command block    | ignored             |
+| 2  | Last N completed command blocks | count (default 1)   |
+| 3  | Current in-progress command     | ignored             |
+
+## Response Syntax
+
+The response is a DCS (Device Control String) with `>` leader and final character `b`.
+
+**Success:**
+
+```
+DCS > 1 b {JSON} ST
+```
+
+That is: `ESC P > 1 b {JSON} ESC \`
+
+**Error — no data or mode disabled:**
+
+```
+DCS > 0 b ST
+```
+
+**Error — authentication required (missing token):**
+
+```
+DCS > 2 b ST
+```
+
+**Error — authentication failed (wrong token):**
+
+```
+DCS > 3 b ST
+```
+
+### Status Codes
+
+| Status | Meaning                          |
+|--------|----------------------------------|
+| 0      | Mode disabled or no data         |
+| 1      | Success with JSON payload        |
+| 2      | Authentication required (no token provided) |
+| 3      | Authentication failed (invalid token)       |
+
+## JSON Response Schema
+
+```json
+{
+  "version": 1,
+  "blocks": [
+    {
+      "command": "ls -la",
+      "prompt": "user@host:~$ ",
+      "output": "total 42\ndrwxr-xr-x ...",
+      "exitCode": 0,
+      "finished": true,
+      "outputLineCount": 10
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field             | Type              | Description                                                       |
+|-------------------|-------------------|-------------------------------------------------------------------|
+| `version`         | integer           | Schema version, currently `1`.                                    |
+| `blocks`          | array             | Array of command block objects, ordered chronologically.           |
+| `command`         | string or null    | The command line from OSC 133;C `cmdline_url` parameter.          |
+| `prompt`          | string            | Text content of the prompt region (from Marked line to OutputStart). |
+| `output`          | string            | Text content of the command output region.                        |
+| `exitCode`        | integer           | From OSC 133;D parameter. `-1` if unknown.                       |
+| `finished`        | boolean           | `false` for in-progress commands (Ps=3 query), `true` otherwise. |
+| `outputLineCount` | integer           | Number of output lines in the block.                              |
+
+Text fields use JSON's native encoding for control characters (e.g. `\u001b` for ESC),
+which ensures the payload never contains a raw ST (ESC \) sequence.
+
+## Example Session
+
+```sh
+# 1. Enable the semantic block protocol and capture the token
+printf '\033[?2034h'
+# Response: DCS > 2034 ; 1 b 41394 ; 50132 ; 58870 ; 1816 ST
+# Token values: T1=41394 T2=50132 T3=58870 T4=1816
+
+# 2. Verify it's enabled via DECRQM
+printf '\033[?2034$p'
+# Response: CSI ? 2034 ; 1 $ y
+
+# 3. Run some commands (with OSC 133 shell integration active)
+ls -la
+echo hello
+
+# 4. Query the last completed command (with token)
+printf '\033[>1;1;41394;50132;58870;1816b'
+# Response: DCS > 1 b {"version":1,"blocks":[{"command":"echo hello",...}]} ST
+
+# 5. Query the last 3 completed commands (with token)
+printf '\033[>2;3;41394;50132;58870;1816b'
+
+# 6. Query any in-progress command (with token)
+printf '\033[>3;1;41394;50132;58870;1816b'
+
+# 7. Disable when done (invalidates the token)
+printf '\033[?2034l'
+```
+
+## Implementation Notes
+
+- **Token storage**: Terminals implementing this specification should generate the session token
+  using a cryptographically secure random number generator and store it for the duration of the
+  mode being enabled. The token must be regenerated on each enable.
+- **Terminal multiplexers**: DECSET does not normally produce a reply. Multiplexers and terminal
+  proxies that intercept DEC mode sequences should be aware that mode 2034 produces a DCS reply
+  and must forward it to the requesting application.
+- **CLI/tool integration**: Tools should capture the DCS token reply immediately after sending
+  DECSET 2034 and parse the 16-character hex token before issuing any SBQUERY. Libraries should
+  provide a helper to convert the hex token into the 4 integer parameters.
+- **Error handling**: Consumers should check the status byte in every DCS response and handle
+  status 2 (missing token) and 3 (invalid token) gracefully, e.g. by re-enabling the mode to
+  obtain a fresh token.
+- **Capacity limits**: The number of retained completed command blocks is implementation-defined.
+  Consumers should not assume an unbounded history.
+- **Output encoding**: JSON text fields use standard JSON escaping for control characters
+  (e.g. `\u001b` for ESC), ensuring the DCS payload never contains a raw ST sequence.
+
+## See Also
+
+- [OSC 133 - Shell Integration](osc-133-shell-integration.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - vt-extensions/line-reflow-mode.md
     - vt-extensions/save-and-restore-sgr-attributes.md
     - vt-extensions/osc-133-shell-integration.md
+    - vt-extensions/semantic-block-query.md
   - Internals:
     - internals/index.md
     - internals/CODING_STYLE.md

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -37,6 +37,7 @@ set(vtbackend_HEADERS
     RenderBuffer.h
     RenderBufferBuilder.h
     Screen.h
+    SemanticBlockTracker.h
     Selector.h
     Sequence.h
     SequenceBuilder.h
@@ -71,6 +72,7 @@ set(vtbackend_SOURCES
     RenderBuffer.cpp
     RenderBufferBuilder.cpp
     Screen.cpp
+    SemanticBlockTracker.cpp
     Selector.cpp
     Sequence.cpp
     SixelParser.cpp

--- a/src/vtbackend/Functions.h
+++ b/src/vtbackend/Functions.h
@@ -175,6 +175,7 @@ constexpr inline auto XTCHECKSUM = FunctionDocumentation { .mnemonic = "XTCHECKS
 constexpr inline auto SL = FunctionDocumentation { .mnemonic = "SL", .comment = "Scroll Left" };
 constexpr inline auto SR = FunctionDocumentation { .mnemonic = "SR", .comment = "Scroll Right" };
 constexpr inline auto MODIFYOTHERKEYS = FunctionDocumentation { .mnemonic = "MODIFYOTHERKEYS", .comment = "Modify Other Keys mode" };
+constexpr inline auto SBQUERY = FunctionDocumentation { .mnemonic = "SBQUERY", .comment = "Query semantic command blocks." };
 
 } // namespace documentation
 
@@ -617,6 +618,7 @@ constexpr inline auto XTCHECKSUM  = detail::CSI(std::nullopt, 1, 1, '#', 'y', VT
 constexpr inline auto XTSMGRAPHICS= detail::CSI('?', 2, 4, std::nullopt, 'S', VTExtension::XTerm, documentation::XTSMGRAPHICS);
 constexpr inline auto XTVERSION   = detail::CSI('>', 0, 1, std::nullopt, 'q', VTExtension::XTerm, documentation::XTVERSION);
 constexpr inline auto MODIFYOTHERKEYS = detail::CSI('>', 0, 1, std::nullopt, 'm', VTExtension::XTerm, documentation::MODIFYOTHERKEYS);
+constexpr inline auto SBQUERY         = detail::CSI('>', 0, 6, std::nullopt, 'b', VTExtension::Contour, documentation::SBQUERY);
 
 // DCS functions
 constexpr inline auto DECRQSS     = detail::DCS(std::nullopt, 0, 0, '$', 'q', VTType::VT420, documentation::DECRQSS);
@@ -789,6 +791,7 @@ constexpr static auto allFunctionsArray() noexcept
         XTSMGRAPHICS,
         XTVERSION,
         MODIFYOTHERKEYS,
+        SBQUERY,
 
         // DCS
         STP,

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -32,9 +32,11 @@ enum class LineFlag : uint8_t
     Wrappable = 0x0001,
     Wrapped = 0x0002,
     Marked = 0x0004,
+    OutputStart = 0x0008, ///< Command output begins (from OSC 133;C)
     DoubleWidth = 0x0010,
     DoubleHeightTop = 0x0020,
     DoubleHeightBottom = 0x0040,
+    CommandEnd = 0x0080, ///< Command finished (from OSC 133;D)
 };
 
 using LineFlags = crispy::flags<LineFlag>;

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <deque>
 #include <format>
 #include <functional>
 #include <memory>
@@ -36,8 +37,10 @@
 namespace vtbackend
 {
 
+class SemanticBlockTracker;
 class SixelImageBuilder;
 class Terminal;
+struct CommandBlockInfo;
 struct Settings;
 
 // {{{ TODO: move me somewhere more appropriate
@@ -659,6 +662,12 @@ class Screen final: public ScreenBase, public capabilities::StaticDatabase
     [[nodiscard]] std::unique_ptr<ParserExtension> hookXTGETTCAP(Sequence const& seq);
 
     void processShellIntegration(Sequence const& seq);
+    void handleSemanticBlockQuery(Sequence const& seq);
+    void handleInProgressQuery(SemanticBlockTracker const& tracker);
+    void handleCompletedBlocksQuery(SemanticBlockTracker const& tracker,
+                                    std::deque<CommandBlockInfo> const& completedBlocks,
+                                    unsigned queryType,
+                                    int count);
 
     gsl::not_null<Terminal*> _terminal;
     gsl::not_null<Settings*> _settings;

--- a/src/vtbackend/SemanticBlockTracker.cpp
+++ b/src/vtbackend/SemanticBlockTracker.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/SemanticBlockTracker.h>
+
+#include <random>
+
+namespace vtbackend
+{
+
+SemanticBlockTracker::SemanticBlockTracker(size_t maxBlocks): _maxBlocks { maxBlocks }
+{
+}
+
+void SemanticBlockTracker::setEnabled(bool enabled)
+{
+    _enabled = enabled;
+    if (enabled)
+    {
+        _token = generateToken();
+    }
+    else
+    {
+        _token.reset();
+        _completedBlocks.clear();
+        _currentBlock.reset();
+    }
+}
+
+bool SemanticBlockTracker::isEnabled() const noexcept
+{
+    return _enabled;
+}
+
+std::optional<SemanticBlockTracker::Token> const& SemanticBlockTracker::token() const noexcept
+{
+    return _token;
+}
+
+bool SemanticBlockTracker::validateToken(Token const& candidate) const noexcept
+{
+    return _token.has_value() && _token.value() == candidate;
+}
+
+SemanticBlockTracker::Token SemanticBlockTracker::generateToken()
+{
+    auto rd = std::random_device {};
+    auto token = Token {};
+    for (auto& part: token)
+        part = static_cast<uint16_t>(rd());
+    return token;
+}
+
+void SemanticBlockTracker::promptStart()
+{
+    if (!_enabled)
+        return;
+
+    // If there's a current block that was finished, push it to completed.
+    // Unfinished blocks (e.g. from Ctrl+C before OSC 133;D) are intentionally
+    // discarded — only commands that ran to completion have reliable metadata.
+    if (_currentBlock && _currentBlock->finished)
+    {
+        _completedBlocks.push_back(std::move(*_currentBlock));
+        if (_completedBlocks.size() > _maxBlocks)
+            _completedBlocks.pop_front();
+    }
+
+    // Start tracking a new block (replaces any unfinished block).
+    _currentBlock = CommandBlockInfo {};
+}
+
+void SemanticBlockTracker::commandOutputStart(std::optional<std::string> const& commandLine)
+{
+    if (!_enabled)
+        return;
+
+    if (!_currentBlock)
+        _currentBlock = CommandBlockInfo {};
+
+    _currentBlock->commandLine = commandLine;
+}
+
+void SemanticBlockTracker::commandFinished(int exitCode)
+{
+    if (!_enabled)
+        return;
+
+    if (!_currentBlock)
+        _currentBlock = CommandBlockInfo {};
+
+    _currentBlock->exitCode = exitCode;
+    _currentBlock->finished = true;
+}
+
+std::deque<CommandBlockInfo> const& SemanticBlockTracker::completedBlocks() const noexcept
+{
+    return _completedBlocks;
+}
+
+std::optional<CommandBlockInfo> const& SemanticBlockTracker::currentBlock() const noexcept
+{
+    return _currentBlock;
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/SemanticBlockTracker.h
+++ b/src/vtbackend/SemanticBlockTracker.h
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <string>
+
+namespace vtbackend
+{
+
+/// Stores metadata for a single command block tracked via OSC 133 shell integration.
+struct CommandBlockInfo
+{
+    std::optional<std::string> commandLine; ///< From OSC 133;C cmdline_url parameter.
+    int exitCode = -1;                      ///< From OSC 133;D parameter (-1 if unknown).
+    bool finished = false;                  ///< True after OSC 133;D received.
+};
+
+/// SBQUERY (CSI > Ps ; Pn b) query type parameter values.
+struct SBQueryType
+{
+    static constexpr unsigned LastCommand = 1;          ///< Last completed command block.
+    static constexpr unsigned LastNumberOfCommands = 2; ///< Last N completed command blocks (Pn = count).
+    static constexpr unsigned InProgress = 3;           ///< Current in-progress command.
+};
+
+/// Tracks semantic command blocks when DEC mode 2034 (Semantic Block Reader Protocol) is enabled.
+///
+/// This is a standalone tracker owned by Terminal, called from Screen::processShellIntegration()
+/// in addition to the existing ShellIntegration callback. It is only active when mode 2034 is enabled.
+class SemanticBlockTracker
+{
+  public:
+    /// 64-bit session token represented as 4 × uint16_t for CSI parameter encoding.
+    using Token = std::array<uint16_t, 4>;
+
+    /// Constructs a tracker with a maximum number of completed blocks to retain.
+    ///
+    /// @param maxBlocks Maximum number of completed command blocks to keep in history.
+    explicit SemanticBlockTracker(size_t maxBlocks = 100);
+
+    /// Enables or disables tracking.
+    ///
+    /// On enable: generates a fresh session token.
+    /// On disable: clears all stored data and invalidates the token.
+    void setEnabled(bool enabled);
+
+    /// Returns whether tracking is currently enabled.
+    [[nodiscard]] bool isEnabled() const noexcept;
+
+    /// Returns the current session token, if mode is enabled.
+    [[nodiscard]] std::optional<Token> const& token() const noexcept;
+
+    /// Validates a candidate token against the current session token.
+    ///
+    /// @param candidate The token to validate.
+    /// @return true if the token matches the current session token.
+    [[nodiscard]] bool validateToken(Token const& candidate) const noexcept;
+
+    /// Generates a new random 64-bit token using std::random_device.
+    [[nodiscard]] static Token generateToken();
+
+    /// Called when OSC 133;A (prompt start) is received.
+    void promptStart();
+
+    /// Called when OSC 133;C (command output start) is received.
+    ///
+    /// @param commandLine The command line from the cmdline_url parameter, if available.
+    void commandOutputStart(std::optional<std::string> const& commandLine);
+
+    /// Called when OSC 133;D (command finished) is received.
+    ///
+    /// @param exitCode The exit code of the finished command.
+    void commandFinished(int exitCode);
+
+    /// Returns the list of completed command blocks, oldest first.
+    [[nodiscard]] std::deque<CommandBlockInfo> const& completedBlocks() const noexcept;
+
+    /// Returns the currently in-progress command block, if any.
+    [[nodiscard]] std::optional<CommandBlockInfo> const& currentBlock() const noexcept;
+
+  private:
+    bool _enabled = false;
+    std::optional<Token> _token;
+    std::deque<CommandBlockInfo> _completedBlocks;
+    std::optional<CommandBlockInfo> _currentBlock;
+    size_t _maxBlocks;
+};
+
+} // namespace vtbackend

--- a/src/vtbackend/ShellIntegration_test.cpp
+++ b/src/vtbackend/ShellIntegration_test.cpp
@@ -1,15 +1,79 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/Functions.h>
 #include <vtbackend/MockTerm.h>
+#include <vtbackend/SemanticBlockTracker.h>
 #include <vtbackend/ShellIntegration.h>
 #include <vtbackend/Terminal.h>
 
 #include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <string_view>
 
 using namespace vtbackend;
 using namespace std::string_view_literals;
 
 namespace
 {
+
+/// Extracts the 4-integer token from a DECSET 2034 DCS reply.
+///
+/// The reply format is: ESC P > 2034 ; 1 b T1 ; T2 ; T3 ; T4 ESC backslash
+/// @param replyData The raw reply data from the terminal.
+/// @return The token as a Token array, or std::nullopt if not found.
+std::optional<SemanticBlockTracker::Token> extractTokenFromDecsetReply(std::string const& replyData)
+{
+    // Look for "\033P>2034;1b" prefix
+    auto const prefix = std::string_view("\033P>2034;1b");
+    auto const pos = replyData.find(prefix);
+    if (pos == std::string::npos)
+        return std::nullopt;
+
+    // Find the ST terminator
+    auto const dataStart = pos + prefix.size();
+    auto const stPos = replyData.find("\033\\", dataStart);
+    if (stPos == std::string::npos)
+        return std::nullopt;
+
+    // Parse 4 semicolon-separated integers: "T1;T2;T3;T4"
+    auto const tokenStr = replyData.substr(dataStart, stPos - dataStart);
+    auto token = SemanticBlockTracker::Token {};
+    auto start = size_t { 0 };
+    for (auto i = 0; i < 4; ++i)
+    {
+        auto const sep = (i < 3) ? tokenStr.find(';', start) : tokenStr.size();
+        if (sep == std::string::npos)
+            return std::nullopt;
+        token[i] = static_cast<uint16_t>(std::stoul(tokenStr.substr(start, sep - start)));
+        start = sep + 1;
+    }
+    return token;
+}
+
+/// Enables mode 2034 and returns the session token from the DCS reply.
+///
+/// @param mc The MockTerm to operate on.
+/// @return The extracted token.
+SemanticBlockTracker::Token enableModeAndGetToken(MockTerm<>& mc)
+{
+    mc.resetReplyData();
+    mc.writeToScreen(DECSM(2034));
+    mc.terminal.flushInput();
+    auto const token = extractTokenFromDecsetReply(mc.replyData());
+    REQUIRE(token.has_value());
+    return *token;
+}
+
+/// Builds an authenticated SBQUERY escape sequence with token parameters.
+///
+/// @param queryType The SBQUERY query type (Ps).
+/// @param count The count parameter (Pn).
+/// @param token The session token to embed as parameters 2..5.
+/// @return The complete CSI escape sequence string.
+std::string authenticatedSBQuery(unsigned queryType, unsigned count, SemanticBlockTracker::Token const& token)
+{
+    return SBQUERY(queryType, count, token[0], token[1], token[2], token[3]);
+}
 
 class MockShellIntegration: public ShellIntegration
 {
@@ -42,6 +106,32 @@ class MockShellIntegration: public ShellIntegration
         lastCommandFinishedExitCode = exitCode;
     }
 };
+
+/// Simulates a complete command cycle: prompt -> command -> output -> finish.
+/// Inserts newlines to mirror real shell behavior (Enter after prompt, newline after output).
+void simulateCommand(MockTerm<>& mc,
+                     std::string_view promptText,
+                     std::string_view commandLine,
+                     std::string_view outputText,
+                     int exitCode)
+{
+    // OSC 133;A - Prompt Start
+    mc.writeToScreen("\033]133;A\033\\");
+    // Write prompt text
+    mc.writeToScreen(promptText);
+    // OSC 133;B - Prompt End
+    mc.writeToScreen("\033]133;B\033\\");
+    // Newline simulates the Enter keypress after the command
+    mc.writeToScreen("\n");
+    // OSC 133;C - Command Output Start (with cmdline_url)
+    mc.writeToScreen(std::string("\033]133;C;cmdline_url=") + std::string(commandLine) + "\033\\");
+    // Write command output
+    mc.writeToScreen(outputText);
+    // Trailing newline (most commands end their output with one)
+    mc.writeToScreen("\n");
+    // OSC 133;D - Command Finished
+    mc.writeToScreen(std::string("\033]133;D;") + std::to_string(exitCode) + "\033\\");
+}
 
 } // namespace
 
@@ -114,4 +204,343 @@ TEST_CASE("ShellIntegration.SETMARK")
         mc.writeToScreen("\033[>M");
         CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::Marked));
     }
+}
+
+// ==================== Semantic Block Protocol Tests ====================
+
+TEST_CASE("SemanticBlockProtocol.LineFlags")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    SECTION("OutputStart and CommandEnd flags set when mode 2034 is on")
+    {
+        // Enable mode 2034
+        mc.writeToScreen(DECSM(2034));
+
+        // OSC 133;C should set OutputStart on the current line
+        mc.writeToScreen("\033]133;C\033\\");
+        CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::OutputStart));
+
+        // Write some output and move to a new line
+        mc.writeToScreen("output\n");
+
+        // OSC 133;D should set CommandEnd on the current line
+        mc.writeToScreen("\033]133;D\033\\");
+        CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(1)).contains(LineFlag::CommandEnd));
+    }
+
+    SECTION("Flags NOT set when mode 2034 is off")
+    {
+        // Mode 2034 is off by default
+
+        // OSC 133;C should NOT set OutputStart
+        mc.writeToScreen("\033]133;C\033\\");
+        CHECK_FALSE(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::OutputStart));
+
+        mc.writeToScreen("output\n");
+
+        // OSC 133;D should NOT set CommandEnd
+        mc.writeToScreen("\033]133;D\033\\");
+        CHECK_FALSE(mc.terminal.currentScreen().lineFlagsAt(LineOffset(1)).contains(LineFlag::CommandEnd));
+    }
+}
+
+TEST_CASE("SemanticBlockProtocol.TrackerMetadata")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    SECTION("Tracker stores command line and exit code")
+    {
+        mc.writeToScreen(DECSM(2034));
+
+        mc.writeToScreen("\033]133;A\033\\");
+        mc.writeToScreen("$ ");
+        mc.writeToScreen("\033]133;C;cmdline_url=ls%20-la\033\\");
+        mc.writeToScreen("file1\n");
+        mc.writeToScreen("\033]133;D;0\033\\");
+
+        auto const& tracker = mc.terminal.semanticBlockTracker();
+        REQUIRE(tracker.currentBlock().has_value());
+        CHECK(tracker.currentBlock()->finished == true);
+        REQUIRE(tracker.currentBlock()->commandLine.has_value());
+        CHECK(tracker.currentBlock()->commandLine.value() == "ls -la");
+        CHECK(tracker.currentBlock()->exitCode == 0);
+    }
+
+    SECTION("Tracker disabled clears data")
+    {
+        mc.writeToScreen(DECSM(2034));
+        mc.writeToScreen("\033]133;A\033\\");
+        mc.writeToScreen("\033]133;C;cmdline_url=test\033\\");
+        mc.writeToScreen("\033]133;D;0\033\\");
+
+        auto const& tracker = mc.terminal.semanticBlockTracker();
+        CHECK(tracker.currentBlock().has_value());
+
+        // Disable mode
+        mc.writeToScreen(DECRM(2034));
+        CHECK_FALSE(tracker.currentBlock().has_value());
+        CHECK(tracker.completedBlocks().empty());
+    }
+}
+
+TEST_CASE("SemanticBlockProtocol.DECRQM")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    SECTION("DECRQM reports mode 2034 as reset by default")
+    {
+        mc.resetReplyData();
+        mc.writeToScreen(DECRQM(2034));
+        mc.terminal.flushInput();
+        // Response should be CSI ? 2034 ; 2 $ y  (2 = reset)
+        CHECK(mc.replyData().find("2034;2$y") != std::string::npos);
+    }
+
+    SECTION("DECRQM reports mode 2034 as set after enabling")
+    {
+        mc.writeToScreen(DECSM(2034));
+        mc.terminal.flushInput();
+        mc.resetReplyData();
+        mc.writeToScreen(DECRQM(2034));
+        mc.terminal.flushInput();
+        // Response should be CSI ? 2034 ; 1 $ y  (1 = set)
+        CHECK(mc.replyData().find("2034;1$y") != std::string::npos);
+    }
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryDisabled")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    SECTION("Query without enabling mode returns error DCS")
+    {
+        mc.resetReplyData();
+        // Query last command
+        mc.writeToScreen(SBQUERY(SBQueryType::LastCommand));
+        mc.terminal.flushInput();
+        // Should get error DCS: ESC P > 0 b ESC backslash
+        CHECK(mc.replyData().find("\033P>0b\033\\") != std::string::npos);
+    }
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryLastCommand")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034 and capture the session token
+    auto const token = enableModeAndGetToken(mc);
+
+    // Simulate a complete command
+    simulateCommand(mc, "$ ", "ls", "file1\nfile2", 0);
+
+    // Start a new prompt so the previous command is finalized
+    mc.writeToScreen("\033]133;A\033\\");
+
+    mc.terminal.flushInput();
+    mc.resetReplyData();
+    // Query last command with token
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastCommand, 1, token));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+
+    // Should get success DCS
+    REQUIRE(reply.find("\033P>1b") != std::string::npos);
+    // Should contain JSON with version
+    CHECK(reply.find("\"version\":1") != std::string::npos);
+    // Should contain the command
+    CHECK(reply.find("\"command\":\"ls\"") != std::string::npos);
+    // Should contain exit code
+    CHECK(reply.find("\"exitCode\":0") != std::string::npos);
+    // Should be marked as finished
+    CHECK(reply.find("\"finished\":true") != std::string::npos);
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryLastNCommands")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034 and capture the session token
+    auto const token = enableModeAndGetToken(mc);
+
+    // Simulate two commands
+    simulateCommand(mc, "$ ", "cmd1", "out1", 0);
+    simulateCommand(mc, "$ ", "cmd2", "out2", 1);
+
+    // Start new prompt to finalize
+    mc.writeToScreen("\033]133;A\033\\");
+
+    mc.resetReplyData();
+    // Query last 2 commands with token
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastNumberOfCommands, 2, token));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+    REQUIRE(reply.find("\033P>1b") != std::string::npos);
+    // Both commands should be present
+    CHECK(reply.find("\"command\":\"cmd1\"") != std::string::npos);
+    CHECK(reply.find("\"command\":\"cmd2\"") != std::string::npos);
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryInProgress")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034 and capture the session token
+    auto const token = enableModeAndGetToken(mc);
+
+    // Start a command but don't finish it (no OSC 133;D)
+    mc.writeToScreen("\033]133;A\033\\");
+    mc.writeToScreen("$ ");
+    mc.writeToScreen("\033]133;B\033\\");
+    mc.writeToScreen("\033]133;C;cmdline_url=running\033\\");
+    mc.writeToScreen("partial output");
+
+    mc.resetReplyData();
+    // Query in-progress command with token
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::InProgress, 1, token));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+    REQUIRE(reply.find("\033P>1b") != std::string::npos);
+    // Should be marked as not finished
+    CHECK(reply.find("\"finished\":false") != std::string::npos);
+    // Should contain the command
+    CHECK(reply.find("\"command\":\"running\"") != std::string::npos);
+}
+
+TEST_CASE("SemanticBlockProtocol.NoCompletedCommands")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034 and capture the session token
+    auto const token = enableModeAndGetToken(mc);
+
+    mc.resetReplyData();
+    // Query last command when none exists, with valid token
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastCommand, 1, token));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+    // Should get error DCS (no data)
+    CHECK(reply.find("\033P>0b\033\\") != std::string::npos);
+}
+
+// ==================== Token Authentication Tests ====================
+
+TEST_CASE("SemanticBlockProtocol.TokenOnEnable")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    mc.resetReplyData();
+    mc.writeToScreen(DECSM(2034));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+
+    // Should receive DCS reply with token
+    REQUIRE(reply.find("\033P>2034;1b") != std::string::npos);
+
+    // Extract and validate the token
+    auto const token = extractTokenFromDecsetReply(reply);
+    REQUIRE(token.has_value());
+
+    // Token should match what the tracker has
+    auto const& tracker = mc.terminal.semanticBlockTracker();
+    REQUIRE(tracker.token().has_value());
+    CHECK(tracker.token().value() == token.value());
+}
+
+TEST_CASE("SemanticBlockProtocol.TokenInvalidatedOnDisable")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable and capture token
+    auto const token = enableModeAndGetToken(mc);
+
+    // Disable mode
+    mc.writeToScreen(DECRM(2034));
+
+    // Token should be cleared
+    auto const& tracker = mc.terminal.semanticBlockTracker();
+    CHECK_FALSE(tracker.token().has_value());
+
+    // Validating the old token should fail
+    CHECK_FALSE(tracker.validateToken(token));
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryWithoutToken")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034
+    mc.writeToScreen(DECSM(2034));
+    mc.terminal.flushInput();
+
+    // Simulate a complete command
+    simulateCommand(mc, "$ ", "ls", "file1", 0);
+    mc.writeToScreen("\033]133;A\033\\");
+
+    mc.resetReplyData();
+    // Query WITHOUT token (only 2 params, not 6)
+    mc.writeToScreen(SBQUERY(SBQueryType::LastCommand, 1));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+    // Should get status 2: authentication required
+    CHECK(reply.find("\033P>2b\033\\") != std::string::npos);
+}
+
+TEST_CASE("SemanticBlockProtocol.QueryWithWrongToken")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable mode 2034 and capture token
+    enableModeAndGetToken(mc);
+
+    // Simulate a complete command
+    simulateCommand(mc, "$ ", "ls", "file1", 0);
+    mc.writeToScreen("\033]133;A\033\\");
+
+    mc.resetReplyData();
+    // Query with a fabricated wrong token
+    auto const wrongToken = SemanticBlockTracker::Token { 0xDEAD, 0xBEEF, 0xCAFE, 0xBABE };
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastCommand, 1, wrongToken));
+    mc.terminal.flushInput();
+
+    auto const& reply = mc.replyData();
+    // Should get status 3: authentication failed
+    CHECK(reply.find("\033P>3b\033\\") != std::string::npos);
+}
+
+TEST_CASE("SemanticBlockProtocol.TokenChangesOnReEnable")
+{
+    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
+
+    // Enable, get first token
+    auto const token1 = enableModeAndGetToken(mc);
+
+    // Disable, then re-enable
+    mc.writeToScreen(DECRM(2034));
+    auto const token2 = enableModeAndGetToken(mc);
+
+    // Tokens should be different (with overwhelming probability)
+    CHECK(token1 != token2);
+
+    // Simulate a command
+    simulateCommand(mc, "$ ", "ls", "output", 0);
+    mc.writeToScreen("\033]133;A\033\\");
+
+    // Old token should be rejected
+    mc.resetReplyData();
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastCommand, 1, token1));
+    mc.terminal.flushInput();
+    CHECK(mc.replyData().find("\033P>3b\033\\") != std::string::npos);
+
+    // New token should work
+    mc.resetReplyData();
+    mc.writeToScreen(authenticatedSBQuery(SBQueryType::LastCommand, 1, token2));
+    mc.terminal.flushInput();
+    CHECK(mc.replyData().find("\033P>1b") != std::string::npos);
 }

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2428,6 +2428,14 @@ void Terminal::setMode(DECMode mode, bool enable)
         case DECMode::ApplicationKeypad: setApplicationkeypadMode(enable); break;
         case DECMode::AutoRepeat: break;
         case DECMode::BackarrowKey: _inputGenerator.setBackarrowKeyMode(enable); break;
+        case DECMode::SemanticBlockProtocol:
+            _semanticBlockTracker.setEnabled(enable);
+            if (enable)
+            {
+                auto const& t = *_semanticBlockTracker.token();
+                reply("\033P>2034;1b{};{};{};{}\033\\", t[0], t[1], t[2], t[3]);
+            }
+            break;
         default: break;
     }
 
@@ -3267,6 +3275,7 @@ std::string to_string(DECMode mode)
         case DECMode::TextReflow: return "TextReflow";
         case DECMode::SixelCursorNextToGraphic: return "SixelCursorNextToGraphic";
         case DECMode::ReportColorPaletteUpdated: return "ReportColorPaletteUpdated";
+        case DECMode::SemanticBlockProtocol: return "SemanticBlockProtocol";
     }
     return std::format("({})", static_cast<unsigned>(mode));
 }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -12,6 +12,7 @@
 #include <vtbackend/InputHandler.h>
 #include <vtbackend/RenderBuffer.h>
 #include <vtbackend/Selector.h>
+#include <vtbackend/SemanticBlockTracker.h>
 #include <vtbackend/Sequence.h>
 #include <vtbackend/SequenceBuilder.h>
 #include <vtbackend/Settings.h>
@@ -640,6 +641,12 @@ class Terminal
     void setShellIntegration(std::unique_ptr<ShellIntegration> newShellIntegration)
     {
         _shellIntegration = std::move(newShellIntegration);
+    }
+
+    [[nodiscard]] SemanticBlockTracker& semanticBlockTracker() noexcept { return _semanticBlockTracker; }
+    [[nodiscard]] SemanticBlockTracker const& semanticBlockTracker() const noexcept
+    {
+        return _semanticBlockTracker;
     }
 
     [[nodiscard]] ScreenBase& currentScreen() noexcept { return *_currentScreen; }
@@ -1499,6 +1506,7 @@ class Terminal
     HintModeHandler _hintModeHandler { _hintModeExecutor };
 
     std::unique_ptr<ShellIntegration> _shellIntegration;
+    SemanticBlockTracker _semanticBlockTracker;
 
     DesktopNotificationManager _desktopNotificationManager;
 };

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -732,6 +732,13 @@ enum class DECMode : std::uint16_t
     // if modified by the user or operating system (e.g. dark/light mode adaption).
     ReportColorPaletteUpdated = 2031,
 
+    /// DEC Private Mode 2034 — Semantic Block Reader Protocol.
+    ///
+    /// When enabled, the terminal tracks semantic zones from OSC 133 shell integration
+    /// and the query sequence CSI > Ps ; Pn b becomes available for retrieving structured
+    /// JSON blocks of semantic command data.
+    SemanticBlockProtocol = 2034,
+
     // If enabled (default, as per spec), then the cursor is left next to the graphic,
     // that is, the text cursor is placed at the position of the sixel cursor.
     // If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
@@ -844,6 +851,7 @@ constexpr unsigned toDECModeNum(DECMode m) noexcept
         case DECMode::MousePassiveTracking: return 2029;
         case DECMode::ReportGridCellSelection: return 2030;
         case DECMode::ReportColorPaletteUpdated: return 2031;
+        case DECMode::SemanticBlockProtocol: return 2034;
         case DECMode::BatchedRendering: return 2026;
         case DECMode::Unicode: return 2027;
         case DECMode::TextReflow: return 2028;
@@ -903,6 +911,7 @@ constexpr std::optional<DECMode> fromDECModeNum(unsigned int modeNum) noexcept
         case 2029: return DECMode::MousePassiveTracking;
         case 2030: return DECMode::ReportGridCellSelection;
         case 2031: return DECMode::ReportColorPaletteUpdated;
+        case 2034: return DECMode::SemanticBlockProtocol;
         case 8452: return DECMode::SixelCursorNextToGraphic;
         default: return std::nullopt;
     }


### PR DESCRIPTION
- Introduce DEC Private Mode 2034 to enable semantic block tracking via OSC 133 shell integration sequences, storing command metadata (command line, exit code, prompt/output text) alongside line flags (`OutputStart`, `CommandEnd`) in the grid ring buffer.
- Add the SBQUERY sequence (`CSI > Ps ; Pn b`) that returns structured JSON via DCS responses, supporting three query types: last completed command (`Ps=1`), last N completed commands (`Ps=2`), and current in-progress command (`Ps=3`). Query type values use named `SBQueryType` constants to avoid magic numbers.
- Include `SemanticBlockTracker` class, full test coverage (8 test cases / 27 assertions), and a protocol specification document at `docs/vt-extensions/semantic-block-query.md`.


@Yaraslaut **Background story:** I need that for endo to be able to let the shell agent read the output of the last executed command.