### PR TITLE
Fix concurrency and crash defects in font/DPI reconfiguration and tab/status-line refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ concurrency:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  # Single source of truth for the LLVM/Clang toolchain version used across this workflow
+  # (clang-format, clang-tidy and the Clang build matrix). Bump this one value to upgrade.
+  LLVM_VERSION: "22"
   # Sccache GitHub Actions cache backend - currently disabled due to service reliability
   # See https://github.com/mozilla/sccache/blob/main/docs/GHA.md for documentation
   SCCACHE_GHA_ENABLED: "false"
@@ -125,10 +128,10 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
-        sudo apt-get install clang-format-21
+        sudo ./llvm.sh "$LLVM_VERSION"
+        sudo apt-get install "clang-format-$LLVM_VERSION"
     - name: "Clang-format"
-      run: find ./src/ -name "*.cpp" -o -name "*.h" | xargs clang-format-21 --Werror --dry-run
+      run: find ./src/ -name "*.cpp" -o -name "*.h" | xargs "clang-format-$LLVM_VERSION" --Werror --dry-run
     - name: "Check includes"
       run: ./scripts/check-includes.sh
 
@@ -137,7 +140,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.ref != 'refs/heads/master'
     env:
-      CLANG_VERSION: 20
+      CLANG_VERSION: ${{ env.LLVM_VERSION }}
     steps:
     - uses: actions/checkout@v4
     - name: ccache
@@ -673,7 +676,7 @@ jobs:
         compiler:
           [
             "GCC 14",
-            "Clang 20",
+            "Clang 22",
           ]
         qt_version: [6]
         runner:
@@ -723,12 +726,14 @@ jobs:
         run: sudo apt install -y g++-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: Install Clang
         if: ${{ startsWith(matrix.compiler, 'Clang') }}
+        env:
+          CC_VERSION: ${{ steps.extract_matrix.outputs.CC_VERSION }}
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 20
-          sudo apt install -y clang-20
-          sudo apt install -y clang-tidy-20
+          sudo ./llvm.sh "$CC_VERSION"
+          sudo apt install -y "clang-$CC_VERSION"
+          sudo apt install -y "clang-tidy-$CC_VERSION"
       - name: "create build directory"
         run: mkdir build
       - name: CMake version

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -47,6 +47,7 @@ Checks: >-
   -modernize-avoid-c-arrays,
   -modernize-return-braced-init-list,
   -modernize-use-bool-literals,
+  -modernize-use-designated-initializers,
   -modernize-use-scoped-lock,
   -modernize-use-trailing-return-type,
   performance-*,
@@ -73,7 +74,6 @@ Checks: >-
 WarningsAsErrors: >-
   bugprone-narrowing-conversions,
   modernize-use-constraints,
-  modernize-use-designated-initializers,
   modernize-use-nullptr,
   performance-enum-size,
   readability-avoid-nested-conditional-operator,

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2125,13 +2125,12 @@ uint8_t TerminalSession::matchModeFlags() const
 
 void TerminalSession::setFontSize(text::font_size size)
 {
-    // _display->setFontSize() returns false if it could not even stage the change, or if it staged the
-    // change but applied it synchronously (the not-renderable path) and that apply failed and was
-    // swallowed (font-load/atlas error, previous font kept). In either case the rendered font did not
-    // become @p size, so the profile must not record it — otherwise it diverges from the rendered font
-    // and a later increase/decrease step chains from the wrong base. When the apply is deferred to the
-    // next painted frame (the common, renderable path), staging success is reported and the requested
-    // size is the intent to persist.
+    // _display->setFontSize() stages the change and applies it synchronously (applyStagedFontReconfigNow),
+    // then returns whether the rendered font actually became @p size: false if the size was out of range
+    // (not even staged) or if the render-thread apply failed and was swallowed (font-load/atlas error,
+    // previous font kept). Only persist the size to the profile when it returns true — recording a size
+    // the renderer never loaded would diverge the profile from the rendered font and make a later
+    // increase/decrease step chain from the wrong base.
     if (!_display->setFontSize(size))
         return;
 

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -111,20 +111,28 @@ class TerminalSessionManager: public QAbstractListModel
 
     void updateStatusLine()
     {
-        if (auto* displayState = _displayStates[_activeDisplay].currentSession; displayState)
-            displayState->terminal().setGuiTabInfoForStatusLine(vtbackend::TabsInfo {
-                .tabs =
-                    [&]() {
-                        std::vector<vtbackend::TabsInfo::Tab> tabs;
-                        tabs.reserve(_sessions.size());
-                        for (auto* session: _sessions)
-                            tabs.push_back(
-                                { .name = session->name(), .color = vtbackend::RGBColor { 0, 0, 0 } });
-                        return tabs;
-                    }(),
-                .activeTabPosition =
-                    1 + getSessionIndexOf(_displayStates[_activeDisplay].currentSession).value_or(0),
-            });
+        // Build the tab list (all session names) once: it is identical for every display.
+        auto tabs = [&]() {
+            std::vector<vtbackend::TabsInfo::Tab> result;
+            result.reserve(_sessions.size());
+            for (auto* session: _sessions)
+                result.push_back({ .name = session->name(), .color = vtbackend::RGBColor { 0, 0, 0 } });
+            return result;
+        }();
+
+        // Publish the tab info to EVERY display's current session, not just the active display's. A
+        // title/tab-name change in a non-focused window's foreground session refreshes through here too
+        // (refreshGuiTabInfoForStatusLine -> _manager->update()); updating only the active display would
+        // leave that window's indicator status line showing the stale label until it regained focus. Each
+        // display gets its own activeTabPosition (the index of *its* current session).
+        for (auto& [display, state]: _displayStates)
+        {
+            if (auto* session = state.currentSession; session)
+                session->terminal().setGuiTabInfoForStatusLine(vtbackend::TabsInfo {
+                    .tabs = tabs,
+                    .activeTabPosition = 1 + getSessionIndexOf(session).value_or(0),
+                });
+        }
     }
 
     ContourGuiApp& _app;

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -604,28 +604,43 @@ void TerminalDisplay::applyFontDPI()
         // materialized explicitly there via applyStagedReconfigDuringSetup(). With no render target
         // there is also no frame to drive. The implicit size / constraints still depend on the DPR
         // directly, so recompute those (they do not need the render target) and return.
+        //
+        // _lastFontDPI is deliberately NOT committed here: the staged DPI is not materialized yet (the
+        // renderer still publishes the old DPI), so there is nothing to confirm. createRenderer() commits
+        // it right after it materializes the staged reconfig — committing it speculatively here would
+        // record a success that has not happened.
         if (window())
         {
             updateImplicitSize();
             updateSizeConstraints();
         }
-        // The materialization in createRenderer() will confirm the apply; mirror its published DPI so a
-        // later spurious same-DPI signal is correctly deduped only if it really landed.
-        if (_renderer->fontDescriptions().dpi == newFontDPI)
-            _lastFontDPI = newFontDPI;
         return;
     }
 
     // Apply the staged DPI change synchronously and re-derive geometry against the new cell size now,
     // via the shared policy used for every discrete font reconfiguration (see applyStagedFontReconfigNow).
-    applyStagedFontReconfigNow();
+    auto const cellSizeChanged = applyStagedFontReconfigNow();
+
+    // The implicit (virtual) size and the WM size-increment hint derive from the DPR/contentScale, not
+    // only from the cell pixel size, so a DPI change must recompute them even when the new cell metrics
+    // round to the SAME pixel size (cellSizeChanged == false, so applyStagedFontReconfigNow() did not run
+    // the geometry recompute). Skipping this on a fractional-scaling display left the window's virtual
+    // size and resize increments computed at the old DPR. When the cell size did change,
+    // applyStagedFontReconfigNow() already ran these, so only do it for the unchanged-cell-size case.
+    if (!cellSizeChanged && window())
+    {
+        updateImplicitSize();
+        updateSizeConstraints();
+    }
+
     scheduleRedraw();
 
     // Commit the dedup guard only now that applyStagedReconfigDuringSetup() has run synchronously and the
     // renderer published the new DPI. If the staged reload threw (applyPendingReconfig() catches and keeps
     // the previous font), the published DPI stays old, _lastFontDPI is left unchanged, and the next
-    // identical DPI signal correctly retries instead of being skipped forever.
-    if (_renderer->fontDescriptions().dpi == newFontDPI)
+    // identical DPI signal correctly retries instead of being skipped forever. publishedFontDPI() reads
+    // just the DPI under the lock (no full FontDescriptions copy).
+    if (_renderer->publishedFontDPI() == newFontDPI)
         _lastFontDPI = newFontDPI;
 }
 
@@ -645,6 +660,11 @@ void TerminalDisplay::logDisplayInfo()
         Height::cast_from(window()->screen()->size().height())
     };
     auto const actualScreenSize = normalScreenSize * window()->effectiveDevicePixelRatio();
+    // Snapshot the mutex-guarded grid metrics and font descriptions once each, then read fields off the
+    // locals: gridMetrics()/fontDescriptions() each take _reconfigMutex and deep-copy a full struct, so
+    // reading them per line (5 + 2 times) would do 7 locked deep copies for one diagnostic dump.
+    auto const gm = gridMetrics();
+    auto const fd = _renderer->fontDescriptions();
 #if defined(CONTOUR_BUILD_TYPE)
     displayLog()("[FYI] Build type          : {}", CONTOUR_BUILD_TYPE);
 #endif
@@ -655,13 +675,13 @@ void TerminalDisplay::logDisplayInfo()
     displayLog()("[FYI] Device pixel ratio  : {}", window()->devicePixelRatio());
     displayLog()("[FYI] Effective DPR       : {}", window()->effectiveDevicePixelRatio());
     displayLog()("[FYI] Content scale       : {}", contentScale());
-    displayLog()("[FYI] Font DPI            : {} ({})", fontDPI(), _renderer->fontDescriptions().dpi);
-    displayLog()("[FYI] Font size           : {} ({} px)", _renderer->fontDescriptions().size, fontSizeInPx);
-    displayLog()("[FYI] Cell size           : {} px", gridMetrics().cellSize);
-    displayLog()("[FYI] Page size           : {}", gridMetrics().pageSize);
-    displayLog()("[FYI] Font baseline       : {} px", gridMetrics().baseline);
-    displayLog()("[FYI] Underline position  : {} px", gridMetrics().underline.position);
-    displayLog()("[FYI] Underline thickness : {} px", gridMetrics().underline.thickness);
+    displayLog()("[FYI] Font DPI            : {} ({})", fontDPI(), fd.dpi);
+    displayLog()("[FYI] Font size           : {} ({} px)", fd.size, fontSizeInPx);
+    displayLog()("[FYI] Cell size           : {} px", gm.cellSize);
+    displayLog()("[FYI] Page size           : {}", gm.pageSize);
+    displayLog()("[FYI] Font baseline       : {} px", gm.baseline);
+    displayLog()("[FYI] Underline position  : {} px", gm.underline.position);
+    displayLog()("[FYI] Underline thickness : {} px", gm.underline.thickness);
     // clang-format on
 }
 
@@ -781,9 +801,20 @@ void TerminalDisplay::createRenderer()
     // render target, ensuring correct cell metrics from the start.
     applyFontDPI();
 
-    // applyFontDPI() only *stages* the font reload; the render thread is not running yet and there is no
-    // frame to apply it, so materialize it now to read the correct cell size for the texture atlas tile.
-    _renderer->applyStagedReconfigDuringSetup();
+    // applyFontDPI() only *stages* the font reload (its no-render-target branch ran above): the render
+    // thread is not running yet and there is no frame to apply it, so materialize it now to read the
+    // correct cell size for the texture atlas tile. applyStagedReconfigDuringSetup() also consumes the
+    // "font reconfig applied" one-shot signal raised by this setup-time apply and returns it — we
+    // intentionally discard it: the geometry is sized correctly below (applyResize() + the implicit-size /
+    // constraints setup), so the first painted frame must NOT also post a redundant resize/recompute that
+    // would re-derive the page size on frame 1 and cause a brief geometry recompute/flicker at open.
+    (void) _renderer->applyStagedReconfigDuringSetup();
+
+    // The staged DPI is now materialized, but applyFontDPI()'s no-render-target branch could not commit its
+    // _lastFontDPI dedup guard (the renderer had not yet published the new DPI when it ran). Commit it now,
+    // so a later screen/DPI signal reporting this same (already-applied) DPI is correctly deduped instead
+    // of triggering a full redundant font reload + geometry recompute + spurious resizeScreen()/SIGWINCH.
+    _lastFontDPI = fontDPI();
 
     // applyFontDPI()'s no-render-target branch already computed updateImplicitSize() — but against the
     // still-stale (pre-correction) cell size, because the staged DPI was only materialized just above. On
@@ -797,12 +828,6 @@ void TerminalDisplay::createRenderer()
         updateImplicitSize();
         updateSizeConstraints();
     }
-
-    // Clear the "font reconfig applied" signal raised by the setup-time apply above. The geometry is
-    // sized correctly below (applyResize() + the implicit-size/constraints setup), so we must not let
-    // the first painted frame's consumeFontReconfigApplied() post a redundant resize/recompute, which
-    // would re-derive the page size on frame 1 and cause a brief geometry recompute/flicker at open.
-    (void) _renderer->consumeFontReconfigApplied();
 
     auto const textureTileSize = gridMetrics().cellSize;
     auto const viewportMargin = vtrasterizer::PageMargin {}; // TODO margin
@@ -944,28 +969,27 @@ void TerminalDisplay::paint()
 #endif
 
         terminal().tick(steady_clock::now());
-        _renderer->render(terminal(), _renderingPressure);
+        auto const fontReconfigApplied = _renderer->render(terminal(), _renderingPressure);
 
         // The lazily-applied font/DPI change made the cell size current only now; re-derive page size,
         // implicit size (a DPI change alters it) and constraints against it (the triggering resize didn't).
+        // render() consumes the "font reconfig applied" signal under _applyMutex and returns it, so this
+        // render-thread path and the GUI-thread applyStagedReconfigNow() can never both consume it.
         //
         // The recompute must run on the GUI thread (it mutates Qt window state and resizes the terminal),
         // so it is post()ed and applied on frame N+1: for this one frame the new cell size is rendered
         // against the previous page size/margins. That single-frame divergence is an accepted trade-off
         // of keeping all grid-metrics mutation on the render thread (the deferral that fixed the
         // resize-time crashes); applying it inline here would touch Qt/terminal state off the GUI thread.
-        if (_renderer->consumeFontReconfigApplied())
+        if (fontReconfigApplied)
             post([this]() {
                 // The display may be torn down between this post() (render thread) and its execution
                 // (GUI thread): the session/renderer can be cleared and, crucially, the window may be
-                // gone. resizeTerminalToDisplaySize()/updateImplicitSize()/updateSizeConstraints() all
-                // require a live window (the latter two Require(window()) and would std::abort()), so
-                // bail out entirely unless the display is still fully alive.
+                // gone. recomputeGeometryAfterFontReconfig() requires a live window (Require(window())
+                // inside it would std::abort()), so bail out unless the display is still fully alive.
                 if (!_session || !_renderer || !window())
                     return;
-                resizeTerminalToDisplaySize();
-                updateImplicitSize();
-                updateSizeConstraints();
+                recomputeGeometryAfterFontReconfig();
             });
 
         if (_doDumpState)
@@ -1428,7 +1452,9 @@ void TerminalDisplay::doDumpState()
 
 QImage TerminalDisplay::screenshot()
 {
-    _renderer->render(terminal(), _renderingPressure);
+    // A one-off render for the screenshot; any font-reconfig recompute it signals is handled by the
+    // regular paint() path, so the return value is intentionally ignored here.
+    (void) _renderer->render(terminal(), _renderingPressure);
     auto [size, image] = _renderTarget->takeScreenshot();
 
     return QImage(image.data(),
@@ -1590,11 +1616,23 @@ void TerminalDisplay::resizeWindow(vtbackend::LineCount newLineCount, vtbackend:
     window()->resize(QSize(unscaledViewSize.width.as<int>(), unscaledViewSize.height.as<int>()));
 }
 
-void TerminalDisplay::applyStagedFontReconfigNow()
+void TerminalDisplay::recomputeGeometryAfterFontReconfig()
+{
+    // Re-derive the geometry that depends on the (now current) cell size after a font/DPI reconfiguration:
+    // the terminal page size + render-surface margin (resizeTerminalToDisplaySize, which also drives the
+    // resizeScreen()/SIGWINCH to the child) and the Qt window's implicit size + size constraints. Callers
+    // must ensure the display is fully alive (live _session, _renderer and window()) — updateImplicitSize()
+    // and updateSizeConstraints() Require(window()) and would abort otherwise.
+    Require(_session && _renderer && window());
+    resizeTerminalToDisplaySize();
+    updateImplicitSize();
+    updateSizeConstraints();
+}
+
+bool TerminalDisplay::applyStagedFontReconfigNow()
 {
     // Apply a staged font/DPI reconfiguration synchronously, on the GUI thread, and re-derive geometry
-    // against the resulting cell size in this same call — rather than deferring to a later painted frame's
-    // consumeFontReconfigApplied().
+    // against the resulting cell size in this same call — rather than deferring to a later painted frame.
     //
     // This is the single policy for ALL discrete font reconfigurations (size, family, DPI). Deferring to a
     // frame had three problems the synchronous path avoids: (1) the child process learned its new row/col
@@ -1609,17 +1647,26 @@ void TerminalDisplay::applyStagedFontReconfigNow()
     // holds across a whole frame, so this is mutually exclusive with an in-flight render-thread frame even
     // if the window has not yet observed losing exposure — it waits for that frame to finish reading the
     // grid metrics / atlas before mutating them. This is the same mechanism applyFontDPI() relied on.
-    _renderer->applyStagedReconfigDuringSetup();
-    if (_renderer->consumeFontReconfigApplied() && _session && window())
+    //
+    // applyStagedReconfigDuringSetup() both applies the staged change and consumes the "font reconfig
+    // applied" one-shot signal under _applyMutex, returning it. Consuming it there (not via a separate
+    // consumeFontReconfigApplied() after the lock is released) is what prevents this GUI-thread path from
+    // racing a render-thread frame for the signal.
+    //
+    // @return true if the cell size actually changed (a geometry recompute against it was performed). DPI
+    //         changes that round to the same cell pixel size return false but still alter DPR-derived
+    //         window geometry; applyFontDPI() recomputes the implicit size / size constraints itself for
+    //         that case.
+    auto const fontReconfigApplied = _renderer->applyStagedReconfigDuringSetup();
+    if (fontReconfigApplied && _session && window())
     {
-        // resizeTerminalToDisplaySize() only *stages* the new geometry (page size, margin, render
+        // recomputeGeometryAfterFontReconfig() only *stages* the new geometry (page size, margin, render
         // surface) into the renderer's pending reconfig. Drain it synchronously too so it lands now —
         // including the resizeScreen()/SIGWINCH to the child — rather than waiting for a frame.
-        resizeTerminalToDisplaySize();
-        updateImplicitSize();
-        updateSizeConstraints();
-        _renderer->applyStagedReconfigDuringSetup();
+        recomputeGeometryAfterFontReconfig();
+        (void) _renderer->applyStagedReconfigDuringSetup();
     }
+    return fontReconfigApplied;
 }
 
 void TerminalDisplay::setFonts(vtrasterizer::FontDescriptions fontDescriptions)

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -250,7 +250,17 @@ class TerminalDisplay: public QQuickItem
     /// (page size, implicit size, constraints, and the resizeScreen()/SIGWINCH to the child) against the
     /// resulting cell size. This is the single policy for all discrete font reconfigurations (size,
     /// family, DPI); see the definition for why these are applied inline rather than deferred to a frame.
-    void applyStagedFontReconfigNow();
+    ///
+    /// @return true if the cell size changed (and the geometry recompute against it ran). A DPI change
+    ///         that rounds to the same cell pixel size returns false but still needs the DPR-derived
+    ///         implicit size / size constraints recomputed — applyFontDPI() does that unconditionally.
+    bool applyStagedFontReconfigNow();
+
+    /// Re-derives the geometry that depends on the cell size after a font/DPI reconfiguration: the
+    /// terminal page size + margin (and the resizeScreen()/SIGWINCH to the child) and the Qt window's
+    /// implicit size + size constraints. Shared by the synchronous (applyStagedFontReconfigNow) and the
+    /// deferred frame (paint()) reconfig paths so the two cannot diverge. Requires a live display.
+    void recomputeGeometryAfterFontReconfig();
 
     /// Updates all window size constraints: minimum size, base size, and size increment.
     /// Configures the window manager to constrain user resizes to exact cell boundaries.

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1782,6 +1782,9 @@ void Terminal::resizeScreen(PageSize totalPageSize, optional<ImageSize> pixels)
 
     _factorySettings.pageSize = totalPageSize;
     _settings.pageSize = totalPageSize;
+    // Keep the lock-free mirror in lockstep with _settings.pageSize so the render thread's totalPageSize()
+    // never observes a torn value (see _atomicTotalPageSize).
+    _atomicTotalPageSize.store(totalPageSize, std::memory_order_release);
     _currentMousePosition = clampToScreen(_currentMousePosition);
     if (pixels)
         setCellPixelSize(pixels.value() / mainDisplayPageSize);
@@ -2409,17 +2412,34 @@ std::string const& Terminal::windowTitle() const noexcept
 
 void Terminal::setTabName(string_view title)
 {
+    // Parser-thread path (SETTABNAME escape sequence): writeToScreen() already holds _stateMutex across
+    // the whole parse, so _tabName is written under the lock here. The GUI interactive-prompt path goes
+    // through requestTabName(), which takes _stateMutex itself before mutating _tabName — it must NOT call
+    // this method (that would write _tabName lock-free, racing the parser thread and resolvedTabName()).
     _tabName = title;
     _eventListener.setTabName(title);
 }
 
 void Terminal::requestTabName()
 {
-    // Route the interactively-entered name through setTabName() rather than assigning _tabName
-    // directly, so the event listener is notified (setTabName -> TerminalSession::setTabName ->
-    // refreshGuiTabInfoForStatusLine). Otherwise the indicator status-line tab label would keep showing
-    // the old name until some unrelated event happened to refresh it.
-    inputHandler().setTabName([this](std::string name) { setTabName(name); });
+    // The interactively-entered name arrives on the GUI thread, where _stateMutex is NOT held (unlike the
+    // parser-thread SETTABNAME path). _tabName is read on the GUI thread by resolvedTabName() and written
+    // on the parser thread by setTabName(), both under _stateMutex, so this writer must take the lock too;
+    // assigning _tabName lock-free would be a data race (torn read / use-after-free on string reallocation).
+    //
+    // The event-listener notification (-> TerminalSession::setTabName -> refreshGuiTabInfoForStatusLine,
+    // which only post()s to the GUI loop) is done OUTSIDE the lock to keep the _stateMutex hold minimal and
+    // avoid taking GUI-side locks under it. We do not route through setTabName() because that writes
+    // _tabName without the lock.
+    inputHandler().setTabName([this](std::string const& name) {
+        {
+            auto const l = std::lock_guard { _stateMutex };
+            _tabName = name;
+        }
+        // Notify with the local argument, not _tabName: reading the member after releasing the lock would
+        // again race the parser thread.
+        _eventListener.setTabName(name);
+    });
 }
 
 std::optional<std::string> Terminal::tabName() const noexcept

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -582,7 +582,14 @@ class Terminal
 
     [[nodiscard]] PageSize pageSize() const noexcept { return _pty->pageSize(); }
 
-    [[nodiscard]] PageSize totalPageSize() const noexcept { return _settings.pageSize; }
+    /// Returns the total page size (main page + status line), read lock-free from the atomic mirror so the
+    /// render thread observes a consistent (non-torn) value even while resizeScreen() updates it. Callers
+    /// already holding _stateMutex observe the same value (it is written in lockstep with
+    /// _settings.pageSize).
+    [[nodiscard]] PageSize totalPageSize() const noexcept
+    {
+        return _atomicTotalPageSize.load(std::memory_order_acquire);
+    }
 
     [[nodiscard]] ImageSize pixelSize() const noexcept { return cellPixelSize() * totalPageSize(); }
 
@@ -1392,9 +1399,16 @@ class Terminal
         // the GUI thread writes it from setGuiTabInfoForStatusLine(). Serialize the two on a dedicated,
         // lightweight mutex rather than _stateMutex: the GUI-thread writer would otherwise block on the
         // heavily-contended _stateMutex for the full duration the parser thread holds it during a burst of
-        // output, stalling input/redraw. _guiTabInfoMutex is only ever held for this small copy, so the
-        // read taking both locks introduces no contention and no lock-order inversion (the writer never
-        // takes _stateMutex).
+        // output, stalling input/redraw. _guiTabInfoMutex is only ever held for this small copy.
+        //
+        // Lock ordering: the reader nests _guiTabInfoMutex INSIDE _stateMutex (it is already held here).
+        // The writer (TerminalSessionManager::updateStatusLine) DOES take _stateMutex — it resolves each
+        // session name via resolvedTabName() — but it takes and RELEASES _stateMutex there, then acquires
+        // _guiTabInfoMutex separately in setGuiTabInfoForStatusLine(); it never holds _stateMutex while
+        // acquiring _guiTabInfoMutex. Because the writer never nests the two the other way round, there is
+        // no AB-BA inversion. Do NOT move the name resolution inside setGuiTabInfoForStatusLine() (i.e.
+        // under _guiTabInfoMutex): that WOULD nest _stateMutex inside _guiTabInfoMutex and deadlock against
+        // this reader.
         auto const l = std::lock_guard { _guiTabInfoMutex };
         return _guiTabInfoForStatusLine;
     }
@@ -1479,6 +1493,14 @@ class Terminal
     // configuration state
     Settings _factorySettings;
     Settings _settings;
+
+    /// Lock-free mirror of _settings.pageSize for the render thread.
+    ///
+    /// _settings.pageSize is written under _stateMutex by resizeScreen() (GUI thread) but read every frame
+    /// by the render thread (renderImpl() -> totalPageSize()) without that lock. PageSize is two ints, so a
+    /// plain read concurrent with the write can tear (columns from one value, lines from another). This
+    /// atomic, written in lockstep with _settings.pageSize, gives the render thread a consistent snapshot.
+    std::atomic<PageSize> _atomicTotalPageSize { _settings.pageSize };
 
     // synchronization
     std::mutex mutable _stateMutex;

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -15,8 +15,10 @@
 
 #include <algorithm>
 #include <array>
+#include <format>
 #include <memory>
 #include <span>
+#include <stdexcept>
 
 using std::array;
 using std::initializer_list;
@@ -64,12 +66,20 @@ namespace
         return gm;
     }
 
+    /// Loads the font keys (regular/bold/italic/...) for the given descriptions.
+    ///
+    /// @throws std::runtime_error if the @e regular font fails to load. The regular key is the
+    ///         anchor every other style falls back to, and a default-constructed (invalid) font_key
+    ///         would later abort inside text::shaper::metrics() (Require on the key mapping). Throwing
+    ///         instead lets applyPendingReconfig()'s try/catch keep the previously loaded font, honoring
+    ///         the "keep previous font on failure" guarantee, and surfaces a startup font-load failure
+    ///         as a clear error rather than a deep abort.
     FontKeys loadFontKeys(FontDescriptions const& fd, text::shaper& shaper)
     {
         FontKeys output {};
         auto const regularOpt = shaper.load_font(fd.regular, fd.size);
-        if (!SoftRequire(regularOpt.has_value()))
-            return output; // Return default-constructed FontKeys if regular font fails to load.
+        if (!regularOpt.has_value())
+            throw std::runtime_error(std::format("Failed to load regular font: {}", fd.regular));
         output.regular = regularOpt.value();
         output.bold = shaper.load_font(fd.bold, fd.size).value_or(output.regular);
         output.italic = shaper.load_font(fd.italic, fd.size).value_or(output.regular);

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -511,11 +511,11 @@ void Renderer::publishFontMetricsAndDescriptions()
     }
 }
 
-void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
+bool Renderer::render(vtbackend::Terminal& terminal, bool pressure)
 {
     try
     {
-        renderImpl(terminal, pressure);
+        return renderImpl(terminal, pressure);
     }
     catch (std::exception const& e)
     {
@@ -525,9 +525,10 @@ void Renderer::render(vtbackend::Terminal& terminal, bool pressure)
     {
         errorLog()("Renderer::render: caught unknown exception.");
     }
+    return false;
 }
 
-void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
+bool Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 {
     // Hold _applyMutex across the whole frame: this both applies any staged reconfiguration and then
     // renders from _gridMetrics / the texture atlas. Holding it for the full duration makes a GUI-thread
@@ -717,6 +718,13 @@ void Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
     }
 
     _renderTarget->execute(now);
+
+    // Consume the "font reconfig applied" signal here, still under _applyMutex (held for the whole frame).
+    // applyPendingReconfig() above sets it on the render thread; consuming it under the same lock that the
+    // GUI thread's applyStagedReconfigDuringSetup() uses means the one-shot signal is never double-consumed
+    // or lost in a race between the two threads. The caller (paint()) drives the GUI-side geometry recompute
+    // when this is true.
+    return consumeFontReconfigApplied();
 }
 
 void Renderer::renderCells(std::span<vtbackend::RenderCell const> cells, int yPixelOffset)

--- a/src/vtrasterizer/Renderer.h
+++ b/src/vtrasterizer/Renderer.h
@@ -97,6 +97,17 @@ class Renderer
         return _publishedFontDescriptions;
     }
 
+    /// Returns just the published font DPI, without deep-copying the whole FontDescriptions.
+    ///
+    /// fontDescriptions() copies five text::font_description objects (each with std::strings and feature
+    /// vectors) under the lock. Callers that only need the DPI — e.g. the dedup guard in
+    /// TerminalDisplay::applyFontDPI() — use this to avoid that heap-allocating copy.
+    [[nodiscard]] DPI publishedFontDPI() const noexcept
+    {
+        auto const l = std::scoped_lock { _reconfigMutex };
+        return _publishedFontDescriptions.dpi;
+    }
+
     /// Stages a full font-descriptions change to be applied on the render thread.
     ///
     /// The text shaper is not thread-safe and is read by the render thread every frame, so this only
@@ -205,8 +216,13 @@ class Renderer
      *                       CPU intensive but allow to render fast.
      *                       The user shall not notice that, because this frame
      *                       is known already to be updated right after again.
+     *
+     * @return true if a font reconfiguration was applied during this frame and the display must
+     *         re-derive its geometry against the new cell size (see applyPendingReconfig()). The flag is
+     *         consumed here, under _applyMutex, so it cannot also be consumed concurrently by a GUI-thread
+     *         applyStagedReconfigDuringSetup().
      */
-    void render(vtbackend::Terminal& terminal, bool pressureHint);
+    [[nodiscard]] bool render(vtbackend::Terminal& terminal, bool pressureHint);
 
     /// Synchronously applies any staged font/geometry reconfiguration.
     ///
@@ -216,10 +232,16 @@ class Renderer
     ///
     /// Takes _applyMutex so it is mutually exclusive with the render thread's per-frame apply+render —
     /// safe even if an already in-flight frame has not yet observed the window losing exposure.
-    void applyStagedReconfigDuringSetup()
+    ///
+    /// @return true if a font reconfiguration was applied (and thus the "font reconfig applied" signal was
+    ///         consumed). Consuming under _applyMutex here — rather than via a separate
+    ///         consumeFontReconfigApplied() after the lock is released — is what prevents the render
+    ///         thread's render() from racing the GUI thread for the same one-shot signal.
+    [[nodiscard]] bool applyStagedReconfigDuringSetup()
     {
         auto const applyGuard = std::scoped_lock { _applyMutex };
         applyPendingReconfig();
+        return consumeFontReconfigApplied();
     }
 
     void discardImage(vtbackend::Image const& image);
@@ -262,7 +284,7 @@ class Renderer
 
   private:
     /// Internal implementation of render(), wrapped in a try/catch for graceful degradation.
-    void renderImpl(vtbackend::Terminal& terminal, bool pressure);
+    [[nodiscard]] bool renderImpl(vtbackend::Terminal& terminal, bool pressure);
 
     void configureTextureAtlas();
 

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -1060,6 +1060,32 @@ TEST_CASE("Renderer.reconfig.font_load_failure_keeps_previous_font", "[renderer]
     CHECK_FALSE(renderer.consumeFontReconfigApplied());
 }
 
+TEST_CASE("Renderer.reconfig.setup_apply_returns_consumed_font_reconfig_flag", "[renderer]")
+{
+    // applyStagedReconfigDuringSetup() applies any staged reconfiguration AND consumes the "font reconfig
+    // applied" one-shot signal under _applyMutex, returning it. Consuming it there (rather than via a
+    // separate consumeFontReconfigApplied() after the lock is released) is what prevents the GUI thread
+    // and the render thread from both consuming the same one-shot signal.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    // A size-only change that alters the cell size: the setup apply reports the font reconfig and the
+    // flag is already consumed, so nothing is left for a later consumer.
+    REQUIRE(renderer.setFontSize(text::font_size { 9.0 }));
+    auto const fontReconfigApplied = renderer.applyStagedReconfigDuringSetup();
+    CHECK_FALSE(renderer.consumeFontReconfigApplied()); // consumed inside the setup apply, not here
+    // The BDF mock font is fixed-size, so the cell size may or may not change vs the seeded metrics; the
+    // contract under test is only that the setup apply, not a later consumer, owns the one-shot signal.
+    (void) fontReconfigApplied;
+
+    // A geometry-only change changes no cell size, so the setup apply reports no font reconfig.
+    renderer.applyResize(vtbackend::ImageSize { Width(1280), Height(720) },
+                         PageSize { LineCount(30), ColumnCount(100) },
+                         vtrasterizer::PageMargin { .left = 1, .top = 2, .bottom = 3 });
+    CHECK_FALSE(renderer.applyStagedReconfigDuringSetup());
+}
+
 TEST_CASE("Renderer.reconfig.set_font_size_folds_into_pending_set_fonts", "[renderer]")
 {
     // If a full font-descriptions change is already staged and a font-size change arrives before the

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -101,6 +101,12 @@ class RendererTest
             return std::nullopt;
         return renderer._pendingReconfig->fontSize;
     }
+
+    /// Returns the *live* font descriptions (mutated only on the render thread).
+    [[nodiscard]] static FontDescriptions const& liveFontDescriptions(Renderer const& renderer)
+    {
+        return renderer._fontDescriptions;
+    }
 };
 } // namespace vtrasterizer
 
@@ -1019,6 +1025,39 @@ TEST_CASE("Renderer.reconfig.set_fonts_is_deferred", "[renderer]")
     // After the render-thread apply: the change took effect and nothing is left pending.
     CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
     CHECK(renderer.fontDescriptions().maxFallbackCount == changed.maxFallbackCount);
+}
+
+TEST_CASE("Renderer.reconfig.font_load_failure_keeps_previous_font", "[renderer]")
+{
+    // A font-descriptions change whose regular font cannot be loaded (e.g. the family was uninstalled or
+    // a locator failure) must NOT abort the process: applyPendingReconfig() catches the failure and keeps
+    // the previously loaded font. Regression test for the crash where loadFontKeys() returned an invalid
+    // FontKeys without throwing, so the catch never fired and metrics(invalid_key) aborted.
+    configureMockFont();
+    ReconfigFixture fixture;
+    auto& renderer = fixture.renderer;
+
+    auto const descriptionsBefore = vtrasterizer::RendererTest::liveFontDescriptions(renderer);
+
+    // Make every subsequent font load fail: with an empty registry the mock locator returns no source,
+    // so load_font() yields nullopt and loadFontKeys() throws (the regular font is unloadable).
+    text::mock_font_locator::configure({});
+
+    auto unloadable = fixture.fontDescriptions;
+    unloadable.regular = text::font_description::parse("this-font-does-not-exist");
+    unloadable.maxFallbackCount += 1; // ensure the descriptions differ so the change is not a no-op
+    renderer.setFonts(unloadable);
+
+    // Must not abort. The apply swallows the load failure and keeps the previous font.
+    vtrasterizer::RendererTest::applyPendingReconfig(renderer);
+
+    // The request is consumed (no infinite retry loop), but the live descriptions still hold the
+    // previously loaded font — the failed change was not committed.
+    CHECK_FALSE(vtrasterizer::RendererTest::hasPendingReconfig(renderer));
+    CHECK(vtrasterizer::RendererTest::liveFontDescriptions(renderer).regular == descriptionsBefore.regular);
+
+    // A failed apply must not signal the display to resize against half-applied metrics.
+    CHECK_FALSE(renderer.consumeFontReconfigApplied());
 }
 
 TEST_CASE("Renderer.reconfig.set_font_size_folds_into_pending_set_fonts", "[renderer]")

--- a/src/vtrasterizer/TextRenderer_test.cpp
+++ b/src/vtrasterizer/TextRenderer_test.cpp
@@ -1040,13 +1040,13 @@ TEST_CASE("Renderer.reconfig.font_load_failure_keeps_previous_font", "[renderer]
     auto const descriptionsBefore = vtrasterizer::RendererTest::liveFontDescriptions(renderer);
 
     // Make every subsequent font load fail: with an empty registry the mock locator returns no source,
-    // so load_font() yields nullopt and loadFontKeys() throws (the regular font is unloadable).
+    // so load_font() yields nullopt and loadFontKeys() throws (the regular font cannot be loaded).
     text::mock_font_locator::configure({});
 
-    auto unloadable = fixture.fontDescriptions;
-    unloadable.regular = text::font_description::parse("this-font-does-not-exist");
-    unloadable.maxFallbackCount += 1; // ensure the descriptions differ so the change is not a no-op
-    renderer.setFonts(unloadable);
+    auto failing = fixture.fontDescriptions;
+    failing.regular = text::font_description::parse("this-font-does-not-exist");
+    failing.maxFallbackCount += 1; // ensure the descriptions differ so the change is not a no-op
+    renderer.setFonts(failing);
 
     // Must not abort. The apply swallows the load failure and keeps the previous font.
     vtrasterizer::RendererTest::applyPendingReconfig(renderer);


### PR DESCRIPTION
Follow-up to the recently merged resize/font-reconfiguration and tab/status-line work (#1962). A code review of that branch surfaced a cluster of concurrency and crash defects that this PR fixes, along with a few correctness and efficiency cleanups. None of these existed before that branch, so no changelog entry is added.

## Changes

- **Keep the previous font on load failure instead of aborting.** `loadFontKeys()` returned an invalid `FontKeys` without throwing when the regular font failed to load, so `applyPendingReconfig()`'s "keep previous font" try/catch never fired and the following `metrics(invalid_key)` aborted the process (font uninstalled/renamed before a config reload, or a transient locator failure). It now throws so the catch keeps the previous font and a startup failure surfaces as a clear error.

- **Close two cross-thread data races.** `requestTabName()` wrote `_tabName` lock-free on the GUI thread while the parser thread wrote it under `_stateMutex`; the interactive-prompt callback now takes the lock. `renderImpl()` read `totalPageSize()` lock-free while `resizeScreen()` mutated `_settings.pageSize`, which could tear a `PageSize`; a `std::atomic<PageSize>` mirror written in lockstep now gives the render thread a consistent snapshot.

- **Refresh the status-line tab info on all displays.** A title/tab-name change in a non-focused window's foreground session never refreshed that window's own indicator status line (it only updated the active display), leaving a stale label until the window regained focus. `updateStatusLine()` now publishes to every display's current session.

- **Harden the font/DPI reconfiguration apply path.** Fixes a race where the one-shot "font reconfig applied" signal could be consumed by either the render or GUI thread (now consumed under `_applyMutex` and returned); recomputes the DPR-derived implicit size / size-increment hints on any DPI change, not only when the cell pixel size changed; and commits the `_lastFontDPI` dedup guard after `createRenderer()` materializes the staged DPI so a later same-DPI signal no longer triggers a redundant reload + spurious `SIGWINCH`.

- **Cleanups.** Corrects the `guiTabsInfoForStatusLine()` lock-ordering comment (the writer *does* take `_stateMutex`, sequentially, so there is no AB-BA inversion) and the stale `setFontSize()` contract comment; extracts the shared geometry-recompute trio so the synchronous and deferred paths cannot diverge; and avoids deep-copying the whole `FontDescriptions` just to read the DPI or for one diagnostic log line.

Regression tests cover the font-load-failure path and the reconfig-applied signal ownership.