### PR TITLE
[terminal] Fix trivial flag not invalidated after SoA cell operations

### DIFF
--- a/src/vtbackend/CellProxy.h
+++ b/src/vtbackend/CellProxy.h
@@ -266,14 +266,21 @@ class BasicCellProxy
     }
 
   private:
-    /// Invalidate the trivial flag if this cell's SGR or hyperlink differs from cell 0.
+    /// Invalidate the trivial flag if this cell's SGR or hyperlink differs from another cell.
+    /// When at col 0, compare against col 1 (an unwritten cell).
+    /// When at col > 0, compare against col 0.
     void invalidateTrivialIfNeeded() noexcept
         requires(!IsConst)
     {
-        if (_line->trivial && _col > 0
-            && (_line->sgr[_col] != _line->sgr[0] || _line->hyperlinks[_col] != _line->hyperlinks[0]))
+        if (_line->trivial)
         {
-            _line->trivial = false;
+            auto const checkCol = (_col > 0) ? size_t(0) : size_t(1);
+            if (checkCol < _line->codepoints.size()
+                && (_line->sgr[_col] != _line->sgr[checkCol]
+                    || _line->hyperlinks[_col] != _line->hyperlinks[checkCol]))
+            {
+                _line->trivial = false;
+            }
         }
     }
 

--- a/src/vtbackend/LineSoA.cpp
+++ b/src/vtbackend/LineSoA.cpp
@@ -29,6 +29,7 @@ void initializeLineSoA(LineSoA& line, ColumnCount cols, GraphicsAttributes const
 
 void resizeLineSoA(LineSoA& line, ColumnCount newCols, GraphicsAttributes const& fillAttrs)
 {
+    auto const oldSize = line.codepoints.size();
     auto const n = unbox<size_t>(newCols);
 
     line.codepoints.resize(n, char32_t { 0 });
@@ -41,6 +42,10 @@ void resizeLineSoA(LineSoA& line, ColumnCount newCols, GraphicsAttributes const&
     // Clamp usedColumns to new size
     if (line.usedColumns > newCols)
         line.usedColumns = newCols;
+
+    // When growing, new cells get fillAttrs. If existing cells had different SGR, no longer trivial.
+    if (n > oldSize && line.trivial && oldSize > 0 && fillAttrs != line.sgr[0])
+        line.trivial = false;
 }
 
 void clearRange(LineSoA& line, size_t from, size_t count, GraphicsAttributes const& attrs)
@@ -143,6 +148,9 @@ void copyColumns(LineSoA const& src, size_t srcCol, LineSoA& dst, size_t dstCol,
             }
         }
     }
+
+    // Copied SGR data may break uniformity on the destination line.
+    dst.trivial = false;
 }
 
 void moveColumns(LineSoA& line, size_t srcCol, size_t dstCol, size_t count)

--- a/src/vtbackend/LineSoA_test.cpp
+++ b/src/vtbackend/LineSoA_test.cpp
@@ -129,6 +129,46 @@ TEST_CASE("LineSoA.copyColumns", "[LineSoA]")
     CHECK(dst.codepoints[0] == 0);
 }
 
