### PR TITLE
fix(contour): avoid GL_INVALID_OPERATION when applying text outline color off the render thread

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -131,6 +131,7 @@
           <li>Adds Ctrl-click support for opening detected local filesystem paths under the mouse cursor (#1947)</li>
           <li>Fixes terminal grid not syncing to the window tile size on tiling Wayland compositors, where a freshly-spawned terminal was mis-sized until a manual resize (#1955)</li>
           <li>Fixes crashes and heap corruption when rapidly changing the font or window size, caused by data races between the UI thread and the Qt Scene Graph render thread; geometry/font changes are now deferred and applied on the render thread (#1922, probably #1712, #408)</li>
+          <li>Fixes GL_INVALID_OPERATION (1282) OpenGL error when applying a font/DPI reconfiguration synchronously from the GUI thread (e.g. minimized/occluded window) without a current OpenGL context; the text outline color uniform upload is now deferred to the render thread instead of erroring</li>
         </ul>
       </description>
     </release>

--- a/src/contour/display/OpenGLRenderer.cpp
+++ b/src/contour/display/OpenGLRenderer.cpp
@@ -16,6 +16,7 @@
 #include <QtCore/QtGlobal>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QImage>
+#include <QtGui/QOpenGLContext>
 
 #include <algorithm>
 #include <array>
@@ -596,6 +597,12 @@ void OpenGLRenderer::execute(std::chrono::steady_clock::time_point now)
         // TODO: only upload when it actually DOES change
         _textShader->setUniformValue(_textProjectionLocation, mvp);
         _textShader->setUniformValue(_textTimeLocation, timeValue);
+        if (_textOutlineColorDirty)
+        {
+            auto const [cr, cg, cb, ca] = atlas::normalize(_textOutlineColor);
+            _textShader->setUniformValue(_textOutlineColorLocation, QVector4D(cr, cg, cb, ca));
+            _textOutlineColorDirty = false;
+        }
         executeRenderTextures();
     });
 
@@ -830,10 +837,22 @@ void OpenGLRenderer::setTextOutline(float /*thickness*/, vtbackend::RGBAColor co
     if (!_initialized || !_textShader)
         return;
 
+    // Font/DPI reconfiguration can be applied synchronously from the GUI thread (e.g. during initial
+    // display setup, or while the window is minimized/occluded), not just from the render thread that
+    // normally owns the current OpenGL context. Calling into the shader without a current context here
+    // caused GL_INVALID_OPERATION (1282) on setUniformValue(). Defer the upload to execute() (always
+    // called on the render thread, with the context current) instead of dropping it.
+    if (!QOpenGLContext::currentContext())
+    {
+        _textOutlineColorDirty = true;
+        return;
+    }
+
     bound(*_textShader, [&]() {
         auto const [cr, cg, cb, ca] = atlas::normalize(_textOutlineColor);
         CHECKED_GL(_textShader->setUniformValue(_textOutlineColorLocation, QVector4D(cr, cg, cb, ca)));
     });
+    _textOutlineColorDirty = false;
 }
 
 void OpenGLRenderer::inspect(std::ostream& /*output*/) const

--- a/src/contour/display/OpenGLRenderer.h
+++ b/src/contour/display/OpenGLRenderer.h
@@ -179,6 +179,10 @@ class OpenGLRenderer final:
     int _textOutlineColorLocation = -1;
 
     vtbackend::RGBAColor _textOutlineColor { 0x00, 0x00, 0x00, 0xFF };
+    // Set whenever _textOutlineColor changes but could not be uploaded immediately (e.g. setTextOutline()
+    // was called from the GUI thread without a current OpenGL context). Consumed by execute() on the
+    // render thread, which always has the context current while _textShader is bound.
+    bool _textOutlineColorDirty = false;
 
     // private data members for rendering textures
     //


### PR DESCRIPTION
## Summary
- `OpenGLRenderer::setTextOutline()` called into the shader (`bind()` / `setUniformValue()`) unconditionally once the renderer had been initialized, assuming an OpenGL context was always current on the calling thread.
- `Renderer::applyStagedReconfigDuringSetup()` is documented to run font/DPI reconfiguration synchronously from the GUI thread during initial display setup and for the minimized/occluded case, not just from the render thread that normally owns the current context.
- Applying it in that situation made `setUniformValue(_textOutlineColorLocation, ...)` fail with `GL_INVALID_OPERATION` (error 1282), logged as an OpenGL error.
- `setTextOutline()` now checks `QOpenGLContext::currentContext()` and, when absent, only updates the CPU-side color and marks it dirty. The pending color is uploaded lazily from `execute()`, which always runs on the render thread with the context current while the text shader is bound.

## Test plan
- [x] `contour.exe` builds cleanly with the fix
- [x] `vtrasterizer_test.exe` — all 624 assertions / 36 test cases pass