### PR TITLE
Add autoScrollOnUpdate setting to keep viewport parked in scrollback

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -136,6 +136,7 @@ namespace
         settings.ptyBufferObjectSize = config.ptyBufferObjectSize.value();
         settings.ptyReadBufferSize = config.ptyReadBufferSize.value();
         settings.maxHistoryLineCount = profile.history.value().maxHistoryLineCount;
+        settings.autoScrollOnUpdate = profile.history.value().autoScrollOnUpdate;
         settings.copyLastMarkRangeOffset = profile.copyLastMarkRangeOffset.value();
         settings.cursorBlinkInterval = profile.modeInsert.value().cursor.cursorBlinkInterval;
         settings.cursorShape = profile.modeInsert.value().cursor.cursorShape;
@@ -1978,6 +1979,7 @@ void TerminalSession::configureTerminal()
     configureCursor(_profile.modeInsert.value().cursor);
     updateColorPreference(_app.colorPreference());
     _terminal.setMaxHistoryLineCount(_profile.history.value().maxHistoryLineCount);
+    _terminal.settings().autoScrollOnUpdate = _profile.history.value().autoScrollOnUpdate;
     _terminal.setHighlightTimeout(_profile.highlightTimeout.value());
     _terminal.viewport().setScrollOff(_profile.modalCursorScrollOff.value());
     _terminal.inputHandler().setSearchModeSwitch(_profile.searchModeSwitch.value());

--- a/src/vtbackend/Settings.h
+++ b/src/vtbackend/Settings.h
@@ -80,6 +80,12 @@ struct Settings
     /// Enables momentum (inertia) scrolling for touchpad gestures.
     bool momentumScrolling = true;
 
+    /// When true, PTY/app-caused updates (key input forwarded to the PTY, buffer
+    /// switches, scrollback clears, etc.) force the viewport to snap to the
+    /// bottom. When false, the viewport stays wherever the user parked it.
+    /// User-initiated transitions (e.g. leaving Vi mode) are not affected.
+    bool autoScrollOnUpdate = true;
+
     // Size in bytes per PTY Buffer Object.
     //
     // Defaults to 1 MB, that's roughly 10k lines when column count is 100.

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -823,6 +823,18 @@ void Terminal::updateIndicatorStatusLine()
     }
 }
 
+void Terminal::autoScrollToBottomIfEnabled()
+{
+    if (_settings.autoScrollOnUpdate)
+        _viewport.scrollToBottom();
+}
+
+void Terminal::forceAutoScrollToBottomIfEnabled()
+{
+    if (_settings.autoScrollOnUpdate)
+        _viewport.forceScrollToBottom();
+}
+
 Handled Terminal::sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventType eventType, Timestamp now)
 {
     _cursorBlinkState = 1;
@@ -853,7 +865,7 @@ Handled Terminal::sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventType e
         {
             _inputGenerator.generateRaw(*udkStr);
             flushInput();
-            _viewport.scrollToBottom();
+            autoScrollToBottomIfEnabled();
             return Handled { true };
         }
     }
@@ -863,7 +875,7 @@ Handled Terminal::sendKeyEvent(Key key, Modifiers modifiers, KeyboardEventType e
     {
         flushInput();
         if (!isModifierKey(key))
-            _viewport.scrollToBottom();
+            autoScrollToBottomIfEnabled();
     }
     return Handled { success };
 }
@@ -898,7 +910,7 @@ Handled Terminal::sendCharEvent(
     if (success)
     {
         flushInput();
-        _viewport.scrollToBottom();
+        autoScrollToBottomIfEnabled();
     }
     return Handled { success };
 }
@@ -1920,14 +1932,14 @@ void Terminal::bell()
 void Terminal::bufferChanged(ScreenType type)
 {
     clearSelection();
-    _viewport.forceScrollToBottom();
+    forceAutoScrollToBottomIfEnabled();
     _eventListener.bufferChanged(type);
 }
 
 void Terminal::scrollbackBufferCleared()
 {
     clearSelection();
-    _viewport.scrollToBottom();
+    autoScrollToBottomIfEnabled();
     breakLoopAndRefreshRenderBuffer();
 }
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1380,6 +1380,17 @@ class Terminal
     void requestTabName();
 
   private:
+    /// Scroll the viewport to the bottom if `settings().autoScrollOnUpdate` is enabled.
+    /// Intended for PTY/app-caused code paths only (e.g. key/char forwarding,
+    /// scrollback clears). User-initiated transitions should call
+    /// `_viewport.forceScrollToBottom()` directly.
+    void autoScrollToBottomIfEnabled();
+
+    /// Like `autoScrollToBottomIfEnabled()` but bypasses the `scrollingDisabled()`
+    /// check (used e.g. on alt-screen switch, where scrolling is "disabled" on the
+    /// target buffer but pixel/offset state still needs to be reset).
+    void forceAutoScrollToBottomIfEnabled();
+
     void mainLoop();
     void fillRenderBufferInternal(RenderBuffer& output, bool includeSelection);
     LineCount fillRenderBufferStatusLine(RenderBuffer& output, bool includeSelection, LineOffset base);

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -166,6 +166,118 @@ TEST_CASE("Terminal.ModifierKeysDoNotScrollViewport", "[terminal]")
     }
 }
 
