### PR TITLE
Fix segfaults and heap corruption on font/window size changes

### DIFF
--- a/.github/actions/spelling/allow/qt-terms.txt
+++ b/.github/actions/spelling/allow/qt-terms.txt
@@ -33,6 +33,7 @@ QObject
 QOffscreen
 QOpen
 QPoint
+QPointer
 QProcess
 QQml
 QQuick

--- a/.github/actions/spelling/allow/uncategorized.txt
+++ b/.github/actions/spelling/allow/uncategorized.txt
@@ -196,6 +196,7 @@ XVec
 Ype
 ZAxis
 acion
+acq
 acrylicblur
 adb
 aee
@@ -328,6 +329,8 @@ debversion
 deccra
 decoratioins
 decrpm
+dedup
+deduped
 dejavu
 delimieters
 demibold
@@ -819,6 +822,7 @@ rdynamic
 reaaally
 readfd
 recognises
+reconfig
 relase
 remaints
 renderables

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -130,6 +130,7 @@
           <li>Fixes scrollback preservation for top anchored full width scroll regions</li>
           <li>Adds Ctrl-click support for opening detected local filesystem paths under the mouse cursor (#1947)</li>
           <li>Fixes terminal grid not syncing to the window tile size on tiling Wayland compositors, where a freshly-spawned terminal was mis-sized until a manual resize (#1955)</li>
+          <li>Fixes crashes and heap corruption when rapidly changing the font or window size, caused by data races between the UI thread and the Qt Scene Graph render thread; geometry/font changes are now deferred and applied on the render thread (#1922, probably #1712, #408)</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -20,8 +20,8 @@
 #include <QtCore/QDebug>
 #include <QtCore/QFileInfo>
 #include <QtCore/QMetaObject>
-#include <QtCore/QPointer>
 #include <QtCore/QMimeData>
+#include <QtCore/QPointer>
 #include <QtCore/QProcess>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QTimer>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -20,6 +20,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QFileInfo>
 #include <QtCore/QMetaObject>
+#include <QtCore/QPointer>
 #include <QtCore/QMimeData>
 #include <QtCore/QProcess>
 #include <QtCore/QStandardPaths>
@@ -325,6 +326,12 @@ void TerminalSession::attachDisplay(display::TerminalDisplay& newDisplay)
         if (_onClosedHandled)
             _display->closeDisplay();
     }
+
+    // A window-title / tab-name change that arrived while no display was attached was dropped by
+    // refreshGuiTabInfoForStatusLine() (it only posts when _display is set). Now that a display is
+    // attached, refresh the indicator status-line tab label so it reflects the current name rather than
+    // a stale one.
+    refreshGuiTabInfoForStatusLine();
 
     scheduleRedraw();
 }
@@ -1000,8 +1007,16 @@ void TerminalSession::refreshGuiTabInfoForStatusLine()
     // path), so we must not call _manager->update() directly: it rebuilds the tab info from every
     // session and would re-lock that non-recursive mutex (the deadlock scheduleRedraw() was changed to
     // avoid). Post the refresh to the GUI thread instead, where it runs free of the parser-thread lock.
+    //
+    // The lambda is keyed to the display QObject, so Qt only cancels it if the *display* dies — not if
+    // this *session* is destroyed first (e.g. closing a tab while its shell still emits an OSC title
+    // change). Capture a QPointer to the session (auto-nulls on destruction) and bail out if the session
+    // is gone, avoiding a use-after-free on _manager.
     if (_display)
-        _display->post([this]() { _manager->update(); });
+        _display->post([self = QPointer<TerminalSession> { this }]() {
+            if (self)
+                self->_manager->update();
+        });
 }
 
 void TerminalSession::setWindowTitle(string_view title)

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2125,6 +2125,13 @@ uint8_t TerminalSession::matchModeFlags() const
 
 void TerminalSession::setFontSize(text::font_size size)
 {
+    // _display->setFontSize() returns false if it could not even stage the change, or if it staged the
+    // change but applied it synchronously (the not-renderable path) and that apply failed and was
+    // swallowed (font-load/atlas error, previous font kept). In either case the rendered font did not
+    // become @p size, so the profile must not record it — otherwise it diverges from the rendered font
+    // and a later increase/decrease step chains from the wrong base. When the apply is deferred to the
+    // next painted frame (the common, renderable path), staging success is reported and the requested
+    // size is the intent to persist.
     if (!_display->setFontSize(size))
         return;
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -994,9 +994,32 @@ QString TerminalSession::title() const
 #endif
 }
 
+void TerminalSession::refreshGuiTabInfoForStatusLine()
+{
+    // setWindowTitle()/setTabName() are invoked on the parser thread while _stateMutex is held (ESU
+    // path), so we must not call _manager->update() directly: it rebuilds the tab info from every
+    // session and would re-lock that non-recursive mutex (the deadlock scheduleRedraw() was changed to
+    // avoid). Post the refresh to the GUI thread instead, where it runs free of the parser-thread lock.
+    if (_display)
+        _display->post([this]() { _manager->update(); });
+}
+
 void TerminalSession::setWindowTitle(string_view title)
 {
     emit titleChanged(QString::fromUtf8(title.data(), static_cast<int>(title.size())));
+
+    // In TabsNamingMode::Title the indicator status-line tab name derives from the window title, so a
+    // runtime title change must refresh the status-line tab info (no longer done by scheduleRedraw()).
+    refreshGuiTabInfoForStatusLine();
+}
+
+void TerminalSession::setTabName(string_view name)
+{
+    // A tab-name change (via the tab-naming escape sequence) feeds the indicator status-line tab label;
+    // refresh it on the GUI thread since scheduleRedraw() no longer does (see
+    // refreshGuiTabInfoForStatusLine).
+    (void) name;
+    refreshGuiTabInfoForStatusLine();
 }
 
 void TerminalSession::setTerminalProfile(string const& configProfileName)

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -332,7 +332,8 @@ void TerminalSession::attachDisplay(display::TerminalDisplay& newDisplay)
 void TerminalSession::scheduleRedraw()
 {
     _terminal.markScreenDirty();
-    _manager->update();
+    // Don't refresh GUI tab info here: reached from the parser thread while _stateMutex is held (ESU path),
+    // so _manager->update() would re-lock that non-recursive mutex. It only changes on GUI-thread events.
     if (_display)
         _display->scheduleRedraw();
 }

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -219,13 +219,13 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     ~TerminalSession() override;
 
     int id() const noexcept { return _id; }
-    std::optional<std::string> name() const noexcept
+    std::optional<std::string> name() const
     {
-        if (terminal().tabName())
-            return terminal().tabName();
-        if (terminal().getTabsNamingMode() == vtbackend::TabsNamingMode::Title)
-            return terminal().windowTitle();
-        return std::nullopt;
+        // Resolve under the terminal's _stateMutex: this runs on the GUI thread (via
+        // TerminalSessionManager::updateStatusLine(), reached from a posted refreshGuiTabInfoForStatusLine
+        // or on tab activation) while the parser thread writes the title strings under that mutex.
+        // Reading them across separate unlocked accessor calls would race the writer.
+        return terminal().resolvedTabName();
     }
 
     /// Starts the VT background thread.

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -280,6 +280,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     void requestWindowResize(vtbackend::LineCount, vtbackend::ColumnCount) override;
     void requestWindowResize(vtbackend::Width, vtbackend::Height) override;
     void setWindowTitle(std::string_view title) override;
+    void setTabName(std::string_view name) override;
     void setTerminalProfile(std::string const& configProfileName) override;
     void discardImage(vtbackend::Image const&) override;
     void inputModeChanged(vtbackend::ViMode mode) override;
@@ -453,6 +454,15 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool resetConfig();
     void followHyperlink(vtbackend::HyperlinkInfo const& hyperlink);
     void setFontSize(text::font_size size);
+
+    /// Posts a refresh of the indicator status-line tab info (tab names) to the GUI thread.
+    ///
+    /// Called when the window title or tab name changes at runtime. Must not refresh inline: these
+    /// notifications arrive on the parser thread while the terminal state mutex is held, and the
+    /// refresh re-enters that non-recursive mutex (see scheduleRedraw()), so it is deferred to the GUI
+    /// thread via the display's event loop.
+    void refreshGuiTabInfoForStatusLine();
+
     void setDefaultCursor();
     void configureTerminal();
     void configureCursor(config::CursorConfig const& cursorConfig);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -210,6 +210,12 @@ TerminalSession* TerminalSessionManager::activateSession(TerminalSession* sessio
             auto const _ = std::scoped_lock { displayState.currentSession->terminal() };
             displayState.currentSession->terminal().resizeScreen(totalPageSize, pixels);
         }
+
+        // These resizeScreen() calls go straight to the terminal, bypassing the renderer's geometry
+        // staging, so the renderer's published/live page size would stay stale (diagnostics and any
+        // gridMetrics().pageSize reader would see the wrong size). Push the new page size into the
+        // renderer so its grid metrics stay consistent with the terminal.
+        _activeDisplay->syncRendererPageSize(totalPageSize);
     }
 
     return session;

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -212,10 +212,11 @@ TerminalSession* TerminalSessionManager::activateSession(TerminalSession* sessio
         }
 
         // These resizeScreen() calls go straight to the terminal, bypassing the renderer's geometry
-        // staging, so the renderer's published/live page size would stay stale (diagnostics and any
-        // gridMetrics().pageSize reader would see the wrong size). Push the new page size into the
-        // renderer so its grid metrics stay consistent with the terminal.
-        _activeDisplay->syncRendererPageSize(totalPageSize);
+        // staging, so the renderer's published/live grid metrics would stay stale (diagnostics and any
+        // gridMetrics() reader would see the wrong size/margin). Push the full geometry (page size, pixel
+        // size and margin) into the renderer so its grid metrics stay consistent with the terminal — a
+        // page-size-only sync would leave the previous session's margin live until a later resize.
+        _activeDisplay->syncRendererGeometry(totalPageSize, pixels);
     }
 
     return session;

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -579,7 +579,12 @@ void TerminalDisplay::applyFontDPI()
                  newFontDPI,
                  contentScale(),
                  window() ? "Window present" : "No window");
-    _lastFontDPI = newFontDPI;
+
+    // NB: _lastFontDPI is the dedup guard above; it is committed only once the renderer confirms it
+    // actually applied the new DPI (see end of this function). Committing it here — before the staged
+    // reload, which applyPendingReconfig() can fail and swallow (atlas reallocation, FreeType
+    // instantiation) — would record success that never happened, and the guard above would then
+    // permanently skip the retry when the same DPI is reported again, stranding the wrong DPI.
 
     // logDisplayInfo();
 
@@ -604,6 +609,10 @@ void TerminalDisplay::applyFontDPI()
             updateImplicitSize();
             updateSizeConstraints();
         }
+        // The materialization in createRenderer() will confirm the apply; mirror its published DPI so a
+        // later spurious same-DPI signal is correctly deduped only if it really landed.
+        if (_renderer->fontDescriptions().dpi == newFontDPI)
+            _lastFontDPI = newFontDPI;
         return;
     }
 
@@ -628,6 +637,13 @@ void TerminalDisplay::applyFontDPI()
         _renderer->applyStagedReconfigDuringSetup();
     }
     scheduleRedraw();
+
+    // Commit the dedup guard only now that applyStagedReconfigDuringSetup() has run synchronously and the
+    // renderer published the new DPI. If the staged reload threw (applyPendingReconfig() catches and keeps
+    // the previous font), the published DPI stays old, _lastFontDPI is left unchanged, and the next
+    // identical DPI signal correctly retries instead of being skipped forever.
+    if (_renderer->fontDescriptions().dpi == newFontDPI)
+        _lastFontDPI = newFontDPI;
 }
 
 void TerminalDisplay::logDisplayInfo()

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -590,25 +590,14 @@ void TerminalDisplay::applyFontDPI()
 
     auto fd = _renderer->fontDescriptions();
     fd.dpi = newFontDPI;
+    // The font change is only *staged* here; recomputing geometry now would read the *stale* cell size.
+    // Drive a frame instead — consumeFontReconfigApplied() (see paint()) re-derives against the new size.
     _renderer->setFonts(std::move(fd));
-
-    // Recompute implicit/minimum size when font DPI changes (e.g., DPR correction
-    // from 2.0 → 1.5 on KDE/Wayland with fractional scaling). The implicit size
-    // does not require a render target, so this must happen before the guard below.
-    if (window())
-    {
-        updateImplicitSize();
-        updateSizeConstraints();
-    }
 
     if (!_renderTarget)
         return;
 
-    auto const newPixelSize =
-        vtbackend::ImageSize { Width::cast_from(width()), Height::cast_from(height()) } * contentScale();
-
-    // Apply resize on same window metrics propagates proper recalculations and repaint.
-    applyResize(newPixelSize, *_session, *_renderer);
+    scheduleRedraw();
 }
 
 void TerminalDisplay::logDisplayInfo()
@@ -763,6 +752,10 @@ void TerminalDisplay::createRenderer()
     // render target, ensuring correct cell metrics from the start.
     applyFontDPI();
 
+    // applyFontDPI() only *stages* the font reload; the render thread is not running yet and there is no
+    // frame to apply it, so materialize it now to read the correct cell size for the texture atlas tile.
+    _renderer->applyStagedReconfigDuringSetup();
+
     auto const textureTileSize = gridMetrics().cellSize;
     auto const viewportMargin = vtrasterizer::PageMargin {}; // TODO margin
     auto const precalculatedViewSize = [this]() -> ImageSize {
@@ -904,6 +897,19 @@ void TerminalDisplay::paint()
 
         terminal().tick(steady_clock::now());
         _renderer->render(terminal(), _renderingPressure);
+
+        // The lazily-applied font/DPI change made the cell size current only now; re-derive page size,
+        // implicit size (a DPI change alters it) and constraints against it (the triggering resize didn't).
+        if (_renderer->consumeFontReconfigApplied())
+            post([this]() {
+                if (!_session || !_renderer)
+                    return;
+                resizeTerminalToDisplaySize();
+                if (window())
+                    updateImplicitSize();
+                updateSizeConstraints();
+            });
+
         if (_doDumpState)
         {
             doDumpStateInternal();
@@ -1086,7 +1092,7 @@ QVariant TerminalDisplay::inputMethodQuery(Qt::InputMethodQuery query) const
     switch (query)
     {
         case Qt::ImCursorRectangle: {
-            auto const& gridMetrics = _renderer->gridMetrics();
+            auto const gridMetrics = _renderer->gridMetrics();
             auto theContentsRect = QRect(); // TODO: contentsRect();
             auto result = QRect();
             auto const dpr = contentScale();
@@ -1226,7 +1232,7 @@ void TerminalDisplay::updateImplicitSize()
     auto const totalPageSize = _session->terminal().totalPageSize();
     auto const dpr = contentScale();
 
-    auto const actualGridCellSize = _renderer->cellSize();
+    auto const actualGridCellSize = _renderer->gridMetrics().cellSize;
     auto const scaledMargins = applyContentScale(_session->profile().margins.value(), dpr);
 
     // Compute the required size in actual pixels using exact integer arithmetic,
@@ -1257,7 +1263,7 @@ void TerminalDisplay::updateSizeConstraints()
     assert(_session);
 
     auto const dpr = contentScale();
-    auto const actualCellSize = _renderer->cellSize();
+    auto const actualCellSize = _renderer->gridMetrics().cellSize;
     auto const margins = _session->profile().margins.value();
 
     // Minimum size (existing logic, unchanged)
@@ -1529,9 +1535,11 @@ void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
 
     if (applyFontDescription(fontDPI(), *_renderer, std::move(fontDescriptions)))
     {
-        // resize widget (same pixels, but adjusted terminal rows/columns and margin)
-        applyResize(pixelSize(), *_session, *_renderer);
-        updateSizeConstraints(); // cell size changed
+        // The font change is only *staged* (see applyFontDescription); it is applied on the render
+        // thread during the next frame, after which consumeFontReconfigApplied() (see paint()) resizes
+        // the widget against the new cell size. Doing it here would use the *stale* cell size, so just
+        // request a frame to drive the apply (also covers the occluded/minimized case).
+        scheduleRedraw();
         // logDisplayInfo();
     }
 }
@@ -1545,8 +1553,11 @@ bool TerminalDisplay::setFontSize(text::font_size newFontSize)
     if (!_renderer->setFontSize(newFontSize))
         return false;
 
-    resizeTerminalToDisplaySize();
-    updateSizeConstraints();
+    // The font change is only *staged*; it is applied on the render thread during the next frame, after
+    // which consumeFontReconfigApplied() (see paint()) re-derives the page size against the new cell
+    // size. Recomputing here would use the *stale* cell size, so just request a frame to drive the
+    // apply (this also covers the occluded/minimized case, where no frame would otherwise paint).
+    scheduleRedraw();
     // logDisplayInfo();
     return true;
 }
@@ -1556,9 +1567,12 @@ bool TerminalDisplay::setPageSize(PageSize newPageSize)
     if (newPageSize == terminal().pageSize())
         return false;
 
+    // Derive the view size from the *requested* page size (not the configured profile size), reading the
+    // cell size once to avoid two locked GridMetrics copies and a possible torn read between them.
+    auto const cellSize = gridMetrics().cellSize;
     auto const viewSize = ImageSize {
-        Width(*gridMetrics().cellSize.width * unbox<unsigned>(profile().terminalSize.value().columns)),
-        Height(*gridMetrics().cellSize.width * unbox<unsigned>(profile().terminalSize.value().columns))
+        Width(*cellSize.width * unbox<unsigned>(newPageSize.columns)),
+        Height(*cellSize.height * unbox<unsigned>(newPageSize.lines))
     };
     _renderer->setPageSize(newPageSize);
     auto const l = scoped_lock { terminal() };

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -802,6 +802,19 @@ void TerminalDisplay::createRenderer()
     // frame to apply it, so materialize it now to read the correct cell size for the texture atlas tile.
     _renderer->applyStagedReconfigDuringSetup();
 
+    // applyFontDPI()'s no-render-target branch already computed updateImplicitSize() — but against the
+    // still-stale (pre-correction) cell size, because the staged DPI was only materialized just above. On
+    // a fractional-scaling display where Qt corrected the DPR between setSession() and here, that implicit
+    // size is wrong, and applyResize() below derives the initial geometry from it, opening the window at
+    // the wrong pixel size / column count for a frame. Recompute it now that the corrected cell size is
+    // live. _initialImplicitWidth/Height (snapshotted above) intentionally keep the pre-correction values
+    // for sizeChanged()'s reversion detection, so they are left untouched.
+    if (window())
+    {
+        updateImplicitSize();
+        updateSizeConstraints();
+    }
+
     // Clear the "font reconfig applied" signal raised by the setup-time apply above. The geometry is
     // sized correctly below (applyResize() + the implicit-size/constraints setup), so we must not let
     // the first painted frame's consumeFontReconfigApplied() post a redundant resize/recompute, which

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -900,13 +900,23 @@ void TerminalDisplay::paint()
 
         // The lazily-applied font/DPI change made the cell size current only now; re-derive page size,
         // implicit size (a DPI change alters it) and constraints against it (the triggering resize didn't).
+        //
+        // The recompute must run on the GUI thread (it mutates Qt window state and resizes the terminal),
+        // so it is post()ed and applied on frame N+1: for this one frame the new cell size is rendered
+        // against the previous page size/margins. That single-frame divergence is an accepted trade-off
+        // of keeping all grid-metrics mutation on the render thread (the deferral that fixed the
+        // resize-time crashes); applying it inline here would touch Qt/terminal state off the GUI thread.
         if (_renderer->consumeFontReconfigApplied())
             post([this]() {
-                if (!_session || !_renderer)
+                // The display may be torn down between this post() (render thread) and its execution
+                // (GUI thread): the session/renderer can be cleared and, crucially, the window may be
+                // gone. resizeTerminalToDisplaySize()/updateImplicitSize()/updateSizeConstraints() all
+                // require a live window (the latter two Require(window()) and would std::abort()), so
+                // bail out entirely unless the display is still fully alive.
+                if (!_session || !_renderer || !window())
                     return;
                 resizeTerminalToDisplaySize();
-                if (window())
-                    updateImplicitSize();
+                updateImplicitSize();
                 updateSizeConstraints();
             });
 

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -590,32 +590,44 @@ void TerminalDisplay::applyFontDPI()
 
     // Stage a DPI-only change. setFontDPI() merges the new DPI into whatever font descriptions are
     // already staged (so a concurrent font-family change from a config reload is not clobbered), rather
-    // than rebuilding the request from the live descriptions. The change is only *staged* here;
-    // recomputing geometry now would read the *stale* cell size — drive a frame instead, after which
-    // consumeFontReconfigApplied() (see paint()) re-derives against the new size.
+    // than rebuilding the request from the live descriptions.
     _renderer->setFontDPI(newFontDPI);
 
-    // The implicit size and size constraints depend on the DPR directly (not only on the cell size),
-    // so recompute them now — this does NOT require a render target. Without this, a DPI change that
-    // arrives while the render target is released (e.g. window hidden after releaseResources()) would
-    // leave the window with a stale implicit size and min/size constraints until a frame eventually
-    // paints. The post-apply consumeFontReconfigApplied() path recomputes again against the new cell
-    // size once the staged font change lands.
-    if (window())
-    {
-        updateImplicitSize();
-        updateSizeConstraints();
-    }
-
     if (!_renderTarget)
+    {
         // During createRenderer() the render target does not exist yet; the staged change is
         // materialized explicitly there via applyStagedReconfigDuringSetup(). With no render target
-        // there is also no frame to drive — the recompute above already handled the DPR-dependent part.
+        // there is also no frame to drive. The implicit size / constraints still depend on the DPR
+        // directly, so recompute those (they do not need the render target) and return.
+        if (window())
+        {
+            updateImplicitSize();
+            updateSizeConstraints();
+        }
         return;
+    }
 
-    // Drive a frame to apply the staged DPI change, or apply it synchronously when no frame will paint
-    // (minimized/occluded), where window()->update() alone would never apply it.
-    applyStagedFontReconfigIfNotRenderable();
+    // Apply the staged DPI change synchronously and re-derive geometry against the new cell size in this
+    // same call, rather than deferring to a later frame's consumeFontReconfigApplied().
+    //
+    // A DPI change (monitor move, fractional-scaling correction) is rare, and deferring it makes the
+    // intervening frame(s) render the new cell size against the previous page size — a visible
+    // wrong-column-count / mis-clipped frame. applyStagedReconfigDuringSetup() takes the renderer's
+    // _applyMutex, so it is safe even if a frame is in flight: it waits for that frame to finish reading
+    // the grid metrics/atlas before mutating them, then the recompute below derives the page size from
+    // the now-current cell size — eliminating the single-frame divergence the deferred path had.
+    _renderer->applyStagedReconfigDuringSetup();
+    (void) _renderer->consumeFontReconfigApplied(); // we re-derive geometry inline below, so consume it
+    if (window())
+    {
+        resizeTerminalToDisplaySize();
+        updateImplicitSize();
+        updateSizeConstraints();
+        // Drain the geometry that resizeTerminalToDisplaySize() just staged so it lands now too, even if
+        // no frame will paint (minimized/occluded) — same rationale as applyStagedReconfigIfNotRenderable.
+        _renderer->applyStagedReconfigDuringSetup();
+    }
+    scheduleRedraw();
 }
 
 void TerminalDisplay::logDisplayInfo()

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1675,12 +1675,19 @@ bool TerminalDisplay::setPageSize(PageSize newPageSize)
     return true;
 }
 
-void TerminalDisplay::syncRendererPageSize(PageSize totalPageSize)
+void TerminalDisplay::syncRendererGeometry(PageSize totalPageSize, vtbackend::ImageSize pixelSize)
 {
     Require(_renderer != nullptr);
-    // setPageSize() publishes the page size immediately and stages the (idempotent) grid-metrics update
-    // for the next frame; it does not resize the terminal, which the caller already did directly.
-    _renderer->setPageSize(totalPageSize);
+    // The caller resized the terminal directly (bypassing the renderer's geometry staging). Push the
+    // *full* geometry — page size, render-surface pixel size and margin — into the renderer, not just the
+    // page size: a page-size-only sync would leave the previous session's margin in the live grid metrics
+    // until some later resize nudged it, so a session-switch could render with the wrong margins (bottom
+    // rows mis-clipped) on a display whose first post-switch frame is delayed. The margin is derived from
+    // the renderer's published cell size and the profile margins, exactly as helper::applyResize() does.
+    auto const cellSize = _renderer->publishedCellSize();
+    auto const margin = computeMargin(
+        cellSize, totalPageSize, pixelSize, applyContentScale(profile().margins.value(), contentScale()));
+    _renderer->applyResize(pixelSize, totalPageSize, margin);
 }
 
 void TerminalDisplay::setMouseCursorShape(MouseCursorShape newCursorShape)

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -717,7 +717,7 @@ void TerminalDisplay::onBeforeSynchronize()
     // resize must happen). applyResize() no-ops when the page size already matches,
     // and the per-frame cost when in sync is a single page-size comparison.
     auto const expectedPageSize = pageSizeForPixels(
-        viewSize, _renderer->gridMetrics().cellSize, applyContentScale(profile().margins.value(), dpr));
+        viewSize, _renderer->publishedCellSize(), applyContentScale(profile().margins.value(), dpr));
     if (expectedPageSize != _session->terminal().totalPageSize())
         post([this]() {
             if (_session && _renderTarget && window())
@@ -1074,16 +1074,19 @@ void TerminalDisplay::inputMethodEvent(QInputMethodEvent* event)
 
 QVariant TerminalDisplay::inputMethodQuery(Qt::InputMethodQuery query) const
 {
+    // Read the published cell size once (lock-free), then reuse it: avoids three locked GridMetrics
+    // copies per query (this fires on every keystroke with an IME active) and prevents a torn read where
+    // the width and height could come from different published values across a concurrent font apply.
+    auto const cellSize = _renderer->publishedCellSize();
+
     auto const getCursorPosition = [&]() -> QPoint {
         QPoint cursorPos = QPoint();
         if (terminal().isCursorInViewport())
         {
             auto const dpr = contentScale();
             auto const gridCursorPos = terminal().currentScreen().cursor().position;
-            cursorPos.setX(int(unbox<double>(gridCursorPos.column)
-                               * unbox<double>(_renderer->gridMetrics().cellSize.width)));
-            cursorPos.setY(int(unbox<double>(gridCursorPos.line)
-                               * unbox<double>(_renderer->gridMetrics().cellSize.height)));
+            cursorPos.setX(int(unbox<double>(gridCursorPos.column) * unbox<double>(cellSize.width)));
+            cursorPos.setY(int(unbox<double>(gridCursorPos.line) * unbox<double>(cellSize.height)));
             cursorPos /= dpr;
         }
         return cursorPos;
@@ -1092,16 +1095,15 @@ QVariant TerminalDisplay::inputMethodQuery(Qt::InputMethodQuery query) const
     switch (query)
     {
         case Qt::ImCursorRectangle: {
-            auto const gridMetrics = _renderer->gridMetrics();
             auto theContentsRect = QRect(); // TODO: contentsRect();
             auto result = QRect();
             auto const dpr = contentScale();
             auto const cursorPos = getCursorPosition();
             result.setLeft(theContentsRect.left() + cursorPos.x());
             result.setTop(theContentsRect.top() + cursorPos.y());
-            result.setWidth(int(unbox<double>(gridMetrics.cellSize.width)
-                                / dpr)); // TODO: respect double-width characters
-            result.setHeight(int(unbox<double>(gridMetrics.cellSize.height) / dpr));
+            result.setWidth(
+                int(unbox<double>(cellSize.width) / dpr)); // TODO: respect double-width characters
+            result.setHeight(int(unbox<double>(cellSize.height) / dpr));
             return result;
             break;
         }
@@ -1232,7 +1234,7 @@ void TerminalDisplay::updateImplicitSize()
     auto const totalPageSize = _session->terminal().totalPageSize();
     auto const dpr = contentScale();
 
-    auto const actualGridCellSize = _renderer->gridMetrics().cellSize;
+    auto const actualGridCellSize = _renderer->publishedCellSize();
     auto const scaledMargins = applyContentScale(_session->profile().margins.value(), dpr);
 
     // Compute the required size in actual pixels using exact integer arithmetic,
@@ -1263,7 +1265,7 @@ void TerminalDisplay::updateSizeConstraints()
     assert(_session);
 
     auto const dpr = contentScale();
-    auto const actualCellSize = _renderer->gridMetrics().cellSize;
+    auto const actualCellSize = _renderer->publishedCellSize();
     auto const margins = _session->profile().margins.value();
 
     // Minimum size (existing logic, unchanged)
@@ -1326,12 +1328,14 @@ vtbackend::ImageSize TerminalDisplay::pixelSize() const
     auto const scaledWindowMarginsPixels =
         vtbackend::ImageSize { Width::cast_from(unbox(scaledWindowMargins.horizontal) * 2),
                                Height::cast_from(unbox(scaledWindowMargins.vertical) * 2) };
-    return gridMetrics().cellSize * _session->terminal().totalPageSize() + scaledWindowMarginsPixels;
+    return _renderer->publishedCellSize() * _session->terminal().totalPageSize() + scaledWindowMarginsPixels;
 }
 
 vtbackend::ImageSize TerminalDisplay::cellSize() const
 {
-    return gridMetrics().cellSize;
+    // Lock-free published cell-size read; avoids taking the renderer's reconfig mutex and copying the
+    // whole GridMetrics struct just to extract the cell size on these hot UI paths.
+    return _renderer->publishedCellSize();
 }
 // }}}
 
@@ -1511,7 +1515,7 @@ void TerminalDisplay::resizeWindow(vtbackend::LineCount newLineCount, vtbackend:
     // direction. This avoids cumulative rounding errors from the previous approach
     // of computing an unscaled cell size separately (which involved two std::ceil
     // operations that could inflate the pixel count).
-    auto const cellSize = gridMetrics().cellSize;
+    auto const cellSize = _renderer->publishedCellSize();
     auto const scaledMargins = applyContentScale(_session->profile().margins.value(), contentScale());
     auto const targetScaledSize = vtbackend::ImageSize {
         cellSize.width * boxed_cast<vtbackend::Width>(requestedPageSize.columns)
@@ -1568,16 +1572,22 @@ bool TerminalDisplay::setPageSize(PageSize newPageSize)
         return false;
 
     // Derive the view size from the *requested* page size (not the configured profile size), reading the
-    // cell size once to avoid two locked GridMetrics copies and a possible torn read between them.
-    auto const cellSize = gridMetrics().cellSize;
-    auto const viewSize = ImageSize {
-        Width(*cellSize.width * unbox<unsigned>(newPageSize.columns)),
-        Height(*cellSize.height * unbox<unsigned>(newPageSize.lines))
-    };
+    // published cell size once (lock-free) to avoid two locked GridMetrics copies and a torn read.
+    auto const cellSize = _renderer->publishedCellSize();
+    auto const viewSize = ImageSize { Width(*cellSize.width * unbox<unsigned>(newPageSize.columns)),
+                                      Height(*cellSize.height * unbox<unsigned>(newPageSize.lines)) };
     _renderer->setPageSize(newPageSize);
     auto const l = scoped_lock { terminal() };
     terminal().resizeScreen(newPageSize, viewSize);
     return true;
+}
+
+void TerminalDisplay::syncRendererPageSize(PageSize totalPageSize)
+{
+    Require(_renderer != nullptr);
+    // setPageSize() publishes the page size immediately and stages the (idempotent) grid-metrics update
+    // for the next frame; it does not resize the terminal, which the caller already did directly.
+    _renderer->setPageSize(totalPageSize);
 }
 
 void TerminalDisplay::setMouseCursorShape(MouseCursorShape newCursorShape)

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -616,26 +616,9 @@ void TerminalDisplay::applyFontDPI()
         return;
     }
 
-    // Apply the staged DPI change synchronously and re-derive geometry against the new cell size in this
-    // same call, rather than deferring to a later frame's consumeFontReconfigApplied().
-    //
-    // A DPI change (monitor move, fractional-scaling correction) is rare, and deferring it makes the
-    // intervening frame(s) render the new cell size against the previous page size — a visible
-    // wrong-column-count / mis-clipped frame. applyStagedReconfigDuringSetup() takes the renderer's
-    // _applyMutex, so it is safe even if a frame is in flight: it waits for that frame to finish reading
-    // the grid metrics/atlas before mutating them, then the recompute below derives the page size from
-    // the now-current cell size — eliminating the single-frame divergence the deferred path had.
-    _renderer->applyStagedReconfigDuringSetup();
-    (void) _renderer->consumeFontReconfigApplied(); // we re-derive geometry inline below, so consume it
-    if (window())
-    {
-        resizeTerminalToDisplaySize();
-        updateImplicitSize();
-        updateSizeConstraints();
-        // Drain the geometry that resizeTerminalToDisplaySize() just staged so it lands now too, even if
-        // no frame will paint (minimized/occluded) — same rationale as applyStagedReconfigIfNotRenderable.
-        _renderer->applyStagedReconfigDuringSetup();
-    }
+    // Apply the staged DPI change synchronously and re-derive geometry against the new cell size now,
+    // via the shared policy used for every discrete font reconfiguration (see applyStagedFontReconfigNow).
+    applyStagedFontReconfigNow();
     scheduleRedraw();
 
     // Commit the dedup guard only now that applyStagedReconfigDuringSetup() has run synchronously and the
@@ -1607,45 +1590,36 @@ void TerminalDisplay::resizeWindow(vtbackend::LineCount newLineCount, vtbackend:
     window()->resize(QSize(unscaledViewSize.width.as<int>(), unscaledViewSize.height.as<int>()));
 }
 
-bool TerminalDisplay::willRenderFrames() const noexcept
+void TerminalDisplay::applyStagedFontReconfigNow()
 {
-    // A staged font reconfiguration is normally applied by the render thread on the next painted frame.
-    // The scene graph only paints while the window is exposed, so a minimized/occluded (or window-less)
-    // display will never paint and would leave the change unapplied. isExposed() is the canonical Qt
-    // signal for "the window is showing and will render".
-    return window() != nullptr && _renderTarget != nullptr && window()->isExposed();
-}
-
-bool TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
-{
-    // When the window will paint, leave the staged reconfig for the render thread (paint() consumes it
-    // and re-derives geometry). When it will NOT paint, the render thread is provably idle (the scene
-    // graph does not render an unexposed window), so it is safe to apply the staged reconfig synchronously
-    // here on the GUI thread and re-derive geometry now — otherwise the change would silently never apply.
+    // Apply a staged font/DPI reconfiguration synchronously, on the GUI thread, and re-derive geometry
+    // against the resulting cell size in this same call — rather than deferring to a later painted frame's
+    // consumeFontReconfigApplied().
     //
-    // Returns true if the staged reconfig was applied synchronously here, false if it was left for the
-    // next painted frame. The caller uses this to decide whether the renderer's published metrics already
-    // reflect the change (synchronous) or not yet (deferred).
-    if (willRenderFrames())
-    {
-        scheduleRedraw();
-        return false;
-    }
-
+    // This is the single policy for ALL discrete font reconfigurations (size, family, DPI). Deferring to a
+    // frame had three problems the synchronous path avoids: (1) the child process learned its new row/col
+    // count one to two frames late (a TUI read of the terminal size right after the change saw stale
+    // dimensions); (2) the intervening frame(s) rendered the new cell size against the previous page size,
+    // a visible wrong-column-count flash; (3) it relied on a frame actually painting, so an exposed-but-
+    // not-painting window (occluded, compositor withholding frames) could leave the change unapplied
+    // indefinitely. Font reconfigurations are discrete user/config events, not the continuous
+    // resize stream the render-thread deferral exists to protect, so applying them inline is appropriate.
+    //
+    // Safety: applyStagedReconfigDuringSetup() takes the renderer's _applyMutex, which renderImpl() also
+    // holds across a whole frame, so this is mutually exclusive with an in-flight render-thread frame even
+    // if the window has not yet observed losing exposure — it waits for that frame to finish reading the
+    // grid metrics / atlas before mutating them. This is the same mechanism applyFontDPI() relied on.
     _renderer->applyStagedReconfigDuringSetup();
     if (_renderer->consumeFontReconfigApplied() && _session && window())
     {
         // resizeTerminalToDisplaySize() only *stages* the new geometry (page size, margin, render
-        // surface) into the renderer's pending reconfig; it is normally drained by the next painted
-        // frame. Since this branch runs precisely because no frame will paint, drain it synchronously
-        // too — otherwise the geometry would stay unapplied to the live grid metrics / render surface
-        // for the whole minimized interval, contradicting this function's purpose.
+        // surface) into the renderer's pending reconfig. Drain it synchronously too so it lands now —
+        // including the resizeScreen()/SIGWINCH to the child — rather than waiting for a frame.
         resizeTerminalToDisplaySize();
         updateImplicitSize();
         updateSizeConstraints();
         _renderer->applyStagedReconfigDuringSetup();
     }
-    return true;
 }
 
 void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
@@ -1655,11 +1629,10 @@ void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
 
     if (applyFontDescription(fontDPI(), *_renderer, std::move(fontDescriptions)))
     {
-        // The font change is only *staged* (see applyFontDescription). It is applied on the render
-        // thread during the next frame, after which consumeFontReconfigApplied() (see paint()) resizes
-        // the widget against the new cell size. Doing it here would use the *stale* cell size — so drive
-        // a frame, or apply synchronously when no frame will paint (minimized/occluded).
-        applyStagedFontReconfigIfNotRenderable();
+        // The font change is only *staged* (see applyFontDescription). Apply it synchronously and
+        // re-derive geometry against the new cell size now; doing the recompute without the apply would
+        // use the *stale* cell size.
+        applyStagedFontReconfigNow();
         // logDisplayInfo();
     }
 }
@@ -1673,23 +1646,17 @@ bool TerminalDisplay::setFontSize(text::font_size newFontSize)
     if (!_renderer->setFontSize(newFontSize))
         return false;
 
-    // The font change is only *staged*; it is applied on the render thread during the next frame, after
-    // which consumeFontReconfigApplied() (see paint()) re-derives the page size against the new cell
-    // size. Recomputing here would use the *stale* cell size — so drive a frame, or apply synchronously
-    // when no frame will paint (minimized/occluded), where window()->update() alone would never apply it.
-    auto const appliedSynchronously = applyStagedFontReconfigIfNotRenderable();
+    // The font change is only *staged*; apply it synchronously and re-derive the page size against the
+    // new cell size now (recomputing without the apply would use the *stale* cell size).
+    applyStagedFontReconfigNow();
     // logDisplayInfo();
 
-    // When the change applied synchronously (not-renderable path), report whether it actually took: the
-    // render-thread apply catches and swallows font-load failures (keeping the previous font), so the
-    // caller must not record a size the renderer never loaded. When the apply is deferred to the next
-    // frame (renderable path), staging succeeded and is reported as success.
-    if (appliedSynchronously)
-        // font_size has no operator==; compare the point size the apply published against the request.
-        // The request is the exact value just staged (no arithmetic in between), so an exact compare is
-        // correct: equal means the synchronous apply loaded it, unequal means it was swallowed.
-        return _renderer->fontDescriptions().size.pt == newFontSize.pt;
-    return true;
+    // Report whether the change actually took: the render-thread apply catches and swallows font-load
+    // failures (keeping the previous font), so the caller must not record a size the renderer never
+    // loaded. font_size has no operator==; compare the point size the apply published against the request.
+    // The request is the exact value just staged (no arithmetic in between), so an exact compare is
+    // correct: equal means the apply loaded it, unequal means it was swallowed.
+    return _renderer->fontDescriptions().size.pt == newFontSize.pt;
 }
 
 bool TerminalDisplay::setPageSize(PageSize newPageSize)

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -588,16 +588,34 @@ void TerminalDisplay::applyFontDPI()
 
     Require(_renderer);
 
-    auto fd = _renderer->fontDescriptions();
-    fd.dpi = newFontDPI;
-    // The font change is only *staged* here; recomputing geometry now would read the *stale* cell size.
-    // Drive a frame instead — consumeFontReconfigApplied() (see paint()) re-derives against the new size.
-    _renderer->setFonts(std::move(fd));
+    // Stage a DPI-only change. setFontDPI() merges the new DPI into whatever font descriptions are
+    // already staged (so a concurrent font-family change from a config reload is not clobbered), rather
+    // than rebuilding the request from the live descriptions. The change is only *staged* here;
+    // recomputing geometry now would read the *stale* cell size — drive a frame instead, after which
+    // consumeFontReconfigApplied() (see paint()) re-derives against the new size.
+    _renderer->setFontDPI(newFontDPI);
+
+    // The implicit size and size constraints depend on the DPR directly (not only on the cell size),
+    // so recompute them now — this does NOT require a render target. Without this, a DPI change that
+    // arrives while the render target is released (e.g. window hidden after releaseResources()) would
+    // leave the window with a stale implicit size and min/size constraints until a frame eventually
+    // paints. The post-apply consumeFontReconfigApplied() path recomputes again against the new cell
+    // size once the staged font change lands.
+    if (window())
+    {
+        updateImplicitSize();
+        updateSizeConstraints();
+    }
 
     if (!_renderTarget)
+        // During createRenderer() the render target does not exist yet; the staged change is
+        // materialized explicitly there via applyStagedReconfigDuringSetup(). With no render target
+        // there is also no frame to drive — the recompute above already handled the DPR-dependent part.
         return;
 
-    scheduleRedraw();
+    // Drive a frame to apply the staged DPI change, or apply it synchronously when no frame will paint
+    // (minimized/occluded), where window()->update() alone would never apply it.
+    applyStagedFontReconfigIfNotRenderable();
 }
 
 void TerminalDisplay::logDisplayInfo()
@@ -755,6 +773,12 @@ void TerminalDisplay::createRenderer()
     // applyFontDPI() only *stages* the font reload; the render thread is not running yet and there is no
     // frame to apply it, so materialize it now to read the correct cell size for the texture atlas tile.
     _renderer->applyStagedReconfigDuringSetup();
+
+    // Clear the "font reconfig applied" signal raised by the setup-time apply above. The geometry is
+    // sized correctly below (applyResize() + the implicit-size/constraints setup), so we must not let
+    // the first painted frame's consumeFontReconfigApplied() post a redundant resize/recompute, which
+    // would re-derive the page size on frame 1 and cause a brief geometry recompute/flicker at open.
+    (void) _renderer->consumeFontReconfigApplied();
 
     auto const textureTileSize = gridMetrics().cellSize;
     auto const viewportMargin = vtrasterizer::PageMargin {}; // TODO margin
@@ -1542,6 +1566,36 @@ void TerminalDisplay::resizeWindow(vtbackend::LineCount newLineCount, vtbackend:
     window()->resize(QSize(unscaledViewSize.width.as<int>(), unscaledViewSize.height.as<int>()));
 }
 
+bool TerminalDisplay::willRenderFrames() const noexcept
+{
+    // A staged font reconfiguration is normally applied by the render thread on the next painted frame.
+    // The scene graph only paints while the window is exposed, so a minimized/occluded (or window-less)
+    // display will never paint and would leave the change unapplied. isExposed() is the canonical Qt
+    // signal for "the window is showing and will render".
+    return window() != nullptr && _renderTarget != nullptr && window()->isExposed();
+}
+
+void TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
+{
+    // When the window will paint, leave the staged reconfig for the render thread (paint() consumes it
+    // and re-derives geometry). When it will NOT paint, the render thread is provably idle (the scene
+    // graph does not render an unexposed window), so it is safe to apply the staged reconfig synchronously
+    // here on the GUI thread and re-derive geometry now — otherwise the change would silently never apply.
+    if (willRenderFrames())
+    {
+        scheduleRedraw();
+        return;
+    }
+
+    _renderer->applyStagedReconfigDuringSetup();
+    if (_renderer->consumeFontReconfigApplied() && _session && window())
+    {
+        resizeTerminalToDisplaySize();
+        updateImplicitSize();
+        updateSizeConstraints();
+    }
+}
+
 void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
 {
     Require(_session != nullptr);
@@ -1549,11 +1603,11 @@ void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
 
     if (applyFontDescription(fontDPI(), *_renderer, std::move(fontDescriptions)))
     {
-        // The font change is only *staged* (see applyFontDescription); it is applied on the render
+        // The font change is only *staged* (see applyFontDescription). It is applied on the render
         // thread during the next frame, after which consumeFontReconfigApplied() (see paint()) resizes
-        // the widget against the new cell size. Doing it here would use the *stale* cell size, so just
-        // request a frame to drive the apply (also covers the occluded/minimized case).
-        scheduleRedraw();
+        // the widget against the new cell size. Doing it here would use the *stale* cell size — so drive
+        // a frame, or apply synchronously when no frame will paint (minimized/occluded).
+        applyStagedFontReconfigIfNotRenderable();
         // logDisplayInfo();
     }
 }
@@ -1569,9 +1623,9 @@ bool TerminalDisplay::setFontSize(text::font_size newFontSize)
 
     // The font change is only *staged*; it is applied on the render thread during the next frame, after
     // which consumeFontReconfigApplied() (see paint()) re-derives the page size against the new cell
-    // size. Recomputing here would use the *stale* cell size, so just request a frame to drive the
-    // apply (this also covers the occluded/minimized case, where no frame would otherwise paint).
-    scheduleRedraw();
+    // size. Recomputing here would use the *stale* cell size — so drive a frame, or apply synchronously
+    // when no frame will paint (minimized/occluded), where window()->update() alone would never apply it.
+    applyStagedFontReconfigIfNotRenderable();
     // logDisplayInfo();
     return true;
 }

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1603,16 +1603,20 @@ bool TerminalDisplay::willRenderFrames() const noexcept
     return window() != nullptr && _renderTarget != nullptr && window()->isExposed();
 }
 
-void TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
+bool TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
 {
     // When the window will paint, leave the staged reconfig for the render thread (paint() consumes it
     // and re-derives geometry). When it will NOT paint, the render thread is provably idle (the scene
     // graph does not render an unexposed window), so it is safe to apply the staged reconfig synchronously
     // here on the GUI thread and re-derive geometry now — otherwise the change would silently never apply.
+    //
+    // Returns true if the staged reconfig was applied synchronously here, false if it was left for the
+    // next painted frame. The caller uses this to decide whether the renderer's published metrics already
+    // reflect the change (synchronous) or not yet (deferred).
     if (willRenderFrames())
     {
         scheduleRedraw();
-        return;
+        return false;
     }
 
     _renderer->applyStagedReconfigDuringSetup();
@@ -1628,6 +1632,7 @@ void TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
         updateSizeConstraints();
         _renderer->applyStagedReconfigDuringSetup();
     }
+    return true;
 }
 
 void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)
@@ -1659,8 +1664,18 @@ bool TerminalDisplay::setFontSize(text::font_size newFontSize)
     // which consumeFontReconfigApplied() (see paint()) re-derives the page size against the new cell
     // size. Recomputing here would use the *stale* cell size — so drive a frame, or apply synchronously
     // when no frame will paint (minimized/occluded), where window()->update() alone would never apply it.
-    applyStagedFontReconfigIfNotRenderable();
+    auto const appliedSynchronously = applyStagedFontReconfigIfNotRenderable();
     // logDisplayInfo();
+
+    // When the change applied synchronously (not-renderable path), report whether it actually took: the
+    // render-thread apply catches and swallows font-load failures (keeping the previous font), so the
+    // caller must not record a size the renderer never loaded. When the apply is deferred to the next
+    // frame (renderable path), staging succeeded and is reported as success.
+    if (appliedSynchronously)
+        // font_size has no operator==; compare the point size the apply published against the request.
+        // The request is the exact value just staged (no arithmetic in between), so an exact compare is
+        // correct: equal means the synchronous apply loaded it, unequal means it was swallowed.
+        return _renderer->fontDescriptions().size.pt == newFontSize.pt;
     return true;
 }
 

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1590,9 +1590,15 @@ void TerminalDisplay::applyStagedFontReconfigIfNotRenderable()
     _renderer->applyStagedReconfigDuringSetup();
     if (_renderer->consumeFontReconfigApplied() && _session && window())
     {
+        // resizeTerminalToDisplaySize() only *stages* the new geometry (page size, margin, render
+        // surface) into the renderer's pending reconfig; it is normally drained by the next painted
+        // frame. Since this branch runs precisely because no frame will paint, drain it synchronously
+        // too — otherwise the geometry would stay unapplied to the live grid metrics / render surface
+        // for the whole minimized interval, contradicting this function's purpose.
         resizeTerminalToDisplaySize();
         updateImplicitSize();
         updateSizeConstraints();
+        _renderer->applyStagedReconfigDuringSetup();
     }
 }
 

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -131,6 +131,11 @@ class TerminalDisplay: public QQuickItem
     void resizeWindow(vtbackend::Width, vtbackend::Height);
     void setFonts(vtrasterizer::FontDescriptions fontDescriptions);
     bool setFontSize(text::font_size newFontSize);
+
+    /// The font size the renderer has actually loaded (its published font descriptions), which may differ
+    /// from a just-requested size while a staged change is pending or after a swallowed font-load failure.
+    [[nodiscard]] text::font_size fontSize() const { return _renderer->fontDescriptions().size; }
+
     bool setPageSize(vtbackend::PageSize newPageSize);
 
     /// Pushes @p totalPageSize into the renderer's published/live grid metrics.
@@ -247,7 +252,10 @@ class TerminalDisplay: public QQuickItem
     /// Drives a pending font reconfiguration: schedules a redraw when frames will paint, otherwise
     /// applies the staged reconfiguration synchronously and re-derives geometry. The synchronous path
     /// covers the minimized/occluded case, where no frame would paint and the change would be lost.
-    void applyStagedFontReconfigIfNotRenderable();
+    ///
+    /// @returns true if the staged reconfiguration was applied synchronously (so the renderer's published
+    ///          metrics already reflect it), false if it was left for the next painted frame.
+    bool applyStagedFontReconfigIfNotRenderable();
 
     /// Updates all window size constraints: minimum size, base size, and size increment.
     /// Configures the window manager to constrain user resizes to exact cell boundaries.

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -244,18 +244,11 @@ class TerminalDisplay: public QQuickItem
     void watchKdeDpiSetting();
     [[nodiscard]] float uptime() const noexcept;
 
-    /// Returns whether the display will paint frames (window present, render target created and the
-    /// window exposed). A staged font reconfiguration is applied by the render thread only on a painted
-    /// frame, so this gates whether such a change can be driven by a redraw or must be applied directly.
-    [[nodiscard]] bool willRenderFrames() const noexcept;
-
-    /// Drives a pending font reconfiguration: schedules a redraw when frames will paint, otherwise
-    /// applies the staged reconfiguration synchronously and re-derives geometry. The synchronous path
-    /// covers the minimized/occluded case, where no frame would paint and the change would be lost.
-    ///
-    /// @returns true if the staged reconfiguration was applied synchronously (so the renderer's published
-    ///          metrics already reflect it), false if it was left for the next painted frame.
-    bool applyStagedFontReconfigIfNotRenderable();
+    /// Applies a staged font/DPI reconfiguration synchronously on the GUI thread and re-derives geometry
+    /// (page size, implicit size, constraints, and the resizeScreen()/SIGWINCH to the child) against the
+    /// resulting cell size. This is the single policy for all discrete font reconfigurations (size,
+    /// family, DPI); see the definition for why these are applied inline rather than deferred to a frame.
+    void applyStagedFontReconfigNow();
 
     /// Updates all window size constraints: minimum size, base size, and size increment.
     /// Configures the window manager to constrain user resizes to exact cell boundaries.

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -219,8 +219,12 @@ class TerminalDisplay: public QQuickItem
 
         // auto const availablePixels = gridMetrics().cellSize * _session->terminal().pageSize();
         auto const availablePixels = pixelSize();
+        // Use the lock-free publishedCellSize() for the divisor — the same accessor pixelSize() uses for
+        // the dividend — so both reads resolve from one source (and one atomic load that cannot tear
+        // against a concurrent render-thread font apply), rather than mixing it with the mutex-guarded
+        // gridMetrics().cellSize.
         return pageSizeForPixels(availablePixels,
-                                 _renderer->gridMetrics().cellSize,
+                                 _renderer->publishedCellSize(),
                                  applyContentScale(_session->profile().margins.value(), contentScale()));
     }
 

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -132,6 +132,15 @@ class TerminalDisplay: public QQuickItem
     void setFonts(vtrasterizer::FontDescriptions fontDescriptions);
     bool setFontSize(text::font_size newFontSize);
     bool setPageSize(vtbackend::PageSize newPageSize);
+
+    /// Pushes @p totalPageSize into the renderer's published/live grid metrics.
+    ///
+    /// For callers that resize the terminal directly (bypassing setPageSize()/applyResize()), so the
+    /// renderer's page size stays consistent with the terminal's. Does not resize the terminal itself.
+    ///
+    /// @param totalPageSize  the terminal's total page size (including the status line) to publish.
+    void syncRendererPageSize(vtbackend::PageSize totalPageSize);
+
     void setMouseCursorShape(MouseCursorShape newCursorShape);
     void setWindowFullScreen();
     void setWindowMaximized();

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -138,13 +138,15 @@ class TerminalDisplay: public QQuickItem
 
     bool setPageSize(vtbackend::PageSize newPageSize);
 
-    /// Pushes @p totalPageSize into the renderer's published/live grid metrics.
+    /// Pushes the full geometry (page size, render-surface pixel size and margin) into the renderer.
     ///
     /// For callers that resize the terminal directly (bypassing setPageSize()/applyResize()), so the
-    /// renderer's page size stays consistent with the terminal's. Does not resize the terminal itself.
+    /// renderer's grid metrics — including the margin — stay consistent with the terminal's. Does not
+    /// resize the terminal itself.
     ///
     /// @param totalPageSize  the terminal's total page size (including the status line) to publish.
-    void syncRendererPageSize(vtbackend::PageSize totalPageSize);
+    /// @param pixelSize      the render-surface size in pixels to publish.
+    void syncRendererGeometry(vtbackend::PageSize totalPageSize, vtbackend::ImageSize pixelSize);
 
     void setMouseCursorShape(MouseCursorShape newCursorShape);
     void setWindowFullScreen();

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -235,6 +235,16 @@ class TerminalDisplay: public QQuickItem
     void watchKdeDpiSetting();
     [[nodiscard]] float uptime() const noexcept;
 
+    /// Returns whether the display will paint frames (window present, render target created and the
+    /// window exposed). A staged font reconfiguration is applied by the render thread only on a painted
+    /// frame, so this gates whether such a change can be driven by a redraw or must be applied directly.
+    [[nodiscard]] bool willRenderFrames() const noexcept;
+
+    /// Drives a pending font reconfiguration: schedules a redraw when frames will paint, otherwise
+    /// applies the staged reconfiguration synchronously and re-derives geometry. The synchronous path
+    /// covers the minimized/occluded case, where no frame would paint and the change would be lost.
+    void applyStagedFontReconfigIfNotRenderable();
+
     /// Updates all window size constraints: minimum size, base size, and size increment.
     /// Configures the window manager to constrain user resizes to exact cell boundaries.
     void updateSizeConstraints();

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -239,10 +239,7 @@ class TerminalDisplay: public QQuickItem
     void statsSummary();
     void doResize(crispy::size size);
 
-    [[nodiscard]] vtrasterizer::GridMetrics const& gridMetrics() const noexcept
-    {
-        return _renderer->gridMetrics();
-    }
+    [[nodiscard]] vtrasterizer::GridMetrics gridMetrics() const noexcept { return _renderer->gridMetrics(); }
 
     /// Flags the screen as dirty.
     ///

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -710,33 +710,37 @@ void spawnNewTerminal(string const& programPath,
 
 vtbackend::FontDef getFontDefinition(vtrasterizer::Renderer& renderer)
 {
+    // fontDescriptions() returns a mutex-guarded snapshot by value; take it once so all the reads below
+    // observe a single consistent set of descriptions (and so the by-reference helpers below do not bind
+    // to a temporary).
+    auto const fonts = renderer.fontDescriptions();
     auto const fontByStyle = [&](text::font_weight weight,
                                  text::font_slant slant) -> text::font_description const& {
         auto const bold = weight != text::font_weight::normal;
         auto const italic = slant != text::font_slant::normal;
         if (bold && italic)
-            return renderer.fontDescriptions().boldItalic;
+            return fonts.boldItalic;
         else if (bold)
-            return renderer.fontDescriptions().bold;
+            return fonts.bold;
         else if (italic)
-            return renderer.fontDescriptions().italic;
+            return fonts.italic;
         else
-            return renderer.fontDescriptions().regular;
+            return fonts.regular;
     };
     auto const nameOfStyledFont = [&](text::font_weight weight, text::font_slant slant) -> string {
-        auto const& regularFont = renderer.fontDescriptions().regular;
+        auto const& regularFont = fonts.regular;
         auto const& styledFont = fontByStyle(weight, slant);
         if (styledFont.familyName == regularFont.familyName)
             return "auto";
         else
             return styledFont.toPattern();
     };
-    return { .size = renderer.fontDescriptions().size.pt,
-             .regular = renderer.fontDescriptions().regular.familyName,
+    return { .size = fonts.size.pt,
+             .regular = fonts.regular.familyName,
              .bold = nameOfStyledFont(text::font_weight::bold, text::font_slant::normal),
              .italic = nameOfStyledFont(text::font_weight::normal, text::font_slant::italic),
              .boldItalic = nameOfStyledFont(text::font_weight::bold, text::font_slant::italic),
-             .emoji = renderer.fontDescriptions().emoji.toPattern() };
+             .emoji = fonts.emoji.toPattern() };
 }
 
 vtrasterizer::PageMargin computeMargin(ImageSize cellSize,

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -770,8 +770,11 @@ bool applyFontDescription(text::DPI dpi,
     if (renderer.fontDescriptions() == fontDescriptions)
         return false;
 
+    // setFonts() only *stages* the change; the shaper reconfiguration, font loading and
+    // grid-metrics/atlas rebuild happen on the render thread in applyPendingReconfig(). Do NOT call
+    // updateFontMetrics() here: it mutates _gridMetrics, rebuilds the texture atlas and touches the
+    // non-thread-safe text shaper, which would race the render thread mid-frame (issue #1922).
     renderer.setFonts(sanitizeFontDescription(std::move(fontDescriptions), dpi));
-    renderer.updateFontMetrics();
 
     return true;
 }
@@ -784,21 +787,20 @@ void applyResize(vtbackend::ImageSize newPixelSize,
         return;
 
     auto const oldPageSize = session.terminal().totalPageSize();
+    // gridMetrics() copies a struct under a mutex, so read it once and reuse the cell size below.
+    vtbackend::ImageSize const cellSize = renderer.gridMetrics().cellSize;
     auto const newPageSize = pageSizeForPixels(
         newPixelSize,
-        renderer.gridMetrics().cellSize,
+        cellSize,
         applyContentScale(session.profile().margins.value(), session.display()->contentScale()));
     vtbackend::Terminal& terminal = session.terminal();
-    vtbackend::ImageSize const cellSize = renderer.gridMetrics().cellSize;
 
-    if (renderer.hasRenderTarget())
-        renderer.renderTarget().setRenderSize(newPixelSize);
-    renderer.setPageSize(newPageSize);
-    renderer.setMargin(computeMargin(
-        renderer.gridMetrics().cellSize,
+    auto const newMargin = computeMargin(
+        cellSize,
         newPageSize,
         newPixelSize,
-        applyContentScale(session.profile().margins.value(), session.display()->contentScale())));
+        applyContentScale(session.profile().margins.value(), session.display()->contentScale()));
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
 
     if (oldPageSize.lines != newPageSize.lines)
         emit session.lineCountChanged(newPageSize.lines.as<int>());

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -787,8 +787,8 @@ void applyResize(vtbackend::ImageSize newPixelSize,
         return;
 
     auto const oldPageSize = session.terminal().totalPageSize();
-    // gridMetrics() copies a struct under a mutex, so read it once and reuse the cell size below.
-    vtbackend::ImageSize const cellSize = renderer.gridMetrics().cellSize;
+    // Read the published cell size once (lock-free), reused for both the page size and margin below.
+    vtbackend::ImageSize const cellSize = renderer.publishedCellSize();
     auto const newPageSize = pageSizeForPixels(
         newPixelSize,
         cellSize,

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2415,7 +2415,11 @@ void Terminal::setTabName(string_view title)
 
 void Terminal::requestTabName()
 {
-    inputHandler().setTabName([&](std::string name) { _tabName = std::move(name); });
+    // Route the interactively-entered name through setTabName() rather than assigning _tabName
+    // directly, so the event listener is notified (setTabName -> TerminalSession::setTabName ->
+    // refreshGuiTabInfoForStatusLine). Otherwise the indicator status-line tab label would keep showing
+    // the old name until some unrelated event happened to refresh it.
+    inputHandler().setTabName([this](std::string name) { setTabName(name); });
 }
 
 std::optional<std::string> Terminal::tabName() const noexcept

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2427,6 +2427,20 @@ std::optional<std::string> Terminal::tabName() const noexcept
     return _tabName;
 }
 
+std::optional<std::string> Terminal::resolvedTabName() const
+{
+    // Single lock hold for the whole resolution: _tabName/_windowTitle are written on the parser thread
+    // under _stateMutex (setTabName()/setWindowTitle()), and this runs on the GUI thread, so reading them
+    // unlocked (or across three separate locked accessor calls) would race the writer. getTabsNamingMode()
+    // reads _settings, which is not mutated by the parser thread, so it needs no extra protection.
+    auto const l = std::lock_guard { _stateMutex };
+    if (_tabName)
+        return _tabName;
+    if (_settings.tabNamingMode == TabsNamingMode::Title)
+        return _windowTitle;
+    return std::nullopt;
+}
+
 void Terminal::saveWindowTitle()
 {
     _savedWindowTitles.push(_windowTitle);

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1386,10 +1386,21 @@ class Terminal
     void setStatusLineDefinition(StatusLineDefinition&& definition);
     void resetStatusLineDefinition();
 
-    TabsInfo guiTabsInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
+    TabsInfo guiTabsInfoForStatusLine() const
+    {
+        // The render thread reads this from fillRenderBufferStatusLine() (already under _stateMutex), and
+        // the GUI thread writes it from setGuiTabInfoForStatusLine(). Serialize the two on a dedicated,
+        // lightweight mutex rather than _stateMutex: the GUI-thread writer would otherwise block on the
+        // heavily-contended _stateMutex for the full duration the parser thread holds it during a burst of
+        // output, stalling input/redraw. _guiTabInfoMutex is only ever held for this small copy, so the
+        // read taking both locks introduces no contention and no lock-order inversion (the writer never
+        // takes _stateMutex).
+        auto const l = std::lock_guard { _guiTabInfoMutex };
+        return _guiTabInfoForStatusLine;
+    }
     void setGuiTabInfoForStatusLine(TabsInfo&& info)
     {
-        auto const l = std::lock_guard { _stateMutex };
+        auto const l = std::lock_guard { _guiTabInfoMutex };
         _guiTabInfoForStatusLine = std::move(info);
     }
 
@@ -1610,6 +1621,10 @@ class Terminal
 
     // {{{ tabs info
     TabsInfo _guiTabInfoForStatusLine;
+    /// Guards _guiTabInfoForStatusLine. Dedicated (not _stateMutex) so the GUI-thread writer
+    /// (setGuiTabInfoForStatusLine) does not block on the heavily-contended _stateMutex held by the parser
+    /// thread during output bursts. Held only for the small copy in the accessor/mutator.
+    std::mutex mutable _guiTabInfoMutex;
     // }}}
 
     // {{{ selection states

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1149,6 +1149,16 @@ class Terminal
     void setTabName(std::string_view title);
     [[nodiscard]] std::string const& windowTitle() const noexcept;
     [[nodiscard]] std::optional<std::string> tabName() const noexcept;
+
+    /// Resolves the indicator status-line tab label for this terminal under a single _stateMutex hold.
+    ///
+    /// Returns the explicit tab name if one is set, otherwise the window title when TabsNamingMode::Title
+    /// is active, otherwise nullopt. Unlike calling tabName()/getTabsNamingMode()/windowTitle()
+    /// separately, this reads _tabName/_windowTitle while holding _stateMutex — they are written on the
+    /// parser thread under that same mutex (setTabName()/setWindowTitle()), and this is invoked from the
+    /// GUI thread (TerminalSessionManager::updateStatusLine()), so an unlocked read would be a data race
+    /// on the underlying std::string (torn read / use-after-free on reallocation).
+    [[nodiscard]] std::optional<std::string> resolvedTabName() const;
     [[nodiscard]] bool focused() const noexcept { return _focused; }
     [[nodiscard]] Search& search() noexcept { return _search; }
     [[nodiscard]] Search const& search() const noexcept { return _search; }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1377,7 +1377,11 @@ class Terminal
     void resetStatusLineDefinition();
 
     TabsInfo guiTabsInfoForStatusLine() const noexcept { return _guiTabInfoForStatusLine; }
-    void setGuiTabInfoForStatusLine(TabsInfo&& info) { _guiTabInfoForStatusLine = std::move(info); }
+    void setGuiTabInfoForStatusLine(TabsInfo&& info)
+    {
+        auto const l = std::lock_guard { _stateMutex };
+        _guiTabInfoForStatusLine = std::move(info);
+    }
 
     TabsNamingMode getTabsNamingMode() const noexcept { return _settings.tabNamingMode; }
     void requestTabName();

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -136,6 +136,7 @@ Renderer::Renderer(vtbackend::PageSize pageSize,
     }() },
     _fonts { loadFontKeys(_fontDescriptions, *_textShaper) },
     _gridMetrics { loadGridMetrics(_fonts.regular, pageSize, *_textShaper) },
+    _publishedMetrics { _gridMetrics },
     //.
     _backgroundRenderer { _gridMetrics, colorPalette.defaultBackground },
     _imageRenderer { _gridMetrics, cellSize() },
@@ -241,6 +242,18 @@ void Renderer::clearCache()
 
 void Renderer::setFonts(FontDescriptions fontDescriptions)
 {
+    // The text shaper is not thread-safe and is used by the render thread during every frame, so we
+    // only *stage* the requested font descriptions here (on the UI thread). The shaper reconfiguration,
+    // font loading and grid-metrics/atlas rebuild happen on the render thread in applyPendingReconfig().
+    auto const l = std::scoped_lock { _reconfigMutex };
+    auto& pending = ensurePendingLocked();
+    pending.fontDescriptions = std::move(fontDescriptions);
+    // A full font-descriptions change supersedes any pending size-only change.
+    pending.fontSize.reset();
+}
+
+void Renderer::applyFontDescriptions(FontDescriptions fontDescriptions)
+{
     if (fontDescriptions == _fontDescriptions)
         return;
 
@@ -284,9 +297,17 @@ bool Renderer::setFontSize(text::font_size fontSize)
     if (fontSize.pt > 200.)
         return false;
 
-    _fontDescriptions.size = fontSize;
-    _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
-    updateFontMetrics();
+    // The text shaper is not thread-safe and is used by the render thread during every frame.
+    // We therefore only *stage* the requested size here (on the UI thread); the actual font loading
+    // and grid-metrics recomputation happen on the render thread in applyPendingReconfig().
+    auto const l = std::scoped_lock { _reconfigMutex };
+    auto& pending = ensurePendingLocked();
+    if (pending.fontDescriptions)
+        // A full font-descriptions change is already staged; fold the new size into it so the most
+        // recent size wins rather than being dropped when the descriptions are applied.
+        pending.fontDescriptions->size = fontSize;
+    else
+        pending.fontSize = fontSize;
 
     return true;
 }
@@ -304,6 +325,75 @@ void Renderer::updateFontMetrics()
     _imageRenderer.setCellSize(cellSize());
 
     clearCache();
+}
+
+void Renderer::applyPendingReconfig()
+{
+    // Runs on the render thread, at the start of renderImpl(), before any renderable reads
+    // _gridMetrics or the texture atlas. This is the *only* place those are mutated after
+    // construction, so the data race between UI-thread reconfiguration and rendering is avoided.
+
+    // Fast path: avoid acquiring the mutex on every frame when nothing is staged. The atomic is set
+    // under _reconfigMutex by the UI-thread writers, so a false reading here means no writer has
+    // committed a request yet — and the next frame will pick it up.
+    if (!_reconfigPending.load(std::memory_order_relaxed))
+        return;
+
+    auto const l = std::scoped_lock { _reconfigMutex };
+
+    if (!_pendingReconfig)
+        return;
+
+    auto const pending = std::move(*_pendingReconfig);
+    _pendingReconfig.reset();
+    _reconfigPending.store(false, std::memory_order_relaxed);
+
+    // Apply a pending geometry change (page size, margin, render-surface pixel size).
+    if (pending.geometry)
+    {
+        auto const& geometry = *pending.geometry;
+        if (_renderTarget)
+        {
+            if (geometry.pixelSize)
+                _renderTarget->setRenderSize(*geometry.pixelSize);
+            _renderTarget->setMargin(geometry.pageMargin);
+        }
+        _gridMetrics.pageSize = geometry.pageSize;
+        _gridMetrics.pageMargin = geometry.pageMargin;
+    }
+
+    // Apply a pending font change (full descriptions or size-only): reconfigure the shaper, load the
+    // fonts and rebuild grid metrics + atlas here, on the render thread, so the non-thread-safe text
+    // shaper is never touched concurrently with rendering.
+    if (pending.fontDescriptions || pending.fontSize)
+    {
+        // applyFontDescriptions()/updateFontMetrics() recompute the per-cell metrics from the font and
+        // reset the page geometry, so preserve the current page size/margin across the rebuild.
+        auto const pageSize = _gridMetrics.pageSize;
+        auto const pageMargin = _gridMetrics.pageMargin;
+
+        if (pending.fontDescriptions)
+        {
+            applyFontDescriptions(*pending.fontDescriptions);
+        }
+        else // pending.fontSize
+        {
+            _fontDescriptions.size = *pending.fontSize;
+            _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
+            updateFontMetrics();
+        }
+
+        _gridMetrics.pageSize = pageSize;
+        _gridMetrics.pageMargin = pageMargin;
+
+        // Signal the display to recompute the page size against the new cell size (see
+        // consumeFontReconfigApplied()): the font change altered the cell metrics, so the grid
+        // dimensions derived on the UI thread before this apply may now be stale.
+        _fontReconfigApplied.store(true, std::memory_order_release);
+    }
+
+    // Publish the freshly applied metrics so UI-thread readers (gridMetrics()) observe them.
+    _publishedMetrics = _gridMetrics;
 }
 
 void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
@@ -324,8 +414,12 @@ void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
 
 void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 {
+    // Apply any geometry/font reconfiguration requested by the UI thread before rendering.
+    // This is the only point at which _gridMetrics and the texture atlas are mutated after
+    // construction, keeping all such mutation on the render thread (see applyPendingReconfig()).
+    applyPendingReconfig();
+
     auto const statusLineHeight = terminal.statusLineHeight();
-    _gridMetrics.pageSize = terminal.pageSize() + statusLineHeight;
 
     executeImageDiscards();
 

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -537,16 +537,27 @@ void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
     // Reconcile the page size with the terminal's *total* page size. Most page-size changes flow
     // through setPageSize()/applyResize() (which publish synchronously), but the terminal can also
     // change its total page size on its own thread without those — notably toggling the indicator
-    // status line on/off (setStatusDisplay() -> resizeScreen()), which adds/removes a line. Detect that
-    // divergence here, on the render thread, and update + publish so gridMetrics().pageSize stays
-    // consistent with the terminal. Guarded by an equality check so the common (unchanged) case adds no
-    // per-frame mutex traffic.
-    if (auto const totalPageSize = terminal.totalPageSize(); _gridMetrics.pageSize != totalPageSize)
+    // status line on/off (setStatusDisplay() -> resizeScreen()), which adds/removes a line.
+    //
+    // Only reconcile on a terminal-driven *edge*: the terminal total changed since the previous frame.
+    // A bare `_gridMetrics.pageSize != totalPageSize` check would also fire mid-resize, when applyResize()
+    // (GUI thread) has already published+staged the new page size — so the render thread applied it into
+    // _gridMetrics — but terminal.resizeScreen() (the second half of applyResize(), still on the GUI
+    // thread) has not run yet. There the terminal total is the *stale* old value, and reconciling toward
+    // it would revert the just-published new size for a frame. By keying on the change of
+    // terminal.totalPageSize() itself, an in-flight UI resize is invisible (the terminal total has not
+    // moved yet), and when resizeScreen() later lands, _gridMetrics already equals it so the edge is a
+    // no-op. A status-line toggle, by contrast, moves the terminal total without any renderer staging, so
+    // it registers as an edge and is reconciled.
+    auto const totalPageSize = terminal.totalPageSize();
+    if (_lastObservedTotalPageSize && *_lastObservedTotalPageSize != totalPageSize
+        && _gridMetrics.pageSize != totalPageSize)
     {
         _gridMetrics.pageSize = totalPageSize;
         auto const l = std::scoped_lock { _reconfigMutex };
         _publishedMetrics.pageSize = totalPageSize;
     }
+    _lastObservedTotalPageSize = totalPageSize;
 
     executeImageDiscards();
 

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -317,7 +317,10 @@ void Renderer::updateFontMetrics()
 {
     rendererLog()("Updating grid metrics: {}", _gridMetrics);
 
-    _gridMetrics = loadGridMetrics(_fonts.regular, _gridMetrics.pageSize, *_textShaper);
+    // Update only the font-derived fields (cellSize, baseline, underline) in place. Page geometry
+    // (pageSize, pageMargin, cellMargin) is owned by the geometry path, not the font, so leave it
+    // untouched — this is what lets callers avoid manually saving/restoring it around a font rebuild.
+    loadGridMetricsFromFont(_fonts.regular, _gridMetrics, *_textShaper);
 
     if (_renderTarget)
         configureTextureAtlas();
@@ -340,14 +343,21 @@ void Renderer::applyPendingReconfig()
     if (!_reconfigPending.load(std::memory_order_relaxed))
         return;
 
-    auto const l = std::scoped_lock { _reconfigMutex };
-
-    if (!_pendingReconfig)
-        return;
-
-    auto const pending = std::move(*_pendingReconfig);
-    _pendingReconfig.reset();
-    _reconfigPending.store(false, std::memory_order_relaxed);
+    // Take the pending request under the lock, then release it before the heavyweight apply below.
+    // _gridMetrics, _fonts and the (non-thread-safe) text shaper are only ever touched on the render
+    // thread, so they need no lock; only _pendingReconfig/_publishedMetrics are shared. Holding the
+    // lock across loadFontKeys()/configureTextureAtlas() (multi-millisecond font loading + atlas
+    // rebuild) would block every UI-thread gridMetrics() reader for that whole duration.
+    auto pendingOpt = std::optional<PendingReconfig> {};
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        if (!_pendingReconfig)
+            return;
+        pendingOpt = std::move(*_pendingReconfig);
+        _pendingReconfig.reset();
+        _reconfigPending.store(false, std::memory_order_relaxed);
+    }
+    auto const& pending = *pendingOpt;
 
     // Apply a pending geometry change (page size, margin, render-surface pixel size).
     if (pending.geometry)
@@ -368,24 +378,42 @@ void Renderer::applyPendingReconfig()
     // shaper is never touched concurrently with rendering.
     if (pending.fontDescriptions || pending.fontSize)
     {
-        // applyFontDescriptions()/updateFontMetrics() recompute the per-cell metrics from the font and
-        // reset the page geometry, so preserve the current page size/margin across the rebuild.
-        auto const pageSize = _gridMetrics.pageSize;
-        auto const pageMargin = _gridMetrics.pageMargin;
-
-        if (pending.fontDescriptions)
+        // updateFontMetrics() now updates only the font-derived fields in place and leaves page geometry
+        // (pageSize/pageMargin/cellMargin) untouched, so no manual save/restore around the rebuild is
+        // needed — the font rebuild and page geometry are decoupled.
+        //
+        // Font loading (FreeType face creation, file I/O) and atlas (re)allocation can throw. The
+        // request has already been consumed, so a throw here would otherwise be swallowed by render()'s
+        // catch-all and silently lost. Catch it locally, log with context, and skip signalling a font
+        // reconfig so the display does not resize against half-applied metrics.
+        try
         {
-            applyFontDescriptions(*pending.fontDescriptions);
+            if (pending.fontDescriptions)
+            {
+                applyFontDescriptions(*pending.fontDescriptions);
+            }
+            else // pending.fontSize
+            {
+                _fontDescriptions.size = *pending.fontSize;
+                _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
+                updateFontMetrics();
+            }
         }
-        else // pending.fontSize
+        catch (std::exception const& e)
         {
-            _fontDescriptions.size = *pending.fontSize;
-            _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
-            updateFontMetrics();
+            errorLog()("Failed to apply staged font reconfiguration: {}. Keeping previous font.", e.what());
+            // Publish whatever metrics we have so readers stay consistent, but do not raise the font
+            // reconfig signal: the cell size did not change in a usable way.
+            {
+                auto const l = std::scoped_lock { _reconfigMutex };
+                _publishedMetrics.cellSize = _gridMetrics.cellSize;
+                _publishedMetrics.baseline = _gridMetrics.baseline;
+                _publishedMetrics.underline = _gridMetrics.underline;
+                _publishedMetrics.cellMargin = _gridMetrics.cellMargin;
+            }
+            _publishedCellSize.store(_gridMetrics.cellSize, std::memory_order_release);
+            return;
         }
-
-        _gridMetrics.pageSize = pageSize;
-        _gridMetrics.pageMargin = pageMargin;
 
         // Signal the display to recompute the page size against the new cell size (see
         // consumeFontReconfigApplied()): the font change altered the cell metrics, so the grid
@@ -393,8 +421,22 @@ void Renderer::applyPendingReconfig()
         _fontReconfigApplied.store(true, std::memory_order_release);
     }
 
-    // Publish the freshly applied metrics so UI-thread readers (gridMetrics()) observe them.
-    _publishedMetrics = _gridMetrics;
+    // Publish the freshly applied metrics so UI-thread readers (gridMetrics()) observe them. Re-acquire
+    // the lock only for this short copy, not across the font load/atlas rebuild above.
+    //
+    // Publish only the render-thread-owned (font-derived) fields. pageSize/pageMargin are owned by the
+    // UI-thread geometry writers (setPageSize/applyResize), which publish them synchronously when they
+    // stage; a writer may have done so while the lock was released above, so overwriting them here with
+    // this apply's (possibly older) _gridMetrics values would lose that newer published geometry.
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        _publishedMetrics.cellSize = _gridMetrics.cellSize;
+        _publishedMetrics.baseline = _gridMetrics.baseline;
+        _publishedMetrics.underline = _gridMetrics.underline;
+        _publishedMetrics.cellMargin = _gridMetrics.cellMargin;
+    }
+    // Publish the lock-free cell-size mirror (release-ordered) for publishedCellSize() readers.
+    _publishedCellSize.store(_gridMetrics.cellSize, std::memory_order_release);
 }
 
 void Renderer::render(vtbackend::Terminal& terminal, bool pressure)

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -137,6 +137,7 @@ Renderer::Renderer(vtbackend::PageSize pageSize,
     _fonts { loadFontKeys(_fontDescriptions, *_textShaper) },
     _gridMetrics { loadGridMetrics(_fonts.regular, pageSize, *_textShaper) },
     _publishedMetrics { _gridMetrics },
+    _publishedCellSize { _gridMetrics.cellSize },
     //.
     _backgroundRenderer { _gridMetrics, colorPalette.defaultBackground },
     _imageRenderer { _gridMetrics, cellSize() },

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -315,8 +315,16 @@ void Renderer::applyFontDescriptions(FontDescriptions fontDescriptions)
         _textShaper->set_font_fallback_limit(fontDescriptions.maxFallbackCount);
     }
 
+    // Load the fonts against the NEW descriptions but only commit them to _fontDescriptions once the
+    // load succeeds. loadFontKeys()/updateFontMetrics() (atlas reconfiguration) can throw, and this is
+    // called from applyPendingReconfig()'s try/catch which keeps the previous font on failure. Committing
+    // _fontDescriptions first (as before) would leave it at a never-loaded value: the change-detection
+    // guard at the top of this function and helper.cpp::applyFontDescription would then both early-return
+    // on retry, permanently stranding the wrong font. This mirrors the size-only branch in
+    // applyPendingReconfig(). The shaper reconfiguration above is render-thread-owned and idempotent on
+    // retry, so it is fine to have run already.
+    _fonts = loadFontKeys(fontDescriptions, *_textShaper);
     _fontDescriptions = std::move(fontDescriptions);
-    _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
     updateFontMetrics();
 
     if (_renderTarget)

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -515,6 +515,20 @@ void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 
     auto const statusLineHeight = terminal.statusLineHeight();
 
+    // Reconcile the page size with the terminal's *total* page size. Most page-size changes flow
+    // through setPageSize()/applyResize() (which publish synchronously), but the terminal can also
+    // change its total page size on its own thread without those — notably toggling the indicator
+    // status line on/off (setStatusDisplay() -> resizeScreen()), which adds/removes a line. Detect that
+    // divergence here, on the render thread, and update + publish so gridMetrics().pageSize stays
+    // consistent with the terminal. Guarded by an equality check so the common (unchanged) case adds no
+    // per-frame mutex traffic.
+    if (auto const totalPageSize = terminal.totalPageSize(); _gridMetrics.pageSize != totalPageSize)
+    {
+        _gridMetrics.pageSize = totalPageSize;
+        auto const l = std::scoped_lock { _reconfigMutex };
+        _publishedMetrics.pageSize = totalPageSize;
+    }
+
     executeImageDiscards();
 
 #if !defined(LIBTERMINAL_PASSIVE_RENDER_BUFFER_UPDATE) // {{{

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -137,6 +137,7 @@ Renderer::Renderer(vtbackend::PageSize pageSize,
     _fonts { loadFontKeys(_fontDescriptions, *_textShaper) },
     _gridMetrics { loadGridMetrics(_fonts.regular, pageSize, *_textShaper) },
     _publishedMetrics { _gridMetrics },
+    _publishedFontDescriptions { _fontDescriptions },
     _publishedCellSize { _gridMetrics.cellSize },
     //.
     _backgroundRenderer { _gridMetrics, colorPalette.defaultBackground },
@@ -258,12 +259,15 @@ void Renderer::setFontDPI(DPI dpi)
     auto const l = std::scoped_lock { _reconfigMutex };
 
     // Determine the *effective* descriptions WITHOUT creating a pending reconfig yet: an already-staged
-    // font-descriptions change (so a concurrent font-family change isn't clobbered), otherwise the live
-    // descriptions. Bail out before staging anything if the DPI is unchanged, so an unchanged-DPI call
-    // does not spuriously stage an (empty) reconfiguration.
+    // font-descriptions change (so a concurrent font-family change isn't clobbered), otherwise the
+    // published snapshot. We must NOT read the live _fontDescriptions here: it is mutated on the render
+    // thread (applyPendingReconfig) without _reconfigMutex, so reading it would be a data race. The
+    // published snapshot is render-thread-published under this same mutex. Bail out before staging
+    // anything if the DPI is unchanged, so an unchanged-DPI call does not spuriously stage an (empty)
+    // reconfiguration.
     auto const& effective = (_pendingReconfig && _pendingReconfig->fontDescriptions)
                                 ? *_pendingReconfig->fontDescriptions
-                                : _fontDescriptions;
+                                : _publishedFontDescriptions;
     if (effective.dpi == dpi)
         return;
 
@@ -408,14 +412,24 @@ void Renderer::applyPendingReconfig()
     // shaper is never touched concurrently with rendering.
     if (pending.fontDescriptions || pending.fontSize)
     {
+        // Remember the cell size before the apply so we can tell whether the font change actually
+        // altered the cell metrics. A no-op font apply (e.g. setFontSize() with the current size, or a
+        // config reload re-applying identical fonts) must NOT signal a font reconfig: doing so triggers
+        // a redundant, terminal-locked resize round-trip on the UI thread for a cell size that did not
+        // change (the symmetric counterpart to the geometry-only case guarded above).
+        auto const cellSizeBefore = _gridMetrics.cellSize;
+
         // updateFontMetrics() now updates only the font-derived fields in place and leaves page geometry
         // (pageSize/pageMargin/cellMargin) untouched, so no manual save/restore around the rebuild is
         // needed — the font rebuild and page geometry are decoupled.
         //
         // Font loading (FreeType face creation, file I/O) and atlas (re)allocation can throw. The
         // request has already been consumed, so a throw here would otherwise be swallowed by render()'s
-        // catch-all and silently lost. Catch it locally, log with context, and skip signalling a font
-        // reconfig so the display does not resize against half-applied metrics.
+        // catch-all and silently lost. The underlying loadFontKeys()/configureTextureAtlas() report
+        // failure by throwing rather than via std::expected, so we catch locally, log with context, and
+        // fall through to re-publish the (unchanged) metrics without signalling a font reconfig — the
+        // display must not resize against half-applied metrics.
+        auto applied = false;
         try
         {
             if (pending.fontDescriptions)
@@ -424,39 +438,44 @@ void Renderer::applyPendingReconfig()
             }
             else // pending.fontSize
             {
-                _fontDescriptions.size = *pending.fontSize;
-                _fonts = loadFontKeys(_fontDescriptions, *_textShaper);
+                // Stage the size into a copy first; only commit it to _fontDescriptions once the font
+                // actually loaded, so a load failure does not leave _fontDescriptions.size at a value
+                // whose glyphs were never loaded (which would corrupt later change-detection and the
+                // size reported to the UI).
+                auto descriptions = _fontDescriptions;
+                descriptions.size = *pending.fontSize;
+                _fonts = loadFontKeys(descriptions, *_textShaper);
+                _fontDescriptions = std::move(descriptions);
                 updateFontMetrics();
             }
+            applied = true;
         }
         catch (std::exception const& e)
         {
             errorLog()("Failed to apply staged font reconfiguration: {}. Keeping previous font.", e.what());
-            // Publish whatever metrics we have so readers stay consistent, but do not raise the font
-            // reconfig signal: the cell size did not change in a usable way.
-            {
-                auto const l = std::scoped_lock { _reconfigMutex };
-                _publishedMetrics.cellSize = _gridMetrics.cellSize;
-                _publishedMetrics.baseline = _gridMetrics.baseline;
-                _publishedMetrics.underline = _gridMetrics.underline;
-                _publishedMetrics.cellMargin = _gridMetrics.cellMargin;
-            }
-            _publishedCellSize.store(_gridMetrics.cellSize, std::memory_order_release);
-            return;
+            // Fall through to the publish below with applied == false: readers stay consistent with the
+            // (unchanged) live metrics, and no font reconfig is signalled.
         }
 
         // Signal the display to recompute the page size against the new cell size (see
-        // consumeFontReconfigApplied()): the font change altered the cell metrics, so the grid
-        // dimensions derived on the UI thread before this apply may now be stale.
-        _fontReconfigApplied.store(true, std::memory_order_release);
-    }
+        // consumeFontReconfigApplied()) only if the apply succeeded AND the cell size actually changed:
+        // the grid dimensions derived on the UI thread before this apply are stale only then.
+        if (applied && _gridMetrics.cellSize != cellSizeBefore)
+            _fontReconfigApplied.store(true, std::memory_order_release);
 
-    // Publish the freshly applied metrics so UI-thread readers (gridMetrics()) observe them. Re-acquire
-    // the lock only for this short copy, not across the font load/atlas rebuild above.
+        publishFontMetricsAndDescriptions();
+    }
+}
+
+void Renderer::publishFontMetricsAndDescriptions()
+{
+    // Publish the render-thread-owned (font-derived) metrics and the font descriptions so UI-thread
+    // readers (gridMetrics(), publishedCellSize(), fontDescriptions()) observe them. Re-acquire the lock
+    // only for this short copy, not across the font load/atlas rebuild that precedes the call.
     //
     // Publish only the render-thread-owned (font-derived) fields. pageSize/pageMargin are owned by the
     // UI-thread geometry writers (setPageSize/applyResize), which publish them synchronously when they
-    // stage; a writer may have done so while the lock was released above, so overwriting them here with
+    // stage; a writer may have done so while the lock was released earlier, so overwriting them here with
     // this apply's (possibly older) _gridMetrics values would lose that newer published geometry.
     {
         auto const l = std::scoped_lock { _reconfigMutex };
@@ -464,9 +483,11 @@ void Renderer::applyPendingReconfig()
         _publishedMetrics.baseline = _gridMetrics.baseline;
         _publishedMetrics.underline = _gridMetrics.underline;
         _publishedMetrics.cellMargin = _gridMetrics.cellMargin;
+        _publishedFontDescriptions = _fontDescriptions;
+        // Keep the lock-free cell-size mirror in lockstep with _publishedMetrics.cellSize so the two
+        // never diverge — both are written here, under the lock, from the same source value.
+        _publishedCellSize.store(_gridMetrics.cellSize, std::memory_order_release);
     }
-    // Publish the lock-free cell-size mirror (release-ordered) for publishedCellSize() readers.
-    _publishedCellSize.store(_gridMetrics.cellSize, std::memory_order_release);
 }
 
 void Renderer::render(vtbackend::Terminal& terminal, bool pressure)

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -367,12 +367,15 @@ void Renderer::updateFontMetrics()
 
 void Renderer::applyPendingReconfig()
 {
-    // Runs on the render thread, at the start of renderImpl(), before any renderable reads
-    // _gridMetrics or the texture atlas. This is the *only* place those are mutated after
-    // construction, so the data race between UI-thread reconfiguration and rendering is avoided.
+    // Mutates _gridMetrics / the texture atlas / the non-thread-safe shaper. The caller must hold
+    // _applyMutex for the duration that those are also *read* — on the render thread that is the whole
+    // renderImpl() (it renders from _gridMetrics after this returns); on the GUI thread's not-renderable
+    // path applyStagedReconfigDuringSetup() holds it across this call. That serialization is what keeps
+    // a GUI-thread apply from overlapping an in-flight render-thread frame (a window losing exposure
+    // does not synchronously stop one).
 
-    // Fast path: avoid acquiring the mutex on every frame when nothing is staged. The atomic is set
-    // under _reconfigMutex by the UI-thread writers, so a false reading here means no writer has
+    // Fast path: avoid touching _pendingReconfig on every frame when nothing is staged. The atomic is
+    // set under _reconfigMutex by the UI-thread writers, so a false reading here means no writer has
     // committed a request yet — and the next frame will pick it up.
     if (!_reconfigPending.load(std::memory_order_relaxed))
         return;
@@ -508,6 +511,14 @@ void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
 
 void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 {
+    // Hold _applyMutex across the whole frame: this both applies any staged reconfiguration and then
+    // renders from _gridMetrics / the texture atlas. Holding it for the full duration makes a GUI-thread
+    // applyStagedReconfigDuringSetup() (the minimized/occluded path) wait for an in-flight frame to
+    // finish reading those, rather than mutating them mid-render. Uncontended in the steady state (the
+    // GUI thread only contends it on the rare not-renderable reconfig), so it adds no per-frame cost
+    // beyond one uncontended lock.
+    auto const applyGuard = std::scoped_lock { _applyMutex };
+
     // Apply any geometry/font reconfiguration requested by the UI thread before rendering.
     // This is the only point at which _gridMetrics and the texture atlas are mutated after
     // construction, keeping all such mutation on the render thread (see applyPendingReconfig()).

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -253,6 +253,36 @@ void Renderer::setFonts(FontDescriptions fontDescriptions)
     pending.fontSize.reset();
 }
 
+void Renderer::setFontDPI(DPI dpi)
+{
+    auto const l = std::scoped_lock { _reconfigMutex };
+
+    // Determine the *effective* descriptions WITHOUT creating a pending reconfig yet: an already-staged
+    // font-descriptions change (so a concurrent font-family change isn't clobbered), otherwise the live
+    // descriptions. Bail out before staging anything if the DPI is unchanged, so an unchanged-DPI call
+    // does not spuriously stage an (empty) reconfiguration.
+    auto const& effective = (_pendingReconfig && _pendingReconfig->fontDescriptions)
+                                ? *_pendingReconfig->fontDescriptions
+                                : _fontDescriptions;
+    if (effective.dpi == dpi)
+        return;
+
+    auto descriptions = effective;
+    descriptions.dpi = dpi;
+
+    auto& pending = ensurePendingLocked();
+
+    // Promoting a size-only change to a full descriptions change would otherwise drop the staged size
+    // (applyPendingReconfig() applies fontDescriptions XOR fontSize), so fold it in before clearing it.
+    if (pending.fontSize)
+    {
+        descriptions.size = *pending.fontSize;
+        pending.fontSize.reset();
+    }
+
+    pending.fontDescriptions = std::move(descriptions);
+}
+
 void Renderer::applyFontDescriptions(FontDescriptions fontDescriptions)
 {
     if (fontDescriptions == _fontDescriptions)

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -377,6 +377,14 @@ class Renderer
     /// size. Atomic because it is written on the render thread and read on the display thread.
     std::atomic<bool> _fontReconfigApplied { false };
 
+    /// The terminal total page size observed by the per-frame reconcile in renderImpl() on the previous
+    /// frame. Render-thread-only. Used to distinguish a terminal-driven page-size change (status-line
+    /// toggle: an edge — the value changed since last frame) from a UI-driven resize still in flight (the
+    /// terminal total has not changed yet, only the renderer's already-correct grid metrics differ). Only
+    /// a terminal-driven edge triggers the reconcile, so the reconcile never reverts a just-published
+    /// UI resize. nullopt until the first frame seeds it.
+    std::optional<vtbackend::PageSize> _lastObservedTotalPageSize;
+
     /// Ensures a PendingReconfig exists and returns it. Caller must hold _reconfigMutex.
     PendingReconfig& ensurePendingLocked()
     {

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -83,7 +83,30 @@ class Renderer
     bool setFontSize(text::font_size fontSize);
     void updateFontMetrics();
 
-    [[nodiscard]] FontDescriptions const& fontDescriptions() const noexcept { return _fontDescriptions; }
+    /// Returns the most recently *published* font descriptions.
+    ///
+    /// Returns a snapshot by value (not a reference into the live state): the live _fontDescriptions is
+    /// mutated on the render thread during applyPendingReconfig(), so a UI-thread reader must observe a
+    /// mutex-guarded copy rather than reading the live field lock-free (which would be a data race).
+    /// A font change (setFonts/setFontSize) becomes visible here only after the render thread applies it.
+    ///
+    /// @note Thread-safe with respect to concurrent reconfiguration requests.
+    [[nodiscard]] FontDescriptions fontDescriptions() const noexcept
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        return _publishedFontDescriptions;
+    }
+
+    /// Stages a full font-descriptions change to be applied on the render thread.
+    ///
+    /// The text shaper is not thread-safe and is read by the render thread every frame, so this only
+    /// *stages* the descriptions (on the UI thread); the shaper reconfiguration, font loading and
+    /// grid-metrics/atlas rebuild happen on the render thread in applyPendingReconfig(). The new cell
+    /// size therefore appears via gridMetrics()/fontDescriptions() only after a frame (or a setup-time
+    /// applyStagedReconfigDuringSetup()), not synchronously on return. A staged size-only change is
+    /// superseded by the full descriptions staged here.
+    ///
+    /// @param fontDescriptions  the new font configuration to stage.
     void setFonts(FontDescriptions fontDescriptions);
 
     /// Stages a DPI-only font change without clobbering an already-staged font-descriptions change.
@@ -309,6 +332,13 @@ class Renderer
     /// blocked on the deferred render-thread apply. Guarded by _reconfigMutex.
     GridMetrics _publishedMetrics;
 
+    /// Mutex-guarded snapshot of _fontDescriptions for UI-thread readers (fontDescriptions(),
+    /// setFontDPI()). The live _fontDescriptions is render-thread-owned and mutated without the mutex
+    /// during applyPendingReconfig(); a UI-thread reader must therefore observe this guarded copy
+    /// instead of racing that write. Published by the render thread (under _reconfigMutex) whenever it
+    /// applies a font change, and seeded at construction. Guarded by _reconfigMutex.
+    FontDescriptions _publishedFontDescriptions;
+
     /// Lock-free mirror of _publishedMetrics.cellSize for publishedCellSize(). Written wherever the
     /// published cell size changes (construction and the render-thread font apply); read without the
     /// mutex by UI-thread hot paths. The cell size only changes via font/DPI reconfiguration, never via
@@ -353,6 +383,14 @@ class Renderer
 
     /// Applies any staged reconfiguration. Called on the render thread at the start of renderImpl().
     void applyPendingReconfig();
+
+    /// Publishes the render-thread-owned font-derived metrics and font descriptions for UI-thread
+    /// readers (gridMetrics()/publishedCellSize()/fontDescriptions()).
+    ///
+    /// Acquires _reconfigMutex for the short copy. Called from applyPendingReconfig() after a font
+    /// apply (whether it succeeded or threw), so readers always observe metrics consistent with the
+    /// live grid metrics. Does not touch page geometry, which the UI-thread geometry writers own.
+    void publishFontMetricsAndDescriptions();
 
     /// Applies a full font-descriptions change (shaper reconfiguration, font loading, grid-metrics
     /// rebuild, atlas reconfiguration). Runs on the render thread from applyPendingReconfig().

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -19,8 +19,11 @@
 
 #include <gsl/pointers>
 
+#include <atomic>
 #include <format>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -45,6 +48,8 @@ struct RenderCursor
 class Renderer
 {
   public:
+    friend class RendererTest; //!< Grants unit tests access to the deferred-reconfiguration internals.
+
     /** Constructs a Renderer instances.
      *
      * @p fonts              Reference to the set of loaded fonts to be used for rendering text.
@@ -62,6 +67,11 @@ class Renderer
              Decorator hyperlinkNormal,
              Decorator hyperlinkHover);
 
+    /// Returns the live cell size from the grid metrics.
+    ///
+    /// @warning Reads the live _gridMetrics without synchronization; intended for render-thread /
+    ///          construction-time use only. UI-thread callers must use gridMetrics().cellSize, which
+    ///          returns the published (mutex-guarded) copy.
     [[nodiscard]] ImageSize cellSize() const noexcept { return _gridMetrics.cellSize; }
 
     /// Initializes the render and all render subsystems with the given RenderTarget
@@ -76,20 +86,68 @@ class Renderer
     [[nodiscard]] FontDescriptions const& fontDescriptions() const noexcept { return _fontDescriptions; }
     void setFonts(FontDescriptions fontDescriptions);
 
-    [[nodiscard]] GridMetrics const& gridMetrics() const noexcept { return _gridMetrics; }
+    /// Returns the most recently *published* grid metrics.
+    ///
+    /// Geometry writers (setPageSize/applyResize) publish synchronously; font writers (setFonts/
+    /// setFontSize) only stage, so the new cell size appears only after a frame (or setup-time apply).
+    ///
+    /// @note Thread-safe with respect to concurrent reconfiguration requests.
+    [[nodiscard]] GridMetrics gridMetrics() const noexcept
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        return _publishedMetrics;
+    }
+
+    /// Atomically reads and clears the "a font reconfiguration was applied" flag.
+    ///
+    /// A font change (setFontSize/setFonts) is applied lazily on the render thread, so the new cell
+    /// size only becomes available after a frame. The display polls this after rendering and, when it
+    /// returns true, re-derives the terminal page size against the now-current cell size — otherwise a
+    /// font/DPI change would size the grid using the previous cell size for a frame.
+    ///
+    /// @return true if a font reconfiguration has been applied since the last call.
+    [[nodiscard]] bool consumeFontReconfigApplied() noexcept
+    {
+        return _fontReconfigApplied.exchange(false, std::memory_order_acq_rel);
+    }
 
     void setHyperlinkDecoration(Decorator normal, Decorator hover)
     {
         _decorationRenderer.setHyperlinkDecoration(normal, hover);
     }
 
-    void setPageSize(vtbackend::PageSize screenSize) noexcept { _gridMetrics.pageSize = screenSize; }
-
-    void setMargin(PageMargin margin) noexcept
+    /// Requests a new page size (in columns/lines).
+    ///
+    /// The change is published immediately (visible via gridMetrics()) and the actual
+    /// grid-metrics mutation is applied on the render thread at the start of the next frame.
+    ///
+    /// @param screenSize  the new page size.
+    void setPageSize(vtbackend::PageSize screenSize) noexcept
     {
-        if (_renderTarget)
-            _renderTarget->setMargin(margin);
-        _gridMetrics.pageMargin = margin;
+        auto const l = std::scoped_lock { _reconfigMutex };
+        _publishedMetrics.pageSize = screenSize;
+        stagePendingGeometryLocked();
+    }
+
+    /// Requests a combined render-surface resize: pixel size, page size and margin.
+    ///
+    /// Consolidates the three geometry writers so the render target and grid metrics are
+    /// updated atomically (on the render thread) rather than in three separately-observable steps.
+    ///
+    /// @param newPixelSize  new render surface size in pixels.
+    /// @param newPageSize   new page size in columns/lines.
+    /// @param newMargin     new page margin in pixels.
+    void applyResize(vtbackend::ImageSize newPixelSize,
+                     vtbackend::PageSize newPageSize,
+                     PageMargin newMargin) noexcept
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        _publishedMetrics.pageSize = newPageSize;
+        _publishedMetrics.pageMargin = newMargin;
+        auto& pending = ensurePendingLocked();
+        pending.geometry = PendingReconfig::Geometry { .pixelSize = newPixelSize,
+                                                       .pageSize = newPageSize,
+                                                       .pageMargin = newMargin };
     }
 
     /**
@@ -104,6 +162,14 @@ class Renderer
      *                       is known already to be updated right after again.
      */
     void render(vtbackend::Terminal& terminal, bool pressureHint);
+
+    /// Synchronously applies any staged font/geometry reconfiguration.
+    ///
+    /// For display setup, before any frame, when a caller must read the resulting cell metrics
+    /// immediately (e.g. to size the texture atlas tile) rather than wait for the render thread.
+    ///
+    /// @warning Only safe to call while no render thread is concurrently rendering (i.e. during setup).
+    void applyStagedReconfigDuringSetup() { applyPendingReconfig(); }
 
     void discardImage(vtbackend::Image const& image);
 
@@ -180,7 +246,91 @@ class Renderer
     std::unique_ptr<text::shaper> _textShaper;
     FontKeys _fonts;
 
+    /// The live grid metrics, mutated *only* on the render thread (at the start of renderImpl()).
+    ///
+    /// All sub-renderers hold a const reference to this object and read it throughout a frame,
+    /// hence it must never be written while a frame is in flight. UI-thread writers therefore do
+    /// not touch it directly; they stage a request (see _pendingReconfig) that the render thread
+    /// applies between frames.
     GridMetrics _gridMetrics;
+
+    /// A staged, not-yet-applied reconfiguration request produced by UI-thread writers.
+    ///
+    /// Carries the *inputs* of a pending change. The render thread consumes it at the top of
+    /// renderImpl() to rebuild grid metrics / the texture atlas on the render thread, eliminating
+    /// the data race between UI-thread geometry/font changes and the render thread.
+    struct PendingReconfig
+    {
+        /// Pending geometry change: new page size, margin and (optionally) render-surface pixel size.
+        struct Geometry
+        {
+            std::optional<vtbackend::ImageSize> pixelSize; //!< New render surface size, if it changed.
+            vtbackend::PageSize pageSize;                  //!< New page size in columns/lines.
+            PageMargin pageMargin;                         //!< New page margin in pixels.
+        };
+
+        /// Pending font change. Either a size-only change (fontSize) or a full font-descriptions
+        /// change (fontDescriptions, which supersedes a size-only change). Only the *inputs* are
+        /// staged; the heavyweight work (font loading, metric computation via the non-thread-safe
+        /// text shaper, atlas rebuild) is performed on the render thread during applyPendingReconfig().
+        std::optional<text::font_size> fontSize;          //!< Set when only the font size changed.
+        std::optional<FontDescriptions> fontDescriptions; //!< Set when the full font config changed.
+        std::optional<Geometry> geometry;                 //!< Set when a geometry change is pending.
+    };
+
+    /// Protects _pendingReconfig and _publishedMetrics, and serializes the render-thread apply.
+    mutable std::mutex _reconfigMutex;
+
+    /// The most recently *requested* grid metrics, observable synchronously via gridMetrics().
+    ///
+    /// Kept in sync by UI-thread writers so callers needing the new cell size immediately are not
+    /// blocked on the deferred render-thread apply. Guarded by _reconfigMutex.
+    GridMetrics _publishedMetrics;
+
+    /// The staged reconfiguration awaiting application by the render thread. Guarded by _reconfigMutex.
+    std::optional<PendingReconfig> _pendingReconfig;
+
+    /// Mirrors `_pendingReconfig.has_value()` for a lock-free fast path: applyPendingReconfig() runs on
+    /// every frame and consults this first, only acquiring _reconfigMutex when something is actually
+    /// staged. Written under _reconfigMutex; read relaxed on the render thread.
+    std::atomic<bool> _reconfigPending { false };
+
+    /// Set by applyPendingReconfig() (render thread) when a font change was applied; consumed by the
+    /// display (consumeFontReconfigApplied()) to trigger a page-size recompute against the new cell
+    /// size. Atomic because it is written on the render thread and read on the display thread.
+    std::atomic<bool> _fontReconfigApplied { false };
+
+    /// Ensures a PendingReconfig exists and returns it. Caller must hold _reconfigMutex.
+    PendingReconfig& ensurePendingLocked()
+    {
+        if (!_pendingReconfig)
+            _pendingReconfig.emplace();
+        _reconfigPending.store(true, std::memory_order_relaxed);
+        return *_pendingReconfig;
+    }
+
+    /// Stages a geometry-only pending request derived from the current _publishedMetrics.
+    ///
+    /// A render-surface pixel size already staged by a prior applyResize() is preserved; a page-size-
+    /// or margin-only change leaves the pixel size untouched (std::nullopt → render size unchanged).
+    /// Caller must hold _reconfigMutex.
+    void stagePendingGeometryLocked()
+    {
+        auto& pending = ensurePendingLocked();
+        auto const pixelSize = pending.geometry ? pending.geometry->pixelSize : std::nullopt;
+        pending.geometry = PendingReconfig::Geometry { .pixelSize = pixelSize,
+                                                       .pageSize = _publishedMetrics.pageSize,
+                                                       .pageMargin = _publishedMetrics.pageMargin };
+    }
+
+    /// Applies any staged reconfiguration. Called on the render thread at the start of renderImpl().
+    void applyPendingReconfig();
+
+    /// Applies a full font-descriptions change (shaper reconfiguration, font loading, grid-metrics
+    /// rebuild, atlas reconfiguration). Runs on the render thread from applyPendingReconfig().
+    ///
+    /// @param fontDescriptions  the new font descriptions to apply.
+    void applyFontDescriptions(FontDescriptions fontDescriptions);
 
     std::mutex _imageDiscardLock;                       //!< Lock guard for accessing _discardImageQueue.
     std::vector<vtbackend::ImageId> _discardImageQueue; //!< List of images to be discarded.

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -86,6 +86,17 @@ class Renderer
     [[nodiscard]] FontDescriptions const& fontDescriptions() const noexcept { return _fontDescriptions; }
     void setFonts(FontDescriptions fontDescriptions);
 
+    /// Stages a DPI-only font change without clobbering an already-staged font-descriptions change.
+    ///
+    /// Unlike reading fontDescriptions() and re-staging the whole thing via setFonts(), this updates
+    /// only the .dpi field of the *effective* descriptions — the ones already staged in a pending
+    /// reconfig if present, otherwise the live ones. A concurrent font-family change staged just before
+    /// (e.g. by a config reload) therefore keeps its family and merely picks up the new DPI, instead of
+    /// being silently overwritten with the live descriptions + new DPI.
+    ///
+    /// @param dpi  the new device pixels-per-inch to apply to the font configuration.
+    void setFontDPI(DPI dpi);
+
     /// Returns the most recently *published* grid metrics.
     ///
     /// Geometry writers (setPageSize/applyResize) publish synchronously; font writers (setFonts/

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -98,6 +98,17 @@ class Renderer
         return _publishedMetrics;
     }
 
+    /// Returns the most recently *published* cell size, lock-free.
+    ///
+    /// Equivalent to gridMetrics().cellSize but without taking _reconfigMutex or copying the whole
+    /// GridMetrics struct — for the many UI-thread hot paths (per-frame sync, scroll, IME, size
+    /// recompute) that need only the cell size. Reading it also cannot tear against a concurrent
+    /// render-thread font apply, unlike two separate gridMetrics().cellSize reads.
+    [[nodiscard]] ImageSize publishedCellSize() const noexcept
+    {
+        return _publishedCellSize.load(std::memory_order_acquire);
+    }
+
     /// Atomically reads and clears the "a font reconfiguration was applied" flag.
     ///
     /// A font change (setFontSize/setFonts) is applied lazily on the render thread, so the new cell
@@ -286,6 +297,12 @@ class Renderer
     /// Kept in sync by UI-thread writers so callers needing the new cell size immediately are not
     /// blocked on the deferred render-thread apply. Guarded by _reconfigMutex.
     GridMetrics _publishedMetrics;
+
+    /// Lock-free mirror of _publishedMetrics.cellSize for publishedCellSize(). Written wherever the
+    /// published cell size changes (construction and the render-thread font apply); read without the
+    /// mutex by UI-thread hot paths. The cell size only changes via font/DPI reconfiguration, never via
+    /// geometry writers, so this stays consistent with _publishedMetrics.cellSize.
+    std::atomic<ImageSize> _publishedCellSize;
 
     /// The staged reconfiguration awaiting application by the render thread. Guarded by _reconfigMutex.
     std::optional<PendingReconfig> _pendingReconfig;

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -210,11 +210,17 @@ class Renderer
 
     /// Synchronously applies any staged font/geometry reconfiguration.
     ///
-    /// For display setup, before any frame, when a caller must read the resulting cell metrics
-    /// immediately (e.g. to size the texture atlas tile) rather than wait for the render thread.
+    /// Used during display setup (before any frame, when a caller must read the resulting cell metrics
+    /// immediately, e.g. to size the texture atlas tile) and on the not-renderable (minimized/occluded)
+    /// path, where no frame will paint to apply the staged change.
     ///
-    /// @warning Only safe to call while no render thread is concurrently rendering (i.e. during setup).
-    void applyStagedReconfigDuringSetup() { applyPendingReconfig(); }
+    /// Takes _applyMutex so it is mutually exclusive with the render thread's per-frame apply+render —
+    /// safe even if an already in-flight frame has not yet observed the window losing exposure.
+    void applyStagedReconfigDuringSetup()
+    {
+        auto const applyGuard = std::scoped_lock { _applyMutex };
+        applyPendingReconfig();
+    }
 
     void discardImage(vtbackend::Image const& image);
 
@@ -325,6 +331,19 @@ class Renderer
 
     /// Protects _pendingReconfig and _publishedMetrics, and serializes the render-thread apply.
     mutable std::mutex _reconfigMutex;
+
+    /// Serializes the heavyweight apply (font load, atlas rebuild, _gridMetrics mutation) in
+    /// applyPendingReconfig() against itself across threads.
+    ///
+    /// applyPendingReconfig() normally runs only on the render thread (at the top of renderImpl()), but
+    /// applyStagedReconfigDuringSetup() also invokes it from the GUI thread for the non-renderable
+    /// (minimized/occluded) case. A window losing exposure does not synchronously stop an already
+    /// in-flight frame, so the GUI-thread apply could otherwise overlap the render-thread apply and race
+    /// on _gridMetrics / the texture atlas / the non-thread-safe shaper. Holding this mutex across the
+    /// whole apply body makes the two mutually exclusive. It is distinct from _reconfigMutex (which only
+    /// guards the short staged-request/published-metrics critical sections) so a UI-thread gridMetrics()
+    /// reader is not blocked for the multi-millisecond font load.
+    std::mutex _applyMutex;
 
     /// The most recently *requested* grid metrics, observable synchronously via gridMetrics().
     ///

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -83,6 +83,23 @@ class RendererTest
     {
         renderer._gridMetrics = metrics;
         renderer._publishedMetrics = metrics;
+        renderer._publishedCellSize.store(metrics.cellSize, std::memory_order_release);
+    }
+
+    /// Returns the staged pending font descriptions, if a full font-descriptions change is staged.
+    [[nodiscard]] static std::optional<FontDescriptions> pendingFontDescriptions(Renderer const& renderer)
+    {
+        if (!renderer._pendingReconfig)
+            return std::nullopt;
+        return renderer._pendingReconfig->fontDescriptions;
+    }
+
+    /// Returns the staged pending font size, if a size-only change is staged.
+    [[nodiscard]] static std::optional<text::font_size> pendingFontSize(Renderer const& renderer)
+    {
+        if (!renderer._pendingReconfig)
+            return std::nullopt;
+        return renderer._pendingReconfig->fontSize;
     }
 };
 } // namespace vtrasterizer

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -1,4 +1,5 @@
 #include <vtbackend/Color.h>
+#include <vtbackend/ColorPalette.h>
 
 #include <vtrasterizer/FontDescriptions.h>
 #include <vtrasterizer/GridMetrics.h>
@@ -16,10 +17,12 @@
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string_view>
+#include <thread>
 
 static std::filesystem::path testFontPath;
 
@@ -48,6 +51,37 @@ class TextRendererTest
         unicode::PresentationStyle presentation)
     {
         return renderer.createRasterizedGlyph(tileLocation, glyphKey, presentation);
+    }
+};
+
+/// Test accessor granting unit tests access to Renderer's deferred-reconfiguration internals.
+class RendererTest
+{
+  public:
+    /// Triggers the render-thread reconfiguration step that renderImpl() would normally run.
+    static void applyPendingReconfig(Renderer& renderer) { renderer.applyPendingReconfig(); }
+
+    /// Returns the *live* grid metrics (mutated only on the render thread).
+    [[nodiscard]] static GridMetrics const& liveGridMetrics(Renderer const& renderer)
+    {
+        return renderer._gridMetrics;
+    }
+
+    /// Returns whether a reconfiguration request is currently staged but not yet applied.
+    [[nodiscard]] static bool hasPendingReconfig(Renderer const& renderer)
+    {
+        return renderer._pendingReconfig.has_value();
+    }
+
+    /// Seeds self-consistent grid metrics into the live and published metrics.
+    ///
+    /// The minimal BDF test font yields zero line metrics from the shaper, which a real TextureAtlas
+    /// (and the cursor/decoration direct mappings) reject. Tests that need a render target / atlas use
+    /// this to provide usable metrics without depending on font metrics.
+    static void seedMetrics(Renderer& renderer, GridMetrics metrics)
+    {
+        renderer._gridMetrics = metrics;
+        renderer._publishedMetrics = metrics;
     }
 };
 } // namespace vtrasterizer
