### PR TITLE
Update std::simd feature test.

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -123,6 +123,7 @@
           <li>Fixes VT parser: DCS_Param to DCS_Intermediate transition now correctly collects intermediate bytes</li>
           <li>Removes ScreenBase class — merges into Screen, eliminating unnecessary virtual dispatch</li>
           <li>Fixes loading of optional fields in the config file (#1940)</li>
+          <li>Fix std::simd feature test</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Image.cpp
+++ b/src/vtbackend/Image.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 
 // clang-format off
-#if __has_include(<simd>)
+#if (__cpp_lib_simd >= 202411L)
     #include <simd>
     namespace simd = std;
     #define VTBACKEND_SIMD_FOUND 1


### PR DESCRIPTION
## Description

Update std::simd macro test from checking include to checking macro. With the release of gcc16 the header is present, but it requires C++26.
The gcc doesn't actually define the `__cpp_lib_simd` macro at the moment, however this should not cause any issues since the project is on C++23 for the time being.

## Motivation and Context

With the release of gcc16 contour fails to build if gcc16 is the system's default (e.g. on Arch) because the header is present, but it's contents are disabled because of the C++ version.

## How Has This Been Tested?

I've built contour locally.

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented
