### PR TITLE
Fix initial resizing with tiling WM

### DIFF
--- a/cmake/presets/os-linux.json
+++ b/cmake/presets/os-linux.json
@@ -53,7 +53,8 @@
                 "rhs": "Linux"
             },
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang++"
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_COMPILER": "clang"
             }
         },
         {
@@ -71,6 +72,7 @@
             },
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_COMPILER": "clang",
                 "CMAKE_INSTALL_PREFIX": "/usr/local"
             }
         }

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -159,6 +159,7 @@
           <li>Fixes ~2s startup delay caused by synchronous Qt multimedia driver probing by deferring audio initialization to a background thread</li>
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>
           <li>Fixes third-party dependency files (headers, libraries) leaking into install tree (#1788)</li>
+          <li>Fixes size of the window when using tiling WM (#1908)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -368,13 +368,14 @@ void TerminalDisplay::sizeChanged()
 
     // During initial display setup, the Wayland compositor may revert the window to
     // the stale pre-DPR-correction geometry via a configure event (e.g. in response to
-    // showNormal()). Detect this by checking if BOTH dimensions mismatch the implicit
-    // size — single-dimension mismatch indicates normal QML binding propagation
-    // (which updates width and height sequentially, not atomically).
-    if (steady_clock::now() < _initialResizeDeadline && std::abs(width() - implicitWidth()) > 0.5
-        && std::abs(height() - implicitHeight()) > 0.5)
+    // showNormal()). Detect this by checking if BOTH dimensions match the saved stale
+    // size (the window dimensions before DPR correction in createRenderer). This is more
+    // specific than checking against implicitSize, which would also falsely trigger on
+    // intentional WM-driven resizes (e.g. tiling WM assigning the window a tile size).
+    if (steady_clock::now() < _initialResizeDeadline && std::abs(width() - _lastVirtualWidth) <= 0.5
+        && std::abs(height() - _lastVirtualHeight) <= 0.5)
     {
-        displayLog()("Correcting initial window size from {}x{} to {}x{}",
+        displayLog()("Correcting initial window size from {}x{} (stale) to {}x{} (implicit)",
                      width(),
                      height(),
                      implicitWidth(),
@@ -682,6 +683,13 @@ void TerminalDisplay::createRenderer()
     Require(_renderer);
     Require(_session);
     Require(window());
+
+    // Save the stale (pre-DPR-correction) window dimensions so sizeChanged() can
+    // identify Wayland compositor configure reversions specifically, without
+    // misidentifying intentional WM-driven resizes (e.g. tiling WM assigning a
+    // tile size) as reversions.
+    _lastVirtualWidth = width();
+    _lastVirtualHeight = height();
 
     // Catch DPR corrections that occurred between setSession() and first render
     // (e.g., Qt correcting from integer-ceiling DPR=2 to actual fractional DPR=1.5

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -263,6 +263,8 @@ class TerminalDisplay: public QQuickItem
     TerminalSession* _session = nullptr;
     std::chrono::steady_clock::time_point _startTime;
     std::chrono::steady_clock::time_point _initialResizeDeadline {};
+    double _lastVirtualWidth {};
+    double _lastVirtualHeight {};
     text::DPI _lastFontDPI;
 #if !defined(__APPLE__) && !defined(_WIN32)
     mutable std::optional<double> _lastReportedContentScale;


### PR DESCRIPTION
For tiling WM, resize of the window is intentional during startup, so we need to make sure that we resize in this case, and only do not proceed with resize due to DPR corrections 
can you please check that this fix works for you @christianparpart 

Closes: https://github.com/contour-terminal/contour/issues/1908