+TEST_CASE("Terminal.AutoScrollOnUpdate", "[terminal]")
+{
+    // Set up a terminal with history capacity to allow scrollback.
+    auto mc = MockTerm { PageSize { LineCount(4), ColumnCount(6) }, LineCount(10) };
+    auto& terminal = mc.terminal;
+
+    // Fill terminal and generate scrollback history.
+    mc.writeToScreen("line1\r\n"
+                     "line2\r\n"
+                     "line3\r\n"
+                     "line4\r\n"
+                     "line5\r\n"
+                     "line6\r\n");
+
+    auto const anyModifiers = vtbackend::Modifiers { vtbackend::Modifier::None };
+
+    SECTION("keypress honors autoScrollOnUpdate=false")
+    {
+        terminal.settings().autoScrollOnUpdate = false;
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        terminal.sendKeyEvent(vtbackend::Key::Enter,
+                              anyModifiers,
+                              vtbackend::KeyboardEventType::Press,
+                              std::chrono::steady_clock::now());
+
+        CHECK(terminal.viewport().scrolled());
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
+    SECTION("keypress honors autoScrollOnUpdate=true (default)")
+    {
+        REQUIRE(terminal.settings().autoScrollOnUpdate);
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+
+        terminal.sendKeyEvent(vtbackend::Key::Enter,
+                              anyModifiers,
+                              vtbackend::KeyboardEventType::Press,
+                              std::chrono::steady_clock::now());
+
+        CHECK(!terminal.viewport().scrolled());
+    }
+
+    SECTION("char input honors autoScrollOnUpdate=false")
+    {
+        terminal.settings().autoScrollOnUpdate = false;
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        terminal.sendCharEvent(
+            U'a', 0, anyModifiers, vtbackend::KeyboardEventType::Press, std::chrono::steady_clock::now());
+
+        CHECK(terminal.viewport().scrolled());
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
+    SECTION("char input honors autoScrollOnUpdate=true")
+    {
+        REQUIRE(terminal.settings().autoScrollOnUpdate);
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+
+        terminal.sendCharEvent(
+            U'a', 0, anyModifiers, vtbackend::KeyboardEventType::Press, std::chrono::steady_clock::now());
+
+        CHECK(!terminal.viewport().scrolled());
+    }
+
+    SECTION("scrollbackBufferCleared (CSI 3 J) honors autoScrollOnUpdate=false")
+    {
+        terminal.settings().autoScrollOnUpdate = false;
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        mc.writeToScreen("\x1b[3J");
+
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
+    // Note: we exercise `bufferChanged` directly rather than feeding DECSET 1049,
+    // because the full alt-screen entry sequence also clears the screen which in
+    // turn triggers `onBufferScrolled`, clamping the viewport to the (empty) alt
+    // screen history independently of our flag.
+    SECTION("bufferChanged honors autoScrollOnUpdate=false")
+    {
+        terminal.settings().autoScrollOnUpdate = false;
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        terminal.bufferChanged(vtbackend::ScreenType::Primary);
+
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
+    SECTION("bufferChanged honors autoScrollOnUpdate=true")
+    {
+        REQUIRE(terminal.settings().autoScrollOnUpdate);
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+
+        terminal.bufferChanged(vtbackend::ScreenType::Primary);
+
+        CHECK(!terminal.viewport().scrolled());
+    }
+}
+
 TEST_CASE("Terminal.DECCARA", "[terminal]")
 {
     auto mock = MockTerm { ColumnCount(5), LineCount(5) };


### PR DESCRIPTION
Introduce a new `autoScrollOnUpdate` setting (default `true`, preserving current behavior) that gates whether PTY/app-caused updates snap the viewport to the bottom. With the setting disabled, the viewport stays wherever the user parked it while reading scrollback, so background activity — keystrokes forwarded to the PTY, alt-screen buffer switches, `CSI 3 J` scrollback clears — no longer yanks the view back down. User-initiated transitions (e.g. leaving Vi mode) are intentionally unaffected.

## Changes

- Add `Settings::autoScrollOnUpdate` (default `true`)
- Funnel the auto-scroll call sites in `Terminal::sendKeyEvent`, `sendCharEvent`, `bufferChanged`, and `scrollbackBufferCleared` through two new helpers, `Terminal::autoScrollToBottomIfEnabled()` and `forceAutoScrollToBottomIfEnabled()`, that honor the flag
- Wire the setting through `TerminalSession` from the profile's `history.autoScrollOnUpdate`
- Add a `Terminal.AutoScrollOnUpdate` test case covering each affected code path under both flag states