### PR TITLE
Fix window snapping back to implicit size after screen/DPR change

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -125,6 +125,7 @@
           <li>Fixes loading of optional fields in the config file (#1940)</li>
           <li>Fixes std::simd feature test for GCC 16 compiler</li>
           <li>Fixes sixel crash in sixel parser caused by aspect ratio miscalculation (#1945)</li>
+          <li>Fixes window snapping back to the configured terminal_size after a screen/DPR change on tiling Wayland compositors (#1941), by initialising the window size from the terminal's implicit size only once on creation instead of using a permanent QML binding</li>
         </ul>
       </description>
     </release>

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -24,8 +24,17 @@ ApplicationWindow
     // title: "%1 - Contour".arg(vtui.session.title)
     title: vtui.title
 
-    width: vtui.implicitWidth
-    height: vtui.implicitHeight
+    // Initialise the window size from the terminal's implicit (configured)
+    // size once on creation. Do not use a binding (`width: vtui.implicitWidth`)
+    // because that would re-evaluate every time implicitWidth changes — e.g.
+    // when updateImplicitSize() runs after a screen/DPR change — and snap the
+    // window back to the implicit size, overriding any WM-assigned geometry.
+    // Tiling WMs that resize the window to a tile, and users who resize
+    // manually, expect the window to keep its assigned size.
+    Component.onCompleted: {
+        width = vtui.implicitWidth
+        height = vtui.implicitHeight
+    }
 
     Terminal {
         id: vtui


### PR DESCRIPTION
## Description

The `ApplicationWindow` in `src/contour/ui/main.qml` had permanent QML bindings:

```qml
width: vtui.implicitWidth
height: vtui.implicitHeight
```

These bindings re-evaluate every time `implicitWidth` / `implicitHeight` change. After the window is placed by the compositor and contour's `onScreenChanged()` handler runs, `applyFontDPI()` calls `updateImplicitSize()` which sets the implicit size back to the configured `terminal_size` (e.g. 800x525 virtual px for 80x25 at DPR 1). The QML binding then snaps the window back to that size, overriding the WM-assigned tile geometry.

This is what was happening on river (notion-river) — `propose_dimensions(1436, 1183)` was honoured for the first surface commit, then the screen-change handler fired and the window committed again at 800x525.

## Related Issues

Fixes #1941.

Note: #1908 / PR #1904 attempted to fix the same class of bug for Hyprland by adding a guard against "stale" Wayland configure reversions in `sizeChanged()`. That guard is independent of this fix and is not affected — the actual size revert in the river case happens via the QML binding, not via the stale-configure path.

## Motivation and Context

Tiling WMs (river, hyprland, sway, ...) assign window geometry explicitly. The terminal must respect that. With a permanent `width: implicitWidth` binding, any code path that recomputes `implicitWidth` (DPR change, font change, screen change) overrides the WM-assigned size, leaving the terminal stuck at the configured `terminal_size` until the user manually resizes the tile.

Floating WMs also benefit: a font-size change no longer auto-resizes the window. This matches the behaviour of every other terminal (foot, alacritty, kitty, gnome-terminal, xterm).

## How the fix works

Replace the bindings with a one-shot `Component.onCompleted` initialisation:

```qml
Component.onCompleted: {
    width = vtui.implicitWidth
    height = vtui.implicitHeight
}
```

Direct assignment in JavaScript breaks the QML binding immediately, so subsequent changes to `implicitWidth` no longer propagate to the window. The window still opens at the configured `terminal_size` on first show.

## How Has This Been Tested?

- Built on Linux (openSUSE Tumbleweed, GCC 15, Qt 6, Wayland/river).
- Verified the original bug reproduces on master (38e543a7): contour spawned in a river tile commits at the WM-assigned size, then a second commit drops it to 800x525.
- Verified the fix: contour spawned in the same tile commits at the WM-assigned size and stays there. Subsequent re-tiling, focus changes and font-size changes (Ctrl+= / Ctrl+−) all leave the WM-assigned geometry intact.
- Floating-WM smoke test pending — submitting as draft so a maintainer can sanity-check on KDE/Gnome before merging.

## Checklist

- [x] I have read the **CONTRIBUTING** guide
- [x] I have updated the documentation accordingly (metainfo.xml release notes)
- [ ] I have added tests to cover my changes (QML window-sizing behaviour is not currently covered by the test suite; happy to add one if you can point me at the right place)
- [x] Breaking changes (if any) are documented — minor UX change: font-size changes no longer auto-resize the window, matching all other terminals