+TEST_CASE("LineSoA.copyColumns.trivialInvalidated", "[LineSoA]")
+{
+    // Source line with non-uniform SGR
+    LineSoA src;
+    initializeLineSoA(src, ColumnCount(10));
+    src.codepoints[0] = U'A';
+    src.clusterSize[0] = 1;
+    src.sgr[0].foregroundColor = Color::Indexed(1);
+
+    // Destination line starts trivial
+    LineSoA dst;
+    initializeLineSoA(dst, ColumnCount(10));
+    REQUIRE(dst.trivial);
+
+    copyColumns(src, 0, dst, 0, 1);
+
+    // After copying non-uniform data, trivial must be false
+    CHECK_FALSE(dst.trivial);
+}
+
+TEST_CASE("LineSoA.copyColumns.trivialInvalidated.partialCopy", "[LineSoA]")
+{
+    // Simulates horizontal-margin scroll: copy columns 2-7 from source into destination
+    auto const srcAttrs = GraphicsAttributes { .foregroundColor = Color::Indexed(5) };
+    LineSoA src;
+    initializeLineSoA(src, ColumnCount(10), srcAttrs);
+    src.codepoints[2] = U'X';
+    src.clusterSize[2] = 1;
+
+    LineSoA dst;
+    initializeLineSoA(dst, ColumnCount(10));
+    REQUIRE(dst.trivial);
+
+    // Partial copy: columns 2-7 from source into destination at same position
+    copyColumns(src, 2, dst, 2, 6);
+
+    // Destination now has mixed SGR (cols 0-1 default, cols 2-7 indexed(5)), trivial must be false
+    CHECK_FALSE(dst.trivial);
+}
+
 TEST_CASE("LineSoA.resizeLineSoA.grow", "[LineSoA]")
 {
     LineSoA line;
@@ -141,6 +181,32 @@ TEST_CASE("LineSoA.resizeLineSoA.grow", "[LineSoA]")
     CHECK(line.codepoints.size() == 10);
     CHECK(line.codepoints[2] == U'X'); // preserved
     CHECK(line.codepoints[7] == 0);    // new columns are empty
+}
+
+TEST_CASE("LineSoA.resizeLineSoA.grow.trivialInvalidatedOnMismatch", "[LineSoA]")
+{
+    auto const attrs = GraphicsAttributes { .foregroundColor = Color::Indexed(3) };
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(5), attrs);
+    REQUIRE(line.trivial);
+
+    // Growing with default fillAttrs ({}) differs from the existing sgr[0].
+    resizeLineSoA(line, ColumnCount(10));
+
+    CHECK_FALSE(line.trivial);
+}
+
+TEST_CASE("LineSoA.resizeLineSoA.grow.trivialPreservedOnMatch", "[LineSoA]")
+{
+    auto const attrs = GraphicsAttributes { .foregroundColor = Color::Indexed(3) };
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(5), attrs);
+    REQUIRE(line.trivial);
+
+    // Growing with same fillAttrs keeps trivial.
+    resizeLineSoA(line, ColumnCount(10), attrs);
+
+    CHECK(line.trivial);
 }
 
 TEST_CASE("LineSoA.resizeLineSoA.shrink", "[LineSoA]")
@@ -396,6 +462,19 @@ TEST_CASE("CellProxy.beginsWith", "[CellProxy]")
 // =============================================================================
 // CellProxy trivial flag invalidation tests
 // =============================================================================
+
+TEST_CASE("CellProxy.trivialInvalidation.atCol0", "[CellProxy]")
+{
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(10));
+    CellProxy(line, 0).write(GraphicsAttributes {}, U'A', 1);
+    CellProxy(line, 1).write(GraphicsAttributes {}, U'B', 1);
+    REQUIRE(line.trivial); // uniform SGR — still trivial
+
+    // Changing SGR at col 0 must invalidate trivial (col 1 still has default attrs)
+    CellProxy(line, 0).setForegroundColor(Color::Indexed(IndexedColor::Red));
+    CHECK_FALSE(line.trivial);
+}
 
 TEST_CASE("CellProxy.trivialInvalidation.setForegroundColor", "[CellProxy]")
 {

--- a/src/vtbackend/SoAClusterWriter.cpp
+++ b/src/vtbackend/SoAClusterWriter.cpp
@@ -56,10 +56,16 @@ namespace
 
         clearReplacedImageFragments(line.imageFragments, static_cast<uint16_t>(startCol), count);
 
-        // Trivial flag: all cells got the same SGR. Check once against cell 0.
-        if (line.trivial && startCol > 0 && (attrs != line.sgr[0] || hyperlink != line.hyperlinks[0]))
+        // Trivial flag: check if the written range breaks SGR uniformity.
+        // Compare against an unwritten cell: when writing from col 0, check the cell just past
+        // the written range; when writing from col > 0, check cell 0.
+        if (line.trivial && count < maxCols)
         {
-            line.trivial = false;
+            auto const checkCol = (startCol > 0) ? size_t(0) : startCol + count;
+            if (checkCol < maxCols && (attrs != line.sgr[checkCol] || hyperlink != line.hyperlinks[checkCol]))
+            {
+                line.trivial = false;
+            }
         }
 
         return count;

--- a/src/vtbackend/SoAClusterWriter.h
+++ b/src/vtbackend/SoAClusterWriter.h
@@ -66,11 +66,17 @@ inline void writeCellToSoA(LineSoA& line,
 
     clearReplacedImageFragment(line.imageFragments, static_cast<uint16_t>(col));
 
-    // Invalidate trivial flag if this cell's SGR or hyperlink differs from the first cell's.
-    if (line.trivial && col > 0
-        && (line.sgr[col] != line.sgr[0] || line.hyperlinks[col] != line.hyperlinks[0]))
+    // Invalidate trivial flag if this cell's SGR or hyperlink differs from another cell's.
+    // When writing at col 0, compare against col 1 (an unwritten cell).
+    // When writing at col > 0, compare against col 0.
+    if (line.trivial)
     {
-        line.trivial = false;
+        auto const checkCol = (col > 0) ? size_t(0) : size_t(1);
+        if (checkCol < line.codepoints.size()
+            && (line.sgr[col] != line.sgr[checkCol] || line.hyperlinks[col] != line.hyperlinks[checkCol]))
+        {
+            line.trivial = false;
+        }
     }
 }
 

--- a/src/vtbackend/SoAClusterWriter_test.cpp
+++ b/src/vtbackend/SoAClusterWriter_test.cpp
@@ -200,6 +200,54 @@ TEST_CASE("writeCellToSoA.empty", "[SoAWriter]")
     CHECK(line.clusterSize[0] == 0);
 }
 
