### PR TITLE
Fix noisy Qt/QML warnings and debug output on startup

### DIFF
--- a/src/contour/BenignQtMessages.h
+++ b/src/contour/BenignQtMessages.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace contour
+{
+
+/// One known-benign Qt-internal log message that Contour deliberately drops.
+///
+/// Some messages are emitted deep inside Qt for conditions that are neither actionable by us nor
+/// fixable at their source; printing them only trains users to ignore Contour's real diagnostics.
+/// Each entry documents *why* it is benign so the table stays self-explaining.
+struct BenignQtMessage
+{
+    std::string_view substring {}; //!< Matched anywhere within the formatted message.
+    std::string_view reason {};    //!< Why the message is benign / unfixable at its source (documentation).
+};
+
+/// The table of Qt-internal messages Contour suppresses. Data-driven on purpose: silencing a new
+/// benign Qt message is adding one row here, not another guard scattered across the code.
+inline constexpr auto BenignQtMessages = std::array {
+    // QQuickDragAttachedPrivate::loadPixmap() unconditionally passes a sourceSize to QQuickPixmap::load
+    // for the Drag.imageSource url. Our tab-drag ghost (TabItem.qml) is a grabToImage() result, whose
+    // image provider rejects any sourceSize and warns "Ignoring sourceSize request for image url that
+    // came from grabToImage." No QML property stops Qt requesting one (setting Drag.imageSourceSize only
+    // makes it re-request on every change), so the custom ghost cannot avoid it — and the warning is
+    // purely cosmetic: the ghost still renders.
+    BenignQtMessage { std::string_view("came from grabToImage"),
+                      std::string_view("Qt always requests a sourceSize on Drag.imageSource grab urls") },
+};
+
+/// Decides whether a formatted Qt log message is a known-benign one Contour should not print.
+///
+/// Pure and dependency-free (operates on the already-formatted text) so it is unit-testable without a
+/// Qt message handler or a running QGuiApplication.
+///
+/// @param message The fully formatted Qt log message text.
+/// @return true iff @p message contains the substring of any @ref BenignQtMessages entry.
+[[nodiscard]] inline bool isBenignQtMessage(std::string_view message) noexcept
+{
+    return std::ranges::any_of(BenignQtMessages, [message](BenignQtMessage const& entry) {
+        return message.find(entry.substring) != std::string_view::npos;
+    });
+}
+
+} // namespace contour

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -280,6 +280,7 @@ if(CONTOUR_FRONTEND_GUI)
             test/test_main.cpp
             test/Actions_test.cpp
             test/AudioNote_test.cpp
+            test/BenignQtMessages_test.cpp
             test/CaptureScreen_test.cpp
             test/CatImageArgs_test.cpp
             test/Config_test.cpp

--- a/src/contour/main.cpp
+++ b/src/contour/main.cpp
@@ -6,6 +6,8 @@
     #include <contour/ContourApp.h>
 #endif
 
+#include <contour/BenignQtMessages.h>
+
 #include <crispy/SuppressWindowsDialogs.hpp>
 
 #include <QtCore/QByteArray>
@@ -14,6 +16,9 @@
 #if __has_include(<QtCore/QtLogging>)
     #include <QtCore/QtLogging>
 #endif
+
+#include <cstddef>
+#include <string_view>
 
 #if defined(_WIN32)
     #include <cstdio>
@@ -86,6 +91,16 @@ void tryAttachConsole()
 void qtCustomMessageOutput(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
     QByteArray const localMsg = msg.toLocal8Bit();
+
+    // Drop known-benign, source-unfixable Qt-internal noise (see BenignQtMessages.h) before it reaches
+    // the user, so it never dilutes Contour's real diagnostics. Never suppress a fatal message: Qt
+    // considers it terminal, and swallowing it would skip the abort() below and leave the process running
+    // in an undefined state.
+    if (type != QtFatalMsg
+        && contour::isBenignQtMessage(
+            std::string_view { localMsg.constData(), static_cast<size_t>(localMsg.size()) }))
+        return;
+
     switch (type)
     {
         case QtDebugMsg:

--- a/src/contour/test/BenignQtMessages_test.cpp
+++ b/src/contour/test/BenignQtMessages_test.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Data-driven test for the benign-Qt-message filter (isBenignQtMessage). The predicate decides which
+// Qt-internal log messages the app's message handler (main.cpp) drops before they reach the user;
+// testing it directly verifies that decision without installing a Qt message handler.
+
+#include <contour/BenignQtMessages.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <string>
+#include <string_view>
+
+using contour::isBenignQtMessage;
+
+TEST_CASE("isBenignQtMessage.dropsKnownBenignNoise", "[contour][qt-log]")
+{
+    // Real message shapes as Qt emits them; each must be recognized as benign regardless of surrounding text.
+    auto const message = GENERATE(
+        std::string_view("Ignoring sourceSize request for image url that came from grabToImage. Use the "
+                         "targetSize parameter of the grabToImage() function instead."),
+        // Substring match is position-independent: the same phrase embedded in other framing still matches.
+        std::string_view("prefix :: came from grabToImage :: suffix"));
+
+    CAPTURE(std::string { message });
+    CHECK(isBenignQtMessage(message));
+}
+
+TEST_CASE("isBenignQtMessage.keepsRealDiagnostics", "[contour][qt-log]")
+{
+    // Messages that are NOT in the benign table must pass through (return false) so real diagnostics survive.
+    auto const message = GENERATE(
+        std::string_view(""),
+        std::string_view("qrc:/contour/ui/main.qml:42: ReferenceError: terminalSessions is not defined"),
+        std::string_view("freetype: Failed to set LCD filter. unimplemented feature"),
+        std::string_view("qt.qpa.fonts: Populating font family aliases took 98 ms."),
+        // Mentions grabToImage but not the suppressed phrase -> must still be printed.
+        std::string_view("grabToImage() failed: item has no window"));
+
+    CAPTURE(std::string { message });
+    CHECK(!isBenignQtMessage(message));
+}

--- a/src/contour/ui/TerminalPane.qml
+++ b/src/contour/ui/TerminalPane.qml
@@ -40,6 +40,16 @@ ContourTerminal {
     // Raised when the user clicks this pane, so the owner can make it active.
     signal activated()
 
+    // Lifecycle traces below are diagnostics, not user-facing events: they fire on the perfectly
+    // normal "the shell exited" path. Route them through a category that is off by default (Warning
+    // floor) so they stay silent in normal use but can be re-enabled for debugging via
+    // QT_LOGGING_RULES="contour.pane.debug=true".
+    LoggingCategory {
+        id: paneLog
+        name: "contour.pane"
+        defaultLogLevel: LoggingCategory.Warning
+    }
+
     visible: true
 
     // Item opacity follows the session's (profile) opacity, matching the single-pane view. Null-guarded
@@ -51,7 +61,7 @@ ContourTerminal {
     // the split (driven by paneClosed -> rebuildActiveTabPaneProxies) without closing the window. This is
     // the sole window-close path now that the pane tree is the only renderer.
     onTerminated: {
-        console.log("Client process terminated in pane.");
+        console.debug(paneLog, "Client process terminated in pane.");
         // Ask THIS OS window's controller (main.qml's `win`) whether its last pane just exited. Per-window,
         // so the last pane of this window closes only this window; other in-process windows are unaffected.
         if (Window.window && Window.window.win && Window.window.win.canCloseWindow())

--- a/src/contour/ui/WindowControls.qml
+++ b/src/contour/ui/WindowControls.qml
@@ -31,7 +31,10 @@ RowLayout {
         id: control
         Layout.fillHeight: true
         implicitWidth: 44
-        font.family: "monospace"
+        // The glyphs below are Unicode window-control symbols (—, ❐, ▢, ✕), not code, so they render
+        // fine in the default UI font. Do NOT pin a "monospace"/"Monospace" family here: that generic
+        // alias has no match on some platforms (notably macOS), forcing Qt into an expensive
+        // font-family-alias populate ("Populating font family aliases took … ms") on startup.
         font.pointSize: 10
         // Window controls must not steal keyboard focus from the terminal.
         focusPolicy: Qt.NoFocus

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -41,6 +41,16 @@ ApplicationWindow
     // remain reachable whether or not the native title bar is used.
     property bool showCustomTitleBar: true
 
+    // Diagnostic lifecycle/notification traces below are routed through a category that is off by
+    // default (Warning floor), so they stay silent during normal use (closing a window and firing a
+    // notification are expected events) but can be re-enabled for debugging via
+    // QT_LOGGING_RULES="contour.window.debug=true".
+    LoggingCategory {
+        id: windowLog
+        name: "contour.window"
+        defaultLogLevel: LoggingCategory.Warning
+    }
+
     // The window title follows the ACTIVE PANE's session: focusing another pane changes
     // terminalSessions.activeSession (which emits activeSessionChanged on a pane-focus change as well as on
     // a tab switch), and this binding also re-evaluates when that session's own title changes. Empty string
@@ -145,7 +155,7 @@ ApplicationWindow
     }
 
     onClosing: {
-        console.log("Terminal closed. Removing session.");
+        console.debug(windowLog, "Terminal closed. Removing session.");
         if (appWindow.win)
             appWindow.win.closeWindow();
     }
@@ -153,7 +163,7 @@ ApplicationWindow
     function showNotification(title, content) {
         // "OSC 777 ; notify ; <TITLE> ; <CONTENT> ST"
         // Example: printf "\033]777;notify;Hello Title;Hello Content\033\\"
-        console.log("main: notification [%1] %2".arg(title).arg(content));
+        console.debug(windowLog, "main: notification [%1] %2".arg(title).arg(content));
         if (trayIcon.supportsMessages)
         {
             trayIcon.show();
@@ -162,7 +172,7 @@ ApplicationWindow
                                  60 * 1000);
         }
         else
-            console.log("main: Notification system not supported!");
+            console.warn("main: Notification system not supported!");
     }
 
     // NB: This requires Qt 5.12+

--- a/src/text_shaper/open_shaper.cpp
+++ b/src/text_shaper/open_shaper.cpp
@@ -665,7 +665,17 @@ struct open_shaper::private_open_shaper // {{{
             throw runtime_error { "freetype: Failed to initialize. "s + ftErrorStr(ec) };
 
         if (auto const ec = FT_Library_SetLcdFilter(ft, FT_LCD_FILTER_DEFAULT); ec != FT_Err_Ok)
-            errorLog()("freetype: Failed to set LCD filter. {}", ftErrorStr(ec));
+        {
+            // FreeType built without FT_CONFIG_OPTION_SUBPIXEL_RENDERING (e.g. Homebrew's on macOS)
+            // makes FT_Library_SetLcdFilter a no-op that returns FT_Err_Unimplemented_Feature. That is
+            // expected — LCD/subpixel filtering is simply unavailable — so keep it at render-log
+            // verbosity (off by default) instead of alarming the user on every startup. Any other,
+            // genuinely unexpected error code still surfaces via errorLog().
+            if (ec == FT_Err_Unimplemented_Feature)
+                rasterizerLog()("freetype: LCD filter unavailable (subpixel rendering not built in).");
+            else
+                errorLog()("freetype: Failed to set LCD filter. {}", ftErrorStr(ec));
+        }
     }
 
     /// Extends fontInfo.fallbacks by appending the next batch from allFallbacks.


### PR DESCRIPTION
Starting Contour printed a burst of Qt/QML warnings and stray debug traces that carried no user value and only trained users to ignore real diagnostics. This cleans them up at the source, keeping every message's diagnostic value available for debugging where it made sense to preserve it.

## Changes

- **freetype LCD filter** — `FT_Library_SetLcdFilter` returns `FT_Err_Unimplemented_Feature` when FreeType is built without subpixel rendering (e.g. Homebrew's on macOS), where it is a documented no-op. That expected, benign case now goes to the off-by-default render log instead of `errorLog()`; any other error code still surfaces as an error.
- **Window-control font alias** — the min/maximize/close buttons render Unicode symbol glyphs, not code, so their `font.family: "monospace"` was unnecessary and forced Qt into an expensive font-family-alias populate at startup on platforms with no such family (notably macOS). Dropped it; the glyphs use the default UI font.
- **Lifecycle console traces** — "Client process terminated", "Terminal closed", and the notification trace fired on every ordinary close/notify via unconditional `console.log`. They now go through a QML `LoggingCategory` (`contour.pane` / `contour.window`, Warning floor), silent by default and recoverable via `QT_LOGGING_RULES`. The genuine "Notification system not supported!" gap is upgraded to `console.warn` to match its severity.
- **grabToImage "sourceSize" warning** — binding `Drag.imageSource` to a `grabToImage()` result (the tab-drag ghost) makes Qt warn once at startup; the backtrace shows `QQuickDragAttachedPrivate::loadPixmap()` unconditionally requesting a `sourceSize` that the grab image provider rejects, with no QML property able to prevent it and no visual effect. It is now dropped in the app's existing Qt message handler via a small data-driven table of known-benign, source-unfixable Qt messages (`BenignQtMessages.h`), with the pure predicate extracted to a dependency-free header and unit-tested.