### PR TITLE
Fix window geometry/state changing on split, tab switch, and config reload

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1185,7 +1185,11 @@ void TerminalSession::setTerminalProfile(string const& configProfileName)
     if (!_display)
         return;
 
-    _display->post([this, name = string(configProfileName)]() { activateProfile(name); });
+    // OSC-driven profile switch (application explicitly requested it): fit the window to the new
+    // profile's terminal_size, as with the {ChangeProfile} keybinding.
+    _display->post([this, name = string(configProfileName)]() {
+        activateProfile(name, ProfileWindowSizePolicy::Apply);
+    });
 }
 
 void TerminalSession::discardImage(vtbackend::Image const& image)
@@ -1448,7 +1452,8 @@ bool TerminalSession::operator()(actions::ChangeProfile const& action)
     if (action.name == _profileName)
         return true;
 
-    activateProfile(action.name);
+    // Explicit user action: fit the window to the new profile's terminal_size.
+    activateProfile(action.name, ProfileWindowSizePolicy::Apply);
     return true;
 }
 
@@ -2189,6 +2194,8 @@ bool TerminalSession::reloadConfig(config::Config newConfig, string const& profi
     // clang-format on
 
     _config = std::move(newConfig);
+    // Passive config-file reload: keep the user's live window size (default Preserve policy). Only an
+    // explicit profile switch re-fits the window to the profile's terminal_size.
     activateProfile(profileName);
 
     return true;
@@ -2281,7 +2288,7 @@ void TerminalSession::spawnNewTerminal(string const& profileName)
     }
 }
 
-void TerminalSession::activateProfile(string const& newProfileName)
+void TerminalSession::activateProfile(string const& newProfileName, ProfileWindowSizePolicy windowSizePolicy)
 {
     // findProfile() (not profile()): the name comes from runtime input (a keybinding or the
     // {ChangeProfile} action) and may reference a profile the user removed. profile() asserts on a
@@ -2302,11 +2309,17 @@ void TerminalSession::activateProfile(string const& newProfileName)
     // TerminalPane.qml's overlay binds to the property.
     emit dimUnfocusedChanged();
 
-    // A profile switch may change the configured grid (terminal_size); ask the window to fit it — a
-    // content-driven grid->window request through the controller choke point (refused when
-    // fullscreen/maximized; a WM refusal leaves the reflowed grid). Posted like the sibling display
-    // calls; the inner _display re-check covers a teardown between schedule and dispatch.
-    if (_display != nullptr)
+    // An EXPLICIT profile switch (keybinding / OSC request) may change the configured grid
+    // (terminal_size); ask the window to fit it — a content-driven grid->window request through the
+    // controller choke point (refused when fullscreen/maximized; a WM refusal leaves the reflowed
+    // grid). Posted like the sibling display calls; the inner _display re-check covers a teardown
+    // between schedule and dispatch.
+    //
+    // A passive config-file RELOAD must NOT resize: the window size is the user's live authority once
+    // the window is mapped, so re-fitting to terminal_size on every save would silently discard an
+    // interactively-set size (and, with one file-watcher per pane, fire N competing resizes at once).
+    // Hence the policy gate — the resize is tied to the intent of the activation, not the activation.
+    if (_display != nullptr && windowSizePolicy == ProfileWindowSizePolicy::Apply)
     {
         auto const configuredSize = _profile.terminalSize.value();
         _display->post([this, configuredSize]() {

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2422,13 +2422,15 @@ void TerminalSession::configureDisplay()
         _terminal.setMaxImageSize(actualScreenSize, actualScreenSize);
     }
 
-    if (_profile.maximized.value())
-        _display->setWindowMaximized();
-    else
-        _display->setWindowNormal();
-
-    if (_profile.fullscreen.value() != _display->isFullScreen())
-        _display->toggleFullScreen();
+    // NB: The profile's window show-mode (maximized/fullscreen/normal) is deliberately NOT applied
+    // here. Window-state authority belongs solely to WindowController::showInitial() — which maps
+    // every window (fresh or tab-transplant receiver) directly into the profile's state on open —
+    // and to the explicit user actions (toggleMaximized/toggleFullScreen). configureDisplay() runs
+    // on EVERY renderer (re)creation: the first pane, but also each split leaf's fresh
+    // TerminalDisplay and any scene-graph re-creation after an unexpose. Re-asserting the profile's
+    // (default: non-maximized) state on those would drop the user's live maximized/fullscreen state
+    // — the "window unmaximizes when I split" regression. Splitting is a pure content-area
+    // operation; the QWindow's geometry and state must not change.
 
     _terminal.setRefreshRate(_display->refreshRate());
     _display->setFonts(_profile.fonts.value());

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2427,10 +2427,10 @@ void TerminalSession::configureDisplay()
     // every window (fresh or tab-transplant receiver) directly into the profile's state on open —
     // and to the explicit user actions (toggleMaximized/toggleFullScreen). configureDisplay() runs
     // on EVERY renderer (re)creation: the first pane, but also each split leaf's fresh
-    // TerminalDisplay and any scene-graph re-creation after an unexpose. Re-asserting the profile's
-    // (default: non-maximized) state on those would drop the user's live maximized/fullscreen state
-    // — the "window unmaximizes when I split" regression. Splitting is a pure content-area
-    // operation; the QWindow's geometry and state must not change.
+    // TerminalDisplay and any scene-graph re-creation after the window loses and regains its surface.
+    // Re-asserting the profile's (default: non-maximized) state on those would drop the user's live
+    // maximized/fullscreen state — the "window leaves maximized when I split" regression. Splitting is
+    // a pure content-area operation; the QWindow's geometry and state must not change.
 
     _terminal.setRefreshRate(_display->refreshRate());
     _display->setFonts(_profile.fonts.value());

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -529,7 +529,24 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     int executeAllActions(std::vector<actions::Action> const& actions);
     bool executeAction(actions::Action const& action);
     void spawnNewTerminal(std::string const& profileName);
-    void activateProfile(std::string const& newProfileName);
+
+    /// Whether activating a profile should also resize the window to the profile's configured
+    /// terminal_size. Data-driven so the resize is tied to the *intent* of the activation, not to
+    /// the activation itself: an explicit profile switch (a keybinding / OSC request) should fit the
+    /// new profile's grid, but a passive config-file reload must preserve the user's live window
+    /// size. See activateProfile().
+    enum class ProfileWindowSizePolicy : uint8_t
+    {
+        Preserve, ///< Keep the current window size (config-file reload).
+        Apply,    ///< Resize the window to the profile's terminal_size (explicit profile switch).
+    };
+
+    /// Activates the named profile: applies it to the terminal and, per @p windowSizePolicy,
+    /// optionally resizes the window to the profile's configured terminal_size.
+    /// @param newProfileName The profile to activate (tolerant of a removed profile, keeps default).
+    /// @param windowSizePolicy Whether to resize the window to the profile's terminal_size.
+    void activateProfile(std::string const& newProfileName,
+                         ProfileWindowSizePolicy windowSizePolicy = ProfileWindowSizePolicy::Preserve);
     bool reloadConfigWithProfile(std::string const& profileName);
     bool resetConfig();
     void followHyperlink(vtbackend::HyperlinkInfo const& hyperlink);

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -511,7 +511,7 @@ void WindowController::setChromeHeight(int height)
         updateSizeHintsFor(*_activeDisplay);
 }
 
-void WindowController::updateSizeHintsFor(display::TerminalDisplay& requester)
+void WindowController::updateSizeHintsFor(display::TerminalDisplay& requester, HintApplyMode mode)
 {
     auto* osWindow = osWindowFor(requester);
     if (osWindow == nullptr || !requester.hasSession())
@@ -522,15 +522,24 @@ void WindowController::updateSizeHintsFor(display::TerminalDisplay& requester)
     auto const margins = toGeometryMargins(requester.session().profile().margins.value());
     auto const hints = geometry::sizeHintsFor(cellSize, margins, scale, chrome());
 
+    // The character-cell resize grid (base + increment) is cleared while maximized/fullscreen. An
+    // incidental refresh (RespectWindowState) must not re-arm it while the window is non-normal — that
+    // would put a sub-cell gap around a maximized window on WMs honoring PResizeInc, and can drop the
+    // maximized state entirely. The restore-into-normal paths pass Full: they run BEFORE showNormal()
+    // settles visibility(), so they cannot rely on a live read and instead declare their intent. The
+    // minimum hint never disturbs the maximized state, so it is always applied.
+    auto const applyResizeGrid =
+        mode == HintApplyMode::Full || osWindow->visibility() == QQuickWindow::Visibility::Windowed;
+
     // Apply only the hints this platform can safely honor. macOS omits base + increment: Qt's Cocoa
     // plugin writes the base size straight into `-[NSWindow setFrame:]`, so a small base HARD-RESIZES the
     // freshly-mapped window to title-bar-only — the invisible-window regression. See sizeHintPolicyFor().
     auto const policy = geometry::sizeHintPolicyFor(geometry::currentSizeHintPlatform());
     if (policy.applyMinimum)
         osWindow->setMinimumSize(QSize(hints.minimum.width, hints.minimum.height));
-    if (policy.applyBase)
+    if (policy.applyBase && applyResizeGrid)
         osWindow->setBaseSize(QSize(hints.base.width, hints.base.height));
-    if (policy.applyIncrement)
+    if (policy.applyIncrement && applyResizeGrid)
         osWindow->setSizeIncrement(QSize(hints.increment.width, hints.increment.height));
 
     displayLog()("Size hints: min={}x{}, base={}x{}, increment={}x{} (cellSize={}, scale={}, chrome={})",
@@ -578,7 +587,10 @@ void WindowController::setWindowNormal(display::TerminalDisplay& requester)
     auto* osWindow = osWindowFor(requester);
     if (osWindow == nullptr)
         return;
-    updateSizeHintsFor(requester);
+    // Full: we are restoring into normal, so re-establish the interactive-resize grid unconditionally.
+    // visibility() is still Maximized/FullScreen here (showNormal() below settles it asynchronously), so
+    // the intent — not a live state read — must drive the increment write.
+    updateSizeHintsFor(requester, HintApplyMode::Full);
     osWindow->showNormal();
     _maximizedState = false;
 }
@@ -709,7 +721,9 @@ void WindowController::toggleFullScreen(display::TerminalDisplay& requester)
     }
     else
     {
-        updateSizeHintsFor(requester);
+        // Restoring into normal (see setWindowNormal): re-establish the resize grid unconditionally
+        // before showNormal() settles visibility().
+        updateSizeHintsFor(requester, HintApplyMode::Full);
         osWindow->showNormal();
     }
 }

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -213,12 +213,35 @@ class WindowController: public QAbstractListModel
     /// Sets the declared chrome height (QML binding write) and refreshes the WM size hints.
     void setChromeHeight(int height);
 
+    /// How much of the WM size-hint set @ref updateSizeHintsFor may (re)write.
+    ///
+    /// The character-cell resize grid (base + increment, the X11 @c PResizeInc pair) is deliberately
+    /// CLEARED while the window is maximized/fullscreen (see @c showWithoutSizeIncrements) so the WM
+    /// fills the screen exactly rather than snapping to the nearest cell multiple. An INCIDENTAL hint
+    /// refresh (a split's font reconcile, a DPR settle, a title-bar toggle) must therefore not re-arm
+    /// the increment while the window is non-normal — on WMs that honor @c PResizeInc that re-writes a
+    /// sub-cell gap around the maximized window, and can even drop the maximized state. The @c minimum
+    /// hint is always safe (it never disturbs the maximized state) and is written unconditionally.
+    enum class HintApplyMode : uint8_t
+    {
+        /// Incidental refresh: write the resize grid only while the window is @c Windowed; write
+        /// @c minimum always. Used by font/DPI/chrome refreshes that may fire while maximized.
+        RespectWindowState,
+        /// Establishing the normal-state hints: write the full set unconditionally. Used by the
+        /// restore-into-normal paths, which call this BEFORE @c showNormal() settles @c visibility()
+        /// (so a live @c visibility() read would still see the old maximized value); they KNOW the
+        /// window is becoming normal, so intent — not the not-yet-settled state — drives the write.
+        Full,
+    };
+
     /// Recomputes and applies the WM size hints (minimum/base/increment) for this window from
     /// @p requester's cell geometry, profile margins, content scale and the declared chrome.
     /// Refresh triggers: font/DPI reconfiguration (via the display), chrome changes, and
     /// restore-from-fullscreen/maximize. NEVER called from a resize path.
     /// @param requester The display whose cell geometry defines the hints (the active pane).
-    void updateSizeHintsFor(display::TerminalDisplay& requester);
+    /// @param mode Whether to gate the resize grid on the live window state (@ref HintApplyMode).
+    void updateSizeHintsFor(display::TerminalDisplay& requester,
+                            HintApplyMode mode = HintApplyMode::RespectWindowState);
 
     /// Shows this window fullscreen (size increments cleared while non-normal).
     /// @param requester The display forwarding the request (resolves the OS window).

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -812,9 +812,10 @@ void TerminalDisplay::createRenderer()
 
     // Defer configureDisplay() until the GUI thread processes QML binding propagation
     // and the window is committed at its final initial size (e.g. 1136x600 at DPR 1.5).
-    // Calling it synchronously here (render thread, GUI blocked) causes setWindowNormal()
-    // → showNormal() to trigger a Wayland configure event that uses the stale pre-DPR-correction
-    // window geometry (e.g. 1115x585 at DPR 2.0), reverting the terminal to the wrong size.
+    // configureDisplay() drives setFonts()/resizeTerminalToDisplaySize() against the display's
+    // metrics; running it synchronously here (render thread, GUI blocked) would compute geometry
+    // from the stale pre-DPR-correction window size (e.g. 1115x585 at DPR 2.0) instead of the
+    // committed final size, reverting the terminal to the wrong dimensions.
     // Re-check _session inside the lambda: post() runs it later on the GUI event loop, and the display can be
     // torn down (releaseSession -> _session == null) between this schedule and its dispatch, matching the
     // inner-guard pattern of the other post() lambdas here (863/1134).

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -734,6 +734,39 @@ TEST_CASE("display: window show-mode changes run through the live display", "[di
     h.pump();
 }
 
+TEST_CASE("display: an incidental hint refresh does not re-arm the resize grid while maximized",
+          "[display][geometry]")
+{
+    // [P2] defense-in-depth: maximizing clears the WM size-increment (showWithoutSizeIncrements) so the
+    // window fills the screen exactly. An INCIDENTAL hint refresh while maximized — a split's font
+    // reconcile, a DPR settle, a title-bar toggle — must NOT re-write a non-zero increment (a sub-cell
+    // gap around the maximized window on WMs honoring PResizeInc, and a potential maximize-drop).
+    // Restoring to normal must, by contrast, re-arm the grid.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    auto& controller = h.bindController();
+
+    controller.setWindowMaximized(*h.display);
+    h.pump();
+    if (h.window->visibility() != QQuickWindow::Visibility::Maximized)
+    {
+        WARN("Compositor did not honor maximize for a bare window; skipping the increment assertion.");
+        return;
+    }
+    // Maximize zeroed the increment.
+    CHECK(h.window->sizeIncrement() == QSize(0, 0));
+
+    // Incidental refresh (default RespectWindowState): the increment must stay zeroed while maximized.
+    controller.updateSizeHintsFor(*h.display);
+    h.pump();
+    CHECK(h.window->sizeIncrement() == QSize(0, 0));
+
+    // Restoring to normal re-establishes the interactive-resize grid (Full mode inside setWindowNormal).
+    controller.setWindowNormal(*h.display);
+    h.pump();
+    CHECK(h.window->sizeIncrement() != QSize(0, 0));
+}
+
 TEST_CASE("display: font DPI and refresh-rate/screen hooks re-derive metrics on the live display",
           "[display][metrics]")
 {

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -734,6 +734,37 @@ TEST_CASE("display: window show-mode changes run through the live display", "[di
     h.pump();
 }
 
+TEST_CASE("display: re-configuring a display leaves a maximized window maximized", "[display][geometry]")
+{
+    // Regression: maximize the window, then split — the window must STAY maximized. A split gives its
+    // new leaf a fresh TerminalDisplay whose first render sync creates a renderer and POSTS
+    // configureDisplay(). configureDisplay() used to re-assert the profile's (default: non-maximized)
+    // window state, calling setWindowNormal() -> showNormal() and dropping the user's maximized state.
+    // Here we drive the exact posted call directly on the same live session and assert the state holds.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    auto& controller =
+        h.bindController(); // so windowController() resolves and the show-mode actually applies
+
+    controller.setWindowMaximized(*h.display);
+    h.pump();
+
+    // The compositor may refuse to maximize a bare window; only assert the invariant when it took hold
+    // (otherwise there is no maximized state to preserve — not a failure of the fix).
+    if (h.window->visibility() != QQuickWindow::Visibility::Maximized)
+    {
+        WARN("Compositor did not honor maximize for a bare window; skipping the invariant assertion.");
+        return;
+    }
+
+    // The split-leaf renderer-setup path: re-run configureDisplay() on the already-maximized window.
+    CHECK_NOTHROW(h.session->configureDisplay());
+    h.pump();
+
+    // Post-fix: configureDisplay() no longer touches window show-mode, so the window stays maximized.
+    CHECK(h.window->visibility() == QQuickWindow::Visibility::Maximized);
+}
+
 TEST_CASE("display: an incidental hint refresh does not re-arm the resize grid while maximized",
           "[display][geometry]")
 {

--- a/src/contour/test/WindowSizing_test.cpp
+++ b/src/contour/test/WindowSizing_test.cpp
@@ -142,6 +142,35 @@ TEST_CASE("tab switching never touches window geometry", "[contour][sizing]")
     CHECK(window.minimumSize() == minimum);
 }
 
+TEST_CASE("a maximized window survives a tab switch", "[contour][sizing]")
+{
+    // Same invariant as splitting: content re-binding (here a tab switch) must never drop the window's
+    // show-state. Whatever the offscreen platform settles the visibility to after setWindowMaximized(),
+    // activating another tab and switching back must leave it unchanged — the tab path must not route
+    // through any show-mode call.
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController controller { manager };
+    QQuickWindow window;
+    controller->bindWindow(&window);
+    window.show();
+    QCoreApplication::processEvents();
+
+    REQUIRE(manager.model().createTab(controller->windowId()) != nullptr);
+    REQUIRE(manager.model().createTab(controller->windowId()) != nullptr);
+
+    contour::display::TerminalDisplay requester;
+    controller->setWindowMaximized(requester);
+    QCoreApplication::processEvents();
+    auto const visibility = window.visibility();
+
+    controller->activateTab(1);
+    controller->activateTab(0);
+    QCoreApplication::processEvents();
+
+    CHECK(window.visibility() == visibility);
+}
+
 TEST_CASE("toggleMaximized routes both directions through the show-mode protocol", "[contour][sizing]")
 {
     // The QML window controls / title-bar double-click entry point: maximizing must clear the WM


### PR DESCRIPTION
The native GUI tabs/splits rework made a single `TerminalDisplay` per pane, which turned several window-global operations into per-pane ones. As a result, actions that should only rearrange terminal *content* started mutating the QWindow's geometry and show-state. Most visibly: maximizing the window and then splitting a pane dropped the window out of maximized. Splitting (like a tab switch) is a pure content-area operation — the window's size and state must not change.

This branch restores that invariant and fixes two adjacent window-sizing regressions found while auditing the same paths.

## Changes

- **Keep the window's show-state when splitting a pane.** A split's new leaf gets a fresh `TerminalDisplay` whose renderer setup posts `configureDisplay()`, which re-asserted the profile's window show-mode on every call; with `maximized` defaulting to false it called `showNormal()` and un-maximized the window. Window-state authority already belongs solely to `WindowController::showInitial()` (open/transplant) and the explicit user actions, so the redundant block is removed. This also covers scene-graph re-creation after an unexpose.
- **Keep the interactive window size across a config reload.** `activateProfile()` resized the window to the profile's `terminal_size`, and it runs on every config-file save (not just an explicit profile switch), silently discarding an interactively-set size — amplified by one file-watcher per pane. The resize is now gated on the *intent*: an explicit `ChangeProfile` / OSC profile request still fits the new grid, a passive reload preserves the live size.
- **Don't re-arm the WM size-increment on a maximized window.** `updateSizeHintsFor()` re-wrote the cell resize grid (X11 `PResizeInc`) even while maximized/fullscreen — where the show-mode paths deliberately clear it — so an incidental refresh left a sub-cell gap and could drop the maximized state. A `HintApplyMode` gates the grid write to `Windowed`, while the restore-into-normal paths (which refresh hints before `showNormal()` settles `visibility()`) declare their intent explicitly.

Covered by a display-gated regression test (maximize, re-run `configureDisplay()`, assert still maximized; and the increment-not-re-armed / re-armed-on-restore invariant) plus an offscreen test that a maximized window survives a tab switch.