### PR TITLE
Fix normal-mode highlights on plain-text lines and rework tab-title editing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
         key: "ccache-ubuntu2404-clang-tidy"
         max-size: 256M
     - name: "update APT database"
-      run: sudo apt -q update
+      run: sudo ./scripts/apt-update.sh
     - name: Installing xmllint for ci-set-vars
       run: sudo apt -qy install libxml2-utils
     - name: set environment variables
@@ -231,7 +231,7 @@ jobs:
         with:
           version: latest
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
       - name: Build release
@@ -701,7 +701,7 @@ jobs:
           key: "ccache-{{ matrix.runner }}-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}-${{ matrix.qt_version  }}"
           max-size: 256M
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
       - name: set environment variables
@@ -823,7 +823,7 @@ jobs:
         with:
           version: latest
       - name: update APT database
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars
         run: sudo apt-get -qy install libxml2-utils
       - name: set environment variables
@@ -864,7 +864,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
       - name: set variables
@@ -949,7 +949,7 @@ jobs:
         with:
           name: contour-ubuntu2404-tests
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: "fix unit test permissions"
         run: |
           find . -name '*_test' -exec chmod 0755 {} \;
@@ -987,7 +987,7 @@ jobs:
         with:
           name: contour-ubuntu2404-tests
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: "fix unit test permissions"
         run: |
           find . -name '*_test' -exec chmod 0755 {} \;
@@ -1042,7 +1042,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: "update APT database"
-      run: sudo apt -q update
+      run: sudo ./scripts/apt-update.sh
     - name: Installing xmllint for ci-set-vars
       run: sudo apt -qy install libxml2-utils
     - name: set environment variables
@@ -1122,7 +1122,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: "update APT database"
-      run: sudo apt -q update
+      run: sudo ./scripts/apt-update.sh
     - name: Installing xmllint for ci-set-vars
       run: sudo apt -qy install libxml2-utils
     - name: set environment variables
@@ -1221,7 +1221,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: "update APT database"
-      run: sudo apt -q update
+      run: sudo ./scripts/apt-update.sh
     - name: Installing xmllint for ci-set-vars
       run: sudo apt -qy install libxml2-utils
     - name: set environment variables
@@ -1244,7 +1244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars.sh and check-release.sh
         run: sudo apt -qy install libxml2-utils
       - name: set variables
@@ -1274,7 +1274,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "update APT database"
-        run: sudo apt -q update
+        run: sudo ./scripts/apt-update.sh
       - name: Installing xmllint for ci-set-vars
         run: sudo apt -qy install libxml2-utils
       - name: set variables

--- a/scripts/apt-update.sh
+++ b/scripts/apt-update.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+# Runs `apt update` with retries and exponential backoff so a transiently-unreachable mirror does
+# not flake the whole CI job. `apt update` exits non-zero (typically 100) if ANY configured
+# repository fails to fetch, even when the packages the build actually needs are available; on
+# GitHub's shared runners that happens intermittently, and an outage can outlast a couple of quick
+# retries. Backing off (5s, 10s, 20s, 40s) rides out a longer hiccup.
+#
+# If the update still cannot complete after all attempts, WARN but exit successfully rather than
+# failing the job: GitHub's runner images ship with pre-populated apt lists, so the subsequent
+# `apt install` normally still resolves from cache. If a genuinely-needed package cannot be found,
+# that install step fails with a precise, real error — a far more actionable failure than a blanket
+# "apt update failed" caused by one unrelated, momentarily-unreachable mirror.
+#
+# Tunable via APT_UPDATE_ATTEMPTS (default 5) and APT_UPDATE_RETRY_DELAY (default 5s, the first
+# backoff; each subsequent wait doubles).
+#
+# Usage: sudo ./scripts/apt-update.sh   (needs root to write /var/lib/apt/lists)
+set -uo pipefail
+
+attempts="${APT_UPDATE_ATTEMPTS:-5}"
+delay="${APT_UPDATE_RETRY_DELAY:-5}"
+
+for i in $(seq 1 "$attempts"); do
+    if apt -q update; then
+        exit 0
+    fi
+    if [ "$i" -lt "$attempts" ]; then
+        echo "::warning::apt update failed (attempt ${i}/${attempts}), retrying in ${delay}s…"
+        sleep "$delay"
+        delay=$((delay * 2))
+    fi
+done
+
+echo "::warning::apt update did not complete after ${attempts} attempts (likely a transient mirror" \
+     "outage); continuing with the existing package lists. A later 'apt install' will fail loudly if" \
+     "a required package is genuinely unavailable."
+exit 0

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -90,7 +90,7 @@ optional<Action> fromString(string const& name)
         mapAction<actions::SwitchToPreviousTab>("SwitchToPreviousTab"),
         mapAction<actions::SwitchToTabLeft>("SwitchToTabLeft"),
         mapAction<actions::SwitchToTabRight>("SwitchToTabRight"),
-        mapAction<actions::SetTabName>("SetTabName"),
+        mapAction<actions::SetTabTitle>("SetTabTitle"),
         mapAction<actions::SplitVertical>("SplitVertical"),
         mapAction<actions::SplitHorizontal>("SplitHorizontal"),
         mapAction<actions::ClosePane>("ClosePane"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -109,7 +109,7 @@ struct SwitchToTab{ int position; };
 struct SwitchToPreviousTab{};
 struct SwitchToTabLeft{};
 struct SwitchToTabRight{};
-struct SetTabName{};
+struct SetTabTitle{};
 struct SplitVertical{};    // split the active pane left/right
 struct SplitHorizontal{};  // split the active pane top/bottom
 struct ClosePane{};
@@ -191,7 +191,7 @@ using Action = std::variant<CancelSelection,
                             SwitchToPreviousTab,
                             SwitchToTabLeft,
                             SwitchToTabRight,
-                            SetTabName,
+                            SetTabTitle,
                             SplitVertical,
                             SplitHorizontal,
                             ClosePane,
@@ -395,7 +395,9 @@ namespace documentation
     constexpr inline std::string_view SwitchToPreviousTab { "Switch to the previously focused tab" };
     constexpr inline std::string_view SwitchToTabLeft { "Switch to tab to the left" };
     constexpr inline std::string_view SwitchToTabRight { "Switch to tab to the right" };
-    constexpr inline std::string_view SetTabName { "Set the name of the current tab" };
+    constexpr inline std::string_view SetTabTitle {
+        "Rename the current tab inline (opens the tab-title editor)"
+    };
     constexpr inline std::string_view SplitVertical {
         "Splits the active pane into two side-by-side panes (a vertical divider)."
     };
@@ -489,7 +491,7 @@ constexpr inline auto getDocumentation()
         std::tuple { Action { SwitchToPreviousTab {} }, documentation::SwitchToPreviousTab },
         std::tuple { Action { SwitchToTabLeft {} }, documentation::SwitchToTabLeft },
         std::tuple { Action { SwitchToTabRight {} }, documentation::SwitchToTabRight },
-        std::tuple { Action { SetTabName {} }, documentation::SetTabName },
+        std::tuple { Action { SetTabTitle {} }, documentation::SetTabTitle },
         std::tuple { Action { SplitVertical {} }, documentation::SplitVertical },
         std::tuple { Action { SplitHorizontal {} }, documentation::SplitHorizontal },
         std::tuple { Action { ClosePane {} }, documentation::ClosePane },
@@ -588,7 +590,7 @@ DECLARE_ACTION_FMT(MoveTabToRight)
 DECLARE_ACTION_FMT(SwitchToPreviousTab)
 DECLARE_ACTION_FMT(SwitchToTabLeft)
 DECLARE_ACTION_FMT(SwitchToTabRight)
-DECLARE_ACTION_FMT(SetTabName)
+DECLARE_ACTION_FMT(SetTabTitle)
 DECLARE_ACTION_FMT(SplitVertical)
 DECLARE_ACTION_FMT(SplitHorizontal)
 DECLARE_ACTION_FMT(ClosePane)
@@ -728,7 +730,7 @@ struct std::formatter<contour::actions::Action>: std::formatter<std::string>
         HANDLE_ACTION(SwitchToPreviousTab);
         HANDLE_ACTION(SwitchToTabLeft);
         HANDLE_ACTION(SwitchToTabRight);
-        HANDLE_ACTION(SetTabName);
+        HANDLE_ACTION(SetTabTitle);
         HANDLE_ACTION(SplitVertical);
         HANDLE_ACTION(SplitHorizontal);
         HANDLE_ACTION(ClosePane);

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -620,7 +620,7 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, vtbackend::ColorPal
 
     loadWithLog("cursor", where.cursor);
     loadWithLog("vi_mode_highlight", where.yankHighlight);
-    loadWithLog("vi_mode_cursosrline", where.normalModeCursorline);
+    loadWithLog("vi_mode_cursorline", where.normalModeCursorline);
     loadWithLog("selection", where.selection);
     loadWithLog("search_highlight", where.searchHighlight);
     loadWithLog("search_highlight_focused", where.searchHighlightFocused);

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -888,7 +888,7 @@ constexpr StringLiteral InputMappingsConfig {
     "p.\n"
     "{comment} - WriteScreen       Writes VT sequence in `chars` member to the screen (bypassing the "
     "application).\n"
-    "{comment} - SetTabName        Ask the user to assign a name to the active tab.\n"
+    "{comment} - SetTabTitle       Rename the active tab inline (opens the tab-title editor).\n"
     "\n"
     "input_mapping:\n"
 };

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2054,9 +2054,8 @@ bool TerminalSession::operator()(actions::SwitchToTabRight)
 
 bool TerminalSession::operator()(actions::SetTabTitle)
 {
-    // Open the GUI-native inline tab-title editor for the active tab, rather than the old
-    // in-terminal vi-mode name prompt (terminal().requestTabName()), which predates GUI-native
-    // tabs. Routed through the manager like every other tab op so it targets this session's window.
+    // Open the GUI-native inline tab-title editor for the active tab. Routed through the manager
+    // like every other tab op so it targets this session's window.
     _manager->beginTabTitleEdit(/*acting*/ this);
     return true;
 }

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1157,18 +1157,17 @@ void TerminalSession::refreshGuiTabInfoForStatusLine()
     // session and would re-lock that non-recursive mutex (the deadlock scheduleRedraw() was changed to
     // avoid). Post the refresh to the GUI thread instead, where it runs free of the parser-thread lock.
     //
-    // The lambda is keyed to the display QObject, so Qt only cancels it if the *display* dies — not if
-    // this *session* is destroyed first (e.g. closing a tab while its shell still emits an OSC title
-    // change). Capture a QPointer to the session (auto-nulls on destruction) and bail out if the session
-    // is gone, avoiding a use-after-free on _manager.
-    if (_display)
-        _display->post([self = QPointer<TerminalSession> { this }]() {
-            if (self)
-            {
-                self->_manager->update();                                     // indicator status line
-                self->_manager->refreshTabForSession(self->modelSessionId()); // GUI tab strip label
-            }
-        });
+    // Post through THIS session (a QObject on the GUI thread), NOT through _display: a background
+    // (unfocused) tab's session has no display attached — the display follows the active tab — so
+    // gating on _display would skip the tab-strip label refresh for every unfocused tab, freezing its
+    // title until it was next focused. The tab-strip update is a pure model change and does not need a
+    // display. postToObject targets `this`, so Qt auto-cancels the queued call if the session is
+    // destroyed first (e.g. closing a tab while its shell still emits an OSC title change), avoiding a
+    // use-after-free on _manager.
+    postToObject(this, [this]() {
+        _manager->update();                               // indicator status line
+        _manager->refreshTabForSession(modelSessionId()); // GUI tab strip label
+    });
 }
 
 void TerminalSession::setWindowTitle(string_view title)

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2052,9 +2052,12 @@ bool TerminalSession::operator()(actions::SwitchToTabRight)
     return true;
 }
 
-bool TerminalSession::operator()(actions::SetTabName)
+bool TerminalSession::operator()(actions::SetTabTitle)
 {
-    terminal().requestTabName();
+    // Open the GUI-native inline tab-title editor for the active tab, rather than the old
+    // in-terminal vi-mode name prompt (terminal().requestTabName()), which predates GUI-native
+    // tabs. Routed through the manager like every other tab op so it targets this session's window.
+    _manager->beginTabTitleEdit(/*acting*/ this);
     return true;
 }
 

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -447,7 +447,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::SwitchToPreviousTab);
     bool operator()(actions::SwitchToTabLeft);
     bool operator()(actions::SwitchToTabRight);
-    bool operator()(actions::SetTabName);
+    bool operator()(actions::SetTabTitle);
     bool operator()(actions::SplitVertical);
     bool operator()(actions::SplitHorizontal);
     bool operator()(actions::ClosePane);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -298,6 +298,15 @@ void TerminalSessionManager::switchToTabRight(TerminalSession* acting)
     activateModelTabByRow(win->id(), target);
 }
 
+void TerminalSessionManager::beginTabTitleEdit(TerminalSession* acting)
+{
+    auto* win = windowHostingSession(acting);
+    if (win == nullptr)
+        return;
+    if (auto* controller = controllerFor(win->id()); controller != nullptr)
+        controller->beginActiveTabTitleEdit();
+}
+
 void TerminalSessionManager::switchToTab(int position, TerminalSession* acting)
 {
     auto* win = windowHostingSession(acting);

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -100,6 +100,10 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     void moveTabTo(int position, TerminalSession* acting);
     void moveTabToLeft(TerminalSession* session);
     void moveTabToRight(TerminalSession* session);
+    /// Opens the inline title editor for the active tab of the window hosting @p acting (the
+    /// SetTabTitle keybinding), routed like the other tab ops via the acting session's window.
+    /// @param acting The session that received the keybinding; its hosting window is the target.
+    void beginTabTitleEdit(TerminalSession* acting);
 
     void removeSession(TerminalSession&);
     void currentSessionIsTerminated();

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -176,6 +176,14 @@ void WindowController::resetTabTitle(int index)
         _manager.model().resetTabTitle(tab->id());
 }
 
+void WindowController::beginActiveTabTitleEdit()
+{
+    auto const index = activeTabIndex();
+    if (index < 0)
+        return;
+    emit tabTitleEditRequested(index);
+}
+
 void WindowController::setTabColor(int index, QColor const& color)
 {
     if (auto* tab = tabAtRow(index); tab != nullptr)

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -114,6 +114,10 @@ class WindowController: public QAbstractListModel
     Q_INVOKABLE void tearOffTab(int index);
     Q_INVOKABLE void setTabTitle(int index, QString const& title);
     Q_INVOKABLE void resetTabTitle(int index);
+    /// Asks the active tab's QML delegate to open its inline title editor (the keyboard entry point
+    /// for the SetTabTitle action). No-op when this window has no active tab. Emits
+    /// tabTitleEditRequested() with the active tab's row so exactly that TabItem starts editing.
+    Q_INVOKABLE void beginActiveTabTitleEdit();
     Q_INVOKABLE void setTabColor(int index, QColor const& color);
     Q_INVOKABLE void resetTabColor(int index);
     Q_INVOKABLE void closeTabAtIndex(int index);
@@ -322,6 +326,10 @@ class WindowController: public QAbstractListModel
   signals:
     void countChanged();
     void activeTabIndexChanged();
+    /// Requests that the tab at @p index open its inline title editor. Per-window (this controller
+    /// is the tab-strip model), so it only reaches this window's TabItems; the delegate whose row
+    /// matches @p index starts editing.
+    void tabTitleEditRequested(int index);
     void multimediaReadyChanged();
     void activeTabRootPaneChanged();
     void titleBarVisibleChanged();

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -13,6 +13,7 @@
 
 #include <QtCore/QTemporaryDir>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
@@ -972,6 +973,43 @@ profiles:
     CHECK(simple->colors.defaultForeground == vtbackend::RGBColor { 0xE0E0E0 });
 }
 
+TEST_CASE("Config: vi_mode_cursorline color loads from YAML", "[config]")
+{
+    // Regression: the loader key was misspelled ("vi_mode_cursosrline"), so the documented
+    // `vi_mode_cursorline` key was silently ignored. Assert the correctly-spelled key now takes
+    // effect (and thus that the normal-mode current-line highlight is user-configurable).
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+color_schemes:
+    myscheme:
+        default:
+            background: '0x101010'
+            foreground: '0xE0E0E0'
+        vi_mode_cursorline:
+            foreground: '0x123456'
+            foreground_alpha: 0.3
+            background: '0xABCDEF'
+            background_alpha: 0.7
+profiles:
+    main:
+        shell: /bin/sh
+        colors: myscheme
+)"sv);
+
+    auto const* profile = config.profile("main");
+    REQUIRE(profile != nullptr);
+    auto const* simple = std::get_if<contour::config::SimpleColorConfig>(&profile->colors.value());
+    REQUIRE(simple != nullptr);
+    auto const& cursorline = simple->colors.normalModeCursorline;
+    REQUIRE(std::holds_alternative<vtbackend::RGBColor>(cursorline.background));
+    CHECK(std::get<vtbackend::RGBColor>(cursorline.background) == vtbackend::RGBColor { 0xABCDEF });
+    CHECK(cursorline.backgroundAlpha == Catch::Approx(0.7f));
+    REQUIRE(std::holds_alternative<vtbackend::RGBColor>(cursorline.foreground));
+    CHECK(std::get<vtbackend::RGBColor>(cursorline.foreground) == vtbackend::RGBColor { 0x123456 });
+    CHECK(cursorline.foregroundAlpha == Catch::Approx(0.3f));
+}
+
 TEST_CASE("Config: createDefaultConfig writes a loadable file into a fresh directory", "[config]")
 {
     // createDefaultConfig() creates the parent directory chain and writes the generated default
@@ -1141,4 +1179,42 @@ profiles:
     // NewTerminal and ReloadConfig without a profile still bind (argless fallback); the rest are
     // rejected. The document loads regardless.
     CHECK(config.profile("main") != nullptr);
+}
+
+TEST_CASE("Config: SetTabTitle action binds, old SetTabName name is rejected", "[config]")
+{
+    // The tab-rename action was renamed SetTabName -> SetTabTitle. The new name must resolve to a
+    // binding; the retired name must NOT (fromString() returns nullopt, so it is dropped).
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+input_mapping:
+    - { mods: [Control, Shift], key: 'R', action: SetTabTitle }
+    - { mods: [Control, Shift], key: 'N', action: SetTabName }
+)"sv);
+
+    auto const& mappings = config.inputMappings.value();
+    auto const bindsTo = [&](auto actionTag) {
+        auto const inKey = std::ranges::any_of(mappings.keyMappings, [&](auto const& m) {
+            return std::holds_alternative<decltype(actionTag)>(m.binding.at(0));
+        });
+        auto const inChar = std::ranges::any_of(mappings.charMappings, [&](auto const& m) {
+            return std::holds_alternative<decltype(actionTag)>(m.binding.at(0));
+        });
+        return inKey || inChar;
+    };
+
+    CHECK(bindsTo(contour::actions::SetTabTitle {}));
+    // The retired "SetTabName" string does not resolve, so it is dropped: exactly ONE SetTabTitle
+    // binding survives (the 'R' line), while the 'N'/SetTabName line adds nothing. Count across both
+    // key and char mapping lists (an uppercase letter key may land in either).
+    auto const countIn = [](auto const& list) {
+        return std::ranges::count_if(list, [](auto const& m) {
+            return std::holds_alternative<contour::actions::SetTabTitle>(m.binding.at(0));
+        });
+    };
+    CHECK(countIn(mappings.keyMappings) + countIn(mappings.charMappings) == 1);
 }

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -1182,3 +1182,7 @@ TEST_CASE("display: a Close event closes the PTY and emits terminated on the liv
 
     QObject::disconnect(conn);
 }
+
+// NOTE: The WindowController tab-title-edit seam (beginActiveTabTitleEdit → tabTitleEditRequested)
+// is tested headlessly with real tabs in MultiWindow_test.cpp, where activeTabIndex() is populated;
+// the DisplayHarness session is not registered as a model tab, so it cannot exercise that path.

--- a/src/contour/test/KeyboardRouting_test.cpp
+++ b/src/contour/test/KeyboardRouting_test.cpp
@@ -267,6 +267,7 @@ class RoutingMockController: public QAbstractListModel
     Q_INVOKABLE void tearOffTab(int) {}
     Q_INVOKABLE void setTabTitle(int, QString const&) {}
     Q_INVOKABLE void resetTabTitle(int) {}
+    Q_INVOKABLE void beginActiveTabTitleEdit() { emit tabTitleEditRequested(_activeTabIndex); }
     Q_INVOKABLE void setTabColor(int, QColor const&) {}
     Q_INVOKABLE void resetTabColor(int) {}
     Q_INVOKABLE void closeTabAtIndex(int) {}
@@ -305,6 +306,7 @@ class RoutingMockController: public QAbstractListModel
     void titleBarVisibleChanged();
     void chromeHeightChanged();
     void activeTabRootPaneChanged();
+    void tabTitleEditRequested(int index);
 
   private:
     int _chromeHeight = 0;

--- a/src/contour/test/MainWindowQml_test.cpp
+++ b/src/contour/test/MainWindowQml_test.cpp
@@ -142,6 +142,7 @@ class MockMainController: public QAbstractListModel
     Q_INVOKABLE void tearOffTab(int) {}
     Q_INVOKABLE void setTabTitle(int, QString const&) {}
     Q_INVOKABLE void resetTabTitle(int) {}
+    Q_INVOKABLE void beginActiveTabTitleEdit() { emit tabTitleEditRequested(0); }
     Q_INVOKABLE void setTabColor(int, QColor const&) {}
     Q_INVOKABLE void resetTabColor(int) {}
     Q_INVOKABLE void closeTabAtIndex(int) {}
@@ -182,6 +183,7 @@ class MockMainController: public QAbstractListModel
     void activeTabIndexChanged();
     void titleBarVisibleChanged();
     void chromeHeightChanged();
+    void tabTitleEditRequested(int index);
 
   private:
     int _chromeHeight = 0;

--- a/src/contour/test/MultiWindow_test.cpp
+++ b/src/contour/test/MultiWindow_test.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 
+#include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 #include <vtmux/Pane.h>
 #include <vtmux/SessionModel.h>
@@ -141,6 +142,47 @@ TEST_CASE("REGRESSION: tab operations from a second window target that window, n
         CHECK(windowB->count() == 1);
         CHECK(windowA->count() == 2);
     }
+}
+
+TEST_CASE("beginActiveTabTitleEdit requests the active tab's inline editor, per window",
+          "[contour][multiwindow]")
+{
+    // The SetTabTitle action asks the acting window's WindowController to open the inline title
+    // editor for its ACTIVE tab; the controller signals tabTitleEditRequested(activeTabIndex) so
+    // the matching QML TabItem starts editing. Verify the signal fires with the active tab's row,
+    // and only on the window whose controller was asked (no cross-window leakage).
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController windowA { manager };
+    ScopedController windowB { manager };
+    createTabs(manager, *windowA, 2);
+    createTabs(manager, *windowB, 3);
+
+    windowB->activateTab(2);
+    REQUIRE(windowB->activeTabIndex() == 2);
+
+    auto spyB = QSignalSpy(windowB.controller, &contour::WindowController::tabTitleEditRequested);
+    auto spyA = QSignalSpy(windowA.controller, &contour::WindowController::tabTitleEditRequested);
+
+    windowB->beginActiveTabTitleEdit();
+
+    REQUIRE(spyB.count() == 1);
+    CHECK(spyB.takeFirst().at(0).toInt() == 2); // window B's active tab row
+    CHECK(spyA.count() == 0);                   // window A's controller was not asked
+}
+
+TEST_CASE("beginActiveTabTitleEdit is a no-op when the window has no tabs", "[contour][multiwindow]")
+{
+    // Guard: with no active tab (activeTabIndex() < 0) the controller must not emit, so the QML
+    // editor is never asked to open on a nonexistent tab.
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController window { manager };
+    REQUIRE(window->activeTabIndex() < 0);
+
+    auto spy = QSignalSpy(window.controller, &contour::WindowController::tabTitleEditRequested);
+    window->beginActiveTabTitleEdit();
+    CHECK(spy.count() == 0);
 }
 
 TEST_CASE("REGRESSION: pane-proxy writes (ratio, activate) target their own window's tab",

--- a/src/contour/test/MultiWindow_test.cpp
+++ b/src/contour/test/MultiWindow_test.cpp
@@ -305,6 +305,57 @@ TEST_CASE("WindowController projects real-session tabs and routes rename/color t
         window->closeTabAtIndex(row);
 }
 
+TEST_CASE("a background (unfocused) tab's title updates in real time", "[contour][multiwindow][model]")
+{
+    // Regression: a program-driven title change on a tab that is NOT the active tab (so its session
+    // has no display attached) must still refresh that tab's strip label immediately — not only once
+    // the tab is next focused. The refresh is posted to the session QObject (GUI thread), so it works
+    // without a display; pump the event loop to deliver the queued post.
+    auto factoryOwned = std::make_unique<contour::test::MockPtySessionFactory>();
+    TestApp app(std::move(factoryOwned));
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    window->createNewTab();
+    window->createNewTab();
+    REQUIRE(window->count() == 2);
+
+    // Make row 0 the active tab, so row 1 is the background (display-less) tab under test.
+    window->activateTab(0);
+    REQUIRE(window->activeTabIndex() == 0);
+
+    auto* backgroundTab = manager.model().window(window.id)->tabAt(1);
+    REQUIRE(backgroundTab != nullptr);
+    auto* backgroundSession = manager.sessionForId(backgroundTab->activePane()->session());
+    REQUIRE(backgroundSession != nullptr);
+
+    // Watch the tab strip for a TitleRole change on row 1.
+    auto spy = QSignalSpy(window.controller, &contour::WindowController::dataChanged);
+
+    // Program-driven title change on the BACKGROUND session (as an OSC title sequence would do).
+    backgroundSession->setTitle(QStringLiteral("background-build-running"));
+
+    // The refresh is queued onto the session (GUI thread); deliver it.
+    QCoreApplication::processEvents();
+
+    // The background tab's resolved title now reflects the change...
+    CHECK(window->data(window->index(1), contour::WindowController::TitleRole).toString()
+          == QStringLiteral("background-build-running"));
+    // ...and a dataChanged carrying TitleRole was emitted for row 1 (not row 0, the active tab).
+    auto sawRow1TitleChange = false;
+    for (auto const& emission: spy)
+    {
+        auto const topLeft = emission.at(0).toModelIndex();
+        auto const roles = emission.at(2).value<QList<int>>();
+        if (topLeft.row() == 1 && roles.contains(contour::WindowController::TitleRole))
+            sawRow1TitleChange = true;
+    }
+    CHECK(sawRow1TitleChange);
+
+    for (int row = window->count() - 1; row >= 0; --row)
+        window->closeTabAtIndex(row);
+}
+
 TEST_CASE("WindowController routes bulk-close and move-tab to its own window",
           "[contour][multiwindow][model]")
 {

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -134,6 +134,7 @@ class MockTabController: public QAbstractListModel
     Q_INVOKABLE void tearOffTab(int) {}
     Q_INVOKABLE void setTabTitle(int, QString const&) {}
     Q_INVOKABLE void resetTabTitle(int) {}
+    Q_INVOKABLE void beginActiveTabTitleEdit() { emit tabTitleEditRequested(0); }
     Q_INVOKABLE void setTabColor(int, QColor const&) {}
     Q_INVOKABLE void resetTabColor(int) {}
     Q_INVOKABLE void closeTabAtIndex(int) {}
@@ -174,6 +175,7 @@ class MockTabController: public QAbstractListModel
   signals:
     void activeTabIndexChanged();
     void titleBarVisibleChanged();
+    void tabTitleEditRequested(int index);
 
   private:
     int _count = 3;

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -302,7 +302,7 @@ TEST_CASE("TerminalSession: tab actions from an unregistered session are guarded
     CHECK_NOTHROW((*session)(contour::actions::FocusPaneDown {}));
     CHECK_NOTHROW((*session)(contour::actions::MoveTabTo { .position = 1 }));
     CHECK_NOTHROW((*session)(contour::actions::SwitchToTab { .position = 1 }));
-    CHECK_NOTHROW((*session)(contour::actions::SetTabName {}));
+    CHECK_NOTHROW((*session)(contour::actions::SetTabTitle {}));
 }
 
 TEST_CASE("TerminalSession: opener, paste and reload actions run without a display",

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -1011,8 +1011,10 @@ TEST_CASE("TerminalSession: display-coupled event overrides are safe no-ops with
     TestApp testApp;
     auto session = makeDisplaylessSession(testApp.app());
 
-    // setTabName refreshes the (display-less) status-line tab info; setTerminalProfile early-returns
-    // when no display is attached. Neither must crash.
+    // setTabName posts a tab-strip/status-line refresh to the session (a GUI-thread QObject) even
+    // with no display attached — a background tab must still refresh its title (see the dedicated
+    // real-time-title test in MultiWindow_test). setTerminalProfile early-returns when no display is
+    // attached. Neither must crash.
     CHECK_NOTHROW(session->setTabName("my-tab"));
     CHECK_NOTHROW(session->setTerminalProfile("main"));
 }

--- a/src/contour/ui/TabItem.qml
+++ b/src/contour/ui/TabItem.qml
@@ -252,4 +252,15 @@ Item {
         tabIndex: root.tabIndex
         onRenameRequested: renameLoader.start()
     }
+
+    // Keyboard entry point (the SetTabTitle action): the WindowController emits
+    // tabTitleEditRequested(index) for the active tab; the matching delegate opens its editor.
+    // The active tab's delegate is always realized, so an in-delegate Connections reliably fires.
+    Connections {
+        target: root.controller
+        function onTabTitleEditRequested(index) {
+            if (index === root.tabIndex)
+                renameLoader.start()
+        }
+    }
 }

--- a/src/vtbackend/RenderBufferBuilder.cpp
+++ b/src/vtbackend/RenderBufferBuilder.cpp
@@ -370,7 +370,12 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
     //                lineBuffer.text.view(),
     //                flags);
 
-    _useCursorlineColoring = false;
+    // A trivial line can now sit under the (vi) cursor after the AoS→SoA migration — a plain-text
+    // line with uniform SGR stays trivial even when the normal-mode cursor is on it. So the
+    // cursorline decision must be made here too, exactly as startLine() does for inflated lines;
+    // hard-coding it to false (the old invariant "cursor lines are always inflated") dropped the
+    // current-line highlight on plain-text lines.
+    _useCursorlineColoring = isCursorLine(lineOffset);
     _currentLineFlags = flags;
 
     auto const frontIndex = _output->cells.size();
@@ -383,8 +388,17 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
     // which affects background/foreground color again.
     // We're not testing for cursor shape (which should be done in order to be 100% correct)
     // because it's not really draining performance.
-    bool const canRenderViaSimpleLine =
-        (!_terminal->isSelected(lineOffset) || !_includeSelection) && !gridLineContainsCursor(lineOffset);
+    // A vi yank/motion highlight range (like a selection) recolors part of the line, so a trivial
+    // line intersecting it must drop to the per-cell path where makeColorsForCell() applies the
+    // yankHighlight. _highlightRange lives in grid coordinates, so translate this screen line first
+    // (matching how makeColorsForCell() queries isHighlighted() with grid coordinates).
+    auto const gridLine =
+        _terminal->viewport()
+            .translateScreenToGridCoordinate(CellLocation { .line = lineOffset, .column = ColumnOffset(0) })
+            .line;
+    bool const canRenderViaSimpleLine = (!_terminal->isSelected(lineOffset) || !_includeSelection)
+                                        && !gridLineContainsCursor(lineOffset)
+                                        && !_terminal->isHighlighted(gridLine);
 
     if (canRenderViaSimpleLine)
     {

--- a/src/vtbackend/StatusLineBuilder.cpp
+++ b/src/vtbackend/StatusLineBuilder.cpp
@@ -428,9 +428,6 @@ struct VTSerializer
             return std::format("Search: {}█",
                                unicode::convert_to<char>(std::u32string_view(vt.search().pattern)));
 
-        if (vt.inputHandler().isEditingPrompt())
-            return std::format("{}{}█", vt.prompt().prompt, vt.prompt().text);
-
         return {};
     }
 

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2438,34 +2438,10 @@ std::string Terminal::resolvedWindowTitle() const
 
 void Terminal::setTabName(string_view title)
 {
-    // Parser-thread path (SETTABNAME escape sequence): writeToScreen() already holds _stateMutex across
-    // the whole parse, so _tabName is written under the lock here. The GUI interactive-prompt path goes
-    // through requestTabName(), which takes _stateMutex itself before mutating _tabName — it must NOT call
-    // this method (that would write _tabName lock-free, racing the parser thread and resolvedTabName()).
+    // Parser-thread path (SETTABNAME escape sequence, OSC 30): writeToScreen() already holds _stateMutex
+    // across the whole parse, so _tabName is written under the lock here.
     _tabName = title;
     _eventListener.setTabName(title);
-}
-
-void Terminal::requestTabName()
-{
-    // The interactively-entered name arrives on the GUI thread, where _stateMutex is NOT held (unlike the
-    // parser-thread SETTABNAME path). _tabName is read on the GUI thread by resolvedTabName() and written
-    // on the parser thread by setTabName(), both under _stateMutex, so this writer must take the lock too;
-    // assigning _tabName lock-free would be a data race (torn read / use-after-free on string reallocation).
-    //
-    // The event-listener notification (-> TerminalSession::setTabName -> refreshGuiTabInfoForStatusLine,
-    // which only post()s to the GUI loop) is done OUTSIDE the lock to keep the _stateMutex hold minimal and
-    // avoid taking GUI-side locks under it. We do not route through setTabName() because that writes
-    // _tabName without the lock.
-    inputHandler().setTabName([this](std::string const& name) {
-        {
-            auto const l = std::lock_guard { _stateMutex };
-            _tabName = name;
-        }
-        // Notify with the local argument, not _tabName: reading the member after releasing the lock would
-        // again race the parser thread.
-        _eventListener.setTabName(name);
-    });
 }
 
 std::optional<std::string> Terminal::tabName() const noexcept
@@ -3531,16 +3507,6 @@ bool Terminal::setNewSearchTerm(std::u32string text, bool initiatedByDoubleClick
 
     _search.pattern = std::move(text);
     return true;
-}
-
-void Terminal::setPrompt(std::string prompt)
-{
-    _prompt.prompt = std::move(prompt);
-}
-
-void Terminal::setPromptText(std::string text)
-{
-    _prompt.text = std::move(text);
 }
 
 optional<CellLocation> Terminal::searchReverse(u32string text, CellLocation searchPosition)

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -3651,6 +3651,21 @@ bool Terminal::isHighlighted(CellLocation cell) const noexcept // NOLINT(bugpron
                _highlightRange.value());
 }
 
