### PR TITLE
Preserve scrollback for top anchored scroll regions

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -127,6 +127,7 @@
           <li>Fixes sixel crash in sixel parser caused by aspect ratio miscalculation (#1945)</li>
           <li>Fixes numeric capability reporting by XTGETTCAP</li>
           <li>Fixes window snapping back to the configured terminal_size after a screen/DPR change on tiling Wayland compositors (#1941), by initialising the window size from the terminal's implicit size only once on creation instead of using a permanent QML binding</li>
+          <li>Fixes scrollback preservation for top anchored full width scroll regions</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -345,6 +345,29 @@ LineCount Grid::scrollUp(LineCount n, GraphicsAttributes defaultAttributes, Marg
 
         auto const marginHeight = LineCount(margin.vertical.length());
         auto const n2 = std::min(n, marginHeight);
+        if (*n2 == 0)
+            return LineCount(0);
+
+        if (*margin.vertical.from == 0)
+        {
+            auto const historyLinesAdded = scrollUp(n2, defaultAttributes);
+            auto const firstProtectedLine = margin.vertical.to + 1;
+            auto const pageBottomLine = boxed_cast<LineOffset>(_pageSize.lines) - LineOffset(1);
+
+            for (auto targetLine = pageBottomLine; targetLine >= firstProtectedLine; --targetLine)
+            {
+                auto const sourceLine = targetLine - *n2;
+                lineAt(targetLine) = std::move(lineAt(sourceLine));
+            }
+
+            for (auto lineNumber = margin.vertical.to - *n2 + 1; lineNumber <= margin.vertical.to;
+                 ++lineNumber)
+                lineAt(lineNumber).reset(defaultLineFlags(), defaultAttributes, _pageSize.columns);
+
+            verifyState();
+            return historyLinesAdded;
+        }
+
         if (*n2 && n2 < marginHeight)
         {
             for (auto topLineOffset = *margin.vertical.from; topLineOffset <= *margin.vertical.to - *n2;

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -360,9 +360,11 @@ LineCount Grid::scrollUp(LineCount n, GraphicsAttributes defaultAttributes, Marg
                 lineAt(targetLine) = std::move(lineAt(sourceLine));
             }
 
-            for (auto lineNumber = margin.vertical.to - *n2 + 1; lineNumber <= margin.vertical.to;
-                 ++lineNumber)
-                lineAt(lineNumber).reset(defaultLineFlags(), defaultAttributes, _pageSize.columns);
+            // Blank the new region rows at the region bottom.
+            for (auto const lineNumber:
+                 std::views::iota(*margin.vertical.to - *n2 + 1, *margin.vertical.to + 1))
+                lineAt(LineOffset(lineNumber))
+                    .reset(defaultLineFlags(), defaultAttributes, _pageSize.columns);
 
             verifyState();
             return historyLinesAdded;

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -1034,8 +1034,17 @@ void Screen::scrollUp(LineCount n, GraphicsAttributes sgr, Margin margin)
 {
     auto const scrollCount = _grid.scrollUp(n, sgr, margin);
     updateCursorIterator();
-    // TODO only call onBufferScrolled if full page margin
-    _terminal->onBufferScrolled(scrollCount);
+
+    // Only notify the viewport/Vi-cursor/selection of a scrollback scroll when the
+    // scroll covered the whole page. A scroll confined to a sub-page margin region
+    // (e.g. a top-anchored partial DECSTBM region) may still feed lines into
+    // scrollback, but the live area below the region did not move, so shifting the
+    // viewport, the Normal-mode cursor, or the active selection would be wrong.
+    auto const isFullPageMargin =
+        margin.horizontal.from.value == 0 && margin.horizontal.to.value + 1 == pageSize().columns.value
+        && margin.vertical.from.value == 0 && margin.vertical.to.value + 1 == pageSize().lines.value;
+    if (isFullPageMargin)
+        _terminal->onBufferScrolled(scrollCount);
 }
 
 void Screen::scrollDown(LineCount n, Margin margin)

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2287,4 +2287,65 @@ TEST_CASE("Terminal.KittyKeyRelease.RepeatStillWorks", "[terminal]")
     CHECK(e(mc.replyData()) == e("\033[1;1:2A"s));
 }
 
+// {{{ Regression tests for top-anchored partial scroll regions (PR #1946)
+TEST_CASE("Terminal.TopAnchoredRegion.PartialScrollKeepsViewportFixed", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(6), ColumnCount(8) }, LineCount(20) };
+    auto& terminal = mc.terminal;
+
+    // Generate scrollback so the viewport can be scrolled up.
+    mc.writeToScreen("h1\r\nh2\r\nh3\r\nh4\r\nh5\r\nh6\r\nh7\r\nh8\r\n");
+    terminal.viewport().scrollUp(LineCount(3));
+    REQUIRE(terminal.viewport().scrolled());
+    auto const scrollOffsetBefore = terminal.viewport().scrollOffset();
+
+    // Top-anchored partial region (rows 1..3), cursor at the region bottom.
+    mc.writeToScreen("\033[1;3r");
+    mc.writeToScreen("\033[3;1H");
+
+    // CSI S (SU) scrolls the region up; the viewport the user scrolled to must
+    // not jump as a side effect.
+    mc.writeToScreen("\033[S");
+
+    CHECK(terminal.viewport().scrollOffset() == scrollOffsetBefore);
+}
+
+TEST_CASE("Terminal.TopAnchoredRegion.PartialScrollDoesNotMoveNormalModeCursor", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(6), ColumnCount(8) }, LineCount(20) };
+    auto& terminal = mc.terminal;
+
+    mc.writeToScreen("r1\r\nr2\r\nr3\r\nr4\r\nr5\r\nr6");
+    terminal.inputHandler().setMode(vtbackend::ViMode::Normal);
+    auto const cursorLineBefore = terminal.normalModeCursorPosition().line;
+
+    // Top-anchored partial region (rows 1..3), cursor at region bottom, then IND.
+    mc.writeToScreen("\033[1;3r");
+    mc.writeToScreen("\033[3;1H");
+    mc.writeToScreen("\033D");
+
+    CHECK(terminal.normalModeCursorPosition().line == cursorLineBefore);
+}
+
+TEST_CASE("Terminal.TopAnchoredRegion.ScrollCountMatchesScrolledLines", "[terminal]")
+{
+    auto mc = MockTerm { PageSize { LineCount(4), ColumnCount(8) }, LineCount(2) };
+    auto& terminal = mc.terminal;
+
+    // Fill history to capacity (2 lines) so further scrolls have no headroom.
+    mc.writeToScreen("a\r\nb\r\nc\r\nd\r\ne\r\nf\r\n");
+    terminal.viewport().scrollUp(LineCount(1));
+    REQUIRE(terminal.viewport().scrolled());
+    auto const scrollOffsetBefore = terminal.viewport().scrollOffset();
+
+    // Top-anchored partial region, cursor at region bottom, scroll it.
+    mc.writeToScreen("\033[1;2r");
+    mc.writeToScreen("\033[2;1H");
+    mc.writeToScreen("\033D");
+
+    // The viewport must not drift by the history/scroll-count mismatch.
+    CHECK(terminal.viewport().scrollOffset() == scrollOffsetBefore);
+}
+// }}}
+
 // NOLINTEND(misc-const-correctness)


### PR DESCRIPTION
## Description

Preserve terminal history when a full width scroll region starts at the top of the page. Previously, scrolling a partial vertical region did not append rows that left the top of the region into scrollback. This change reuses the existing full page scroll path to preserve those rows, then restores rows below the requested scroll region because they are outside the scroll operation

## Related Issues

N/A

## Motivation and Context

Applications can use top anchored scroll regions to move completed output into terminal history while keeping a live area below it. in which case rows leaving the top of the scroll region should remain available in scrollback

## How Has This Been Tested?

Built and ran the existing vtbackend_test suite successfully. I am not aware if/how this specific behavior is unit testable

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented (no breaking changes)
