### PR TITLE
fix(contour): fix crash on new tab when OSC 7 CWD is a file:// URL on Windows

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -131,6 +131,7 @@
           <li>Adds Ctrl-click support for opening detected local filesystem paths under the mouse cursor (#1947)</li>
           <li>Fixes terminal grid not syncing to the window tile size on tiling Wayland compositors, where a freshly-spawned terminal was mis-sized until a manual resize (#1955)</li>
           <li>Fixes crashes and heap corruption when rapidly changing the font or window size, caused by data races between the UI thread and the Qt Scene Graph render thread; geometry/font changes are now deferred and applied on the render thread (#1922, probably #1712, #408)</li>
+          <li>Fixes crash on Windows when opening a new tab while the active pane (e.g. vim, emacs, or another full-screen program) had reported its working directory via OSC 7, caused by passing the raw `file://` URL to CreateProcess() instead of the extracted filesystem path</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -3,6 +3,7 @@
 #include <contour/TerminalSession.h>
 #include <contour/TerminalSessionManager.h>
 
+#include <vtbackend/HintModeHandler.h>
 #include <vtbackend/primitives.h>
 
 #include <vtpty/Process.h>
@@ -96,9 +97,16 @@ TerminalSession* TerminalSessionManager::createSessionInBackground()
     if (!_sessions.empty())
     {
         auto& terminal = _sessions[0]->terminal();
+        std::string cwdUrl;
         {
             auto _l = std::scoped_lock { terminal };
-            ptyPath = terminal.currentWorkingDirectory();
+            cwdUrl = terminal.currentWorkingDirectory();
+        }
+        if (!cwdUrl.empty())
+        {
+            auto path = vtbackend::extractPathFromFileUrl(cwdUrl);
+            if (!path.empty())
+                ptyPath = std::move(path);
         }
     }
 #endif

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -279,7 +279,14 @@ auto extractPathFromFileUrl(std::string const& url) -> std::string
         if (isDriveLetterPath(remainder))
             return std::string(remainder);
         if (auto const pos = remainder.find('/'); pos != std::string::npos)
-            return std::string(remainder.substr(pos));
+        {
+            // file://host/C:/path → C:/path : strip the leading slash before a Windows drive
+            // letter so a host-qualified URL still yields a valid native absolute path.
+            auto pathPart = remainder.substr(pos);
+            if (pathPart.size() >= 3 && isDriveLetterPath(pathPart.substr(1)))
+                return std::string(pathPart.substr(1));
+            return std::string(pathPart);
+        }
         return {};
     }
 

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -566,6 +566,16 @@ TEST_CASE("extractPathFromFileUrl.WindowsDriveLetter", "[hintmode]")
     CHECK(extractPathFromFileUrl("file://d:/temp/x") == "d:/temp/x");
 }
 
+TEST_CASE("extractPathFromFileUrl.WindowsDriveLetterWithHost", "[hintmode]")
+{
+    // OSC 7 on Windows commonly reports a real hostname *and* a drive-letter path
+    // (e.g. "file://MYPC/C:/Users/user"). The leading slash before the drive letter
+    // must still be stripped, otherwise callers get an invalid "/C:/..." path that
+    // Windows CreateProcess() rejects with ERROR_DIRECTORY ("directory name is invalid").
+    CHECK(extractPathFromFileUrl("file://hostname/C:/Users/user") == "C:/Users/user");
+    CHECK(extractPathFromFileUrl("file://MYPC/d:/temp/x") == "d:/temp/x");
+}
+
 TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")
 {
     namespace fs = std::filesystem;


### PR DESCRIPTION
TerminalSessionManager::createSessionInBackground() passed the raw OSC 7 file:// URL straight to CreateProcess() as the new tab's working directory on Windows, instead of extracting the filesystem path first. Opening a new tab while the active pane reported a CWD via OSC 7 (common for vim/emacs and other full-screen/alt-screen programs) made CreateProcess() fail with ERROR_DIRECTORY ("The directory name is invalid"), which surfaced as an unhandled std::runtime_error and crashed the whole application.

Also fixes extractPathFromFileUrl() to strip the leading slash before a Windows drive letter when the URL additionally carries a real hostname (file://host/C:/path), which previously left an invalid "/C:/path".