+TEST_CASE("writeCellToSoA.trivial.invalidatedAtCol0", "[SoAWriter]")
+{
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(10));
+    REQUIRE(line.trivial);
+
+    // Write a cell at col 0 with different attrs than the rest of the line.
+    auto const attrs = GraphicsAttributes { .foregroundColor = Color::Indexed(5) };
+    writeCellToSoA(line, 0, U'X', 1, attrs);
+
+    // Col 0 now has Indexed(5), cols 1-9 still have default — trivial must be false.
+    CHECK_FALSE(line.trivial);
+}
+
+// =============================================================================
+// writeTextToSoA / writeAsciiToSoA — trivial flag edge cases
+// =============================================================================
+
+TEST_CASE("writeTextToSoA.ascii.trivial.invalidatedFromCol0Partial", "[SoAWriter]")
+{
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(20));
+    REQUIRE(line.trivial);
+
+    // Partial write from col 0 with non-default attrs.
+    // Only cols 0-4 are written; cols 5-19 still have default SGR.
+    auto const attrs = GraphicsAttributes { .foregroundColor = Color::Indexed(3) };
+    writeTextToSoA(line, 0, "Hello", attrs);
+
+    // Line has mixed SGR — trivial must be false.
+    CHECK_FALSE(line.trivial);
+}
+
+TEST_CASE("writeTextToSoA.ascii.trivial.preservedFullLine", "[SoAWriter]")
+{
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(5));
+    REQUIRE(line.trivial);
+
+    // Full-line bulk ASCII write with uniform attrs — trivial should remain true.
+    // Uses asciiHint=true to exercise the bulk path (per-cell path can't preserve
+    // trivial because it writes one cell at a time and can't predict future writes).
+    auto const attrs = GraphicsAttributes { .foregroundColor = Color::Indexed(3) };
+    writeTextToSoA(line, 0, "Hello", attrs, HyperlinkId {}, /*asciiHint=*/true);
+
+    CHECK(line.trivial);
+}
+
 // =============================================================================
 // fillWideCharContinuation
 // =============================================================================


### PR DESCRIPTION
- Fix SGR color corruption caused by stale `trivial` flag after the AoS-to-SoA grid migration. The cached flag (used by the renderer to fast-path uniform-attribute lines) was not invalidated in `copyColumns()`, `writeCellToSoA()` at col 0, `CellProxy::invalidateTrivialIfNeeded()` at col 0, `writeAsciiToSoA()` for partial writes from col 0, and `resizeLineSoA()` when growing with mismatched fill attrs.
- All fixes are conservative (setting `trivial = false` is always safe — it only disables the render fast path, never produces wrong output). The flag is re-established on the next `resetLine()`.
- Adds 8 targeted unit tests covering each fix path.