### PR TITLE
Fix OOB write crash in SixelParser

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -123,6 +123,7 @@
           <li>Fixes VT parser: DCS_Param to DCS_Intermediate transition now correctly collects intermediate bytes</li>
           <li>Removes ScreenBase class — merges into Screen, eliminating unnecessary virtual dispatch</li>
           <li>Fixes loading of optional fields in the config file (#1940)</li>
+          <li>Fixes sixel crash in sixel parser caused by aspect ratio miscalculation (#1945)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/SixelParser.cpp
+++ b/src/vtbackend/SixelParser.cpp
@@ -392,13 +392,15 @@ RGBAColor SixelImageBuilder::at(CellLocation coord) const noexcept
 
 void SixelImageBuilder::write(CellLocation const& coord, RGBColor const& value) noexcept
 {
-    if (unbox(coord.line) >= 0 && unbox(coord.line) < unbox<int>(_maxSize.height) && unbox(coord.column) >= 0
-        && unbox(coord.column) < unbox<int>(_maxSize.width))
+    if (unbox(coord.line) >= 0
+        && unbox(coord.line) + static_cast<int>(_aspectRatio) <= unbox<int>(_maxSize.height)
+        && unbox(coord.column) >= 0 && unbox(coord.column) < unbox<int>(_maxSize.width))
     {
         if (!_explicitSize)
         {
             if (unbox(coord.line) >= unbox<int>(_size.height))
-                _size.height = Height::cast_from(coord.line.as<unsigned int>() + _aspectRatio);
+                _size.height = Height::cast_from(std::min(coord.line.as<unsigned int>() + _aspectRatio,
+                                                          unbox<unsigned int>(_maxSize.height)));
             if (unbox(coord.column) >= unbox<int>(_size.width))
                 _size.width = Width::cast_from(coord.column + 1);
         }

--- a/src/vtbackend/SixelParser_test.cpp
+++ b/src/vtbackend/SixelParser_test.cpp
@@ -373,3 +373,38 @@ TEST_CASE("SixelParser.vertical_cursor_advance", "[sixel]")
     REQUIRE(ib.size() == vtbackend::ImageSize { Width(1), Height(24) });
     REQUIRE(ib.sixelCursor() == CellLocation { LineOffset(24), ColumnOffset { 0 } });
 }
+
+TEST_CASE("SixelParser.aspect_ratio_overflow", "[sixel]")
+{
+    // 3x7 pixel buffer, aspect ratio 2.  '~' sets all 6 sixel bits.
+    // The sixth pixel row spans rows 6-7; row 7 is past the end.
+    // bit 0: rows 0,1  ok      bit 3: rows 6,7  row 7 overflows
+    // bit 1: rows 2,3  ok      bit 4: rows 8,9  skipped
+    // bit 2: rows 4,5  ok      bit 5: rows 10,11 skipped
+    auto constexpr DefaultColor = RGBAColor { 0, 0, 0, 0xFF };
+    auto constexpr PinColor = RGBColor { 0x10, 0x20, 0x40 };
+
+    auto ib = SixelImageBuilder(
+        { Width(3), Height(7) }, 2, 1, DefaultColor, std::make_shared<SixelColorPalette>(16, 256));
+    ib.setRaster(2, 1, std::nullopt);
+
+    auto sp = SixelParser { ib };
+
+    ib.setColor(0, PinColor);
+
+    sp.parseFragment("~");
+    sp.done();
+
+    REQUIRE(ib.size().width == Width(1));
+    REQUIRE(ib.size().height == Height(6));
+
+    // bit 0: rows 0,1 ok     bit 3: rows 6,7 row 7 overflows
+    // bit 1: rows 2,3 ok     bit 4: rows 8,9 skipped
+    // bit 2: rows 4,5 ok     bit 5: rows 10,11 skipped
+    for (int y = 0; y < 6; ++y)
+    {
+        auto const pos = CellLocation { .line = LineOffset(y), .column = ColumnOffset(0) };
+        auto const actualColor = ib.at(pos);
+        CHECK(actualColor.rgb() == PinColor);
+    }
+}


### PR DESCRIPTION
## Description

This code crashes contour of any window size (aspect ratio):

```python
for ar in range(100, 500):
    print(f'\x1bPq"{ar};1#2' + '~' * 2000 + '\x1b\\', end='', flush=True)
```

The supplied test SixelParser.aspect_ratio_overflow demonstrates out of bounds crash, and the solution is using bounds checks with min().

I also checked "cat snake.six" with varying sizes to ensure correct/same before and after has same working sixel behavior.

https://github.com/csdvrx/sixel-testsuite/blob/master/snake.six

## Related Issues

None

## Motivation and Context

I found heap overflows of the exact same kind in other terminals. This specific crash is unlikely in common sixel use, only misuse by crafted sequences.

## How Has This Been Tested?

with the provided test, and sample python code

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented
