### PR TITLE
Open detected local paths on Ctrl-click

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -128,6 +128,7 @@
           <li>Fixes numeric capability reporting by XTGETTCAP</li>
           <li>Fixes window snapping back to the configured terminal_size after a screen/DPR change on tiling Wayland compositors (#1941), by initialising the window size from the terminal's implicit size only once on creation instead of using a permanent QML binding</li>
           <li>Fixes scrollback preservation for top anchored full width scroll regions</li>
+          <li>Adds Ctrl-click support for opening detected local filesystem paths under the mouse cursor (#1947)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -630,7 +630,7 @@ void TerminalSession::openDocument(std::string_view fileOrUrl)
     sessionLog()("openDocument: {}\n", fileOrUrl);
     auto const text = QString::fromUtf8(fileOrUrl.data(), static_cast<int>(fileOrUrl.size()));
     auto url = QUrl(text);
-    
+
     if (url.scheme().isEmpty())
     {
         auto const fileInfo = QFileInfo(text);

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -24,6 +24,7 @@
 #include <QtCore/QProcess>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QTimer>
+#include <QtCore/QUrl>
 #include <QtGui/QClipboard>
 #include <QtGui/QDesktopServices>
 #include <QtGui/QGuiApplication>
@@ -627,7 +628,18 @@ void TerminalSession::copyToClipboard(std::string_view data)
 void TerminalSession::openDocument(std::string_view fileOrUrl)
 {
     sessionLog()("openDocument: {}\n", fileOrUrl);
-    QDesktopServices::openUrl(QUrl(QString::fromStdString(std::string(fileOrUrl))));
+    auto const text = QString::fromUtf8(fileOrUrl.data(), static_cast<int>(fileOrUrl.size()));
+    auto url = QUrl(text);
+    
+    if (url.scheme().isEmpty())
+    {
+        auto const fileInfo = QFileInfo(text);
+        if (fileInfo.exists())
+            url = QUrl::fromLocalFile(fileInfo.absoluteFilePath());
+    }
+
+    if (!QDesktopServices::openUrl(url))
+        errorLog()("Could not open document \"{}\".", fileOrUrl);
 }
 
 void TerminalSession::inspect()
@@ -1156,7 +1168,8 @@ void TerminalSession::sendMouseMoveEvent(vtbackend::Modifiers modifiers,
     {
         // Change cursor shape only when changing grid cell.
         _currentMousePosition = pos;
-        if (terminal().isMouseHoveringHyperlink())
+        if (terminal().isMouseHoveringHyperlink()
+            || (modifiers.contains(vtbackend::Modifier::Control) && terminal().localPathAtMousePosition()))
             _display->setMouseCursorShape(MouseCursorShape::PointingHand);
         else
             setDefaultCursor();
@@ -1352,6 +1365,11 @@ bool TerminalSession::operator()(actions::FollowHyperlink)
     if (auto const hyperlink = terminal().tryGetHoveringHyperlink())
     {
         followHyperlink(*hyperlink);
+        return true;
+    }
+    if (auto const path = terminal().localPathAtMousePosition())
+    {
+        openDocument(*path);
         return true;
     }
     return false;

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -9,20 +9,7 @@ using namespace std;
 namespace vtbackend
 {
 
-/// Converts a UTF-8 byte offset within @p text to the corresponding codepoint index.
-///
-/// In the UTF-8 strings produced by Line::toUtf8(), each grid cell emits exactly one
-/// codepoint (wide-character continuation cells emit a space). Therefore the codepoint
-/// index equals the column index for these strings.
-///
-/// @note This function counts UTF-8 leading bytes and does not perform grapheme-cluster
-///       segmentation. The returned index equals a terminal grid column only when the
-///       input was produced by Line::toUtf8(), which guarantees one codepoint per cell.
-///
-/// @param text       The UTF-8 encoded string.
-/// @param byteOffset The byte offset to convert.
-/// @return The number of codepoints before @p byteOffset.
-static constexpr auto utf8ByteOffsetToCodepointIndex(string_view text, size_t byteOffset) noexcept -> size_t
+auto utf8ByteOffsetToCodepointIndex(string_view text, size_t byteOffset) noexcept -> size_t
 {
     auto const limit = min(byteOffset, text.size());
     // Count bytes that are NOT continuation bytes (10xxxxxx).

--- a/src/vtbackend/HintModeHandler.h
+++ b/src/vtbackend/HintModeHandler.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace vtbackend
@@ -140,5 +141,13 @@ class HintModeHandler
 /// Extracts a local filesystem path from a file:// URL (as set by OSC 7).
 /// Returns the URL unchanged if it does not start with "file://".
 [[nodiscard]] auto extractPathFromFileUrl(std::string const& url) -> std::string;
+
+/// Converts a UTF-8 byte offset within @p text to the corresponding codepoint index.
+///
+/// In the UTF-8 strings produced by Line::toUtf8(), each grid cell emits exactly one
+/// codepoint (wide-character continuation cells emit a space). Therefore the codepoint
+/// index equals the column index for these strings.
+[[nodiscard]] auto utf8ByteOffsetToCodepointIndex(std::string_view text, size_t byteOffset) noexcept
+    -> size_t;
 
 } // namespace vtbackend

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -30,6 +30,7 @@
 #include <filesystem>
 #include <format>
 #include <ranges>
+#include <regex>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -54,6 +55,32 @@ namespace vtbackend
 
 namespace // {{{ helpers
 {
+    std::optional<std::string> resolveExistingLocalPath(std::string const& cwd,
+                                                        std::string const& home,
+                                                        std::string const& match)
+    {
+        auto candidate = std::filesystem::path {};
+        if (match.starts_with("/"))
+            candidate = match;
+        else if (match.starts_with("~/"))
+        {
+            if (home.empty())
+                return std::nullopt;
+            candidate = std::filesystem::path(home) / match.substr(2);
+        }
+        else
+        {
+            if (cwd.empty())
+                return std::nullopt;
+            candidate = std::filesystem::path(cwd) / match;
+        }
+
+        auto ec = std::error_code {};
+        if (!std::filesystem::exists(candidate, ec))
+            return std::nullopt;
+        return candidate.lexically_normal().string();
+    }
+
     constexpr size_t MaxColorPaletteSaveStackSize = 10;
 
     void trimSpaceRight(string& value)
@@ -1991,6 +2018,47 @@ void Terminal::copyToClipboard(string_view data)
 void Terminal::openDocument(string_view data)
 {
     _eventListener.openDocument(data);
+}
+
+std::optional<std::string> Terminal::localPathAtMousePosition() const
+{
+    auto const mousePosition = currentMouseGridPosition();
+    if (!mousePosition)
+        return std::nullopt;
+
+    auto const lineText = currentScreen().lineTextAt(mousePosition->line, false, false);
+    auto const mouseColumn = static_cast<size_t>(*mousePosition->column);
+    auto const cwd = extractPathFromFileUrl(currentWorkingDirectory());
+    auto const* const homeEnv = std::getenv("HOME");
+    auto const home = std::string(homeEnv ? homeEnv : "");
+
+    static auto const LocalPathRegex = [] {
+        return std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
+                          std::regex_constants::ECMAScript | std::regex_constants::optimize);
+    }();
+
+    auto matchIter = std::sregex_iterator(lineText.begin(), lineText.end(), LocalPathRegex);
+    auto const matchEnd = std::sregex_iterator();
+    for (; matchIter != matchEnd; ++matchIter)
+    {
+        auto const& match = *matchIter;
+        if (match.empty())
+            continue;
+
+        auto const startColumn =
+            utf8ByteOffsetToCodepointIndex(lineText, static_cast<size_t>(match.position()));
+        auto const endColumn =
+            utf8ByteOffsetToCodepointIndex(lineText, static_cast<size_t>(match.position() + match.length()))
+            - 1;
+            
+        if (mouseColumn < startColumn || mouseColumn > endColumn)
+            continue;
+
+        if (auto path = resolveExistingLocalPath(cwd, home, match.str()))
+            return path;
+    }
+
+    return std::nullopt;
 }
 
 // {{{ Hint mode

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -60,19 +60,19 @@ namespace // {{{ helpers
                                                         std::string const& match)
     {
         auto candidate = std::filesystem::path {};
-        if (match.starts_with("/"))
-            candidate = match;
-        else if (match.starts_with("~/"))
+        if (match.starts_with("~/"))
         {
             if (home.empty())
                 return std::nullopt;
             candidate = std::filesystem::path(home) / match.substr(2);
         }
+        else if (auto const matchPath = std::filesystem::path(match); matchPath.is_absolute())
+            candidate = matchPath;
         else
         {
             if (cwd.empty())
                 return std::nullopt;
-            candidate = std::filesystem::path(cwd) / match;
+            candidate = std::filesystem::path(cwd) / matchPath;
         }
 
         auto ec = std::error_code {};
@@ -2032,12 +2032,17 @@ std::optional<std::string> Terminal::localPathAtMousePosition() const
     auto const* const homeEnv = std::getenv("HOME");
     auto const home = std::string(homeEnv ? homeEnv : "");
 
-    static auto const LocalPathRegex = [] {
-        return std::regex(R"((?:~?/[\w./-]+|\.{1,2}/[\w./-]+|[\w.][\w.-]*/[\w./-]+|[\w.][\w.-]+))",
-                          std::regex_constants::ECMAScript | std::regex_constants::optimize);
+    static auto const localPathRegex = [] {
+        // Matches, in order: drive-letter absolute paths (C:/foo, C:\foo) for Windows,
+        // ~/ home-relative paths, / absolute paths, ./ and ../ relative paths, paths
+        // containing a separator, and bare filenames. Both '/' and '\\' separators are
+        // accepted so native Windows paths are detected as well as POSIX ones.
+        return std::regex(
+            R"((?:[A-Za-z]:[\\/][\w.\\/-]+|~?[\\/][\w.\\/-]+|\.{1,2}[\\/][\w.\\/-]+|[\w.][\w.-]*[\\/][\w.\\/-]+|[\w.][\w.-]+))",
+            std::regex_constants::ECMAScript | std::regex_constants::optimize);
     }();
 
-    auto matchIter = std::sregex_iterator(lineText.begin(), lineText.end(), LocalPathRegex);
+    auto matchIter = std::sregex_iterator(lineText.begin(), lineText.end(), localPathRegex);
     auto const matchEnd = std::sregex_iterator();
     for (; matchIter != matchEnd; ++matchIter)
     {
@@ -2050,7 +2055,7 @@ std::optional<std::string> Terminal::localPathAtMousePosition() const
         auto const endColumn =
             utf8ByteOffsetToCodepointIndex(lineText, static_cast<size_t>(match.position() + match.length()))
             - 1;
-            
+
         if (mouseColumn < startColumn || mouseColumn > endColumn)
             continue;
 

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1087,6 +1087,9 @@ class Terminal
         return {};
     }
 
+    /// Returns the local filesystem path under the mouse cursor, if any.
+    [[nodiscard]] std::optional<std::string> localPathAtMousePosition() const;
+
     [[nodiscard]] ExecutionMode executionMode() const noexcept { return _executionMode; }
     void setExecutionMode(ExecutionMode mode);
 

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -189,11 +189,17 @@ TEST_CASE("Terminal.localPathAtMousePosition", "[terminal]")
     auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
     auto constexpr UiHandledHint = false;
 
+    // Use forward-slash (generic) path forms throughout: that is how OSC-7 delivers the
+    // working directory URL and how the path-detection regex expects paths to look, on every
+    // platform (including Windows, where native paths use backslashes the regex would reject).
+    auto const tmpRootUrl = "file://" + tmpRoot.generic_string();
+    auto const expectedFile = (tmpRoot / "nested" / "file.txt").lexically_normal().string();
+
     SECTION("relative path")
     {
         auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(80) } };
         auto& terminal = mc.terminal;
-        terminal.setCurrentWorkingDirectory("file://" + tmpRoot.string());
+        terminal.setCurrentWorkingDirectory(tmpRootUrl);
         mc.writeToScreen("open nested/file.txt now");
 
         terminal.sendMouseMoveEvent(Modifier::None,
@@ -203,14 +209,14 @@ TEST_CASE("Terminal.localPathAtMousePosition", "[terminal]")
 
         auto const path = terminal.localPathAtMousePosition();
         REQUIRE(path.has_value());
-        CHECK(*path == (tmpRoot / "nested" / "file.txt").string());
+        CHECK(*path == expectedFile);
     }
 
     SECTION("absolute path")
     {
         auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(240) } };
         auto& terminal = mc.terminal;
-        auto const absolutePath = (tmpRoot / "nested" / "file.txt").string();
+        auto const absolutePath = (tmpRoot / "nested" / "file.txt").generic_string();
         mc.writeToScreen("open " + absolutePath);
 
         terminal.sendMouseMoveEvent(Modifier::None,
@@ -220,14 +226,14 @@ TEST_CASE("Terminal.localPathAtMousePosition", "[terminal]")
 
         auto const path = terminal.localPathAtMousePosition();
         REQUIRE(path.has_value());
-        CHECK(*path == absolutePath);
+        CHECK(*path == expectedFile);
     }
 
     SECTION("missing path")
     {
         auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(80) } };
         auto& terminal = mc.terminal;
-        terminal.setCurrentWorkingDirectory("file://" + tmpRoot.string());
+        terminal.setCurrentWorkingDirectory(tmpRootUrl);
         mc.writeToScreen("open nested/missing.txt now");
 
         terminal.sendMouseMoveEvent(Modifier::None,

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -8,23 +8,29 @@
 
 #include <crispy/App.h>
 #include <crispy/times.h>
+#include <crispy/utils.h>
 
 #include <libunicode/convert.h>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <filesystem>
+#include <format>
+#include <fstream>
 #include <string>
 #include <vector>
 
 using namespace std;
 using namespace std::chrono_literals;
 using vtbackend::CellFlag;
+using vtbackend::CellLocation;
 using vtbackend::ColumnCount;
 using vtbackend::ColumnOffset;
 using vtbackend::LineCount;
 using vtbackend::LineOffset;
 using vtbackend::MockTerm;
+using vtbackend::Modifier;
 using vtbackend::PageSize;
 using vtbackend::SmoothScrollResult;
 
@@ -163,6 +169,73 @@ TEST_CASE("Terminal.ModifierKeysDoNotScrollViewport", "[terminal]")
 
             CHECK(terminal.viewport().scrolled());
         }
+    }
+}
+
+TEST_CASE("Terminal.localPathAtMousePosition", "[terminal]")
+{
+    namespace fs = std::filesystem;
+
+    auto const tmpRoot =
+        fs::temp_directory_path()
+        / std::format("contour-local-path-{}", std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(tmpRoot / "nested");
+    {
+        auto file = std::ofstream(tmpRoot / "nested" / "file.txt");
+        file << "test";
+    }
+
+    auto const cleanup = crispy::finally { [&]() { fs::remove_all(tmpRoot); } };
+    auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
+    auto constexpr UiHandledHint = false;
+
+    SECTION("relative path")
+    {
+        auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(80) } };
+        auto& terminal = mc.terminal;
+        terminal.setCurrentWorkingDirectory("file://" + tmpRoot.string());
+        mc.writeToScreen("open nested/file.txt now");
+
+        terminal.sendMouseMoveEvent(Modifier::None,
+                                    CellLocation { .line = LineOffset(0), .column = ColumnOffset(10) },
+                                    PixelCoordinate,
+                                    UiHandledHint);
+
+        auto const path = terminal.localPathAtMousePosition();
+        REQUIRE(path.has_value());
+        CHECK(*path == (tmpRoot / "nested" / "file.txt").string());
+    }
+
+    SECTION("absolute path")
+    {
+        auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(240) } };
+        auto& terminal = mc.terminal;
+        auto const absolutePath = (tmpRoot / "nested" / "file.txt").string();
+        mc.writeToScreen("open " + absolutePath);
+
+        terminal.sendMouseMoveEvent(Modifier::None,
+                                    CellLocation { .line = LineOffset(0), .column = ColumnOffset(8) },
+                                    PixelCoordinate,
+                                    UiHandledHint);
+
+        auto const path = terminal.localPathAtMousePosition();
+        REQUIRE(path.has_value());
+        CHECK(*path == absolutePath);
+    }
+
+    SECTION("missing path")
+    {
+        auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(80) } };
+        auto& terminal = mc.terminal;
+        terminal.setCurrentWorkingDirectory("file://" + tmpRoot.string());
+        mc.writeToScreen("open nested/missing.txt now");
+
+        terminal.sendMouseMoveEvent(Modifier::None,
+                                    CellLocation { .line = LineOffset(0), .column = ColumnOffset(10) },
+                                    PixelCoordinate,
+                                    UiHandledHint);
+
+        CHECK_FALSE(terminal.localPathAtMousePosition().has_value());
     }
 }
 


### PR DESCRIPTION
## Description

Add ctrl click support for opening detected local filesystem paths. when no OSC 8 hyperlink is under the mouse, FollowHyperlink now falls back to matching a local path under the cursor. Existing relative paths are resolved against the terminal working directory and local paths are opened via the platform file URL path

## Related Issues

N/A

## Motivation and Context

There are often paths on the terminal such as build artifacts, logs, or directories that are useful to open directly

## How Has This Been Tested?

Added backend coverage for ctrl click path detection of relative existing paths, absolute existing paths, as well as missing paths

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented
