### PR TITLE
Fix terminal grid not syncing to tile size on tiling WMs

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -129,6 +129,7 @@
           <li>Fixes window snapping back to the configured terminal_size after a screen/DPR change on tiling Wayland compositors (#1941), by initialising the window size from the terminal's implicit size only once on creation instead of using a permanent QML binding</li>
           <li>Fixes scrollback preservation for top anchored full width scroll regions</li>
           <li>Adds Ctrl-click support for opening detected local filesystem paths under the mouse cursor (#1947)</li>
+          <li>Fixes terminal grid not syncing to the window tile size on tiling Wayland compositors, where a freshly-spawned terminal was mis-sized until a manual resize (#1955)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -402,8 +402,17 @@ void TerminalDisplay::sizeChanged()
     // size (the window dimensions before DPR correction in createRenderer). This is more
     // specific than checking against implicitSize, which would also falsely trigger on
     // intentional WM-driven resizes (e.g. tiling WM assigning the window a tile size).
-    if (steady_clock::now() < _initialResizeDeadline && std::abs(width() - _lastVirtualWidth) <= 0.5
-        && std::abs(height() - _lastVirtualHeight) <= 0.5)
+    //
+    // Crucially, only treat the saved size as "stale" if the implicit size has
+    // actually changed since createRenderer() — i.e. a DPR correction really
+    // happened. Without that check, a tiling WM that maps the window directly at
+    // its tile size (so width() == _lastVirtual* with no DPR correction) is
+    // wrongly "corrected" down to the implicit 80x25, leaving a tiny near-square
+    // window until a manual resize.
+    auto const implicitSizeChanged = std::abs(implicitWidth() - _initialImplicitWidth) > 0.5
+                                     || std::abs(implicitHeight() - _initialImplicitHeight) > 0.5;
+    if (steady_clock::now() < _initialResizeDeadline && implicitSizeChanged
+        && std::abs(width() - _lastVirtualWidth) <= 0.5 && std::abs(height() - _lastVirtualHeight) <= 0.5)
     {
         displayLog()("Correcting initial window size from {}x{} (stale) to {}x{} (implicit)",
                      width(),
@@ -705,6 +714,26 @@ void TerminalDisplay::onBeforeSynchronize()
     _renderTarget->setModelMatrix(createModelMatrix());
     _renderTarget->setTranslation(float(x() * dpr), float(y() * dpr), float(z() * dpr));
     _renderTarget->setViewSize(viewSize);
+
+    // Reconcile the terminal grid (page size) with the actual surface.
+    //
+    // This runs on the render thread and sets the render viewport from the live
+    // window()->size(). The grid (page size) is computed separately by the GUI-
+    // thread sizeChanged()/applyResize(). At initial map under a tiling WM the
+    // final surface size can arrive here after sizeChanged() last ran, leaving the
+    // grid at a stale, larger page size than the viewport — so the bottom rows
+    // render off-screen until a manual resize nudges sizeChanged() again.
+    //
+    // Detect that divergence and post a sizeChanged() to the GUI thread (where the
+    // resize must happen). applyResize() no-ops when the page size already matches,
+    // and the per-frame cost when in sync is a single page-size comparison.
+    auto const expectedPageSize = pageSizeForPixels(
+        viewSize, _renderer->gridMetrics().cellSize, applyContentScale(profile().margins.value(), dpr));
+    if (expectedPageSize != _session->terminal().totalPageSize())
+        post([this]() {
+            if (_session && _renderTarget && window())
+                sizeChanged();
+        });
 }
 
 void TerminalDisplay::createRenderer()
@@ -720,6 +749,13 @@ void TerminalDisplay::createRenderer()
     // tile size) as reversions.
     _lastVirtualWidth = width();
     _lastVirtualHeight = height();
+
+    // Snapshot the implicit size before applyFontDPI() may recompute it. The
+    // stale-geometry correction in sizeChanged() compares against this to tell a
+    // real DPR-correction reversion (implicit size changed) from a legitimate
+    // WM-assigned size that simply hasn't changed (implicit size unchanged).
+    _initialImplicitWidth = implicitWidth();
+    _initialImplicitHeight = implicitHeight();
 
     // Catch DPR corrections that occurred between setSession() and first render
     // (e.g., Qt correcting from integer-ceiling DPR=2 to actual fractional DPR=1.5

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -265,6 +265,12 @@ class TerminalDisplay: public QQuickItem
     std::chrono::steady_clock::time_point _initialResizeDeadline {};
     double _lastVirtualWidth {};
     double _lastVirtualHeight {};
+    // Implicit (configured) size snapshot taken in createRenderer(). The stale-
+    // geometry correction in sizeChanged() only applies when the implicit size has
+    // since changed (i.e. a DPR correction actually happened) — otherwise the saved
+    // _lastVirtual* size is legitimate (e.g. a tiling WM's tile) and must be kept.
+    double _initialImplicitWidth {};
+    double _initialImplicitHeight {};
     text::DPI _lastFontDPI;
 #if !defined(__APPLE__) && !defined(_WIN32)
     mutable std::optional<double> _lastReportedContentScale;

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -2,6 +2,7 @@
 #include <vtbackend/HintModeHandler.h>
 
 #include <algorithm>
+#include <cctype>
 #include <ranges>
 
 using namespace std;
@@ -266,13 +267,27 @@ auto extractPathFromFileUrl(std::string const& url) -> std::string
     if (!url.starts_with(Prefix))
         return url;
     auto remainder = url.substr(Prefix.size());
-    // file:///path → /path  ;  file://host/path → /path
+
+    // A Windows drive-letter authority (e.g. file://C:/path) is not a real host: keep it.
+    auto const isDriveLetterPath = [](std::string_view path) {
+        return path.size() >= 2 && (std::isalpha(static_cast<unsigned char>(path[0])) != 0) && path[1] == ':';
+    };
+
+    // file:///path → /path  ;  file://host/path → /path  ;  file://C:/path → C:/path
     if (!remainder.empty() && remainder[0] != '/')
     {
+        if (isDriveLetterPath(remainder))
+            return std::string(remainder);
         if (auto const pos = remainder.find('/'); pos != std::string::npos)
             return std::string(remainder.substr(pos));
         return {};
     }
+
+    // file:///C:/path → C:/path : strip the leading slash before a Windows drive letter so the
+    // resulting string is a valid native absolute path rather than a rooted POSIX-looking one.
+    if (remainder.size() >= 3 && remainder[0] == '/' && isDriveLetterPath(remainder.substr(1)))
+        return std::string(remainder.substr(1));
+
     return std::string(remainder);
 }
 

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -556,6 +556,16 @@ TEST_CASE("extractPathFromFileUrl.FileUrlWithHost", "[hintmode]")
     CHECK(extractPathFromFileUrl("file://hostname") == "");
 }
 
+TEST_CASE("extractPathFromFileUrl.WindowsDriveLetter", "[hintmode]")
+{
+    // A Windows drive-letter authority must not be mistaken for a host and stripped.
+    CHECK(extractPathFromFileUrl("file://C:/Users/user/file.txt") == "C:/Users/user/file.txt");
+    // The standards-conformant form has an empty authority and a leading slash before the drive.
+    CHECK(extractPathFromFileUrl("file:///C:/Users/user/file.txt") == "C:/Users/user/file.txt");
+    // Lower-case drive letters are equally valid.
+    CHECK(extractPathFromFileUrl("file://d:/temp/x") == "d:/temp/x");
+}
+
 TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")
 {
     namespace fs = std::filesystem;

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2036,9 +2036,11 @@ std::optional<std::string> Terminal::localPathAtMousePosition() const
         // Matches, in order: drive-letter absolute paths (C:/foo, C:\foo) for Windows,
         // ~/ home-relative paths, / absolute paths, ./ and ../ relative paths, paths
         // containing a separator, and bare filenames. Both '/' and '\\' separators are
-        // accepted so native Windows paths are detected as well as POSIX ones.
+        // accepted so native Windows paths are detected as well as POSIX ones. A literal '~'
+        // is allowed inside path components so Windows 8.3 short names (e.g. RUNNER~1) and
+        // tilde-suffixed backup files (e.g. file~) are matched in full rather than truncated.
         return std::regex(
-            R"((?:[A-Za-z]:[\\/][\w.\\/-]+|~?[\\/][\w.\\/-]+|\.{1,2}[\\/][\w.\\/-]+|[\w.][\w.-]*[\\/][\w.\\/-]+|[\w.][\w.-]+))",
+            R"((?:[A-Za-z]:[\\/][\w.~\\/-]+|~?[\\/][\w.~\\/-]+|\.{1,2}[\\/][\w.~\\/-]+|[\w.][\w.~-]*[\\/][\w.~\\/-]+|[\w.][\w.~-]+))",
             std::regex_constants::ECMAScript | std::regex_constants::optimize);
     }();
 

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -229,6 +229,35 @@ TEST_CASE("Terminal.localPathAtMousePosition", "[terminal]")
         CHECK(*path == expectedFile);
     }
 
+    SECTION("absolute path with tilde in a component")
+    {
+        // Windows resolves long user names to 8.3 short names containing a '~'
+        // (e.g. C:\Users\RUNNER~1\...). The detection regex must keep such a component
+        // intact instead of truncating the match at the tilde. A directory literally
+        // named "short~1" reproduces the same shape on every platform.
+        auto const shortDir = tmpRoot / "short~1";
+        fs::create_directories(shortDir);
+        {
+            auto file = std::ofstream(shortDir / "file.txt");
+            file << "test";
+        }
+        auto const tildePath = (shortDir / "file.txt").generic_string();
+        auto const expectedTildeFile = (shortDir / "file.txt").lexically_normal().string();
+
+        auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(240) } };
+        auto& terminal = mc.terminal;
+        mc.writeToScreen("open " + tildePath);
+
+        terminal.sendMouseMoveEvent(Modifier::None,
+                                    CellLocation { .line = LineOffset(0), .column = ColumnOffset(8) },
+                                    PixelCoordinate,
+                                    UiHandledHint);
+
+        auto const path = terminal.localPathAtMousePosition();
+        REQUIRE(path.has_value());
+        CHECK(*path == expectedTildeFile);
+    }
+
     SECTION("missing path")
     {
         auto mc = MockTerm { PageSize { LineCount(2), ColumnCount(80) } };


### PR DESCRIPTION
On tiling Wayland WMs (reproduced on river), a freshly-spawned terminal is mis-sized until a manual resize, due to two related faults:

1. The stale-geometry correction in `sizeChanged()` (added in #1904) misfires on a legitimate WM-assigned tile size, force-resizing the window down to the implicit/configured size (e.g. 80x25). It now only triggers when the implicit size actually changed since `createRenderer()` (i.e. a real DPR correction).

2. `onBeforeSynchronize()` sets the render viewport from the live window size, but the grid/page size is computed separately on the GUI thread; at initial map the grid can be left larger than the viewport (e.g. 131x67 cells in a ~98x50 viewport), so bottom rows render off-screen. It now posts a `sizeChanged()` to reconcile when the page size diverges; `applyResize()` no-ops when already in sync (verified no resize loop while idle).