### PR TITLE
[clang-tidy] Enforce CamelCase for constexpr and static const member variables

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -126,8 +126,10 @@ CheckOptions:
     value:           '_'
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           CamelCase
   - key:             readability-identifier-naming.ClassMemberCase
-    value:           camelBack
+    value:           CamelCase
   - key:             readability-identifier-naming.PublicMemberCase
     value:           camelBack
   - key:             readability-identifier-naming.PrivateMemberCase

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -2645,13 +2645,13 @@ std::string createKeyMapping(Config const& c)
     {
         const auto _ = typename Writer::Offset {};
         for (auto&& entry: c.inputMappings.value().keyMappings)
-            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::levels * Writer::OneOffset));
+            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::Levels * Writer::OneOffset));
 
         for (auto&& entry: c.inputMappings.value().charMappings)
-            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::levels * Writer::OneOffset));
+            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::Levels * Writer::OneOffset));
 
         for (auto&& entry: c.inputMappings.value().mouseMappings)
-            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::levels * Writer::OneOffset));
+            doc.append(Writer::addOffset(writer.format(entry), Writer::Offset::Levels * Writer::OneOffset));
     }
 
     return doc;

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -1096,9 +1096,9 @@ struct Writer
 
     struct Offset
     {
-        static inline int levels = 0;
-        Offset() { levels++; }
-        ~Offset() { --levels; }
+        static inline int Levels = 0;
+        Offset() { Levels++; }
+        ~Offset() { --Levels; }
     };
 
     template <typename F>
@@ -1503,14 +1503,14 @@ struct YAMLConfigWriter: Writer
     template <typename... T>
     std::string process(std::string_view doc, T... val)
     {
-        return format(addOffset(replaceCommentPlaceholder(std::string { doc }), Offset::levels * OneOffset),
+        return format(addOffset(replaceCommentPlaceholder(std::string { doc }), Offset::Levels * OneOffset),
                       val...);
     }
 
     template <typename... T>
     std::string process(std::string_view doc, [[maybe_unused]] std::string_view name, T... val)
     {
-        return format(addOffset(replaceCommentPlaceholder(std::string { doc }), Offset::levels * OneOffset),
+        return format(addOffset(replaceCommentPlaceholder(std::string { doc }), Offset::Levels * OneOffset),
                       val...);
     }
 

--- a/src/vtbackend/ColorPalette.cpp
+++ b/src/vtbackend/ColorPalette.cpp
@@ -28,7 +28,7 @@ namespace
     }
 } // namespace
 
-ColorPalette::Palette const ColorPalette::defaultColorPalette = []() constexpr {
+ColorPalette::Palette const ColorPalette::DefaultColorPalette = []() constexpr {
     ColorPalette::Palette colors;
 
     // normal colors

--- a/src/vtbackend/ColorPalette.h
+++ b/src/vtbackend/ColorPalette.h
@@ -63,9 +63,9 @@ struct ColorPalette
     /// TODO: And even the naming sounds wrong. Better would be makeIndexedColorsBrightForBoldText or similar.
     bool useBrightColors = false;
 
-    static Palette const defaultColorPalette;
+    static Palette const DefaultColorPalette;
 
-    Palette palette = defaultColorPalette;
+    Palette palette = DefaultColorPalette;
 
     [[nodiscard]] RGBColor normalColor(size_t index) const noexcept
     {

--- a/src/vtbackend/Viewport.cpp
+++ b/src/vtbackend/Viewport.cpp
@@ -12,7 +12,7 @@ namespace vtbackend
 
 bool Viewport::scrollUp(LineCount numLines)
 {
-    viewportLog()("scrollUp");
+    ViewportLog()("scrollUp");
     auto offset =
         std::min(_scrollOffset + numLines.as<ScrollOffset>(), boxed_cast<ScrollOffset>(historyLineCount()));
     return scrollTo(offset);
@@ -21,19 +21,19 @@ bool Viewport::scrollUp(LineCount numLines)
 bool Viewport::scrollDown(LineCount numLines)
 {
 
-    viewportLog()("scrollDown");
+    ViewportLog()("scrollDown");
     return scrollTo(std::max(_scrollOffset - numLines.as<ScrollOffset>(), ScrollOffset(0)));
 }
 
 bool Viewport::scrollToTop()
 {
-    viewportLog()("scrollToTop");
+    ViewportLog()("scrollToTop");
     return scrollTo(boxed_cast<ScrollOffset>(historyLineCount()));
 }
 
 bool Viewport::scrollToBottom()
 {
-    viewportLog()("scrollToBottom");
+    ViewportLog()("scrollToBottom");
     if (scrollingDisabled())
         return false;
 
@@ -42,7 +42,7 @@ bool Viewport::scrollToBottom()
 
 bool Viewport::forceScrollToBottom()
 {
-    viewportLog()("force ScrollToBottom");
+    ViewportLog()("force ScrollToBottom");
     bool changed = scrollTo(ScrollOffset(0));
     if (_pixelOffset != 0.0f)
     {
@@ -56,7 +56,7 @@ bool Viewport::forceScrollToBottom()
 
 bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset)
 {
-    viewportLog()("makeVisibleWithinSafeArea");
+    ViewportLog()("makeVisibleWithinSafeArea");
     return makeVisibleWithinSafeArea(lineOffset, _scrollOff);
 }
 
@@ -81,7 +81,7 @@ bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset, LineCount paddin
     auto const viewportBottom = boxed_cast<LineOffset>(screenLineCount() - 1) - _scrollOffset.as<int>()
                                 - boxed_cast<LineOffset>(paddingLines);
 
-    viewportLog()("viewportTop {} viewportBottom {} lineOffset {}", viewportTop, viewportBottom, lineOffset);
+    ViewportLog()("viewportTop {} viewportBottom {} lineOffset {}", viewportTop, viewportBottom, lineOffset);
     // Is the line above the viewport?
     if (!(viewportTop < lineOffset))
         return scrollUp(LineCount::cast_from(viewportTop - lineOffset));
@@ -95,13 +95,13 @@ bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset, LineCount paddin
 
 bool Viewport::makeVisible(LineOffset lineOffset)
 {
-    viewportLog()("makeVisible {}", unbox(lineOffset));
+    ViewportLog()("makeVisible {}", unbox(lineOffset));
     return makeVisibleWithinSafeArea(lineOffset, LineCount(0));
 }
 
 bool Viewport::scrollTo(ScrollOffset offset)
 {
-    viewportLog()("scroll to {}", offset);
+    ViewportLog()("scroll to {}", offset);
     if (scrollingDisabled() && offset != ScrollOffset(0))
         return false;
 
@@ -110,19 +110,19 @@ bool Viewport::scrollTo(ScrollOffset offset)
 
     if (0 <= *offset && offset <= boxed_cast<ScrollOffset>(historyLineCount()))
     {
-        viewportLog()("Scroll to offset {}", offset);
+        ViewportLog()("Scroll to offset {}", offset);
         _scrollOffset = offset;
         _modified();
         return true;
     }
 
-    viewportLog()("Scroll to offset {} ignored. Out of bounds.", offset);
+    ViewportLog()("Scroll to offset {} ignored. Out of bounds.", offset);
     return false;
 }
 
 bool Viewport::scrollMarkUp()
 {
-    viewportLog()("Scroll to Mark Down");
+    ViewportLog()("Scroll to Mark Down");
     if (scrollingDisabled())
         return false;
 
@@ -136,7 +136,7 @@ bool Viewport::scrollMarkUp()
 
 bool Viewport::scrollMarkDown()
 {
-    viewportLog()("Scroll to Mark Down");
+    ViewportLog()("Scroll to Mark Down");
     if (scrollingDisabled())
         return false;
 

--- a/src/vtbackend/Viewport.h
+++ b/src/vtbackend/Viewport.h
@@ -16,7 +16,7 @@ namespace vtbackend
 class Viewport
 {
   public:
-    static auto inline const viewportLog = logstore::category("vt.viewport", "Logs viewport details.");
+    static auto inline const ViewportLog = logstore::category("vt.viewport", "Logs viewport details.");
 
     using ModifyEvent = std::function<void()>;
 

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -1517,12 +1517,12 @@ namespace detail
 
             static bool isBraille(char32_t codepoint)
             {
-                return style != Style::Font and codepoint >= 0x2800 and codepoint <= 0x28FF;
+                return CurrentStyle != Style::Font and codepoint >= 0x2800 and codepoint <= 0x28FF;
             }
 
             using Style = BoxDrawingRenderer::BrailleStyle;
-            inline static Style style = Style::Circle;
-            static void setStyle(Style newStyle) { style = newStyle; }
+            inline static Style CurrentStyle = Style::Circle;
+            static void setStyle(Style newStyle) { CurrentStyle = newStyle; }
 
             static auto build(char32_t codepoint,
                               ImageSize size,
@@ -1530,16 +1530,17 @@ namespace detail
                               [[maybe_unused]] size_t ss)
             {
                 uint8_t const value = codepoint - 0x2800;
-                switch (style)
+                switch (CurrentStyle)
                 {
                     using enum Style;
                     case Solid: return buildSolid(value, size);
                     case Circle: [[fallthrough]];
-                    case CircleEmpty: return buildCircle(value, size, th, ss, style == CircleEmpty);
+                    case CircleEmpty: return buildCircle(value, size, th, ss, CurrentStyle == CircleEmpty);
                     case Square: [[fallthrough]];
-                    case SquareEmpty: return buildSquare(value, size, th, 1, style == SquareEmpty);
+                    case SquareEmpty: return buildSquare(value, size, th, 1, CurrentStyle == SquareEmpty);
                     case AASquare: [[fallthrough]];
-                    case AASquareEmpty: return buildSquare(value, size, th, ss, style == AASquareEmpty);
+                    case AASquareEmpty:
+                        return buildSquare(value, size, th, ss, CurrentStyle == AASquareEmpty);
                     case Font: (void) SoftRequire(false); return atlas::Buffer(*size.width * *size.height);
                 }
                 (void) SoftRequire(false);
@@ -1745,7 +1746,7 @@ void BoxDrawingRenderer::setGitDrawingsStyle(BoxDrawingRenderer::GitDrawingsStyl
     using GitBranchStyle = BoxDrawingRenderer::GitDrawingsStyle::BranchStyle;
     using MergeCommitStyle = BoxDrawingRenderer::GitDrawingsStyle::MergeCommitStyle;
 
-    if (arcStyle == ArcStyle::Elliptic && newStyle.branchStyle != GitBranchStyle::Thin)
+    if (DefaultArcStyle == ArcStyle::Elliptic && newStyle.branchStyle != GitBranchStyle::Thin)
     {
         // log warning ??
         newStyle.arcStyle = ArcStyle::Round;
@@ -1768,7 +1769,7 @@ void BoxDrawingRenderer::setGitDrawingsStyle(BoxDrawingRenderer::GitDrawingsStyl
             default: assert(false); return detail::Line::Light;
         }
     }();
-    gitArcStyle = newStyle.arcStyle;
+    DefaultGitArcStyle = newStyle.arcStyle;
     detail::branchDrawingDefinitions = detail::getBranchBoxes(mcLine, branchLine);
 }
 void BoxDrawingRenderer::setBrailleStyle(BoxDrawingRenderer::BrailleStyle newStyle)
@@ -2902,7 +2903,7 @@ optional<atlas::Buffer> BoxDrawingRenderer::buildBoxElements(char32_t codepoint,
     auto box = detail::getBoxDrawing(codepoint);
     if (not box)
         return std::nullopt;
-    auto lArcStyle = detail::isGitBranchDrawing(codepoint) ? gitArcStyle : arcStyle;
+    auto lArcStyle = detail::isGitBranchDrawing(codepoint) ? DefaultGitArcStyle : DefaultArcStyle;
     auto image = buildBox(*box, size, lineThickness, supersampling, lArcStyle == ArcStyle::Elliptic);
     boxDrawingLog()("BoxDrawing: build U+{:04X} ({})", static_cast<uint32_t>(codepoint), size);
     return image;

--- a/src/vtrasterizer/BoxDrawingRenderer.h
+++ b/src/vtrasterizer/BoxDrawingRenderer.h
@@ -75,7 +75,7 @@ class BoxDrawingRenderer: public Renderable
 
     static void setBrailleStyle(BrailleStyle newStyle);
     static void setGitDrawingsStyle(GitDrawingsStyle newStyle);
-    static void setArcStyle(ArcStyle newStyle) { arcStyle = newStyle; }
+    static void setArcStyle(ArcStyle newStyle) { DefaultArcStyle = newStyle; }
 
   private:
     AtlasTileAttributes const* getOrCreateCachedTileAttributes(char32_t codepoint,
@@ -97,9 +97,9 @@ class BoxDrawingRenderer: public Renderable
                                                              ImageSize size,
                                                              int lineThickness);
 
-    static inline ArcStyle arcStyle = ArcStyle::Round;
-    static inline ArcStyle gitArcStyle = ArcStyle::Round;
-    static inline BrailleStyle brailleStyle = BrailleStyle::Font;
+    static inline ArcStyle DefaultArcStyle = ArcStyle::Round;
+    static inline ArcStyle DefaultGitArcStyle = ArcStyle::Round;
+    static inline BrailleStyle DefaultBrailleStyle = BrailleStyle::Font;
 };
 
 } // namespace vtrasterizer


### PR DESCRIPTION
Add `readability-identifier-naming.ClassConstantCase` and switch `ClassMemberCase` to `CamelCase`