### PR TITLE
Add Win32 Input Mode (DEC private mode 9001)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -9,6 +9,7 @@ BBBBB
 BCDE
 BLval
 BRval
+capslock
 CCCCC
 CDEFGH
 COLSx
@@ -62,6 +63,7 @@ WXYZ
 bpp
 circleval
 crtdbg
+csiu
 ctrled
 dcx
 decdld
@@ -76,6 +78,8 @@ entrantly
 gitbranch
 gitgraph
 isakbm
+LMENU
+LWin
 nabcd
 ndrwxr
 nfile
@@ -84,6 +88,8 @@ pseudoconsole
 qmljsdebugger
 rbong
 redefinable
+RWin
+SCROLLLOCK
 soa
 udk
 unscroll

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.7.0" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Adds Win32 Input Mode (DEC private mode 9001) for native ConPTY keyboard input encoding, fixing keyboard input for applications that request this mode on Windows</li>
           <li>Fixes Unicode characters sometimes being wrongly decoded during high-bandwidth output</li>
           <li>Improves PTY throughput performance determinism by rewriting the internal grid cell storage</li>
           <li>Adds **experimental** Good Image Protocol (GIP) implementation — a DCS-based protocol for displaying raster images with named image pools, LRU eviction, three compositing layers (below/replace/above), configurable resize and alignment policies, Auto/PNG/RGB/RGBA format support with automatic format detection, and DA1 capability advertisement via code 90 (#100)</li>

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -56,7 +56,9 @@ using vtbackend::Width;
 namespace contour
 {
 
-vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers, quint32 nativeModifiers)
+vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers,
+                                   quint32 nativeModifiers,
+                                   [[maybe_unused]] bool stripAltGr)
 {
     using vtbackend::Modifier;
     using vtbackend::Modifiers;
@@ -74,10 +76,15 @@ vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers, quint32 na
         modifiers |= Modifier::Super;
 
 #if defined(_WIN32)
-    // Windows: Handle AltGr (Ctrl+Alt combination)
-    auto constexpr AltGrEquivalent = Modifiers { Modifier::Alt, Modifier::Control };
-    if (modifiers.contains(AltGrEquivalent))
-        modifiers = modifiers.without(AltGrEquivalent);
+    // Windows: Handle AltGr (Ctrl+Alt combination).
+    // In Win32 Input Mode, we keep the raw modifier state so ConPTY receives
+    // the correct dwControlKeyState flags.
+    if (stripAltGr)
+    {
+        auto constexpr AltGrEquivalent = Modifiers { Modifier::Alt, Modifier::Control };
+        if (modifiers.contains(AltGrEquivalent))
+            modifiers = modifiers.without(AltGrEquivalent);
+    }
 
     // Windows: Query lock states directly via Win32 API
     // GetKeyState returns toggle state in low-order bit (0x0001)
@@ -350,6 +357,7 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         pair { Qt::Key_VolumeDown, Key::VolumeDown },
         pair { Qt::Key_VolumeMute, Key::VolumeMute },
 
+        pair { Qt::Key_Shift, Key::LeftShift },     // NB: Qt cannot distinguish between left and right
         pair { Qt::Key_Control, Key::LeftControl }, // NB: Qt cannot distinguish between left and right
         pair { Qt::Key_Alt, Key::LeftAlt },         // NB: Qt cannot distinguish between left and right
         pair { Qt::Key_Meta, Key::LeftMeta },       // NB: Qt cannot distinguish between left and right
@@ -441,7 +449,9 @@ bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, Term
         // clang-format on
     }; // }}}
 
-    auto const modifiers = makeModifiers(event->modifiers(), event->nativeModifiers());
+    auto const isWin32Mode = session.terminal().isModeEnabled(vtbackend::DECMode::Win32InputMode);
+    auto const modifiers =
+        makeModifiers(event->modifiers(), event->nativeModifiers(), /*stripAltGr=*/!isWin32Mode);
     auto const key = event->key();
 
     if (event->modifiers().testFlag(Qt::KeypadModifier))

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -121,8 +121,13 @@ constexpr inline char32_t makeChar(Qt::Key key, Qt::KeyboardModifiers mods)
 /// Extracts CapsLock and NumLock states from platform-specific native modifiers.
 /// @param qtModifiers Standard Qt keyboard modifiers
 /// @param nativeModifiers Platform-specific value from QKeyEvent::nativeModifiers()
+/// @param stripAltGr When true (default), removes the Ctrl+Alt combination on Windows
+///                   that represents AltGr. Set to false for Win32 Input Mode which
+///                   needs the raw modifier state.
 /// @return Combined modifiers including lock key states
-vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers, quint32 nativeModifiers = 0);
+vtbackend::Modifiers makeModifiers(Qt::KeyboardModifiers qtModifiers,
+                                   quint32 nativeModifiers = 0,
+                                   bool stripAltGr = true);
 
 constexpr inline vtbackend::MouseButton makeMouseButton(Qt::MouseButton button)
 {

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -625,11 +625,296 @@ bool ExtendedKeyboardInputGenerator::generateKey(Key key, Modifiers modifiers, K
 }
 // }}}
 
+// {{{ Win32 Input Mode (DEC private mode 9001)
+
+// clang-format off
+
+/// Maps Windows Virtual Key codes used in Win32 Input Mode.
+namespace VK
+{
+    constexpr uint32_t Back      = 0x08;
+    constexpr uint32_t Tab       = 0x09;
+    constexpr uint32_t Return    = 0x0D;
+    constexpr uint32_t Pause     = 0x13;
+    constexpr uint32_t Capital   = 0x14;
+    constexpr uint32_t Escape    = 0x1B;
+    constexpr uint32_t Prior     = 0x21;
+    constexpr uint32_t Next      = 0x22;
+    constexpr uint32_t End       = 0x23;
+    constexpr uint32_t Home      = 0x24;
+    constexpr uint32_t Left      = 0x25;
+    constexpr uint32_t Up        = 0x26;
+    constexpr uint32_t Right     = 0x27;
+    constexpr uint32_t Down      = 0x28;
+    constexpr uint32_t Snapshot  = 0x2C;
+    constexpr uint32_t Insert    = 0x2D;
+    constexpr uint32_t Delete    = 0x2E;
+    constexpr uint32_t LWin      = 0x5B;
+    constexpr uint32_t RWin      = 0x5C;
+    constexpr uint32_t Apps      = 0x5D;
+    constexpr uint32_t Numpad0   = 0x60;
+    constexpr uint32_t Numpad1   = 0x61;
+    constexpr uint32_t Numpad2   = 0x62;
+    constexpr uint32_t Numpad3   = 0x63;
+    constexpr uint32_t Numpad4   = 0x64;
+    constexpr uint32_t Numpad5   = 0x65;
+    constexpr uint32_t Numpad6   = 0x66;
+    constexpr uint32_t Numpad7   = 0x67;
+    constexpr uint32_t Numpad8   = 0x68;
+    constexpr uint32_t Numpad9   = 0x69;
+    constexpr uint32_t Multiply  = 0x6A;
+    constexpr uint32_t Add       = 0x6B;
+    constexpr uint32_t Subtract  = 0x6D;
+    constexpr uint32_t Decimal   = 0x6E;
+    constexpr uint32_t Divide    = 0x6F;
+    constexpr uint32_t F1        = 0x70;
+    constexpr uint32_t F2        = 0x71;
+    constexpr uint32_t F3        = 0x72;
+    constexpr uint32_t F4        = 0x73;
+    constexpr uint32_t F5        = 0x74;
+    constexpr uint32_t F6        = 0x75;
+    constexpr uint32_t F7        = 0x76;
+    constexpr uint32_t F8        = 0x77;
+    constexpr uint32_t F9        = 0x78;
+    constexpr uint32_t F10       = 0x79;
+    constexpr uint32_t F11       = 0x7A;
+    constexpr uint32_t F12       = 0x7B;
+    constexpr uint32_t F13       = 0x7C;
+    constexpr uint32_t F14       = 0x7D;
+    constexpr uint32_t F15       = 0x7E;
+    constexpr uint32_t F16       = 0x7F;
+    constexpr uint32_t F17       = 0x80;
+    constexpr uint32_t F18       = 0x81;
+    constexpr uint32_t F19       = 0x82;
+    constexpr uint32_t F20       = 0x83;
+    constexpr uint32_t F21       = 0x84;
+    constexpr uint32_t F22       = 0x85;
+    constexpr uint32_t F23       = 0x86;
+    constexpr uint32_t F24       = 0x87;
+    constexpr uint32_t NumLock   = 0x90;
+    constexpr uint32_t Scroll    = 0x91;
+    constexpr uint32_t Shift     = 0x10; // VK_SHIFT (generic)
+    constexpr uint32_t Control   = 0x11; // VK_CONTROL (generic)
+    constexpr uint32_t Menu      = 0x12; // VK_MENU / Alt (generic)
+    constexpr uint32_t RMenu     = 0xA5;
+    constexpr uint32_t MediaNextTrack     = 0xB0;
+    constexpr uint32_t MediaPrevTrack     = 0xB1;
+    constexpr uint32_t MediaStop          = 0xB2;
+    constexpr uint32_t MediaPlayPause     = 0xB3;
+    constexpr uint32_t VolumeMute         = 0xAD;
+    constexpr uint32_t VolumeDown         = 0xAE;
+    constexpr uint32_t VolumeUp           = 0xAF;
+} // namespace VK
+
+// clang-format on
+
+/// Returns true if the given Key represents an enhanced key in Windows terminology.
+/// Enhanced keys have E0 scan code prefixes on a standard 101/102-key keyboard layout.
+/// This sets the ENHANCED_KEY (0x0100) flag in dwControlKeyState.
+constexpr bool isEnhancedKey(Key key) noexcept
+{
+    // clang-format off
+    switch (key)
+    {
+        // Dedicated navigation cluster (not numpad equivalents)
+        case Key::UpArrow:
+        case Key::DownArrow:
+        case Key::LeftArrow:
+        case Key::RightArrow:
+        case Key::Home:
+        case Key::End:
+        case Key::Insert:
+        case Key::Delete:
+        case Key::PageUp:
+        case Key::PageDown:
+        // Numpad keys with E0 scan codes
+        case Key::Numpad_Enter:
+        case Key::Numpad_Divide:
+        // Right-side modifiers (E0 prefix distinguishes from left-side)
+        case Key::RightControl:
+        case Key::RightAlt:
+        // Other enhanced keys
+        case Key::PrintScreen:
+            return true;
+        default:
+            return false;
+    }
+    // clang-format on
+}
+
+constexpr uint32_t InputGenerator::keyToVirtualKeyCode(Key key)
+{
+    // clang-format off
+    switch (key)
+    {
+        case Key::F1:  return VK::F1;
+        case Key::F2:  return VK::F2;
+        case Key::F3:  return VK::F3;
+        case Key::F4:  return VK::F4;
+        case Key::F5:  return VK::F5;
+        case Key::F6:  return VK::F6;
+        case Key::F7:  return VK::F7;
+        case Key::F8:  return VK::F8;
+        case Key::F9:  return VK::F9;
+        case Key::F10: return VK::F10;
+        case Key::F11: return VK::F11;
+        case Key::F12: return VK::F12;
+        case Key::F13: return VK::F13;
+        case Key::F14: return VK::F14;
+        case Key::F15: return VK::F15;
+        case Key::F16: return VK::F16;
+        case Key::F17: return VK::F17;
+        case Key::F18: return VK::F18;
+        case Key::F19: return VK::F19;
+        case Key::F20: return VK::F20;
+        case Key::F21: return VK::F21;
+        case Key::F22: return VK::F22;
+        case Key::F23: return VK::F23;
+        case Key::F24: return VK::F24;
+        case Key::F25: return VK::F24; // No VK for F25+, map to F24
+        case Key::F26: return VK::F24;
+        case Key::F27: return VK::F24;
+        case Key::F28: return VK::F24;
+        case Key::F29: return VK::F24;
+        case Key::F30: return VK::F24;
+        case Key::F31: return VK::F24;
+        case Key::F32: return VK::F24;
+        case Key::F33: return VK::F24;
+        case Key::F34: return VK::F24;
+        case Key::F35: return VK::F24;
+
+        case Key::Escape:    return VK::Escape;
+        case Key::Enter:     return VK::Return;
+        case Key::Tab:       return VK::Tab;
+        case Key::Backspace: return VK::Back;
+
+        case Key::DownArrow:  return VK::Down;
+        case Key::LeftArrow:  return VK::Left;
+        case Key::RightArrow: return VK::Right;
+        case Key::UpArrow:    return VK::Up;
+
+        case Key::Insert:   return VK::Insert;
+        case Key::Delete:   return VK::Delete;
+        case Key::Home:     return VK::Home;
+        case Key::End:      return VK::End;
+        case Key::PageUp:   return VK::Prior;
+        case Key::PageDown: return VK::Next;
+
+        case Key::MediaPlay:            return VK::MediaPlayPause;
+        case Key::MediaStop:            return VK::MediaStop;
+        case Key::MediaPrevious:        return VK::MediaPrevTrack;
+        case Key::MediaNext:            return VK::MediaNextTrack;
+        case Key::MediaPause:           return VK::MediaPlayPause;
+        case Key::MediaTogglePlayPause: return VK::MediaPlayPause;
+
+        case Key::VolumeUp:   return VK::VolumeUp;
+        case Key::VolumeDown: return VK::VolumeDown;
+        case Key::VolumeMute: return VK::VolumeMute;
+
+        case Key::LeftShift:    return VK::Shift;   // Generic VK_SHIFT, matching Windows KEY_EVENT_RECORD
+        case Key::RightShift:   return VK::Shift;   // Qt cannot distinguish left/right
+        case Key::LeftControl:  return VK::Control;  // Generic VK_CONTROL
+        case Key::RightControl: return VK::Control;  // Qt cannot distinguish left/right
+        case Key::LeftAlt:      return VK::Menu;     // Generic VK_MENU
+        case Key::RightAlt:     return VK::Menu;     // Qt cannot distinguish left/right
+        case Key::LeftSuper:    return VK::LWin;
+        case Key::RightSuper:   return VK::RWin;
+        case Key::LeftHyper:    return VK::LWin;
+        case Key::RightHyper:   return VK::RWin;
+        case Key::LeftMeta:     return VK::LWin;
+        case Key::RightMeta:    return VK::RWin;
+        case Key::IsoLevel3Shift: return VK::RMenu;
+        case Key::IsoLevel5Shift: return VK::RMenu;
+
+        case Key::CapsLock:    return VK::Capital;
+        case Key::ScrollLock:  return VK::Scroll;
+        case Key::NumLock:     return VK::NumLock;
+        case Key::PrintScreen: return VK::Snapshot;
+        case Key::Pause:       return VK::Pause;
+        case Key::Menu:        return VK::Apps;
+
+        case Key::Numpad_Divide:   return VK::Divide;
+        case Key::Numpad_Multiply: return VK::Multiply;
+        case Key::Numpad_Subtract: return VK::Subtract;
+        case Key::Numpad_Add:      return VK::Add;
+        case Key::Numpad_Decimal:  return VK::Decimal;
+        case Key::Numpad_Enter:    return VK::Return;
+        case Key::Numpad_Equal:    return VK::Return; // No VK_NUMPAD_EQUAL, use Return
+        case Key::Numpad_0: return VK::Numpad0;
+        case Key::Numpad_1: return VK::Numpad1;
+        case Key::Numpad_2: return VK::Numpad2;
+        case Key::Numpad_3: return VK::Numpad3;
+        case Key::Numpad_4: return VK::Numpad4;
+        case Key::Numpad_5: return VK::Numpad5;
+        case Key::Numpad_6: return VK::Numpad6;
+        case Key::Numpad_7: return VK::Numpad7;
+        case Key::Numpad_8: return VK::Numpad8;
+        case Key::Numpad_9: return VK::Numpad9;
+    }
+    // clang-format on
+    return 0;
+}
+
+constexpr Win32ControlKeyState InputGenerator::buildWin32ControlKeyState(Modifiers modifiers)
+{
+    auto state = Win32ControlKeyState {};
+    if (modifiers.test(Modifier::Shift))
+        state.enable(Win32ControlKeyFlag::ShiftPressed);
+    if (modifiers.test(Modifier::Alt))
+        state.enable(Win32ControlKeyFlag::LeftAltPressed);
+    if (modifiers.test(Modifier::Control))
+        state.enable(Win32ControlKeyFlag::LeftCtrlPressed);
+    if (modifiers.test(Modifier::CapsLock))
+        state.enable(Win32ControlKeyFlag::CapsLockOn);
+    if (modifiers.test(Modifier::NumLock))
+        state.enable(Win32ControlKeyFlag::NumLockOn);
+    return state;
+}
+
+bool InputGenerator::generateWin32KeyInput(uint32_t virtualKeyCode,
+                                           char32_t unicodeChar,
+                                           Modifiers modifiers,
+                                           KeyboardEventType eventType,
+                                           Win32ControlKeyState extraControlKeyState)
+{
+    // Format: CSI Vk ; Sc ; Uc ; Kd ; Cs ; Rc _
+    auto const kd = (eventType == KeyboardEventType::Release) ? 0u : 1u;
+    auto const cs = buildWin32ControlKeyState(modifiers).with(extraControlKeyState);
+
+    // Apply Ctrl mapping to the unicode character, matching Windows KEY_EVENT_RECORD behavior.
+    // When Ctrl is held, Windows reports the control character (e.g., Ctrl+R → 0x12),
+    // not the raw letter. Without this, ConPTY/PSReadLine may not recognize Ctrl+key combos.
+    auto uc = static_cast<uint32_t>(unicodeChar);
+    if (modifiers.test(Modifier::Control))
+    {
+        if (auto const mapped = ctrlMappedKey(unicodeChar); mapped.has_value())
+            uc = static_cast<uint32_t>(static_cast<unsigned char>(*mapped));
+    }
+
+    append(std::format("\033[{};{};{};{};{};{}_",
+                       virtualKeyCode,
+                       0u, // scan code (not available from Qt)
+                       uc,
+                       kd,
+                       cs.value(),
+                       1u)); // repeat count
+    inputLog()("Sending Win32 input: VK={:#x} UC={:#x} KD={} CS={:#x} {}.",
+               virtualKeyCode,
+               uc,
+               kd,
+               cs.value(),
+               eventType);
+    return true;
+}
+
+// }}}
+
 void InputGenerator::reset()
 {
     _keyboardInputGenerator.reset();
     _bracketedPaste = false;
     _generateFocusEvents = false;
+    _win32InputMode = false;
     _mouseProtocol = std::nullopt;
     _mouseTransport = MouseTransport::Default;
     _mouseWheelMode = MouseWheelMode::Default;
@@ -669,6 +954,12 @@ bool InputGenerator::generate(char32_t characterEvent,
                               Modifiers modifiers,
                               KeyboardEventType eventType)
 {
+    // Win32 Input Mode supersedes all other keyboard protocols when active.
+    // It is the native ConPTY input format and carries richer key information
+    // (VK codes, scan codes) than CSI u in the Windows environment.
+    if (_win32InputMode)
+        return generateWin32KeyInput(physicalKey, characterEvent, modifiers, eventType);
+
     // modifyOtherKeys mode 2: emit CSI 27 ; modifier ; codepoint ~ for modified keys.
     // This takes precedence over the CSI u keyboard protocol but only when no CSI u flags are active.
     if (_modifyOtherKeys == 2 && !_keyboardInputGenerator.flags().any()
@@ -699,8 +990,37 @@ bool InputGenerator::generate(char32_t characterEvent,
     return success;
 }
 
+/// Strips the modifier corresponding to a modifier-only key from the modifier set.
+/// On key release, Windows KEY_EVENT_RECORDs reflect the post-release state
+/// (e.g., releasing Alt clears LEFT_ALT_PRESSED from dwControlKeyState).
+/// Qt may still report the pre-release modifier, so we strip it explicitly.
+constexpr Modifiers stripSelfModifier(Key key, Modifiers modifiers) noexcept
+{
+    // clang-format off
+    switch (key)
+    {
+        case Key::LeftShift:    case Key::RightShift:   return modifiers.without(Modifier::Shift);
+        case Key::LeftControl:  case Key::RightControl: return modifiers.without(Modifier::Control);
+        case Key::LeftAlt:      case Key::RightAlt:     return modifiers.without(Modifier::Alt);
+        case Key::LeftSuper:    case Key::RightSuper:
+        case Key::LeftMeta:     case Key::RightMeta:    return modifiers.without(Modifier::Super);
+        default:                                        return modifiers;
+    }
+    // clang-format on
+}
+
 bool InputGenerator::generate(Key key, Modifiers modifiers, KeyboardEventType eventType)
 {
+    if (_win32InputMode)
+    {
+        auto effectiveModifiers = modifiers;
+        if (eventType == KeyboardEventType::Release)
+            effectiveModifiers = stripSelfModifier(key, effectiveModifiers);
+        auto const extra = isEnhancedKey(key) ? Win32ControlKeyState { Win32ControlKeyFlag::EnhancedKey }
+                                              : Win32ControlKeyState {};
+        return generateWin32KeyInput(keyToVirtualKeyCode(key), 0, effectiveModifiers, eventType, extra);
+    }
+
     bool const success = _keyboardInputGenerator.generateKey(key, modifiers, eventType);
 
     if (success)

--- a/src/vtbackend/InputGenerator.h
+++ b/src/vtbackend/InputGenerator.h
@@ -220,6 +220,24 @@ constexpr bool isModifierKey(Key key) noexcept
     // clang-format on
 }
 
+/// Win32 dwControlKeyState bitmask flags from KEY_EVENT_RECORD.
+/// These map 1:1 to the Windows API constants.
+enum class Win32ControlKeyFlag : uint16_t
+{
+    RightAltPressed = 0x0001,  // RIGHT_ALT_PRESSED
+    LeftAltPressed = 0x0002,   // LEFT_ALT_PRESSED
+    RightCtrlPressed = 0x0004, // RIGHT_CTRL_PRESSED
+    LeftCtrlPressed = 0x0008,  // LEFT_CTRL_PRESSED
+    ShiftPressed = 0x0010,     // SHIFT_PRESSED
+    NumLockOn = 0x0020,        // NUMLOCK_ON
+    ScrollLockOn = 0x0040,     // SCROLLLOCK_ON
+    CapsLockOn = 0x0080,       // CAPSLOCK_ON
+    EnhancedKey = 0x0100,      // ENHANCED_KEY
+};
+
+/// Type-safe bitset for Win32 control key state flags.
+using Win32ControlKeyState = crispy::flags<Win32ControlKeyFlag>;
+
 std::string to_string(Key key);
 
 enum class KeyMode : uint8_t
@@ -488,6 +506,14 @@ class InputGenerator
     void setPassiveMouseTracking(bool v) noexcept { _passiveMouseTracking = v; }
     [[nodiscard]] bool passiveMouseTracking() const noexcept { return _passiveMouseTracking; }
 
+    /// Enables or disables Win32 Input Mode (DEC private mode 9001).
+    ///
+    /// When enabled, key events are encoded in the Win32 KEY_EVENT_RECORD format
+    /// (CSI Vk;Sc;Uc;Kd;Cs;Rc _) instead of CSI u or legacy VT sequences.
+    /// This is the native input protocol for Windows ConPTY.
+    void setWin32InputMode(bool enable) noexcept { _win32InputMode = enable; }
+    [[nodiscard]] bool win32InputMode() const noexcept { return _win32InputMode; }
+
     /// Sets the modifyOtherKeys mode (0 = disabled, 1 = mode 1, 2 = mode 2).
     void setModifyOtherKeys(int mode) noexcept { _modifyOtherKeys = mode; }
 
@@ -589,6 +615,14 @@ class InputGenerator
 
     bool mouseTransportURXVT(MouseEventType type, uint8_t button, uint8_t modifier, CellLocation pos);
 
+    bool generateWin32KeyInput(uint32_t virtualKeyCode,
+                               char32_t unicodeChar,
+                               Modifiers modifiers,
+                               KeyboardEventType eventType,
+                               Win32ControlKeyState extraControlKeyState = {});
+    static constexpr Win32ControlKeyState buildWin32ControlKeyState(Modifiers modifiers);
+    static constexpr uint32_t keyToVirtualKeyCode(Key key);
+
     inline bool append(std::string_view sequence);
     inline bool append(char asciiChar);
     inline bool append(uint8_t byte);
@@ -598,6 +632,7 @@ class InputGenerator
     //
     bool _bracketedPaste = false;
     bool _generateFocusEvents = false;
+    bool _win32InputMode = false;
     std::optional<MouseProtocol> _mouseProtocol = std::nullopt;
     bool _passiveMouseTracking = false;
     MouseTransport _mouseTransport = MouseTransport::Default;

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -896,3 +896,636 @@ TEST_CASE("InputBinding.match_still_requires_real_modifiers", "[terminal,input]"
 }
 
 // }}}
+// {{{ Win32 Input Mode tests
+
+TEST_CASE("InputGenerator.Win32InputMode.character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Typing 'a' (VK=0x41 on Windows, passed as physicalKey) with no modifiers
+    // Expected: CSI 65;0;97;1;0;1_
+    input.generate(U'a', 0x41, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.character_with_shift", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Typing 'A' (Shift+a), VK=0x41, unicode='A'=65, Shift pressed -> CS=0x0010
+    input.generate(U'A', 0x41, Modifier::Shift, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;65;1;16;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.character_with_ctrl", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+L: VK=0x4C, unicode char is Ctrl-mapped: 'l' -> 0x0C (12), Ctrl pressed -> CS=0x0008
+    input.generate(U'l', 0x4C, Modifier::Control, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[76;0;12;1;8;1_"); // UC=12 (0x0C), not 108 ('l')
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.arrow_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Up arrow: VK_UP=0x26, no unicode char, no modifiers, ENHANCED_KEY=0x0100=256
+    input.generate(Key::UpArrow, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[38;0;0;1;256;1_"); // VK_UP=0x26=38, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.function_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // F5: VK_F5=0x74=116, no unicode char, no modifiers
+    input.generate(Key::F5, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[116;0;0;1;0;1_"); // VK_F5=0x74=116
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.key_release", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Key release should set Kd=0
+    input.generate(U'a', 0x41, Modifier::None, KeyboardEventType::Release);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;0;0;1_"); // Kd=0 for release
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.combined_modifiers", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+Alt+Delete: VK_DELETE=0x2E=46
+    // CS = LeftAlt(0x0002) | LeftCtrl(0x0008) | ENHANCED_KEY(0x0100) = 0x010A = 266
+    auto const ctrlAlt = Modifiers { Modifier::Control } | Modifiers { Modifier::Alt };
+    input.generate(Key::Delete, ctrlAlt, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[46;0;0;1;266;1_"); // CS=266 (0x010A)
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.supersedes_csiu", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+
+    // Enable both CSI u (Kitty keyboard protocol) and Win32 Input Mode.
+    // Win32 Input Mode should take precedence.
+    input.keyboardProtocol().enter(KeyboardEventFlag::DisambiguateEscapeCodes);
+    input.setWin32InputMode(true);
+
+    // Typing 'a' should produce Win32 format, not CSI u format
+    input.generate(U'a', 0x41, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;0;1_"); // Win32 format, NOT "\033[97u"
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.reset_clears_mode", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+    CHECK(input.win32InputMode() == true);
+
+    input.reset();
+    CHECK(input.win32InputMode() == false);
+
+    // After reset, should generate legacy format, not Win32
+    input.generate(U'a', 0x41, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "a"); // Legacy: plain character
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.enter_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Enter key: VK_RETURN=0x0D=13, unicode='\r'=13
+    input.generate(Key::Enter, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[13;0;0;1;0;1_"); // VK_RETURN via Key path (no unicode char)
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.escape_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Escape: VK_ESCAPE=0x1B=27
+    input.generate(Key::Escape, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[27;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.alt_press", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Alt press: VK_MENU=0x12=18 (generic, not VK_LMENU=0xA4), CS=LeftAltPressed(0x0002)
+    input.generate(Key::LeftAlt, Modifier::Alt, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[18;0;0;1;2;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.alt_release", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Alt release: self-modifier stripped from CS, so CS=0 (not LeftAltPressed)
+    input.generate(Key::LeftAlt, Modifier::Alt, KeyboardEventType::Release);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[18;0;0;0;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_press", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl press: VK_CONTROL=0x11=17, CS=LeftCtrlPressed(0x0008)
+    input.generate(Key::LeftControl, Modifier::Control, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[17;0;0;1;8;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_release", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl release: self-modifier stripped from CS
+    input.generate(Key::LeftControl, Modifier::Control, KeyboardEventType::Release);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[17;0;0;0;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.shift_press", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Shift press: VK_SHIFT=0x10=16, CS=ShiftPressed(0x0010)
+    input.generate(Key::LeftShift, Modifier::Shift, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[16;0;0;1;16;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.shift_release", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Shift release: self-modifier stripped from CS
+    input.generate(Key::LeftShift, Modifier::Shift, KeyboardEventType::Release);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[16;0;0;0;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// {{{ Win32 Input Mode — Navigation keys with ENHANCED_KEY
+
+TEST_CASE("InputGenerator.Win32InputMode.down_arrow", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Down arrow: VK_DOWN=0x28=40, ENHANCED_KEY=0x0100=256
+    input.generate(Key::DownArrow, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[40;0;0;1;256;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.left_arrow", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::LeftArrow, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[37;0;0;1;256;1_"); // VK_LEFT=0x25=37, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.right_arrow", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::RightArrow, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[39;0;0;1;256;1_"); // VK_RIGHT=0x27=39, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.home_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::Home, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[36;0;0;1;256;1_"); // VK_HOME=0x24=36, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.end_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::End, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[35;0;0;1;256;1_"); // VK_END=0x23=35, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.insert_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::Insert, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[45;0;0;1;256;1_"); // VK_INSERT=0x2D=45, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.delete_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::Delete, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[46;0;0;1;256;1_"); // VK_DELETE=0x2E=46, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.page_up", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::PageUp, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[33;0;0;1;256;1_"); // VK_PRIOR=0x21=33, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.page_down", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    input.generate(Key::PageDown, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[34;0;0;1;256;1_"); // VK_NEXT=0x22=34, CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Numpad keys
+
+TEST_CASE("InputGenerator.Win32InputMode.numpad_0", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Numpad 0: VK_NUMPAD0=0x60=96, NOT enhanced
+    input.generate(Key::Numpad_0, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[96;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.numpad_5", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Numpad 5: VK_NUMPAD5=0x65=101, NOT enhanced
+    input.generate(Key::Numpad_5, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[101;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.numpad_add", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Numpad +: VK_ADD=0x6B=107, NOT enhanced
+    input.generate(Key::Numpad_Add, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[107;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.numpad_enter", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Numpad Enter: VK_RETURN=0x0D=13, IS enhanced (E0 scan code prefix)
+    input.generate(Key::Numpad_Enter, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[13;0;0;1;256;1_"); // CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.numpad_divide", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Numpad /: VK_DIVIDE=0x6F=111, IS enhanced (E0 scan code prefix)
+    input.generate(Key::Numpad_Divide, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[111;0;0;1;256;1_"); // CS=ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Lock modifiers in control key state
+
+TEST_CASE("InputGenerator.Win32InputMode.capslock_in_cs", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Typing 'a' with CapsLock on: CS=CAPSLOCK_ON(0x0080)=128
+    input.generate(U'a', 0x41, Modifier::CapsLock, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;128;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.numlock_in_cs", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Typing 'a' with NumLock on: CS=NUMLOCK_ON(0x0020)=32
+    input.generate(U'a', 0x41, Modifier::NumLock, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;32;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.capslock_and_numlock_in_cs", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Both locks: CS=CAPSLOCK_ON|NUMLOCK_ON = 0x0080|0x0020 = 0x00A0 = 160
+    auto const locks = Modifiers { Modifier::CapsLock } | Modifiers { Modifier::NumLock };
+    input.generate(U'a', 0x41, locks, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;160;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Tab and Backspace
+
+TEST_CASE("InputGenerator.Win32InputMode.tab_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Tab: VK_TAB=0x09=9, NOT enhanced
+    input.generate(Key::Tab, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[9;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.backspace_key", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Backspace: VK_BACK=0x08=8, NOT enhanced
+    input.generate(Key::Backspace, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[8;0;0;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Multi-modifier combinations
+
+TEST_CASE("InputGenerator.Win32InputMode.shift_alt_character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Shift+Alt+'a': CS = ShiftPressed(0x0010) | LeftAltPressed(0x0002) = 0x0012 = 18
+    auto const mods = Modifiers { Modifier::Shift } | Modifiers { Modifier::Alt };
+    input.generate(U'a', 0x41, mods, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;18;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_shift_character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+Shift+'a': CS = LeftCtrlPressed(0x0008) | ShiftPressed(0x0010) = 0x0018 = 24
+    // UC = Ctrl-mapped 'a' -> 0x01 = 1
+    auto const mods = Modifiers { Modifier::Control } | Modifiers { Modifier::Shift };
+    input.generate(U'a', 0x41, mods, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;1;1;24;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_shift_alt_character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+Shift+Alt+'a': CS = LeftCtrl(0x0008) | Shift(0x0010) | LeftAlt(0x0002) = 0x001A = 26
+    // UC = Ctrl-mapped 'a' -> 0x01 = 1
+    auto const mods =
+        Modifiers { Modifier::Control } | Modifiers { Modifier::Shift } | Modifiers { Modifier::Alt };
+    input.generate(U'a', 0x41, mods, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;1;1;26;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_alt_arrow", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+Alt+Left: CS = LeftCtrl(0x0008) | LeftAlt(0x0002) | ENHANCED_KEY(0x0100) = 0x010A = 266
+    auto const mods = Modifiers { Modifier::Control } | Modifiers { Modifier::Alt };
+    input.generate(Key::LeftArrow, mods, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[37;0;0;1;266;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Repeat event type
+
+TEST_CASE("InputGenerator.Win32InputMode.repeat_event", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Repeat event should produce Kd=1 (same as Press, since any non-Release is key-down)
+    input.generate(U'a', 0x41, Modifier::None, KeyboardEventType::Repeat);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[65;0;97;1;0;1_"); // Kd=1
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — F-keys with modifiers
+
+TEST_CASE("InputGenerator.Win32InputMode.shift_f5", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Shift+F5: VK_F5=0x74=116, CS=ShiftPressed(0x0010)=16, NOT enhanced
+    input.generate(Key::F5, Modifier::Shift, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[116;0;0;1;16;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_f1", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+F1: VK_F1=0x70=112, CS=LeftCtrlPressed(0x0008)=8, NOT enhanced
+    input.generate(Key::F1, Modifier::Control, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[112;0;0;1;8;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Character variety
+
+TEST_CASE("InputGenerator.Win32InputMode.space_character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Space: VK_SPACE=0x20=32, UC=' '=32
+    input.generate(U' ', 0x20, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[32;0;32;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.digit_character", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Digit '1': VK='1'=0x31=49, UC='1'=49
+    input.generate(U'1', 0x31, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[49;0;49;1;0;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.ctrl_c", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Ctrl+C: VK=0x43=67, UC = Ctrl-mapped 'c' -> 0x03 = 3, CS=LeftCtrl(0x0008)=8
+    input.generate(U'c', 0x43, Modifier::Control, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[67;0;3;1;8;1_");
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — Enhanced key negative cases
+
+TEST_CASE("InputGenerator.Win32InputMode.enter_not_enhanced", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // Main Enter key: VK_RETURN=0x0D=13, NOT enhanced (unlike Numpad Enter)
+    input.generate(Key::Enter, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[13;0;0;1;0;1_"); // CS=0, no ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+TEST_CASE("InputGenerator.Win32InputMode.f5_not_enhanced", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // F5: VK_F5=0x74=116, NOT enhanced (function keys don't have E0 prefix)
+    input.generate(Key::F5, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[116;0;0;1;0;1_"); // CS=0, no ENHANCED_KEY
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+// {{{ Win32 Input Mode — MediaStop regression
+
+TEST_CASE("InputGenerator.Win32InputMode.media_stop_vk", "[terminal,input]")
+{
+    auto input = InputGenerator {};
+    input.setWin32InputMode(true);
+
+    // MediaStop: VK_MEDIA_STOP=0xB2=178 (not 0xB3 which is VK_MEDIA_PLAY_PAUSE)
+    input.generate(Key::MediaStop, Modifier::None, KeyboardEventType::Press);
+    auto const seq = input.peek();
+    CHECK(seq == "\033[178;0;0;1;0;1_"); // VK=178 (0xB2)
+    input.consume(static_cast<int>(seq.size()));
+}
+
+// }}}
+
+// }}}

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2550,6 +2550,7 @@ void Terminal::setMode(DECMode mode, bool enable)
         case DECMode::ApplicationKeypad: setApplicationkeypadMode(enable); break;
         case DECMode::AutoRepeat: break;
         case DECMode::BackarrowKey: _inputGenerator.setBackarrowKeyMode(enable); break;
+        case DECMode::Win32InputMode: _inputGenerator.setWin32InputMode(enable); break;
         case DECMode::SemanticBlockProtocol:
             _semanticBlockTracker.setEnabled(enable);
             if (enable)
@@ -3740,6 +3741,8 @@ std::string to_string(DECMode mode)
         case DECMode::SixelCursorNextToGraphic: return "SixelCursorNextToGraphic";
         case DECMode::ReportColorPaletteUpdated: return "ReportColorPaletteUpdated";
         case DECMode::SemanticBlockProtocol: return "SemanticBlockProtocol";
+        case DECMode::Win32InputMode: return "Win32InputMode";
+        case DECMode::DECModeCount: break;
     }
     return std::format("({})", static_cast<unsigned>(mode));
 }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -152,10 +152,10 @@ class Modes
     }
 
   private:
-    std::bitset<32> _ansi;                            // AnsiMode
-    std::bitset<8452 + 1> _dec;                       // DECMode
-    std::bitset<8452 + 1> _decFrozen;                 // DECMode
-    std::map<DECMode, std::vector<bool>> _savedModes; // saved DEC modes
+    std::bitset<32> _ansi;                                              // AnsiMode
+    std::bitset<static_cast<size_t>(DECMode::DECModeCount)> _dec;       // DECMode
+    std::bitset<static_cast<size_t>(DECMode::DECModeCount)> _decFrozen; // DECMode
+    std::map<DECMode, std::vector<bool>> _savedModes;                   // saved DEC modes
 };
 // }}}
 

--- a/src/vtbackend/primitives.h
+++ b/src/vtbackend/primitives.h
@@ -627,7 +627,7 @@ enum class AnsiMode : uint8_t
     AutomaticNewLine = 20, // LNM
 };
 
-enum class DECMode : std::uint16_t
+enum class DECMode : std::uint8_t
 {
     UseApplicationCursorKeys = 0,
     DesignateCharsetUSASCII = 1,
@@ -716,60 +716,85 @@ enum class DECMode : std::uint16_t
     UsePrivateColorRegisters = 26, // ?1070
 
     // {{{ Mouse related flags
-    /// extend mouse protocl encoding
-    MouseExtended = 1005,
+    /// Extend mouse protocol encoding (DEC mode 1005).
+    MouseExtended = 31,
 
-    /// Uses a (SGR-style?) different encoding.
-    MouseSGR = 1006,
+    /// Uses a (SGR-style?) different encoding (DEC mode 1006).
+    MouseSGR = 32,
 
-    // URXVT invented extend mouse protocol
-    MouseURXVT = 1015,
+    /// URXVT invented extend mouse protocol (DEC mode 1015).
+    MouseURXVT = 33,
 
-    // SGR-Pixels, like SGR but with pixels instead of line/column positions.
-    MouseSGRPixels = 1016,
+    /// SGR-Pixels, like SGR but with pixels instead of line/column positions (DEC mode 1016).
+    MouseSGRPixels = 34,
 
-    /// Toggles scrolling in alternate screen buffer, encodes CUP/CUD instead of mouse wheel events.
-    MouseAlternateScroll = 1007,
+    /// Toggles scrolling in alternate screen buffer, encodes CUP/CUD instead of mouse wheel events
+    /// (DEC mode 1007).
+    MouseAlternateScroll = 35,
     // }}}
     // {{{ Extensions
-    // This merely resembles the "Synchronized Output" feature from iTerm2, except that it is using
-    // a different VT sequence to be enabled. Instead of a DCS,
-    // this feature is using CSI ? 2026 h (DECSM and DECRM).
-    BatchedRendering = 2026,
+    /// Synchronized Output (DEC mode 2026).
+    ///
+    /// This merely resembles the "Synchronized Output" feature from iTerm2, except that it is using
+    /// a different VT sequence to be enabled. Instead of a DCS,
+    /// this feature is using CSI ? 2026 h (DECSM and DECRM).
+    BatchedRendering = 36,
 
-    // See https://github.com/contour-terminal/terminal-unicode-core
-    Unicode = 2027,
+    /// See https://github.com/contour-terminal/terminal-unicode-core (DEC mode 2027).
+    Unicode = 37,
 
-    // If this mode is unset, text reflow is blocked on on this line and any lines below.
-    // If this mode is set, the current line and any line below is allowed to reflow.
-    // Default: Enabled (if supported by terminal).
-    TextReflow = 2028,
+    /// Text reflow control (DEC mode 2028).
+    ///
+    /// If this mode is unset, text reflow is blocked on this line and any lines below.
+    /// If this mode is set, the current line and any line below is allowed to reflow.
+    /// Default: Enabled (if supported by terminal).
+    TextReflow = 38,
 
-    // Tell the terminal emulator that the application is only passively tracking on mouse events.
-    // This for example might be used by the terminal emulator to still allow mouse selection.
-    MousePassiveTracking = 2029,
+    /// Passive mouse tracking (DEC mode 2029).
+    ///
+    /// Tell the terminal emulator that the application is only passively tracking on mouse events.
+    /// This for example might be used by the terminal emulator to still allow mouse selection.
+    MousePassiveTracking = 39,
 
-    // If enabled, UI text selection will be reported to the application for the regions
-    // intersecting with the main page area.
-    ReportGridCellSelection = 2030,
+    /// Grid cell selection reporting (DEC mode 2030).
+    ///
+    /// If enabled, UI text selection will be reported to the application for the regions
+    /// intersecting with the main page area.
+    ReportGridCellSelection = 40,
 
-    // If enabled, the terminal will report color palette changes to the application,
-    // if modified by the user or operating system (e.g. dark/light mode adaption).
-    ReportColorPaletteUpdated = 2031,
+    /// Color palette update reporting (DEC mode 2031).
+    ///
+    /// If enabled, the terminal will report color palette changes to the application,
+    /// if modified by the user or operating system (e.g. dark/light mode adaption).
+    ReportColorPaletteUpdated = 41,
 
     /// DEC Private Mode 2034 — Semantic Block Reader Protocol.
     ///
     /// When enabled, the terminal tracks semantic zones from OSC 133 shell integration
     /// and the query sequence CSI > Ps ; Pn b becomes available for retrieving structured
     /// JSON blocks of semantic command data.
-    SemanticBlockProtocol = 2034,
+    SemanticBlockProtocol = 42,
 
-    // If enabled (default, as per spec), then the cursor is left next to the graphic,
-    // that is, the text cursor is placed at the position of the sixel cursor.
-    // If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
-    // which is how xterm behaves by default (sadly).
-    SixelCursorNextToGraphic = 8452,
+    /// Sixel cursor positioning (DEC mode 8452).
+    ///
+    /// If enabled (default, as per spec), then the cursor is left next to the graphic,
+    /// that is, the text cursor is placed at the position of the sixel cursor.
+    /// If disabled otherwise, the cursor is placed below the image, as if CR LF was sent,
+    /// which is how xterm behaves by default (sadly).
+    SixelCursorNextToGraphic = 43,
+
+    /// Win32 Input Mode (DEC private mode 9001).
+    ///
+    /// When enabled, key events are sent in the Win32 KEY_EVENT_RECORD format:
+    /// CSI Vk ; Sc ; Uc ; Kd ; Cs ; Rc _
+    /// This is the native input protocol for Windows ConPTY. When both Win32 Input Mode
+    /// and CSI u (Kitty keyboard protocol) are active, Win32 Input Mode takes precedence
+    /// as the more powerful and versatile protocol for the ConPTY environment.
+    Win32InputMode = 44,
     // }}}
+
+    /// Sentinel value for sizing the mode bitset. Must remain the last entry.
+    DECModeCount = 45
 };
 
 /// OSC color-setting related commands that can be grouped into one
@@ -882,6 +907,8 @@ constexpr unsigned toDECModeNum(DECMode m) noexcept
         case DECMode::Unicode: return 2027;
         case DECMode::TextReflow: return 2028;
         case DECMode::SixelCursorNextToGraphic: return 8452;
+        case DECMode::Win32InputMode: return 9001;
+        case DECMode::DECModeCount: break;
     }
     return static_cast<unsigned>(m);
 }
@@ -940,6 +967,7 @@ constexpr std::optional<DECMode> fromDECModeNum(unsigned int modeNum) noexcept
         case 2031: return DECMode::ReportColorPaletteUpdated;
         case 2034: return DECMode::SemanticBlockProtocol;
         case 8452: return DECMode::SixelCursorNextToGraphic;
+        case 9001: return DECMode::Win32InputMode;
         default: return std::nullopt;
     }
 }


### PR DESCRIPTION

- Implement Win32 Input Mode (DEC private mode 9001), the native ConPTY input protocol. When enabled via `CSI ?9001h`, key events are encoded as `CSI Vk;Sc;Uc;Kd;Cs;Rc _` sequences matching the Windows `KEY_EVENT_RECORD` format.
- This fixes keyboard input for applications (e.g. Endo shell) that request Win32 Input Mode on Windows. Previously, Contour ignored mode 9001 and fell back to CSI u encoding, which ConPTY does not understand — causing raw escape sequences to be echoed as visible text.
- When both Win32 Input Mode and CSI u (Kitty keyboard protocol) are active, Win32 Input Mode takes precedence as the more powerful and versatile protocol for the ConPTY environment.
- Compact the `DECMode` enum values to be fully sequential, shrinking the `Modes` bitset from `std::bitset<8453>` (~1KB) to `std::bitset<45>` (8 bytes).