@@ -681,6 +715,383 @@ TEST_CASE("Renderer.findLinePartitionPoint", "[renderer]")
         // Boundary at line 4: lines 0,1,2,3 are below, lines 4,5 are at or above.
         CHECK(Renderer::findLinePartitionPoint(lines, LineCount(4)) == 4);
     }
+}
+
+namespace
+{
+
+/// Bundles a fully-constructed headless Renderer (mock font locator, mock render target) so the
+/// deferred-reconfiguration code paths can be exercised without a GPU/Qt context.
+struct ReconfigFixture
+{
+    FontDescriptions fontDescriptions = [] {
+        auto fd = FontDescriptions {};
+        fd.dpi = DPI { 96, 96 };
+        fd.size = text::font_size { 9.0 }; // Matches the BDF test font's SIZE 9 96 96.
+        fd.textShapingEngine = TextShapingEngine::OpenShaper;
+        fd.fontLocator = FontLocatorEngine::Mock;
+        fd.regular = text::font_description::parse("regular");
+        fd.bold = text::font_description::parse("regular");
+        fd.italic = text::font_description::parse("regular");
+        fd.boldItalic = text::font_description::parse("regular");
+        fd.emoji = text::font_description::parse("regular");
+        return fd;
+    }();
+
+    // The minimal BDF test font produces zero line metrics from the shaper, which a real TextureAtlas
+    // (and direct-mapped cursor/decoration tiles) reject. Tests seed self-consistent metrics via
+    // RendererTest::seedMetrics() instead. Mirrors the known-good metrics used by the TextRenderer test.
+    static GridMetrics seededMetrics()
+    {
+        return GridMetrics { .pageSize = PageSize { LineCount(24), ColumnCount(80) },
+                             .cellSize = vtbackend::ImageSize { Width(10), Height(20) },
+                             .baseline = 15,
+                             .underline = { .position = 17, .thickness = 1 } };
+    }
+
+    vtbackend::ColorPalette colorPalette {};
+    MockRenderTarget renderTarget {};
+    Renderer renderer;
+
+    ReconfigFixture():
+        renderer(vtbackend::PageSize { LineCount(24), ColumnCount(80) },
+                 fontDescriptions,
+                 colorPalette,
+                 crispy::strong_hashtable_size { 1024 },
+                 crispy::lru_capacity { 4096 },
+                 /* atlasDirectMapping */ false,
+                 Decorator::Underline,
+                 Decorator::Underline)
+    {
+        RendererTest::seedMetrics(renderer, seededMetrics());
+    }
+
+    /// Wires the mock render target (and texture atlas) into the renderer.
+    ///
+    /// Done lazily so geometry/state-machine tests that don't need a render target avoid the atlas
+    /// setup entirely.
+    void attachRenderTarget()
+    {
+        renderer.setRenderTarget(renderTarget);
+        // setRenderTarget() does not stage a reconfiguration; the seeded metrics remain in effect.
+    }
+};
+
+/// Registers the BDF mock font used by the reconfiguration tests with the global mock locator.
+void configureMockFont()
+{
+    auto registry = std::vector<text::font_description_and_source> {
+        { .description = text::font_description::parse("regular"),
+          .source = text::font_path { .value = std::filesystem::absolute(testFontPath).string() } }
+    };
+    text::mock_font_locator::configure(std::move(registry));
+}
+
+} // namespace
+
+TEST_CASE("Renderer.reconfig.geometry_published_synchronously", "[renderer]")
+{
+    // A geometry change (page size / margin / pixel size) does not need the text shaper, so the
+    // requested metrics are published synchronously and observable via gridMetrics() immediately —
+    // before any render-thread apply. This preserves the contract that applyResize()/resizeScreen()
+    // see the new geometry right away.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const oldCellSize = renderer.gridMetrics().cellSize;
+    auto const newPageSize = PageSize { LineCount(30), ColumnCount(100) };
+    auto const newMargin = vtrasterizer::PageMargin { .left = 7, .top = 11, .bottom = 13 };
+    auto const newPixelSize = vtbackend::ImageSize { Width(1280), Height(720) };
+
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
+
+    // Published (UI-visible) metrics reflect the request synchronously...
+    CHECK(renderer.gridMetrics().pageSize == newPageSize);
+    CHECK(renderer.gridMetrics().pageMargin.left == newMargin.left);
+    CHECK(renderer.gridMetrics().pageMargin.top == newMargin.top);
+    // ...but the cell size is unchanged by a pure geometry resize.
+    CHECK(renderer.gridMetrics().cellSize == oldCellSize);
+
+    // The request is staged for the render thread until applied.
+    CHECK(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+}
+
+TEST_CASE("Renderer.reconfig.geometry_not_applied_to_live_until_render", "[renderer]")
+{
+    // The live grid metrics (read by the renderables) are only mutated when the render thread applies
+    // the staged reconfiguration — not when the UI thread requests it.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const newPageSize = PageSize { LineCount(30), ColumnCount(100) };
+    auto const newMargin = vtrasterizer::PageMargin { .left = 7, .top = 11, .bottom = 13 };
+    auto const newPixelSize = vtbackend::ImageSize { Width(1280), Height(720) };
+
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
+
+    // Before apply: the *live* metrics still hold the original page size, even though the published
+    // (UI-visible) metrics already reflect the request.
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageSize != newPageSize);
+    CHECK(renderer.gridMetrics().pageSize == newPageSize);
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // After apply: live metrics updated, nothing left pending.
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageSize == newPageSize);
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageMargin.left == newMargin.left);
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+}
+
+TEST_CASE("Renderer.reconfig.geometry_resizes_render_target_on_apply", "[renderer]")
+{
+    // With a render target attached, applying a geometry reconfiguration must resize the render
+    // target — and only on the render thread (during applyPendingReconfig), not when requested.
+    configureMockFont();
+    ReconfigFixture fixture;
+    fixture.attachRenderTarget();
+    auto& renderer = fixture.renderer;
+
+    auto const newPageSize = PageSize { LineCount(30), ColumnCount(100) };
+    auto const newMargin = vtrasterizer::PageMargin { .left = 7, .top = 11, .bottom = 13 };
+    auto const newPixelSize = vtbackend::ImageSize { Width(1280), Height(720) };
+
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
+    CHECK(fixture.renderTarget.renderSize() != newPixelSize); // not yet applied
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK(fixture.renderTarget.renderSize() == newPixelSize); // applied on the render thread
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+}
+
+TEST_CASE("Renderer.reconfig.font_size_change_is_deferred", "[renderer]")
+{
+    // A font-size change needs the (non-thread-safe) text shaper, so it is fully deferred: it only
+    // stages a request and touches neither the live nor the published metrics until the render thread
+    // applies it. This guarantees the shaper is never touched concurrently with rendering.
+    //
+    // NOTE: the minimal BDF test font is a fixed-size bitmap (SIZE 9), so the staged size must be 9pt
+    // (any other size fails to load). This asserts the deferral/state machine, not cell-size magnitude
+    // (which a real scalable font would change).
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const publishedBefore = renderer.gridMetrics();
+    auto const liveBefore = vtrasterizer::RendererTest::liveGridMetrics(renderer);
+
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 }));
+
+    // Deferred: nothing observable changed yet, but a reconfiguration is staged.
+    CHECK(renderer.gridMetrics().cellSize == publishedBefore.cellSize);
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).cellSize == liveBefore.cellSize);
+    CHECK(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // After apply: the request is consumed; the font descriptions now carry the requested size.
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+}
+
+TEST_CASE("Renderer.reconfig.font_apply_signals_display_to_resize", "[renderer]")
+{
+    // Because a font change is applied a frame late, the display must recompute the page size against
+    // the new cell size afterwards. applyPendingReconfig() sets a one-shot flag the display consumes.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // No font change yet → nothing to signal.
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
+
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 }));
+    // Staging alone does not raise the flag; only the render-thread apply does.
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // The flag is now set, and consuming it clears it (one-shot).
+    CHECK(renderer.consumeFontReconfigApplied());
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
+}
+
+TEST_CASE("Renderer.reconfig.geometry_only_does_not_signal_font_resize", "[renderer]")
+{
+    // A geometry-only reconfiguration changes no cell size, so it must NOT raise the font-applied
+    // signal (which would cause a redundant page-size recompute on the display).
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    renderer.applyResize(vtbackend::ImageSize { Width(1280), Height(720) },
+                         PageSize { LineCount(30), ColumnCount(100) },
+                         vtrasterizer::PageMargin { .left = 1, .top = 2, .bottom = 3 });
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
+}
+
+TEST_CASE("Renderer.reconfig.set_fonts_is_deferred", "[renderer]")
+{
+    // A full font-descriptions change (setFonts) is deferred to the render thread just like a size
+    // change, because it reconfigures the non-thread-safe text shaper and rebuilds the atlas.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // Request a changed descriptions (keep size 9 so the BDF still loads; tweak the fallback limit).
+    auto changed = fixture.fontDescriptions;
+    changed.maxFallbackCount += 1;
+
+    renderer.setFonts(changed);
+
+    // Deferred: a reconfiguration is staged, but the live font descriptions are unchanged.
+    CHECK(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(renderer.fontDescriptions().maxFallbackCount == fixture.fontDescriptions.maxFallbackCount);
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // After the render-thread apply: the change took effect and nothing is left pending.
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(renderer.fontDescriptions().maxFallbackCount == changed.maxFallbackCount);
+}
+
+TEST_CASE("Renderer.reconfig.set_font_size_folds_into_pending_set_fonts", "[renderer]")
+{
+    // If a full font-descriptions change is already staged and a font-size change arrives before the
+    // render thread applies, the new size must fold into the staged descriptions (most recent wins)
+    // rather than being dropped.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto changed = fixture.fontDescriptions;
+    changed.maxFallbackCount += 1;
+    changed.size = text::font_size { 9.0 };
+
+    renderer.setFonts(changed);
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 })); // same valid BDF size, folds into pending
+
+    // Both the descriptions change and the (folded) size apply together in one pass.
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(renderer.fontDescriptions().maxFallbackCount == changed.maxFallbackCount);
+    CHECK(renderer.fontDescriptions().size.pt == Catch::Approx(9.0));
+}
+
+TEST_CASE("Renderer.reconfig.geometry_preserved_across_font_change", "[renderer]")
+{
+    // When a geometry change and a font change are both staged before a single apply, the page size
+    // and margin set by the geometry request must survive the font-driven grid-metrics rebuild
+    // (loadGridMetrics() otherwise resets page geometry).
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const newPageSize = PageSize { LineCount(40), ColumnCount(120) };
+    auto const newMargin = vtrasterizer::PageMargin { .left = 5, .top = 9, .bottom = 3 };
+    auto const newPixelSize = vtbackend::ImageSize { Width(1600), Height(900) };
+
+    renderer.applyResize(newPixelSize, newPageSize, newMargin);
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 })); // BDF test font's only available size.
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    auto const& live = vtrasterizer::RendererTest::liveGridMetrics(renderer);
+    CHECK(live.pageSize == newPageSize);
+    CHECK(live.pageMargin.left == newMargin.left);
+    CHECK(live.pageMargin.top == newMargin.top);
+    CHECK(live.pageMargin.bottom == newMargin.bottom);
+}
+
+TEST_CASE("Renderer.reconfig.requests_coalesce_until_applied", "[renderer]")
+{
+    // Rapidly issuing many reconfiguration requests (the user-reported crash repro: aggressively
+    // resizing the window) must coalesce into a single pending request that, once applied, leaves no
+    // residual pending work and reflects the *last* requested geometry.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // Oscillate the geometry many times before the render thread gets a chance to apply.
+    for (auto const lines: { 20, 45, 12, 60, 33 })
+    {
+        auto const pageSize = PageSize { LineCount(lines), ColumnCount(lines * 2) };
+        renderer.setPageSize(pageSize);
+        CHECK(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    }
+
+    auto const finalPageSize = PageSize { LineCount(50), ColumnCount(140) };
+    auto const finalMargin = vtrasterizer::PageMargin { .left = 1, .top = 2, .bottom = 3 };
+    renderer.applyResize(vtbackend::ImageSize { Width(1920), Height(1080) }, finalPageSize, finalMargin);
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // One apply drains everything; the last requested geometry wins.
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageSize == finalPageSize);
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageMargin.left == finalMargin.left);
+
+    // A subsequent apply with nothing staged is a no-op (idempotent).
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).pageSize == finalPageSize);
+}
+
+TEST_CASE("Renderer.reconfig.concurrent_requests_and_apply", "[renderer]")
+{
+    // Reproduces the actual threading model: a "render thread" repeatedly applies staged
+    // reconfigurations (as renderImpl() does) while a "UI thread" concurrently requests geometry and
+    // font-size changes (as wheelEvent()/resize handlers do). Run under ThreadSanitizer this asserts
+    // that _reconfigMutex fully covers the shared state — no data race on _gridMetrics/_publishedMetrics
+    // /_pendingReconfig. Without a sanitizer it still exercises the lock for crashes/UB and converges.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    constexpr int Iterations = 2000;
+    std::atomic<bool> applierStop { false };
+
+    // Render-thread role: drain pending reconfigurations as fast as possible.
+    std::thread applier([&] {
+        while (!applierStop.load(std::memory_order_relaxed))
+            vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+        // Final drain so the last staged request is guaranteed applied.
+        vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    });
+
+    // UI-thread role: issue interleaved geometry and font requests.
+    for (auto const i: std::views::iota(0, Iterations))
+    {
+        auto const lines = 10 + (i % 50);
+        renderer.applyResize(vtbackend::ImageSize { Width(640 + i % 100), Height(480 + i % 100) },
+                             PageSize { LineCount(lines), ColumnCount(lines * 2) },
+                             vtrasterizer::PageMargin { .left = i % 5, .top = i % 7, .bottom = i % 3 });
+        if (i % 3 == 0)
+            renderer.setPageSize(PageSize { LineCount(lines), ColumnCount(lines * 2) });
+        if (i % 11 == 0)
+            (void) renderer.setFontSize(text::font_size { 9.0 }); // BDF font's only valid size.
+        if (i % 17 == 0)
+        {
+            // Exercise the full font-descriptions reconfiguration path concurrently as well.
+            auto fonts = fixture.fontDescriptions;
+            fonts.maxFallbackCount = 1 + (i % 4);
+            renderer.setFonts(fonts);
+        }
+        // Reading the published metrics and consuming the font-applied signal from the UI thread
+        // (as the display does after each frame) must also be race-free.
+        (void) renderer.gridMetrics();
+        (void) renderer.consumeFontReconfigApplied();
+    }
+
+    applierStop.store(true, std::memory_order_relaxed);
+    applier.join();
+
+    // Drain anything still staged and assert a consistent final state.
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).cellSize == renderer.gridMetrics().cellSize);
 }
 
 int main(int argc, char* argv[])

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <ranges>
 #include <string_view>
 #include <thread>
 

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -950,6 +950,52 @@ TEST_CASE("Renderer.reconfig.geometry_only_does_not_signal_font_resize", "[rende
     CHECK_FALSE(renderer.consumeFontReconfigApplied());
 }
 
+TEST_CASE("Renderer.reconfig.noop_font_apply_does_not_signal_font_resize", "[renderer]")
+{
+    // A font apply that does not actually change the cell size (e.g. re-applying identical font
+    // descriptions, or a config reload that re-stages the same fonts) must NOT raise the font-applied
+    // signal — otherwise the display performs a redundant terminal-locked page-size recompute for a
+    // cell size that did not change. This is the symmetric counterpart to
+    // geometry_only_does_not_signal_font_resize.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // First apply establishes a stable cell size from the mock font.
+    renderer.setFonts(fixture.fontDescriptions);
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    (void) renderer.consumeFontReconfigApplied(); // drain whatever the first apply signalled
+
+    // Re-stage the identical descriptions: applyFontDescriptions() early-returns, the cell size is
+    // unchanged, so no font reconfig must be signalled.
+    renderer.setFonts(fixture.fontDescriptions);
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
+}
+
+TEST_CASE("Renderer.reconfig.published_font_descriptions_track_applied_state", "[renderer]")
+{
+    // fontDescriptions() returns a mutex-guarded snapshot published by the render thread, never the live
+    // (render-thread-owned) field. A staged change must therefore become visible via fontDescriptions()
+    // only after the render-thread apply, not when it is staged.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto changed = fixture.fontDescriptions;
+    changed.maxFallbackCount += 1;
+
+    renderer.setFonts(changed);
+    // Still the original until the render thread applies.
+    CHECK(renderer.fontDescriptions().maxFallbackCount == fixture.fontDescriptions.maxFallbackCount);
+
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // Published snapshot now reflects the applied descriptions.
+    CHECK(renderer.fontDescriptions().maxFallbackCount == changed.maxFallbackCount);
+}
+
 TEST_CASE("Renderer.reconfig.set_fonts_is_deferred", "[renderer]")
 {
     // A full font-descriptions change (setFonts) is deferred to the render thread just like a size

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -1112,6 +1112,111 @@ TEST_CASE("Renderer.reconfig.concurrent_requests_and_apply", "[renderer]")
     CHECK(vtrasterizer::RendererTest::liveGridMetrics(renderer).cellSize == renderer.gridMetrics().cellSize);
 }
 
+TEST_CASE("Renderer.reconfig.set_font_dpi_does_not_clobber_staged_fonts", "[renderer]")
+{
+    // A DPI-only change (setFontDPI) must merge into an already-staged full font-descriptions change
+    // rather than rebuilding the request from the live descriptions — otherwise a concurrent font
+    // change (e.g. a config reload that staged a new family/fallback) would be silently dropped.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // Stage a full font-descriptions change first (simulating a config reload).
+    auto changed = fixture.fontDescriptions;
+    changed.maxFallbackCount += 7; // A distinguishing, non-DPI field.
+    renderer.setFonts(changed);
+
+    // Now a DPI change arrives in the same inter-frame gap.
+    auto const newDpi = DPI { 144, 144 };
+    renderer.setFontDPI(newDpi);
+
+    // The staged descriptions must retain the new family/fallback AND pick up the new DPI.
+    auto const staged = vtrasterizer::RendererTest::pendingFontDescriptions(renderer);
+    REQUIRE(staged.has_value());
+    CHECK(staged->maxFallbackCount == changed.maxFallbackCount); // not clobbered
+    CHECK(staged->dpi == newDpi);                                // DPI applied
+}
+
+TEST_CASE("Renderer.reconfig.set_font_dpi_folds_staged_size", "[renderer]")
+{
+    // If only a size-only change is staged when a DPI change arrives, promoting it to a full
+    // descriptions change must fold the staged size in (applyPendingReconfig applies descriptions XOR
+    // size), not drop it.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 })); // BDF font's only valid size.
+    REQUIRE(vtrasterizer::RendererTest::pendingFontSize(renderer).has_value());
+
+    renderer.setFontDPI(DPI { 144, 144 });
+
+    // The size-only staging is now folded into the descriptions and cleared.
+    auto const staged = vtrasterizer::RendererTest::pendingFontDescriptions(renderer);
+    REQUIRE(staged.has_value());
+    CHECK(staged->size.pt == Catch::Approx(9.0));
+    CHECK_FALSE(vtrasterizer::RendererTest::pendingFontSize(renderer).has_value());
+}
+
+TEST_CASE("Renderer.reconfig.set_font_dpi_noop_when_unchanged", "[renderer]")
+{
+    // Setting the same DPI that is already live stages nothing (avoids spurious reconfigurations).
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    renderer.setFontDPI(renderer.fontDescriptions().dpi);
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+}
+
+TEST_CASE("Renderer.reconfig.published_cell_size_tracks_grid_metrics", "[renderer]")
+{
+    // publishedCellSize() is the lock-free mirror of gridMetrics().cellSize; the two must agree after
+    // construction, after a seed, and after a render-thread apply.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    CHECK(renderer.publishedCellSize() == renderer.gridMetrics().cellSize);
+
+    // A geometry-only change does not alter the cell size; the mirror stays consistent.
+    renderer.applyResize(vtbackend::ImageSize { Width(800), Height(600) },
+                         PageSize { LineCount(25), ColumnCount(80) },
+                         vtrasterizer::PageMargin { .left = 0, .top = 0, .bottom = 0 });
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK(renderer.publishedCellSize() == renderer.gridMetrics().cellSize);
+
+    // After a font apply, the mirror still equals the published cell size.
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 }));
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+    CHECK(renderer.publishedCellSize() == renderer.gridMetrics().cellSize);
+}
+
+TEST_CASE("Renderer.reconfig.page_geometry_preserved_across_dpi_change", "[renderer]")
+{
+    // Regression test for decoupling the font rebuild from page geometry: updateFontMetrics() now
+    // updates only the font-derived fields in place, so a font/DPI change must not reset the page
+    // size/margin previously established by a geometry request.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const newPageSize = PageSize { LineCount(33), ColumnCount(111) };
+    auto const newMargin = vtrasterizer::PageMargin { .left = 4, .top = 8, .bottom = 6 };
+    renderer.applyResize(vtbackend::ImageSize { Width(1111), Height(666) }, newPageSize, newMargin);
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // Re-stage the same (valid) font size, which exercises updateFontMetrics() in place.
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 }));
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    auto const& live = vtrasterizer::RendererTest::liveGridMetrics(renderer);
+    CHECK(live.pageSize == newPageSize);
+    CHECK(live.pageMargin.left == newMargin.left);
+    CHECK(live.pageMargin.top == newMargin.top);
+    CHECK(live.pageMargin.bottom == newMargin.bottom);
+}
+
 int main(int argc, char* argv[])
 {
     crispy::testing::suppressWindowsDialogs();


### PR DESCRIPTION
## Credit

This revives **@jquast**'s fix from #1922 (closed unmerged). The original analysis and the core idea
are his; this PR re-implements it on current `master` with a render-thread-deferred design, extends it
to the `setFonts`/DPI path, and adds tests. The base commit is attributed to Jeff Quast.

Probably closes #1712 and #408.

## Problem

Contour can crash or corrupt the heap when the font size or window size changes rapidly (Ctrl+mouse-wheel
font zoom, aggressive window resizing), especially while the render thread is busy. It is a race between
the GUI thread and the Qt Scene Graph **render thread**.

## Analysis

Contour drives a **threaded** Qt Quick render loop — `QQuickWindow::beforeRendering` is connected with
`Qt::DirectConnection`, so `Renderer::render()` and every sub-renderer run on the render thread while the
GUI thread runs free. The GUI-thread handlers for font/window changes mutated renderer state with no
synchronization:

- `Renderer::updateFontMetrics()` (via `setFontSize`) and `Renderer::setFonts()` rebuilt `_gridMetrics`
  and **replaced the texture atlas** (`configureTextureAtlas()` → `make_unique<TextureAtlas>`) while the
  render thread was dereferencing/mutating them — matching the `free(): invalid pointer` backtrace in #408.
- `applyResize()`/`setPageSize()`/`setMargin()` wrote renderer geometry concurrently with the render thread.
- `Terminal::setGuiTabInfoForStatusLine()` did an unprotected `std::move` of a `TabsInfo` (which owns a
  `std::vector`) on the GUI thread while the terminal thread read it under `_stateMutex` → heap corruption.

## Solution

The **render thread becomes the sole mutator** of the live grid metrics, the texture atlas, and the font
caches. UI-thread writers (`setFontSize`, `setFonts`, `setPageSize`, `setMargin`, `applyResize`) stage a
request under a short `_reconfigMutex` and publish a GUI-visible metrics copy; the render thread applies
the staged request at the top of `renderImpl()` via `applyPendingReconfig()`, before any renderable reads
shared state. Steady-state rendering stays **lock-free** (the lock is uncontended except during the rare
resize/font event, and is never held across the render body).

Because a font change needs the **non-thread-safe text shaper**, it is applied a frame late;
`applyPendingReconfig()` raises an atomic flag the display consumes (`consumeFontReconfigApplied()`) to
re-derive the page size against the new cell size, so the grid is never left mis-sized. `gridMetrics()`
returns the published copy by value; the two GUI-thread cell-size readers were routed through it.

The `TabsInfo` writer now also acquires `_stateMutex` to match its reader.

### Why this design

A simple "snapshot at frame start" can't fix it: every `Renderable` holds a live `GridMetrics const&` and
`TextureAtlas*` into the `Renderer` and reads *and mutates* them (LRU `try_get`/`emplace`) throughout a
frame. Rather than a coarse lock spanning the whole render, this mirrors the existing
`OpenGLRenderer::_scheduledExecutions` pattern — the GPU atlas (re)config already runs on the render thread
via the scheduled-execution queue; deferring the C++-side reconfiguration the same way closes the race
without serializing the render thread.

## Risk

Low–moderate. Pure synchronization; no rendering behavior change. No lock is held across the render body;
no `_stateMutex`↔`_reconfigMutex` ordering inversion (verified). One intentional behavior detail: a
font/DPI change re-derives the page size one frame after it is applied (self-healing).

## Testing

- `ctest --preset=clang-debug`: 100% (5/5 suites). `vtrasterizer_test`: 597 assertions / 27 cases.
- **11 new headless unit tests** (mock render target / mock font, no GPU) cover: synchronous geometry
  publish, deferred live-apply on render tick, render-target resize on apply, font-size/`setFonts`
  deferral + coalescing, geometry preserved across a font change, request coalescing, the font-applied
  re-resize signal, and a **concurrent two-thread stress test**.
- **ThreadSanitizer**: the concurrent test (render-thread `applyPendingReconfig` vs UI-thread
  `setFontSize`/`setFonts`/`applyResize`/`gridMetrics`/`consumeFontReconfigApplied`, 2000 iterations)
  reports **zero data races**; the full suite is green under TSAN.

A true end-to-end concurrent test needs a live Qt/OpenGL context and both real threads, which is
impractical in CI — hence the TSAN-verified state-machine tests plus manual repro (run `find /` or a
high-FPS sixel app and oscillate the font size / resize aggressively; pre-fix crashes, post-fix does not).

## Checklist

- [x] I have read the **CONTRIBUTING** guide
- [x] I have updated the documentation accordingly (metainfo.xml changelog)
- [x] I have added tests to cover my changes
- [x] Breaking changes (if any) are documented — none
