### PR TITLE
Bugfix XTGETTCAP reporting of numeric capabilities

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -125,6 +125,7 @@
           <li>Fixes loading of optional fields in the config file (#1940)</li>
           <li>Fixes std::simd feature test for GCC 16 compiler</li>
           <li>Fixes sixel crash in sixel parser caused by aspect ratio miscalculation (#1945)</li>
+          <li>Fixes numeric capability reporting by XTGETTCAP (#XXX)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -2617,12 +2617,7 @@ void Screen::requestCapability(std::string_view name)
     if (booleanCapability(name))
         reply("\033P1+r{}\033\\", toHexString(name));
     else if (auto const value = numericCapability(name); value != Database::Npos)
-    {
-        auto hexValue = std::format("{:X}", value);
-        if (hexValue.size() % 2)
-            hexValue.insert(hexValue.begin(), '0');
-        reply("\033P1+r{}={}\033\\", toHexString(name), hexValue);
-    }
+        reply("\033P1+r{}={}\033\\", toHexString(name), asHex(std::to_string(value)));
     else if (auto const value = stringCapability(name); !value.empty())
         reply("\033P1+r{}={}\033\\", toHexString(name), asHex(value));
     else
@@ -2634,12 +2629,7 @@ void Screen::requestCapability(capabilities::Code code)
     if (booleanCapability(code))
         reply("\033P1+r{}\033\\", code.hex());
     else if (auto const value = numericCapability(code); value >= 0)
-    {
-        auto hexValue = std::format("{:X}", value);
-        if (hexValue.size() % 2)
-            hexValue.insert(hexValue.begin(), '0');
-        reply("\033P1+r{}={}\033\\", code.hex(), hexValue);
-    }
+        reply("\033P1+r{}={}\033\\", code.hex(), asHex(std::to_string(value)));
     else if (auto const value = stringCapability(code); !value.empty())
         reply("\033P1+r{}={}\033\\", code.hex(), asHex(value));
     else

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -3598,13 +3598,58 @@ TEST_CASE("OSC.4")
 TEST_CASE("XTGETTCAP")
 {
     auto mock = MockTerm { PageSize { LineCount(2), ColumnCount(2) } };
-    auto const queryStr = std::format("\033P+q{:02X}{:02X}{:02X}\033\\", 'R', 'G', 'B');
-    mock.writeToScreen(queryStr);
-    INFO(std::format("Reply data: {}", mock.terminal.peekInput()));
-    // "\033P1+r8/8/8\033\\"
-    // TODO: CHECK(...)
-}
 
+    // Decodes the hex-encoded value from a valid XTGETTCAP response
+    // "\033P1+r<hex-name>[=<hex-value>]\033\\"
+    auto const extractValue = [](std::string_view reply) -> std::optional<std::string> {
+        auto const eq = reply.find('=');
+        if (eq == std::string_view::npos)
+            return std::nullopt;
+        auto const st = reply.find("\033\\", eq);
+        if (st == std::string_view::npos)
+            return std::nullopt;
+        return crispy::fromHexString(reply.substr(eq + 1, st - eq - 1));
+    };
+
+    auto const queryValue = [&](std::string_view name) -> std::optional<std::string> {
+        mock.resetReplyData();
+        mock.writeToScreen(std::format("\033P+q{}\033\\", crispy::toHexString(name)));
+        auto const reply = std::string(mock.terminal.peekInput());
+        INFO(std::format("Reply: {}", crispy::escape(reply)));
+        if (!reply.starts_with("\033P1+r"))
+            return std::nullopt;
+        return extractValue(reply);
+    };
+
+    SECTION("string: RGB")
+    {
+        auto const value = queryValue("RGB");
+        REQUIRE(value.has_value());
+        CHECK(*value == "8/8/8");
+    }
+
+    SECTION("numeric: colors")
+    {
+        auto const value = queryValue("colors");
+        REQUIRE(value.has_value());
+        CHECK(*value == "256");
+    }
+
+    SECTION("boolean: am")
+    {
+        auto const value = queryValue("am");
+        // Boolean capabilities respond with just the name, no =value.
+        CHECK(!value.has_value());
+    }
+
+    SECTION("nonexistent")
+    {
+        mock.resetReplyData();
+        mock.writeToScreen(std::format("\033P+q{:02X}{:02X}\033\\", 'x', 'x'));
+        // Note how 'xx' is not in the return reply, meaning "not found"
+        CHECK(std::string(mock.terminal.peekInput()) == "\033P0+r\033\\");
+    }
+}
 TEST_CASE("setMaxHistoryLineCount", "[screen]")
 {
     // from zero to something


### PR DESCRIPTION
## Description

Contour is the only terminal of the 15 terminals tested for numeric capabilities using XTGETTCAP
that reports values as raw bytes, for example, "Co" is encoded as "\x01\0", but should be 256:

    contour: Co: "\x01\0"

This change allows contour to match all other terminals tested:

    AbsoluteTelnetSSH: Co: '256'
    foot: Co: '256'
    ghostty: Co: '256'
    gnometerminal: Co: '256'
    iterm2: Co: '256'
    kitty: Co: '256'
    lxterminal: Co: '256'
    mlterm: Co: '256'
    rio: Co: '256'
    terminator: Co: '256'
    termit: Co: '256'
    wezterm: Co: '256'
    xfce4terminal: Co: '256'
    xterm: Co: '256'

## Related Issues

None

## Motivation and Context

I wrote my own terminal library, 'blessed', and testing utility, 'ucs-detect', where this problem
has caused me grief, rather than write strange workarounds, I wish to solve it at its source.

It is important to have correct transfer of XTGETTCAP, to allow TUI programs to have "curses-free"
access to capabilities, as described https://codeberg.org/dnkl/foot#xtgettcap

> Foot supports this, and extends it even further, to also include boolean capabilities. This means
> foot's entire terminfo can be queried via XTGETTCAP.

## How Has This Been Tested?

with the given automatic tests and manual testing

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented
