### PR TITLE
[terminal] Fix trivial line fill attributes lost for empty lines

### DIFF
--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -230,7 +230,7 @@ class Line
         auto const cols = unbox<size_t>(_columns);
         auto const used = trimBlankRight(_storage, cols);
 
-        auto const textAttrs = (used > 0) ? _storage.sgr[0] : GraphicsAttributes {};
+        auto const textAttrs = (cols > 0) ? _storage.sgr[0] : GraphicsAttributes {};
 
         // Direct copy from SoA codepoints — no UTF-8 encoding needed.
         textOut.resize(used);
@@ -241,7 +241,7 @@ class Line
             .displayWidth = _columns,
             .textAttributes = textAttrs,
             .fillAttributes = textAttrs,
-            .hyperlink = (used > 0) ? _storage.hyperlinks[0] : HyperlinkId {},
+            .hyperlink = (cols > 0) ? _storage.hyperlinks[0] : HyperlinkId {},
             .usedColumns = ColumnCount::cast_from(used),
         };
         // text field left empty — caller passes textOut to the renderer directly

--- a/src/vtbackend/LineSoA_test.cpp
+++ b/src/vtbackend/LineSoA_test.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <vtbackend/CellProxy.h>
+#include <vtbackend/Line.h>
 #include <vtbackend/LineSoA.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -567,6 +568,67 @@ TEST_CASE("LineFlags.formatter.composite", "[LineFlags]")
     auto const flags = LineFlags({ LineFlag::Wrapped, LineFlag::OutputStart });
     auto const result = std::format("{}", flags);
     CHECK(result == "Wrapped,OutputStart");
+}
+
+// ---------------------------------------------------------------------------
+// trivialBuffer() regression test: fill attributes must survive empty lines
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Line.trivialBuffer.emptyLinePreservesFillAttributes", "[Line]")
+{
+    // Regression test: when a trivial line is reset/cleared with non-default
+    // SGR attributes but has no text content (all codepoints zero),
+    // trivialBuffer() must still return those SGR attributes as fill attributes.
+    // Previously it returned default GraphicsAttributes{} when used==0.
+
+    auto const navyBg =
+        GraphicsAttributes { .foregroundColor = Color::Indexed(7), .backgroundColor = Color::Indexed(4) };
+
+    auto constexpr Cols = ColumnCount(80);
+    auto line = Line(Cols, LineFlag::None, navyBg);
+
+    // Verify the line is trivial and has no text content.
+    REQUIRE(line.isTrivialBuffer());
+
+    std::u32string textOut;
+    auto const tb = line.trivialBuffer(textOut);
+
+    // The line has zero used columns (no codepoints set).
+    CHECK(tb.usedColumns == ColumnCount(0));
+    CHECK(textOut.empty());
+
+    // Critical: fill attributes must match the SGR the line was initialized with,
+    // NOT default GraphicsAttributes{}.
+    CHECK(tb.fillAttributes.backgroundColor == Color::Indexed(4));
+    CHECK(tb.fillAttributes.foregroundColor == Color::Indexed(7));
+    CHECK(tb.textAttributes.backgroundColor == Color::Indexed(4));
+    CHECK(tb.textAttributes.foregroundColor == Color::Indexed(7));
+}
+
+TEST_CASE("Line.trivialBuffer.resetPreservesFillAttributes", "[Line]")
+{
+    // Verify that resetting a line with specific SGR and then calling
+    // trivialBuffer() returns those attributes even when codepoints are all zero.
+
+    auto constexpr Cols = ColumnCount(40);
+    auto line = Line(Cols, LineFlag::None, GraphicsAttributes {});
+
+    // Write some content first.
+    line.storage().codepoints[0] = U'X';
+    line.storage().clusterSize[0] = 1;
+
+    // Now reset the line with a themed background (simulating EL CSI K at col 0).
+    auto const themedAttrs = GraphicsAttributes { .backgroundColor = Color::Indexed(4) };
+    line.reset(LineFlag::None, themedAttrs);
+
+    REQUIRE(line.isTrivialBuffer());
+
+    std::u32string textOut;
+    auto const tb = line.trivialBuffer(textOut);
+
+    CHECK(tb.usedColumns == ColumnCount(0));
+    CHECK(tb.fillAttributes.backgroundColor == Color::Indexed(4));
+    CHECK(tb.textAttributes.backgroundColor == Color::Indexed(4));
 }
 
 // LineView tests removed — Line is now backed by LineSoA directly (tested via Line_test.cpp)


### PR DESCRIPTION
- Fix `trivialBuffer()` returning default `GraphicsAttributes{}` for erased lines with no text content, causing the render fast path to draw the terminal's default background instead of the themed background (e.g., AstroNvim's navy).
- Root cause: the condition `used > 0` (non-zero codepoint count) was used to decide whether to read `sgr[0]`. For erased lines all codepoints are zero, but the SGR arrays are fully populated with the correct fill attributes. Changed to `cols > 0`.
- Added two regression tests verifying `trivialBuffer()` preserves fill attributes for empty trivial lines.