+bool Terminal::isHighlighted(LineOffset line) const noexcept // NOLINT(bugprone-exception-escape)
+{
+    // A line intersects the highlight range when it falls between the range's endpoints, whichever
+    // way round they were recorded. Linear and rectangular highlights share the same line span
+    // (the rectangle only additionally constrains columns, which do not matter for a line test).
+    return _highlightRange.has_value()
+           && std::visit(
+               [line](auto&& highlightRange) {
+                   auto const lo = std::min(highlightRange.from.line, highlightRange.to.line);
+                   auto const hi = std::max(highlightRange.from.line, highlightRange.to.line);
+                   return lo <= line && line <= hi;
+               },
+               _highlightRange.value());
+}
+
 void Terminal::onSelectionUpdated()
 {
     if (!isModeEnabled(DECMode::ReportGridCellSelection))

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1072,7 +1072,17 @@ class Terminal
                && _selection->containsLine(line);
     }
 
+    /// Tests whether the given cell is covered by the active (vi yank/motion) highlight range.
+    /// @param cell The absolute grid coordinate to test.
+    /// @return true if a highlight range is active and contains @p cell.
     bool isHighlighted(CellLocation cell) const noexcept;
+
+    /// Tests whether the given grid line intersects the active highlight range.
+    /// Mirrors isSelected(LineOffset) so the render fast path can cheaply decide whether a
+    /// trivial (uniform-SGR) line must drop to the per-cell path to receive the highlight.
+    /// @param line The absolute grid line offset to test.
+    /// @return true if a highlight range is active and spans @p line.
+    [[nodiscard]] bool isHighlighted(LineOffset line) const noexcept;
     float blinkState() const noexcept { return _slowBlinker.opacity(_currentTime, _settings.blinkStyle); }
     float rapidBlinkState() const noexcept
     {

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -166,12 +166,6 @@ struct Search
     bool initiatedByDoubleClick = false;
 };
 
-struct Prompt
-{
-    std::string prompt;
-    std::string text;
-};
-
 // Mandates what execution mode the terminal will take to process VT sequences.
 //
 enum class ExecutionMode : uint8_t
@@ -1208,8 +1202,6 @@ class Terminal
     [[nodiscard]] bool focused() const noexcept { return _focused; }
     [[nodiscard]] Search& search() noexcept { return _search; }
     [[nodiscard]] Search const& search() const noexcept { return _search; }
-    [[nodiscard]] Prompt& prompt() noexcept { return _prompt; }
-    [[nodiscard]] Prompt const& prompt() const noexcept { return _prompt; }
 
     // {{{ hint mode
     /// Activates hint mode by scanning visible lines for regex matches.
@@ -1333,9 +1325,6 @@ class Terminal
     bool setNewSearchTerm(std::u32string text, bool initiatedByDoubleClick);
     void clearSearch();
 
-    void setPrompt(std::string prompt);
-    void setPromptText(std::string text);
-
     // Tests if the grid cell at the given location does contain a word delimiter.
     [[nodiscard]] bool wordDelimited(CellLocation position) const noexcept;
     [[nodiscard]] bool wordDelimited(CellLocation position,
@@ -1458,7 +1447,6 @@ class Terminal
     }
 
     TabsNamingMode getTabsNamingMode() const noexcept { return _settings.tabNamingMode; }
-    void requestTabName();
 
   private:
     /// Scroll the viewport to the bottom if `settings().autoScrollOnUpdate` is enabled.
@@ -1767,7 +1755,6 @@ class Terminal
     ActiveStatusDisplay _activeStatusDisplay = ActiveStatusDisplay::Main;
 
     Search _search;
-    Prompt _prompt;
 
     CursorDisplay _cursorDisplay = CursorDisplay::Steady;
     CursorShape _cursorShape = CursorShape::Block;

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2605,7 +2605,9 @@ TEST_CASE("Terminal.Cursorline.trivialLineUnderCursorIsHighlighted", "[terminal]
     // grid line 0: plain text (trivial), 1: colorized (inflated), 2: empty (trivial),
     // 3: plain text (trivial).
     mc.writeToScreen("plain0\r\n");
-    mc.writeToScreen("\033[38;2;255;0;0mcolor1\033[m\r\n");
+    mc.writeToScreen("\033[38;2;255;0;0m"); // red foreground
+    mc.writeToScreen("tinted1");
+    mc.writeToScreen("\033[m\r\n"); // reset SGR
     mc.writeToScreen("\r\n");
     mc.writeToScreen("plain3");
 
@@ -2642,7 +2644,9 @@ TEST_CASE("Terminal.Cursorline.notShownInInsertMode", "[terminal][vi]")
     auto& terminal = mc.terminal;
     auto constexpr ClockBase = chrono::steady_clock::time_point();
     terminal.tick(ClockBase);
-    mc.writeToScreen("plainA\r\nplainB\r\nplainC");
+    mc.writeToScreen("plainA\r\n");
+    mc.writeToScreen("plainB\r\n");
+    mc.writeToScreen("plainC");
 
     // Stays in the default insert mode (no status line, no cursorline).
     terminal.tick(ClockBase + chrono::seconds(1));
@@ -2662,7 +2666,8 @@ TEST_CASE("Terminal.Cursorline.nonCursorTrivialLineNotHighlighted", "[terminal][
     auto& terminal = mc.terminal;
     auto constexpr ClockBase = chrono::steady_clock::time_point();
     terminal.tick(ClockBase);
-    mc.writeToScreen("plainA\r\nplainB");
+    mc.writeToScreen("plainA\r\n");
+    mc.writeToScreen("plainB");
 
     terminal.inputHandler().setMode(vtbackend::ViMode::Normal);
     terminal.moveNormalModeCursorTo(
@@ -2688,7 +2693,9 @@ TEST_CASE("Terminal.YankHighlight.trivialLineIsHighlighted", "[terminal][vi]")
     auto& terminal = mc.terminal;
     auto constexpr ClockBase = chrono::steady_clock::time_point();
     terminal.tick(ClockBase);
-    mc.writeToScreen("plainA\r\nplainB\r\nplainC");
+    mc.writeToScreen("plainA\r\n");
+    mc.writeToScreen("plainB\r\n");
+    mc.writeToScreen("plainC");
 
     // Highlight grid line 1 (a plain-text trivial line) while still in insert mode so no
     // status-line resize shifts coordinates; the highlight alone must recolor the trivial line.

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -2551,4 +2551,159 @@ TEST_CASE("Terminal.TopAnchoredRegion.ScrollCountMatchesScrolledLines", "[termin
 }
 // }}}
 
+// {{{ Normal-mode cursorline & yank-highlight on trivial vs inflated lines
+//
+// Regression coverage for the AoS→SoA grid migration: a plain-text line with uniform SGR stays
+// "trivial" even when the vi/normal-mode cursor is on it, so it takes RenderBufferBuilder's
+// trivial fast path. That path used to hard-code the cursorline off (the old invariant "a line
+// with a cursor is always inflated"), dropping the current-line highlight on plain-text lines.
+// The same fast path also skipped the vi yank/motion highlight. These tests pin both down.
+namespace
+{
+
+/// Background color of screen @p line at a column away from column 0, in a freshly built render
+/// buffer. Sampling off column 0 avoids the block-cursor cell (which inverts fg/bg) when the
+/// cursor sits at the line start. A line is emitted either as per-cell RenderCells (the
+/// per-cell/fallback path) or as one batched RenderLine (the trivial simple path); check both.
+vtbackend::RGBColor screenLineBackground(vtbackend::RenderBufferRef const& buf,
+                                         vtbackend::LineOffset line) noexcept
+{
+    for (auto const& cell: buf.get().cells)
+        if (cell.position.line == line && cell.position.column >= vtbackend::ColumnOffset(2))
+            return cell.attributes.backgroundColor;
+    for (auto const& renderLine: buf.get().lines)
+        if (renderLine.lineOffset == line)
+            // The batched RenderLine covers text (0..usedColumns) and fill (usedColumns..end)
+            // with one attribute set each; the cursorline tint is applied uniformly to both, so
+            // either represents the line background — prefer the fill (always present).
+            return renderLine.fillAttributes.backgroundColor;
+    return vtbackend::RGBColor {};
+}
+
+/// Screen line the cursor is rendered on, per the render buffer itself — the single source of
+/// truth for which line should carry the cursorline highlight (the render loop and the highlight
+/// decision share this coordinate). Returns nullopt when the buffer carries no cursor.
+std::optional<vtbackend::LineOffset> renderedCursorLine(vtbackend::RenderBufferRef const& buf) noexcept
+{
+    if (!buf.get().cursor.has_value())
+        return std::nullopt;
+    return buf.get().cursor->position.line;
+}
+
+} // namespace
+
+TEST_CASE("Terminal.Cursorline.trivialLineUnderCursorIsHighlighted", "[terminal][vi]")
+{
+    // Regression: a plain-text (trivial) line under the vi cursor must be highlighted.
+    // A tall page keeps all four content lines visible above the bottom status line that
+    // normal mode pushes in.
+    auto mc = MockTerm { PageSize { LineCount(8), ColumnCount(10) }, LineCount(0) };
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    terminal.tick(ClockBase);
+
+    // grid line 0: plain text (trivial), 1: colorized (inflated), 2: empty (trivial),
+    // 3: plain text (trivial).
+    mc.writeToScreen("plain0\r\n");
+    mc.writeToScreen("\033[38;2;255;0;0mcolor1\033[m\r\n");
+    mc.writeToScreen("\r\n");
+    mc.writeToScreen("plain3");
+
+    terminal.inputHandler().setMode(vtbackend::ViMode::Normal);
+    auto const defaultBg = terminal.colorPalette().defaultBackground;
+
+    // Every line type (plain trivial, colorized inflated, empty trivial) must highlight when the
+    // cursor lands on it. Assert the tint appears on exactly the cursor's screen line.
+    auto seconds = 2;
+    for (auto const gridLine: { 0, 1, 2, 3 })
+    {
+        terminal.moveNormalModeCursorTo(
+            vtbackend::CellLocation { .line = LineOffset(gridLine), .column = ColumnOffset(0) });
+        terminal.tick(ClockBase + chrono::seconds(seconds++));
+        terminal.refreshRenderBuffer();
+        auto const buf = terminal.renderBuffer();
+
+        auto const cursorLine = renderedCursorLine(buf);
+        REQUIRE(cursorLine.has_value());
+        auto const bgOnCursorLine = screenLineBackground(buf, *cursorLine);
+        INFO(std::format("gridLine={} renderedCursorLine={} bgOnCursorLine={}",
+                         gridLine,
+                         cursorLine->value,
+                         bgOnCursorLine));
+        // The cursor line's background must be tinted away from the default background.
+        CHECK(bgOnCursorLine != defaultBg);
+    }
+}
+
+TEST_CASE("Terminal.Cursorline.notShownInInsertMode", "[terminal][vi]")
+{
+    // The cursorline is a normal-mode affordance; insert mode must not tint any content line.
+    auto mc = MockTerm { PageSize { LineCount(6), ColumnCount(10) }, LineCount(0) };
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    terminal.tick(ClockBase);
+    mc.writeToScreen("plainA\r\nplainB\r\nplainC");
+
+    // Stays in the default insert mode (no status line, no cursorline).
+    terminal.tick(ClockBase + chrono::seconds(1));
+    terminal.refreshRenderBuffer();
+    auto const buf = terminal.renderBuffer();
+    auto const defaultBg = terminal.colorPalette().defaultBackground;
+
+    for (auto const line: { 0, 1, 2 })
+        CHECK(screenLineBackground(buf, LineOffset(line)) == defaultBg);
+}
+
+TEST_CASE("Terminal.Cursorline.nonCursorTrivialLineNotHighlighted", "[terminal][vi]")
+{
+    // Only the cursor's line is tinted; a sibling plain-text trivial line keeps the default bg.
+    // Use a tall page so content lines stay clear of the bottom indicator status line.
+    auto mc = MockTerm { PageSize { LineCount(6), ColumnCount(10) }, LineCount(0) };
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    terminal.tick(ClockBase);
+    mc.writeToScreen("plainA\r\nplainB");
+
+    terminal.inputHandler().setMode(vtbackend::ViMode::Normal);
+    terminal.moveNormalModeCursorTo(
+        vtbackend::CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    terminal.tick(ClockBase + chrono::seconds(1));
+    terminal.refreshRenderBuffer();
+    auto const buf = terminal.renderBuffer();
+    auto const defaultBg = terminal.colorPalette().defaultBackground;
+
+    auto const cursorLine = renderedCursorLine(buf);
+    REQUIRE(cursorLine.has_value());
+    CHECK(screenLineBackground(buf, *cursorLine) != defaultBg);
+    // The immediately following content line (not the cursor line, well above the status line)
+    // must keep the default background.
+    CHECK(screenLineBackground(buf, LineOffset(cursorLine->value + 1)) == defaultBg);
+}
+
+TEST_CASE("Terminal.YankHighlight.trivialLineIsHighlighted", "[terminal][vi]")
+{
+    // Regression: a vi yank/motion highlight over a plain-text (trivial) line must recolor it.
+    // Tall page so content lines stay clear of the bottom indicator status line.
+    auto mc = MockTerm { PageSize { LineCount(6), ColumnCount(10) }, LineCount(0) };
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    terminal.tick(ClockBase);
+    mc.writeToScreen("plainA\r\nplainB\r\nplainC");
+
+    // Highlight grid line 1 (a plain-text trivial line) while still in insert mode so no
+    // status-line resize shifts coordinates; the highlight alone must recolor the trivial line.
+    terminal.setHighlightRange(vtbackend::LinearHighlight {
+        .from = vtbackend::CellLocation { .line = LineOffset(1), .column = ColumnOffset(0) },
+        .to = vtbackend::CellLocation { .line = LineOffset(1), .column = ColumnOffset(5) } });
+    terminal.tick(ClockBase + chrono::seconds(1));
+    terminal.refreshRenderBuffer();
+    auto const buf = terminal.renderBuffer();
+    auto const defaultBg = terminal.colorPalette().defaultBackground;
+
+    CHECK(screenLineBackground(buf, LineOffset(1)) != defaultBg);
+    // A non-highlighted plain-text line keeps the default background.
+    CHECK(screenLineBackground(buf, LineOffset(2)) == defaultBg);
+}
+// }}}
+
 // NOLINTEND(misc-const-correctness)

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -192,28 +192,6 @@ void ViCommands::searchCancel()
     _terminal->screenUpdated();
 }
 
-void ViCommands::promptStart(std::string const& query)
-{
-    _terminal->setPrompt(query);
-    _terminal->screenUpdated();
-}
-
-void ViCommands::promptDone()
-{
-    _terminal->screenUpdated();
-}
-
-void ViCommands::promptCancel()
-{
-    _terminal->screenUpdated();
-}
-
-void ViCommands::updatePromptText(std::string const& text)
-{
-    _terminal->setPromptText(text);
-    _terminal->screenUpdated();
-}
-
 bool ViCommands::jumpToNextMatch(unsigned count)
 {
     for (unsigned i = 0; i < count; ++i)

--- a/src/vtbackend/ViCommands.h
+++ b/src/vtbackend/ViCommands.h
@@ -48,11 +48,6 @@ class ViCommands: public ViInputHandler::Executor
     void searchCancel() override;
     void updateSearchTerm(std::u32string const& text) override;
 
-    void promptStart(std::string const& query) override;
-    void promptDone() override;
-    void promptCancel() override;
-    void updatePromptText(std::string const& text) override;
-
     bool jumpToNextMatch(unsigned count);
     bool jumpToPreviousMatch(unsigned count);
 

--- a/src/vtbackend/ViInputHandler.cpp
+++ b/src/vtbackend/ViInputHandler.cpp
@@ -337,21 +337,6 @@ void ViInputHandler::setMode(ViMode theMode)
 
 Handled ViInputHandler::sendKeyPressEvent(Key key, Modifiers modifiers, KeyboardEventType eventType)
 {
-    if (_promptEditMode != PromptMode::Disabled)
-    {
-        if (eventType == KeyboardEventType::Release)
-            return Handled { true };
-        // TODO: support cursor movements.
-        switch (key)
-        {
-            case Key::Backspace: return handlePromptEditor('\x08', modifiers);
-            case Key::Enter: return handlePromptEditor('\x0D', modifiers);
-            case Key::Escape: return handlePromptEditor('\x1B', modifiers);
-            default: break;
-        }
-        return Handled { true };
-    }
-
     if (_searchEditMode != PromptMode::Disabled)
     {
         if (eventType == KeyboardEventType::Release)
@@ -541,32 +526,6 @@ Handled ViInputHandler::handleSearchEditor(char32_t ch, Modifiers modifiers)
     return Handled { true };
 }
 
-Handled ViInputHandler::handlePromptEditor(char32_t ch, Modifiers modifiers)
-{
-    assert(_promptEditMode != PromptMode::Disabled);
-
-    handleEditor(
-        ch,
-        modifiers,
-        _promptText,
-        _promptEditMode,
-        _settings,
-        [&](auto mode) { setMode(mode); },
-        [&]() { _executor->promptCancel(); },
-        [&]() {
-            _executor->promptDone();
-            if (_setTabNameCallback)
-            {
-                _setTabNameCallback.value()(_promptText);
-                setMode(ViMode::Insert);
-                _setTabNameCallback = std::nullopt;
-            }
-        },
-        [&](const auto& val) { _executor->updatePromptText(val); });
-
-    return Handled { true };
-}
-
 Handled ViInputHandler::sendCharPressEvent(char32_t ch, Modifiers modifiers, KeyboardEventType eventType)
 {
     if (_searchEditMode != PromptMode::Disabled)
@@ -574,13 +533,6 @@ Handled ViInputHandler::sendCharPressEvent(char32_t ch, Modifiers modifiers, Key
         if (eventType == KeyboardEventType::Release)
             return Handled { true };
         return handleSearchEditor(ch, modifiers);
-    }
-
-    if (_promptEditMode != PromptMode::Disabled)
-    {
-        if (eventType == KeyboardEventType::Release)
-            return Handled { true };
-        return handlePromptEditor(ch, modifiers);
     }
 
     if (_viMode == ViMode::Insert)

--- a/src/vtbackend/ViInputHandler.h
+++ b/src/vtbackend/ViInputHandler.h
@@ -183,11 +183,6 @@ class ViInputHandler: public InputHandler
         virtual void searchCancel() = 0;
         virtual void updateSearchTerm(std::u32string const& text) = 0;
 
-        virtual void promptStart(std::string const& query) = 0;
-        virtual void promptDone() = 0;
-        virtual void promptCancel() = 0;
-        virtual void updatePromptText(std::string const& text) = 0;
-
         virtual void scrollViewport(ScrollOffset delta) = 0;
 
         // Starts searching for the word under the cursor position in reverse order.
@@ -228,27 +223,8 @@ class ViInputHandler: public InputHandler
     }
 
     [[nodiscard]] bool isEditingSearch() const noexcept { return _searchEditMode != PromptMode::Disabled; }
-    [[nodiscard]] bool isEditingPrompt() const noexcept { return _promptEditMode != PromptMode::Disabled; }
 
     void startSearchExternally();
-
-    void setTabName(auto&& callback)
-    {
-        _promptText.clear();
-        _executor->promptStart("Tab name: ");
-
-        if (_viMode != ViMode::Insert)
-            _promptEditMode = PromptMode::Enabled;
-        else
-        {
-            _promptEditMode = PromptMode::ExternallyEnabled;
-            setMode(ViMode::Normal);
-            // ^^^ So that we can see the statusline (which contains the search edit field),
-            // AND it's weird to be in insert mode while typing in the prompt term anyways.
-        }
-
-        _setTabNameCallback = callback;
-    }
 
     void setSearchModeSwitch(bool enabled);
     void clearSearch();
@@ -281,17 +257,14 @@ class ViInputHandler: public InputHandler
     bool parseCount(char32_t ch, Modifiers modifiers);
     bool parseTextObject(char32_t ch, Modifiers modifiers);
     Handled handleSearchEditor(char32_t ch, Modifiers modifiers);
-    Handled handlePromptEditor(char32_t ch, Modifiers modifiers);
     Handled handleModeSwitches(char32_t ch, Modifiers modifiers);
     void startSearch();
 
     ViMode _viMode = ViMode::Normal;
 
     PromptMode _searchEditMode = PromptMode::Disabled;
-    PromptMode _promptEditMode = PromptMode::Disabled;
     bool _searchExternallyActivated = false;
     std::u32string _searchTerm;
-    std::string _promptText;
 
     std::string _pendingInput;
     CommandHandlerMap _normalMode;
@@ -299,7 +272,6 @@ class ViInputHandler: public InputHandler
     unsigned _count = 0;
     char32_t _lastChar = 0;
     gsl::not_null<Executor*> _executor;
-    std::optional<std::function<void(std::string)>> _setTabNameCallback { std::nullopt };
 };
 
 } // namespace vtbackend


### PR DESCRIPTION
The AoS→SoA grid migration (landed after the last stable release) silently broke a load-bearing render invariant: before it, writing the cursor into a line *inflated* it, so a cursor or highlighted line was never taken through the trivial fast path. Post-migration, a line is "trivial" purely when its cells share uniform SGR — blind to cursor and highlight state — so a plain-text line under the vi cursor stays trivial and lost both the normal-mode current-line highlight and the vi yank/motion highlight (colorized lines still worked, because they take the per-cell path). This branch restores those highlights, fixes a couple of adjacent tab-title issues surfaced along the way, and cleans up the code the rework left orphaned.

## Changes

- **Restore the normal-mode cursorline and yank/motion highlight on plain-text (trivial) lines.** The trivial fast path now makes the same cursorline decision the per-cell path already makes, and drops a line to the per-cell path when it intersects an active highlight range (mirroring the existing selection guard, via a new line-level `Terminal::isHighlighted(LineOffset)` overload).
- **Fix the `vi_mode_cursorline` color config key.** The loader read a misspelled key (`vi_mode_cursosrline`), so the documented key was silently ignored and the current-line highlight color was not configurable. It now matches the documentation.
- **Rework the tab-rename action for the GUI-native tab bar.** `SetTabName` is renamed to `SetTabTitle` and now opens the inline tab-title editor for the active tab (a keyboard entry point alongside double-tap and the context-menu "Rename…"), instead of arming the old in-terminal vi-mode name prompt that predated GUI-native tabs. It ships unbound; bind `SetTabTitle` via `input_mapping`.
- **Update GUI tab titles in real time for unfocused tabs.** A background tab's title change previously only surfaced once the tab was focused, because the refresh was posted through the (absent) display of a background session; it is now posted through the session itself, so any tab's title updates immediately.
- **Remove the now-orphaned in-terminal tab-name prompt.** With the action re-homed onto the QML editor, the entire in-terminal prompt-editor slice had no remaining consumer and is removed; the OSC-30 tab-name protocol path and the parallel search prompt are preserved.

All changes land with unit tests, including regression pins for the highlight-on-trivial-lines paths (previously untested) and for the background-tab title refresh.