### PR TITLE
refactoring: PtyHandles in UnixPty moved from public interface

### DIFF
--- a/src/vtpty/UnixPty.cpp
+++ b/src/vtpty/UnixPty.cpp
@@ -58,7 +58,13 @@ namespace vtpty
 
 namespace
 {
-    UnixPty::PtyHandles createUnixPty(PageSize const& windowSize, optional<ImageSize> pixels)
+    struct PtyHandles
+    {
+        PtyMasterHandle master;
+        PtySlaveHandle slave;
+    };
+
+    PtyHandles createUnixPty(PageSize const& windowSize, optional<ImageSize> pixels)
     {
         // See https://code.woboq.org/userspace/glibc/login/forkpty.c.html
         assert(std::cmp_less_equal(unbox(windowSize.lines), numeric_limits<unsigned short>::max()));

--- a/src/vtpty/UnixPty.h
+++ b/src/vtpty/UnixPty.h
@@ -42,12 +42,6 @@ class UnixPty final: public Pty
     };
 
   public:
-    struct PtyHandles
-    {
-        PtyMasterHandle master;
-        PtySlaveHandle slave;
-    };
-
     UnixPty(PageSize pageSize, std::optional<ImageSize> pixels);
     ~UnixPty() override;
 


### PR DESCRIPTION
PtyHandles was in public interface, but used only in one .cpp file and should better be defined only there

## Description

what: Moved PtyHandles struct containing two fields from public interface of UnixPty.
why: It polluted UnixPty public interface.

## Motivation and Context

Well just makes the codebase better

## How Has This Been Tested?

Does not need to be tested

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented
