### PR TITLE
fix(contour): flush pending PTY replies on display attach

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,7 @@
         <ul>
           <li>Adds Win32 Input Mode (DEC private mode 9001) for native ConPTY keyboard input encoding, fixing keyboard input for applications that request this mode on Windows</li>
           <li>Fixes Unicode characters sometimes being wrongly decoded during high-bandwidth output</li>
+          <li>Fixes multi-second shell startup stall when the shell (e.g. fish) queries terminal capabilities before the display is attached — queued replies are now flushed on display attach instead of waiting for the next focus/input event</li>
           <li>Improves PTY throughput performance determinism by rewriting the internal grid cell storage</li>
           <li>Adds **experimental** Good Image Protocol (GIP) implementation — a DCS-based protocol for displaying raster images with named image pools, LRU eviction, three compositing layers (below/replace/above), configurable resize and alignment policies, Auto/PNG/RGB/RGBA format support with automatic format detection, and DA1 capability advertisement via code 90 (#100)</li>
           <li>Adds contour cat CLI command for displaying images in the terminal via GIP oneshot sequences</li>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -376,6 +376,15 @@ void TerminalSession::attachDisplay(display::TerminalDisplay& newDisplay)
     // a stale one.
     refreshGuiTabInfoForStatusLine();
 
+    // Similarly, terminal replies (e.g. answers to VT capability queries that shells like fish
+    // send right at startup) that were generated while no display was attached were queued in
+    // the input generator but never flushed: screenUpdated() only posts flushInput() when
+    // _display is set, and the shell may be blocked waiting for the reply, producing no further
+    // PTY output that would trigger another flush. Without this, the shell hangs until the next
+    // focus/input event finally flushes the queue (observed as a multi-second startup stall).
+    if (_terminal.hasInput())
+        _display->post(bind(&TerminalSession::flushInput, this));
+
     scheduleRedraw();
 }
 


### PR DESCRIPTION
Shells that query terminal capabilities at startup and block waiting for the responses (e.g. fish 4.x sends DA1, XTVERSION, XTGETTCAP, and kitty keyboard protocol queries before showing the first prompt) hang for multiple seconds on every new window/tab.

Root cause: replies generated by `Terminal::reply()` while no display is attached to the session are queued in the input generator but never flushed. `TerminalSession::screenUpdated()` only posts `flushInput()` when `_display` is set, and a shell blocked waiting for the reply produces no further PTY output that would trigger another flush. The queued replies sit until the next focus/input event happens to call `flushInput()` — observed as a 3.5–10s startup stall on river/Wayland, with the variance being whenever that next event arrived (mouse move, click, focus change).

Fix: after attaching the display in `TerminalSession::attachDisplay()`, flush any pending terminal input. This mirrors the existing dropped-title-refresh replay directly above it, which handles the same no-display-attached window for tab names.

Measured on Linux (river/Wayland, fish 4.x): new-window launch to first prompt goes from 5.5–10.3s down to ~390ms, consistent across runs. Verified the pending-reply write is picked up on the GUI thread via the same `_display->post()` path used by `screenUpdated()`.

The `CONTOUR_SYNC_PTY_OUTPUT=1` env var also works around the issue (it makes `reply()` flush synchronously), which confirmed the diagnosis, but the flush-on-attach fix closes the race without requiring users to know about the variable.

All tests pass (vtbackend 446 cases, vtparser, crispy, text_shaper, vtrasterizer).