### PR TITLE
ci: fall back to ad-hoc macOS signing on feature branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,7 +420,18 @@ jobs:
           ./scripts/ci-set-vars.sh
           # Please read the following link on how to use MacOS code signing on Github CI:
           # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
-          echo "CODE_SIGN_CERTIFICATE_ID=Developer ID Application: Christian Parpart (6T525MU9UR)" >> "$GITHUB_OUTPUT"
+          #
+          # The signing certificate is only imported into the keychain on master and
+          # release branches (see the "Install the Apple certificate" step below). On
+          # ordinary feature-branch PRs the certificate is unavailable, so attempting to
+          # sign with the Developer ID would fail packaging with
+          # "The specified item could not be found in the keychain.". In that case we fall
+          # back to ad-hoc signing ("-"), which lets cpack produce an unsigned package.
+          if [ "$GITHUB_REF" = "refs/heads/master" ] || [ "$GITHUB_HEAD_REF" = "release" ]; then
+            echo "CODE_SIGN_CERTIFICATE_ID=Developer ID Application: Christian Parpart (6T525MU9UR)" >> "$GITHUB_OUTPUT"
+          else
+            echo "CODE_SIGN_CERTIFICATE_ID=-" >> "$GITHUB_OUTPUT"
+          fi
         env:
           REPOSITORY: ${{ github.event.repository.name }}
       - name: Install the Apple certificate and provisioning profile


### PR DESCRIPTION
## Problem

The `macOSArm` CI job fails on every feature-branch PR at the **Create Package(s)** step:

```
error: The specified item could not be found in the keychain.
...
contour.app: code has no resources but signature indicates they must be present
CPack Error: Error when generating package: Contour
```

## Root cause

The **Install the Apple certificate** step is gated on:

```yaml
if: github.ref == 'refs/heads/master' || github.head_ref == 'release'
```

so the Developer ID certificate is never imported into the keychain on ordinary PR branches. The CMake configure step, however, unconditionally passed:

```
-DCODE_SIGN_CERTIFICATE_ID="Developer ID Application: Christian Parpart (6T525MU9UR)"
```

`cpack` then tried to codesign `contour.app` with a certificate that wasn't present → failure. This is purely a CI/infra issue, unrelated to any source change.

## Fix

Compute `CODE_SIGN_CERTIFICATE_ID` using the same condition that guards the certificate import: use the real Developer ID on `master`/`release`, and fall back to ad-hoc signing (`-`, the CMake default in `src/contour/CMakeLists.txt`) elsewhere. Feature-branch PRs now produce an **unsigned** package instead of failing.

## Risk

Low. Behavior on `master`/`release` is unchanged (real signing still used). Only feature-branch packaging changes — from "fails" to "unsigned but succeeds".