### PR TITLE
Bugfix segfaults when changing font/window size

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -160,6 +160,7 @@
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>
           <li>Fixes third-party dependency files (headers, libraries) leaking into install tree (#1788)</li>
           <li>Fixes size of the window when using tiling WM (#1908)</li>
+          <li>Fixes crash when rapidly changing font size due to data races between UI and render threads (#1922)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -781,14 +781,12 @@ void applyResize(vtbackend::ImageSize newPixelSize,
     vtbackend::Terminal& terminal = session.terminal();
     vtbackend::ImageSize const cellSize = renderer.gridMetrics().cellSize;
 
-    if (renderer.hasRenderTarget())
-        renderer.renderTarget().setRenderSize(newPixelSize);
-    renderer.setPageSize(newPageSize);
-    renderer.setMargin(computeMargin(
+    auto const newMargin = computeMargin(
         renderer.gridMetrics().cellSize,
         newPageSize,
         newPixelSize,
-        applyContentScale(session.profile().margins.value(), session.display()->contentScale())));
+        applyContentScale(session.profile().margins.value(), session.display()->contentScale()));
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
 
     if (oldPageSize.lines != newPageSize.lines)
         emit session.lineCountChanged(newPageSize.lines.as<int>());

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1213,7 +1213,11 @@ class Terminal
     void resetStatusLineDefinition();
 
     TabsInfo guiTabsInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
-    void setGuiTabInfoForStatusLine(TabsInfo&& info) { _guiTabInfoForStatusLine = std::move(info); }
+    void setGuiTabInfoForStatusLine(TabsInfo&& info)
+    {
+        auto const l = std::lock_guard { _stateMutex };
+        _guiTabInfoForStatusLine = std::move(info);
+    }
 
     TabsNamingMode getTabsNamingMode() const noexcept { return _settings.tabNamingMode; }
     void requestTabName();

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -293,6 +293,8 @@ bool Renderer::setFontSize(text::font_size fontSize)
 
 void Renderer::updateFontMetrics()
 {
+    auto const l = std::scoped_lock { _renderMutex };
+
     rendererLog()("Updating grid metrics: {}", _gridMetrics);
 
     _gridMetrics = loadGridMetrics(_fonts.regular, _gridMetrics.pageSize, *_textShaper);
@@ -324,8 +326,9 @@ void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
 
 void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 {
+    auto const renderLock = std::scoped_lock { _renderMutex };
+
     auto const statusLineHeight = terminal.statusLineHeight();
-    _gridMetrics.pageSize = terminal.pageSize() + statusLineHeight;
 
     executeImageDiscards();
 

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -21,6 +21,7 @@
 
 #include <format>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <vector>
 
@@ -83,13 +84,32 @@ class Renderer
         _decorationRenderer.setHyperlinkDecoration(normal, hover);
     }
 
-    void setPageSize(vtbackend::PageSize screenSize) noexcept { _gridMetrics.pageSize = screenSize; }
+    void setPageSize(vtbackend::PageSize screenSize) noexcept
+    {
+        auto const l = std::scoped_lock { _renderMutex };
+        _gridMetrics.pageSize = screenSize;
+    }
 
     void setMargin(PageMargin margin) noexcept
     {
+        auto const l = std::scoped_lock { _renderMutex };
         if (_renderTarget)
             _renderTarget->setMargin(margin);
         _gridMetrics.pageMargin = margin;
+    }
+
+    void applyResize(vtbackend::ImageSize newPixelSize,
+                     vtbackend::PageSize newPageSize,
+                     PageMargin newMargin) noexcept
+    {
+        auto const l = std::scoped_lock { _renderMutex };
+        if (_renderTarget)
+        {
+            _renderTarget->setRenderSize(newPixelSize);
+            _renderTarget->setMargin(newMargin);
+        }
+        _gridMetrics.pageSize = newPageSize;
+        _gridMetrics.pageMargin = newMargin;
     }
 
     /**
@@ -182,6 +202,7 @@ class Renderer
 
     GridMetrics _gridMetrics;
 
+    mutable std::mutex _renderMutex;                    //!< Protects _gridMetrics during resize/render.
     std::mutex _imageDiscardLock;                       //!< Lock guard for accessing _discardImageQueue.
     std::vector<vtbackend::ImageId> _discardImageQueue; //!< List of images to be discarded.
 


### PR DESCRIPTION
Problem
-------

This problem is reproduced by using ctrl+mouse wheel, and crashes more frequently when "very busy" with the render thread, it is a race condition.  I had it crash with very casual use by adjusting the font size a few notches while using [gambaterm](https://github.com/vxgmichel/gambatte-terminal), which has 60Hz full screen redraws with the DEC synchronized output sequence, but it can be reproduced with a little more effort (resizing with *very large* point sizes) by running ``find /`` command, as captured in this recording:

https://github.com/user-attachments/assets/b93f8625-57b3-43ec-97bf-1ffab549f87e

I would say this crash is a little rare, that a majority of users should not experience it.

Analysis
--------

A font change triggers ``updateFontMetrics()`` (UI thread), which rebuilds grid metrics and replaces the texture atlas while the QSG render thread is actively using them in ``renderImpl()`` (render thread).

The resulting window resize has the same problem, with ``applyResize()`` updating page size and margins without mutex. About four different segfaults were possible due to a race condition that can get null atlas dereferences, corrupted line buffers, or assertion failures on atlas dimensions.

Additionally, another race in ``setGuiTabInfoForStatusLine()`` does an unprotected ``std::move`` of a ``TabsInfo`` struct (from UI thread) while the terminal thread copies it under ``_stateMutex``, causing heap corruption.

Solution
--------

Added ``_renderMutex`` to Renderer, held by all geometry/atlas writers and ``renderImpl()``.  The ``TabsInfo`` fix just acquires ``_stateMutex`` on the writer side to match the reader.

(Probably) closes #1712 and #408

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented

no documentation or tests were added or changed, this would be very difficult to create a test for, it would require preparing and running all of these threads with real Qt / OpenGL contexts, I'm afraid I can't do that.