### PR TITLE
bugfix kitty keyboard protocol release events are missing

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -160,6 +160,7 @@
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>
           <li>Fixes third-party dependency files (headers, libraries) leaking into install tree (#1788)</li>
           <li>Fixes size of the window when using tiling WM (#1908)</li>
+          <li>Fixes kitty keyboard protocol release events were missing (#1924)</li>
         </ul>
       </description>
     </release>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -160,7 +160,7 @@
           <li>Fixes build failure on Alpine Linux (musl libc) due to missing close_range() function (#1879)</li>
           <li>Fixes third-party dependency files (headers, libraries) leaking into install tree (#1788)</li>
           <li>Fixes size of the window when using tiling WM (#1908)</li>
-          <li>Fixes kitty keyboard protocol release events were missing (#1924)</li>
+          <li>Fixes missing kitty keyboard protocol release events (#1924)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -917,6 +917,8 @@ void TerminalDisplay::keyPressEvent(QKeyEvent* keyEvent)
 
 void TerminalDisplay::keyReleaseEvent(QKeyEvent* keyEvent)
 {
+    if (keyEvent->isAutoRepeat())
+        return;
     sendKeyEvent(keyEvent, vtbackend::KeyboardEventType::Release, *_session);
 }
 

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2115,16 +2115,16 @@ TEST_CASE("Terminal.KittyKeyRelease.sendKeyEvent", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto constexpr now = std::chrono::steady_clock::time_point {};
+    auto constexpr Now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendKeyEvent(
-        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Press, now);
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Press, Now);
     CHECK(e(mc.replyData()) == e("\033[A"s));
 
     mc.resetReplyData();
     terminal.sendKeyEvent(
-        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Release, now);
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Release, Now);
     CHECK(!mc.replyData().empty());
     CHECK(e(mc.replyData()) == e("\033[1;1:3A"s));
 }
@@ -2137,15 +2137,15 @@ TEST_CASE("Terminal.KittyKeyRelease.sendCharEvent", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto constexpr now = std::chrono::steady_clock::time_point {};
+    auto constexpr Now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
-    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
+    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, Now);
     CHECK(e(mc.replyData()) == e("\033[97;5u"s));
 
     mc.resetReplyData();
     terminal.sendCharEvent(
-        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, now);
+        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, Now);
     CHECK(!mc.replyData().empty());
     CHECK(e(mc.replyData()) == e("\033[97;5:3u"s));
 }
@@ -2157,15 +2157,15 @@ TEST_CASE("Terminal.KittyKeyRelease.NoOutputWithoutFlag", "[terminal]")
 
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
 
-    auto constexpr now = std::chrono::steady_clock::time_point {};
+    auto constexpr Now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
-    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
+    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, Now);
     CHECK(!mc.replyData().empty());
 
     mc.resetReplyData();
     terminal.sendCharEvent(
-        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, now);
+        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, Now);
     CHECK(mc.replyData().empty());
 }
 
@@ -2177,11 +2177,11 @@ TEST_CASE("Terminal.KittyKeyRelease.RepeatStillWorks", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto constexpr now = std::chrono::steady_clock::time_point {};
+    auto constexpr Now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendKeyEvent(
-        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Repeat, now);
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Repeat, Now);
     CHECK(e(mc.replyData()) == e("\033[1;1:2A"s));
 }
 

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2115,7 +2115,7 @@ TEST_CASE("Terminal.KittyKeyRelease.sendKeyEvent", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto const now = std::chrono::steady_clock::now();
+    auto constexpr now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendKeyEvent(
@@ -2137,7 +2137,7 @@ TEST_CASE("Terminal.KittyKeyRelease.sendCharEvent", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto const now = std::chrono::steady_clock::now();
+    auto constexpr now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
@@ -2157,7 +2157,7 @@ TEST_CASE("Terminal.KittyKeyRelease.NoOutputWithoutFlag", "[terminal]")
 
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
 
-    auto const now = std::chrono::steady_clock::now();
+    auto constexpr now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
@@ -2177,7 +2177,7 @@ TEST_CASE("Terminal.KittyKeyRelease.RepeatStillWorks", "[terminal]")
     terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
     terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
 
-    auto const now = std::chrono::steady_clock::now();
+    auto constexpr now = std::chrono::steady_clock::time_point {};
 
     mc.resetReplyData();
     terminal.sendKeyEvent(

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2107,4 +2107,82 @@ TEST_CASE("Terminal.PassiveMouseTracking_Selection", "[terminal]")
     }
 }
 
+TEST_CASE("Terminal.KittyKeyRelease.sendKeyEvent", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(24), ColumnCount(80) } };
+    auto& terminal = mc.terminal;
+
+    terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
+    terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
+
+    auto const now = std::chrono::steady_clock::now();
+
+    mc.resetReplyData();
+    terminal.sendKeyEvent(
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Press, now);
+    CHECK(e(mc.replyData()) == e("\033[A"s));
+
+    mc.resetReplyData();
+    terminal.sendKeyEvent(
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Release, now);
+    CHECK(!mc.replyData().empty());
+    CHECK(e(mc.replyData()) == e("\033[1;1:3A"s));
+}
+
+TEST_CASE("Terminal.KittyKeyRelease.sendCharEvent", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(24), ColumnCount(80) } };
+    auto& terminal = mc.terminal;
+
+    terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
+    terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
+
+    auto const now = std::chrono::steady_clock::now();
+
+    mc.resetReplyData();
+    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
+    CHECK(e(mc.replyData()) == e("\033[97;5u"s));
+
+    mc.resetReplyData();
+    terminal.sendCharEvent(
+        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, now);
+    CHECK(!mc.replyData().empty());
+    CHECK(e(mc.replyData()) == e("\033[97;5:3u"s));
+}
+
+TEST_CASE("Terminal.KittyKeyRelease.NoOutputWithoutFlag", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(24), ColumnCount(80) } };
+    auto& terminal = mc.terminal;
+
+    terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
+
+    auto const now = std::chrono::steady_clock::now();
+
+    mc.resetReplyData();
+    terminal.sendCharEvent('a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Press, now);
+    CHECK(!mc.replyData().empty());
+
+    mc.resetReplyData();
+    terminal.sendCharEvent(
+        'a', 'a', vtbackend::Modifier::Control, vtbackend::KeyboardEventType::Release, now);
+    CHECK(mc.replyData().empty());
+}
+
+TEST_CASE("Terminal.KittyKeyRelease.RepeatStillWorks", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(24), ColumnCount(80) } };
+    auto& terminal = mc.terminal;
+
+    terminal.keyboardProtocol().enter(vtbackend::KeyboardEventFlag::DisambiguateEscapeCodes);
+    terminal.keyboardProtocol().flags().enable(vtbackend::KeyboardEventFlag::ReportEventTypes);
+
+    auto const now = std::chrono::steady_clock::now();
+
+    mc.resetReplyData();
+    terminal.sendKeyEvent(
+        vtbackend::Key::UpArrow, vtbackend::Modifier::None, vtbackend::KeyboardEventType::Repeat, now);
+    CHECK(e(mc.replyData()) == e("\033[1;1:2A"s));
+}
+
 // NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -375,7 +375,10 @@ Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, Keyboard
             // The terminal will handle them and send them to the application.
             return Handled { false };
         case ViMode::Hint:
-            // Hint mode input is handled by HintModeHandler, not the vi handler.
+            // Hint mode presses are consumed by HintModeHandler, so suppress releases
+            // to avoid unmatched release events reaching the application.
+            if (eventType == KeyboardEventType::Release)
+                return Handled { true };
             return Handled { false };
         case ViMode::Visual:
         case ViMode::VisualLine:
@@ -580,8 +583,17 @@ Handled ViInputHandler::sendCharPressEvent(char32_t ch, Modifiers modifiers, Key
         return handlePromptEditor(ch, modifiers);
     }
 
-    if (_viMode == ViMode::Insert || _viMode == ViMode::Hint)
+    if (_viMode == ViMode::Insert)
         return Handled { false };
+
+    if (_viMode == ViMode::Hint)
+    {
+        // Hint mode presses are consumed by HintModeHandler, so suppress releases
+        // to avoid unmatched release events reaching the application.
+        if (eventType == KeyboardEventType::Release)
+            return Handled { true };
+        return Handled { false };
+    }
 
     if (eventType == KeyboardEventType::Release)
         return Handled { true };

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -337,11 +337,10 @@ void ViInputHandler::setMode(ViMode theMode)
 
 Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, KeyboardEventType eventType)
 {
-    if (eventType == KeyboardEventType::Release)
-        return Handled { true };
-
     if (_promptEditMode != PromptMode::Disabled)
     {
+        if (eventType == KeyboardEventType::Release)
+            return Handled { true };
         // TODO: support cursor movements.
         switch (key)
         {
@@ -355,6 +354,8 @@ Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, Keyboard
 
     if (_searchEditMode != PromptMode::Disabled)
     {
+        if (eventType == KeyboardEventType::Release)
+            return Handled { true };
         // TODO: support cursor movements.
         switch (key)
         {
@@ -379,6 +380,8 @@ Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, Keyboard
         case ViMode::Visual:
         case ViMode::VisualLine:
         case ViMode::VisualBlock:
+            if (eventType == KeyboardEventType::Release)
+                return Handled { true };
             if (key == Key::Escape && modifiers.none())
             {
                 clearPendingInput();
@@ -387,6 +390,8 @@ Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, Keyboard
             }
             [[fallthrough]];
         case ViMode::Normal:
+            if (eventType == KeyboardEventType::Release)
+                return Handled { true };
             // We keep on handling key events below.
             break;
     }
@@ -561,17 +566,25 @@ Handled ViInputHandler::handlePromptEditor(char32_t ch, Modifiers modifiers)
 
 Handled ViInputHandler::sendCharPressEvent(char32_t ch, Modifiers modifiers, KeyboardEventType eventType)
 {
-    if (eventType == KeyboardEventType::Release)
-        return Handled { true };
-
     if (_searchEditMode != PromptMode::Disabled)
+    {
+        if (eventType == KeyboardEventType::Release)
+            return Handled { true };
         return handleSearchEditor(ch, modifiers);
+    }
 
     if (_promptEditMode != PromptMode::Disabled)
+    {
+        if (eventType == KeyboardEventType::Release)
+            return Handled { true };
         return handlePromptEditor(ch, modifiers);
+    }
 
     if (_viMode == ViMode::Insert || _viMode == ViMode::Hint)
         return Handled { false };
+
+    if (eventType == KeyboardEventType::Release)
+        return Handled { true };
 
     if (ch == 033 && modifiers.none())
     {


### PR DESCRIPTION
Problem
------------

When using a TUI program that uses the kitty keyboard protocol with the "[report event types](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#report-event-types)" enabled:

       $ kitten show-key -m kitty

And tap any key, the "PRESS" and "REPEAT" events are correctly captured, but not the "RELEASED" [event type](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#event-types), it is missing!

<img width="840" height="590" alt="contour-bug-released-missing" src="https://github.com/user-attachments/assets/ac17cb26-3a74-42da-8fde-d45a6c2b1bd5" />


Analysis
-----------

``ViInputHandler::sendKeyPressEvent()`` was returning early for release events, ``return Handled { true }`` is a signal as to say, "I handled it" for ANY modes of the "release" event at the top of the function, even Insert mode,
so the Terminal never calls _inputGenerator.generate() to produce the release CSI sequence.

Solution
------------

Allow 'Insert' and 'Hint' modes reach their `return Handled { false }` naturally, so that _inputGenerator.generate() is called to produce the CSI sequence for the released event.

Additionally, we have to filter away for keyEvent->isAutoRepeat condition in TerminalDisplay::keyReleaseEvent, otherwise we would have false "release" events, Qt generates a KeyPress+Release pair for each isAutoRepeat cycle

<img width="840" height="590" alt="contour-fixed-released-missing" src="https://github.com/user-attachments/assets/5b044a9b-51a9-4994-a95b-cd1b5ed86a95" />

## Motivation and Context

When using [gambaterm](https://github.com/vxgmichel/gambatte-terminal) to play a gameboy game, only the first key is detected as though it is held down indefinitely, making it impossible to play zelda.

## How Has This Been Tested?

       $ kitten show-key -m kitty

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] Breaking changes (if any) are documented
