### PR TITLE
Add configurable GUI tab bar position and visibility

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.7.0" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Adds profile options tab_bar_position (Top/Bottom) and tab_bar_visibility (Always/Never/Multiple) to place the GUI tab bar at the top or bottom of the window and to hide it entirely or only show it when more than one tab is open</li>
           <li>Adds Win32 Input Mode (DEC private mode 9001) for native ConPTY keyboard input encoding, fixing keyboard input for applications that request this mode on Windows</li>
           <li>Fixes Unicode characters sometimes being wrongly decoded during high-bandwidth output</li>
           <li>Fixes multi-second shell startup stall when the shell (e.g. fish) queries terminal capabilities before the display is attached — queued replies are now flushed on display attach instead of waiting for the next focus/input event</li>

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -477,6 +477,8 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "bell", where.bell);
         loadFromEntry(child, "wm_class", where.wmClass);
         loadFromEntry(child, "tab_label", where.tabLabel);
+        loadFromEntry(child, "tab_bar_position", where.tabBarPosition);
+        loadFromEntry(child, "tab_bar_visibility", where.tabBarVisibility);
         loadFromEntry(child, "option_as_alt", where.optionKeyAsAlt);
         loadFromEntry(child, "margins", where.margins);
         loadFromEntry(child, "terminal_id", where.terminalId);
@@ -1525,6 +1527,52 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
     if (auto const child = node[entry])
     {
         auto opt = parseModifierKey(child.as<std::string>());
+        if (opt.has_value())
+            where = opt.value();
+    }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& entry, TabBarPosition& where)
+{
+    // Case-insensitive; an unrecognized value leaves @p where at its (default) value.
+    auto parsePosition = [&](std::string const& key) -> std::optional<TabBarPosition> {
+        auto const literal = crispy::toLower(key);
+        logger()("Loading entry: {}, value {}", entry, literal);
+        if (literal == "top")
+            return TabBarPosition::Top;
+        if (literal == "bottom")
+            return TabBarPosition::Bottom;
+        return std::nullopt;
+    };
+
+    if (auto const child = node[entry])
+    {
+        auto opt = parsePosition(child.as<std::string>());
+        if (opt.has_value())
+            where = opt.value();
+    }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
+                                     std::string const& entry,
+                                     TabBarVisibility& where)
+{
+    // Case-insensitive; an unrecognized value leaves @p where at its (default) value.
+    auto parseVisibility = [&](std::string const& key) -> std::optional<TabBarVisibility> {
+        auto const literal = crispy::toLower(key);
+        logger()("Loading entry: {}, value {}", entry, literal);
+        if (literal == "always")
+            return TabBarVisibility::Always;
+        if (literal == "never")
+            return TabBarVisibility::Never;
+        if (literal == "multiple")
+            return TabBarVisibility::Multiple;
+        return std::nullopt;
+    };
+
+    if (auto const child = node[entry])
+    {
+        auto opt = parseVisibility(child.as<std::string>());
         if (opt.has_value())
             where = opt.value();
     }

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -73,6 +73,23 @@ enum class ScrollBarPosition : uint8_t
     Right
 };
 
+/// Where the GUI tab strip (tab bar) is placed within the window.
+/// @note Exposed to QML as an @c int (0 = Top, 1 = Bottom); keep the enumerator order in sync
+///       with the literals in @c main.qml if this is ever extended or reordered.
+enum class TabBarPosition : uint8_t
+{
+    Top,    //!< The tab strip sits above the terminal content (default, historical behavior).
+    Bottom, //!< The tab strip sits below the terminal content.
+};
+
+/// When the GUI tab strip (tab bar) is shown.
+enum class TabBarVisibility : uint8_t
+{
+    Always,   //!< Always show the tab strip (default, historical behavior).
+    Never,    //!< Never show the tab strip.
+    Multiple, //!< Show the tab strip only when the window has more than one tab.
+};
+
 enum class Permission : uint8_t
 {
     Deny,
@@ -491,6 +508,10 @@ struct TerminalProfile
 
     ConfigEntry<std::string, documentation::WMClass> wmClass { CONTOUR_APP_ID };
     ConfigEntry<std::string, documentation::TabLabel> tabLabel { "{WindowTitle}" };
+    ConfigEntry<TabBarPosition, documentation::TabBarPosition> tabBarPosition { TabBarPosition::Top };
+    ConfigEntry<TabBarVisibility, documentation::TabBarVisibility> tabBarVisibility {
+        TabBarVisibility::Always
+    };
     ConfigEntry<bool, documentation::OptionKeyAsAlt> optionKeyAsAlt { false };
 };
 
@@ -1129,6 +1150,8 @@ struct YAMLConfigReader
     void loadFromEntry(YAML::Node const& node, std::string const& entry, std::string& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtbackend::StatusDisplayPosition& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ScrollBarPosition& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, TabBarPosition& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, TabBarVisibility& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtrasterizer::FontDescriptions& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, text::render_mode& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtrasterizer::TextOutlineConfig& where);
@@ -1873,6 +1896,37 @@ struct std::formatter<contour::config::ScrollBarPosition>: formatter<std::string
             case contour::config::ScrollBarPosition::Hidden: name = "Hidden"; break;
             case contour::config::ScrollBarPosition::Left: name = "Left"; break;
             case contour::config::ScrollBarPosition::Right: name = "Right"; break;
+        }
+        return formatter<std::string_view>::format(name, ctx);
+    }
+};
+
+template <>
+struct std::formatter<contour::config::TabBarPosition>: formatter<std::string_view>
+{
+    auto format(contour::config::TabBarPosition value, auto& ctx) const
+    {
+        std::string_view name;
+        switch (value)
+        {
+            case contour::config::TabBarPosition::Top: name = "Top"; break;
+            case contour::config::TabBarPosition::Bottom: name = "Bottom"; break;
+        }
+        return formatter<std::string_view>::format(name, ctx);
+    }
+};
+
+template <>
+struct std::formatter<contour::config::TabBarVisibility>: formatter<std::string_view>
+{
+    auto format(contour::config::TabBarVisibility value, auto& ctx) const
+    {
+        std::string_view name;
+        switch (value)
+        {
+            case contour::config::TabBarVisibility::Always: name = "Always"; break;
+            case contour::config::TabBarVisibility::Never: name = "Never"; break;
+            case contour::config::TabBarVisibility::Multiple: name = "Multiple"; break;
         }
         return formatter<std::string_view>::format(name, ctx);
     }

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -175,6 +175,23 @@ constexpr StringLiteral TabLabelConfig {
     "{comment} Split tabs show \"Multiple panes\" instead.\n"
 };
 
+constexpr StringLiteral TabBarPositionConfig {
+    "{comment} Where the GUI tab strip (tab bar) is placed within the window (ignore-case):\n"
+    "{comment}   Top    = above the terminal content (default).\n"
+    "{comment}   Bottom = below the terminal content.\n"
+    "tab_bar_position: {}\n"
+    "\n"
+};
+
+constexpr StringLiteral TabBarVisibilityConfig {
+    "{comment} When the GUI tab strip (tab bar) is shown (ignore-case):\n"
+    "{comment}   Always   = always show the tab strip (default).\n"
+    "{comment}   Never    = never show the tab strip.\n"
+    "{comment}   Multiple = show the tab strip only when the window has more than one tab.\n"
+    "tab_bar_visibility: {}\n"
+    "\n"
+};
+
 constexpr StringLiteral MarginsConfig {
     "{comment} Window margins\n"
     "{comment}\n"
@@ -1435,6 +1452,26 @@ constexpr StringLiteral TabLabelWeb {
     "\n"
 };
 
+constexpr StringLiteral TabBarPositionWeb {
+    "\n"
+    "Selects where the GUI tab strip (tab bar) is placed within the window. Valid values (ignore-case):\n"
+    "\n"
+    "- `Top` — the tab strip is drawn above the terminal content. This is the default.\n"
+    "- `Bottom` — the tab strip is drawn below the terminal content.\n"
+    "\n"
+};
+
+constexpr StringLiteral TabBarVisibilityWeb {
+    "\n"
+    "Selects when the GUI tab strip (tab bar) is shown. Valid values (ignore-case):\n"
+    "\n"
+    "- `Always` — the tab strip is always shown. This is the default.\n"
+    "- `Never` — the tab strip is never shown.\n"
+    "- `Multiple` — the tab strip is shown only when the window has more than one tab, and hidden while a "
+    "single tab remains.\n"
+    "\n"
+};
+
 constexpr StringLiteral TerminalIdWeb {
     "\n"
     "configuration option allows you to specify the terminal type that will be advertised by the terminal "
@@ -1962,6 +1999,8 @@ using InsertAfterYank = DocumentationEntry<InsertAfterYankConfig, InsertAfterYan
 using CopyLastMarkRangeOffset = DocumentationEntry<CopyLastMarkRangeOffsetConfig, CopyLastMarkRangeOffsetWeb>;
 using WMClass = DocumentationEntry<WMClassConfig, WMClassWeb>;
 using TabLabel = DocumentationEntry<TabLabelConfig, TabLabelWeb>;
+using TabBarPosition = DocumentationEntry<TabBarPositionConfig, TabBarPositionWeb>;
+using TabBarVisibility = DocumentationEntry<TabBarVisibilityConfig, TabBarVisibilityWeb>;
 using Margins = DocumentationEntry<MarginsConfig, MarginsWeb>;
 using TerminalSize = DocumentationEntry<TerminalSizeConfig, TerminalSizeWeb>;
 using TerminalId = DocumentationEntry<TerminalIdConfig, TerminalIdWeb>;

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -371,6 +371,56 @@ void WindowController::toggleTitleBar()
     setTitleBarVisible(!_titleBarVisible);
 }
 
+int WindowController::tabBarPosition() const noexcept
+{
+    return static_cast<int>(_tabBarPosition);
+}
+
+int WindowController::tabBarVisibility() const noexcept
+{
+    return static_cast<int>(_tabBarVisibility);
+}
+
+bool WindowController::tabBarShouldShow() const noexcept
+{
+    switch (_tabBarVisibility)
+    {
+        case config::TabBarVisibility::Always: return true;
+        case config::TabBarVisibility::Never: return false;
+        case config::TabBarVisibility::Multiple: return count() > 1;
+    }
+    return true;
+}
+
+void WindowController::seedTabBarPosition(config::TabBarPosition position)
+{
+    // First-write-wins, mirroring seedTitleBarVisible: the seed arrives on every session rebind, but
+    // only the first (the window's initial profile value) takes effect.
+    if (_tabBarPositionSeeded)
+        return;
+    _tabBarPositionSeeded = true;
+    if (_tabBarPosition == position)
+        return;
+    _tabBarPosition = position;
+    emit tabBarPositionChanged();
+}
+
+void WindowController::seedTabBarVisibility(config::TabBarVisibility visibility)
+{
+    // First-write-wins (see seedTabBarPosition).
+    if (_tabBarVisibilitySeeded)
+        return;
+    _tabBarVisibilitySeeded = true;
+    if (_tabBarVisibility == visibility)
+        return;
+    _tabBarVisibility = visibility;
+    emit tabBarVisibilityChanged();
+    // The visibility mode is one of the two inputs to the resolved gate; notify QML so a Never/Multiple
+    // seed re-evaluates the tab strip's `visible` binding immediately (Always is the default, so a
+    // window seeded to Always sees no change).
+    emit tabBarShouldShowChanged();
+}
+
 bool WindowController::isMultimediaReady() const noexcept
 {
     return _manager.isMultimediaReady();
@@ -825,6 +875,9 @@ void WindowController::onTabAdded(int)
 {
     endInsertRows();
     emit countChanged();
+    // The resolved tab-strip gate depends on the live tab count (Multiple mode): re-notify QML so the
+    // strip re-shows when the count crosses 1.
+    emit tabBarShouldShowChanged();
     refreshAllTabTitles();
 }
 
@@ -837,6 +890,8 @@ void WindowController::onTabClosed()
 {
     endRemoveRows();
     emit countChanged();
+    // See onTabAdded: re-notify so the strip re-hides in Multiple mode when the count falls back to 1.
+    emit tabBarShouldShowChanged();
     emit activeTabIndexChanged();
     refreshAllTabTitles();
 }

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -55,6 +55,12 @@ class WindowController: public QAbstractListModel
     Q_PROPERTY(contour::PaneProxy* activeTabRootPane READ activeTabRootPane NOTIFY activeTabRootPaneChanged)
     Q_PROPERTY(contour::TerminalSession* activeSession READ activeSession NOTIFY activeSessionChanged)
     Q_PROPERTY(bool titleBarVisible READ titleBarVisible NOTIFY titleBarVisibleChanged)
+    // Tab-strip (tab bar) placement + visibility, exposed to main.qml. `tabBarPosition` is an int
+    // (0 = Top, 1 = Bottom) matching the config::TabBarPosition enumerator order. `tabBarShouldShow`
+    // is the resolved gate (mode + live tab count) the QML binds its `visible` to.
+    Q_PROPERTY(int tabBarPosition READ tabBarPosition NOTIFY tabBarPositionChanged)
+    Q_PROPERTY(int tabBarVisibility READ tabBarVisibility NOTIFY tabBarVisibilityChanged)
+    Q_PROPERTY(bool tabBarShouldShow READ tabBarShouldShow NOTIFY tabBarShouldShowChanged)
     Q_PROPERTY(int chromeHeight READ chromeHeight WRITE setChromeHeight NOTIFY chromeHeightChanged)
     QML_ELEMENT
     QML_UNCREATABLE("Created by the session manager")
@@ -176,6 +182,33 @@ class WindowController: public QAbstractListModel
 
     /// Flips the window's title-bar visibility (the ToggleTitleBar action, routed here by the display).
     void toggleTitleBar();
+    // }}}
+
+    // {{{ Tab strip (tab bar) placement + visibility
+    // Like title-bar visibility, these are WINDOW state seeded once from the profile (first-write-wins),
+    // so later session rebinds (tab switch, split collapse) never clobber them.
+
+    /// The tab strip position as an int for QML (0 = Top, 1 = Bottom; see config::TabBarPosition).
+    [[nodiscard]] int tabBarPosition() const noexcept;
+
+    /// The tab strip visibility mode as an int for QML (see config::TabBarVisibility).
+    [[nodiscard]] int tabBarVisibility() const noexcept;
+
+    /// Whether the tab strip should currently be shown, resolving the visibility mode against the live
+    /// tab count: Always => true, Never => false, Multiple => count() > 1. main.qml binds the tab
+    /// strip's `visible` to this.
+    /// @return True if the tab strip should be shown.
+    [[nodiscard]] bool tabBarShouldShow() const noexcept;
+
+    /// Seeds this window's tab strip position from the profile's tab_bar_position setting.
+    /// First-write-wins (see seedTitleBarVisible).
+    /// @param position The profile's tab_bar_position value.
+    void seedTabBarPosition(config::TabBarPosition position);
+
+    /// Seeds this window's tab strip visibility mode from the profile's tab_bar_visibility setting.
+    /// First-write-wins (see seedTitleBarVisible).
+    /// @param visibility The profile's tab_bar_visibility value.
+    void seedTabBarVisibility(config::TabBarVisibility visibility);
     // }}}
 
     /// This window's currently focused display (for window services + status-line targeting).
@@ -333,6 +366,9 @@ class WindowController: public QAbstractListModel
     void multimediaReadyChanged();
     void activeTabRootPaneChanged();
     void titleBarVisibleChanged();
+    void tabBarPositionChanged();
+    void tabBarVisibilityChanged();
+    void tabBarShouldShowChanged();
     void activeSessionChanged();
     void chromeHeightChanged();
 
@@ -398,6 +434,14 @@ class WindowController: public QAbstractListModel
     bool _titleBarVisible = true;
     // First-write-wins latch for seedTitleBarVisible(): session rebinds must not reset a runtime toggle.
     bool _titleBarSeeded = false;
+
+    // Window-scoped tab strip placement + visibility (see the tab-strip block above). Seeded once from
+    // the profile's tab_bar_position / tab_bar_visibility (first display attach). Defaults mirror the
+    // ConfigEntry defaults so a window with no seed yet behaves like the historical Top/Always.
+    config::TabBarPosition _tabBarPosition = config::TabBarPosition::Top;
+    bool _tabBarPositionSeeded = false;
+    config::TabBarVisibility _tabBarVisibility = config::TabBarVisibility::Always;
+    bool _tabBarVisibilitySeeded = false;
 
     // Declared title-bar chrome height in logical px (written by main.qml's binding).
     int _chromeHeight = 0;

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -257,7 +257,13 @@ void TerminalDisplay::setSession(TerminalSession* newSession)
     // titleBarVisible. Only SEED the window default here (first-write-wins): re-applying the profile
     // value on every session rebind silently reverted a runtime ToggleTitleBar on each tab switch.
     if (auto* controller = windowController())
+    {
         controller->seedTitleBarVisible(profile().showTitleBar.value());
+        // Tab-strip placement + visibility are window state seeded once from the profile, same
+        // first-write-wins contract as the title bar (so a runtime state is never reset on rebind).
+        controller->seedTabBarPosition(profile().tabBarPosition.value());
+        controller->seedTabBarVisibility(profile().tabBarVisibility.value());
+    }
 
     if (!_renderer)
     {

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -628,6 +628,14 @@ TEST_CASE("Config: generated default config round-trips through the loader", "[c
     CHECK(profile->terminalSize.value().columns == defaults.profile().terminalSize.value().columns);
     CHECK(profile->terminalSize.value().lines == defaults.profile().terminalSize.value().lines);
     CHECK(profile->showTitleBar.value() == defaults.profile().showTitleBar.value());
+    // Guards the tab_bar_* writer<->reader key match: the std::formatter emits "Top"/"Always" into the
+    // generated doc, and the loader must read the same key back. A typo in only one side would surface
+    // here as a default-valued mismatch (which, for these two, would still equal the default — so also
+    // assert the rendered document actually carries the keys below).
+    CHECK(profile->tabBarPosition.value() == defaults.profile().tabBarPosition.value());
+    CHECK(profile->tabBarVisibility.value() == defaults.profile().tabBarVisibility.value());
+    CHECK(rendered.find("tab_bar_position:") != std::string::npos);
+    CHECK(rendered.find("tab_bar_visibility:") != std::string::npos);
 }
 
 TEST_CASE("Config: dual color schemes, palette list forms, and infinite history load", "[config]")
@@ -853,6 +861,83 @@ profiles:
     CHECK(profile->modeInsert.value().cursor.cursorShape == vtbackend::CursorShape::Rectangle);
     CHECK(profile->blinkStyle.value() == vtbackend::BlinkStyle::Linger);
     CHECK(profile->screenTransitionStyle.value() == vtbackend::ScreenTransitionStyle::Classic);
+}
+
+TEST_CASE("Config: tab_bar_position and tab_bar_visibility parse each value (ignore-case)", "[config]")
+{
+    using contour::config::TabBarPosition;
+    using contour::config::TabBarVisibility;
+
+    SECTION("bottom + never")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        tab_bar_position: Bottom
+        tab_bar_visibility: Never
+)"sv);
+        auto const* profile = config.profile("main");
+        REQUIRE(profile != nullptr);
+        CHECK(profile->tabBarPosition.value() == TabBarPosition::Bottom);
+        CHECK(profile->tabBarVisibility.value() == TabBarVisibility::Never);
+    }
+
+    SECTION("top + multiple, lower-case tokens prove case-insensitivity")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        tab_bar_position: top
+        tab_bar_visibility: multiple
+)"sv);
+        auto const* profile = config.profile("main");
+        REQUIRE(profile != nullptr);
+        CHECK(profile->tabBarPosition.value() == TabBarPosition::Top);
+        CHECK(profile->tabBarVisibility.value() == TabBarVisibility::Multiple);
+    }
+
+    SECTION("always (the default) still parses explicitly")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        tab_bar_visibility: Always
+)"sv);
+        auto const* profile = config.profile("main");
+        REQUIRE(profile != nullptr);
+        CHECK(profile->tabBarVisibility.value() == TabBarVisibility::Always);
+    }
+}
+
+TEST_CASE("Config: invalid tab_bar_* values fall back to the defaults", "[config]")
+{
+    using contour::config::TabBarPosition;
+    using contour::config::TabBarVisibility;
+
+    QTemporaryDir dir;
+    // Unrecognized tokens must leave the fields at their ConfigEntry defaults (Top / Always), not throw
+    // or zero them out — the loadFromEntry overloads only write on a successful parse.
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        tab_bar_position: Sideways
+        tab_bar_visibility: Sometimes
+)"sv);
+    auto const* profile = config.profile("main");
+    REQUIRE(profile != nullptr);
+    CHECK(profile->tabBarPosition.value() == TabBarPosition::Top);
+    CHECK(profile->tabBarVisibility.value() == TabBarVisibility::Always);
 }
 
 TEST_CASE("Config: git-drawings, arc and braille styles parse from YAML", "[config]")

--- a/src/contour/test/KeyboardRouting_test.cpp
+++ b/src/contour/test/KeyboardRouting_test.cpp
@@ -200,6 +200,10 @@ class RoutingMockController: public QAbstractListModel
     Q_PROPERTY(int activeTabIndex READ activeTabIndex NOTIFY activeTabIndexChanged)
     Q_PROPERTY(bool multimediaReady READ multimediaReady CONSTANT)
     Q_PROPERTY(bool titleBarVisible READ titleBarVisible NOTIFY titleBarVisibleChanged)
+    // Tab-strip placement + visibility main.qml binds; defaults (Top, shown) keep this routing test's
+    // layout identical to production without needing to vary them.
+    Q_PROPERTY(int tabBarPosition READ tabBarPosition NOTIFY tabBarPositionChanged)
+    Q_PROPERTY(bool tabBarShouldShow READ tabBarShouldShow NOTIFY tabBarShouldShowChanged)
     Q_PROPERTY(int splitHandleThickness READ splitHandleThickness CONSTANT)
     Q_PROPERTY(int chromeHeight READ chromeHeight WRITE setChromeHeight NOTIFY chromeHeightChanged)
     Q_PROPERTY(QObject* activeTabRootPane READ activeTabRootPane NOTIFY activeTabRootPaneChanged)
@@ -219,6 +223,8 @@ class RoutingMockController: public QAbstractListModel
     [[nodiscard]] int activeTabIndex() const noexcept { return _activeTabIndex; }
     [[nodiscard]] bool multimediaReady() const noexcept { return false; }
     [[nodiscard]] bool titleBarVisible() const noexcept { return false; }
+    [[nodiscard]] int tabBarPosition() const noexcept { return 0; }       // Top
+    [[nodiscard]] bool tabBarShouldShow() const noexcept { return true; } // shown
     [[nodiscard]] constexpr int splitHandleThickness() const noexcept
     {
         return vtmux::DefaultSplitHandleThickness;
@@ -304,6 +310,8 @@ class RoutingMockController: public QAbstractListModel
   signals:
     void activeTabIndexChanged();
     void titleBarVisibleChanged();
+    void tabBarPositionChanged();
+    void tabBarShouldShowChanged();
     void chromeHeightChanged();
     void activeTabRootPaneChanged();
     void tabTitleEditRequested(int index);

--- a/src/contour/test/MainWindowQml_test.cpp
+++ b/src/contour/test/MainWindowQml_test.cpp
@@ -76,6 +76,11 @@ class MockMainController: public QAbstractListModel
     Q_PROPERTY(int activeTabIndex READ activeTabIndex NOTIFY activeTabIndexChanged)
     Q_PROPERTY(bool multimediaReady READ multimediaReady CONSTANT)
     Q_PROPERTY(bool titleBarVisible READ titleBarVisible NOTIFY titleBarVisibleChanged)
+    // Tab-strip placement + resolved visibility, mirroring the production WindowController properties
+    // main.qml binds. Writable here so a test can flip them and re-load main.qml to assert the layout.
+    Q_PROPERTY(int tabBarPosition READ tabBarPosition WRITE setTabBarPosition NOTIFY tabBarPositionChanged)
+    Q_PROPERTY(
+        bool tabBarShouldShow READ tabBarShouldShow WRITE setTabBarShouldShow NOTIFY tabBarShouldShowChanged)
     Q_PROPERTY(int splitHandleThickness READ splitHandleThickness CONSTANT)
     Q_PROPERTY(int chromeHeight READ chromeHeight WRITE setChromeHeight NOTIFY chromeHeightChanged)
     Q_PROPERTY(QObject* activeTabRootPane READ activeTabRootPane CONSTANT)
@@ -95,6 +100,25 @@ class MockMainController: public QAbstractListModel
     [[nodiscard]] int activeTabIndex() const noexcept { return 0; }
     [[nodiscard]] bool multimediaReady() const noexcept { return false; }
     [[nodiscard]] bool titleBarVisible() const noexcept { return false; } // frameless CSD (default)
+
+    [[nodiscard]] int tabBarPosition() const noexcept { return _tabBarPosition; }
+    void setTabBarPosition(int position)
+    {
+        if (_tabBarPosition != position)
+        {
+            _tabBarPosition = position;
+            emit tabBarPositionChanged();
+        }
+    }
+    [[nodiscard]] bool tabBarShouldShow() const noexcept { return _tabBarShouldShow; }
+    void setTabBarShouldShow(bool show)
+    {
+        if (_tabBarShouldShow != show)
+        {
+            _tabBarShouldShow = show;
+            emit tabBarShouldShowChanged();
+        }
+    }
     [[nodiscard]] constexpr int splitHandleThickness() const noexcept
     {
         return vtmux::DefaultSplitHandleThickness;
@@ -182,28 +206,36 @@ class MockMainController: public QAbstractListModel
   signals:
     void activeTabIndexChanged();
     void titleBarVisibleChanged();
+    void tabBarPositionChanged();
+    void tabBarShouldShowChanged();
     void chromeHeightChanged();
     void tabTitleEditRequested(int index);
 
   private:
     int _chromeHeight = 0;
+    int _tabBarPosition = 0;       // 0 = Top (default), 1 = Bottom
+    bool _tabBarShouldShow = true; // strip shown by default
 };
 
-} // namespace
-
-TEST_CASE("main.qml startup: sized-before-shown ordering and declared chrome (offscreen)",
-          "[contour][gui][qml][mainwindow]")
+/// Loads main.qml offscreen against @p controller and returns the created root object: registers the
+/// ContourTerminal stub type, pins the mock to C++ ownership, exposes it as `terminalSessions`, waits
+/// for the component to finish loading, and asserts a diagnostic-free load. Every main.qml load case
+/// (startup ordering + the tab-strip layout cases) goes through here so the load protocol lives in one
+/// place. Fails the enclosing test (via REQUIRE) if the component does not load cleanly.
+/// @param engine     The QML engine (kept alive by the caller for the root's lifetime).
+/// @param controller The mock manager + window controller to expose as `terminalSessions`.
+/// @param warnings   Captures QML diagnostics emitted during the load.
+/// @return The created root ApplicationWindow object.
+[[nodiscard]] std::unique_ptr<QObject> loadMainWindow(QQmlEngine& engine,
+                                                      MockMainController& controller,
+                                                      contour::test::QmlMessageCapture& warnings)
 {
-    QQmlEngine engine;
     qmlRegisterType<StubContourTerminal>("Contour.Terminal", 1, 0, "ContourTerminal");
-    MockMainController controller;
-    // createWindowController() returns `this` through a Q_INVOKABLE, which defaults the returned
-    // object to JavaScript ownership — the engine's GC would delete the stack-allocated mock.
-    // Pin it, exactly as the production manager pins its controllers.
+    // createWindowController() returns `this` through a Q_INVOKABLE, which defaults the returned object
+    // to JavaScript ownership — the engine's GC would delete the stack-allocated mock. Pin it, exactly
+    // as the production manager pins its controllers.
     QQmlEngine::setObjectOwnership(&controller, QQmlEngine::CppOwnership);
     engine.rootContext()->setContextProperty("terminalSessions", &controller);
-
-    contour::test::QmlMessageCapture warnings;
 
     QQmlComponent component(&engine, QUrl(QStringLiteral("qrc:/contour/ui/main.qml")));
     while (component.status() == QQmlComponent::Loading)
@@ -216,6 +248,22 @@ TEST_CASE("main.qml startup: sized-before-shown ordering and declared chrome (of
     std::unique_ptr<QObject> root(component.create());
     REQUIRE(root != nullptr);
     QCoreApplication::processEvents();
+
+    for (auto const& w: warnings.messages())
+        INFO("QML warning: " << w.toStdString());
+    CHECK(warnings.count(contour::test::isQmlDiagnostic) == 0);
+    return root;
+}
+
+} // namespace
+
+TEST_CASE("main.qml startup: sized-before-shown ordering and declared chrome (offscreen)",
+          "[contour][gui][qml][mainwindow]")
+{
+    QQmlEngine engine;
+    MockMainController controller;
+    contour::test::QmlMessageCapture warnings;
+    auto root = loadMainWindow(engine, controller, warnings);
 
     // 1. Startup order: mint the controller, bind THIS window, check for a torn-off tab to adopt
     //    (none here -> returns false), create the first tab (so the window can be sized from real
@@ -235,12 +283,95 @@ TEST_CASE("main.qml startup: sized-before-shown ordering and declared chrome (of
     // 3. Declared chrome: with the custom title bar shown, win.chromeHeight tracks the TitleBar's
     //    effective height (34 logical px, its implicitHeight).
     CHECK(controller.chromeHeight() == 34);
+}
 
-    // 4. The whole load must be free of QML diagnostics (TypeErrors, binding loops, missing
-    //    properties) — the run-wide gate in test_main re-checks this over the entire suite.
-    for (auto const& w: warnings.messages())
-        INFO("QML warning: " << w.toStdString());
-    CHECK(warnings.count(contour::test::isQmlDiagnostic) == 0);
+TEST_CASE("main.qml tab strip: visibility gate collapses the chrome when hidden (offscreen)",
+          "[contour][gui][qml][mainwindow]")
+{
+    // When win.tabBarShouldShow is false (tab_bar_visibility: Never, or Multiple with a single tab),
+    // the TitleBar collapses: its effectiveHeight -> 0 -> the declared chromeHeight -> 0, and the strip
+    // item is not visible. When true, the strip occupies its 34px implicitHeight (as the startup test
+    // already pins). Driving the mock property proves the real main.qml binding reacts.
+    SECTION("hidden -> zero chrome, strip invisible")
+    {
+        QQmlEngine engine;
+        MockMainController controller;
+        controller.setTabBarShouldShow(false);
+        contour::test::QmlMessageCapture warnings;
+        auto root = loadMainWindow(engine, controller, warnings);
+
+        CHECK(controller.chromeHeight() == 0);
+        auto* titleBar = root->findChild<QQuickItem*>(QStringLiteral("titleBar"));
+        REQUIRE(titleBar != nullptr);
+        CHECK_FALSE(titleBar->isVisible());
+    }
+
+    SECTION("shown -> full chrome, strip visible")
+    {
+        QQmlEngine engine;
+        MockMainController controller;
+        controller.setTabBarShouldShow(true);
+        contour::test::QmlMessageCapture warnings;
+        auto root = loadMainWindow(engine, controller, warnings);
+
+        CHECK(controller.chromeHeight() == 34);
+        auto* titleBar = root->findChild<QQuickItem*>(QStringLiteral("titleBar"));
+        REQUIRE(titleBar != nullptr);
+        CHECK(titleBar->isVisible());
+    }
+}
+
+TEST_CASE("main.qml tab strip: position flips the title-bar / content stacking (offscreen)",
+          "[contour][gui][qml][mainwindow]")
+{
+    // The strip is pinned to the top OR bottom edge via conditional anchors; the content area fills the
+    // opposite side. chromeHeight is position-invariant (34px either way). We read the laid-out y/height
+    // off the live items to prove the stacking flipped.
+    auto const readGeometry = [](QObject& root, qreal& titleBarY, qreal& titleBarH, qreal& contentY) {
+        auto* titleBar = root.findChild<QQuickItem*>(QStringLiteral("titleBar"));
+        auto* content = root.findChild<QQuickItem*>(QStringLiteral("content"));
+        REQUIRE(titleBar != nullptr);
+        REQUIRE(content != nullptr);
+        titleBarY = titleBar->y();
+        titleBarH = titleBar->height();
+        contentY = content->y();
+    };
+
+    SECTION("Top (default): title bar at y=0, content below it")
+    {
+        QQmlEngine engine;
+        MockMainController controller;
+        controller.setTabBarPosition(0);
+        contour::test::QmlMessageCapture warnings;
+        auto root = loadMainWindow(engine, controller, warnings);
+
+        qreal titleBarY = -1;
+        qreal titleBarH = -1;
+        qreal contentY = -1;
+        readGeometry(*root, titleBarY, titleBarH, contentY);
+        CHECK(titleBarY == 0.0);
+        CHECK(contentY == titleBarH); // content starts right below the strip
+        CHECK(controller.chromeHeight() == 34);
+    }
+
+    SECTION("Bottom: content at y=0, title bar below the content")
+    {
+        QQmlEngine engine;
+        MockMainController controller;
+        controller.setTabBarPosition(1);
+        contour::test::QmlMessageCapture warnings;
+        auto root = loadMainWindow(engine, controller, warnings);
+
+        qreal titleBarY = -1;
+        qreal titleBarH = -1;
+        qreal contentY = -1;
+        readGeometry(*root, titleBarY, titleBarH, contentY);
+        CHECK(contentY == 0.0);
+        auto* content = root->findChild<QQuickItem*>(QStringLiteral("content"));
+        REQUIRE(content != nullptr);
+        CHECK(titleBarY == content->height()); // strip sits just past the content's bottom edge
+        CHECK(controller.chromeHeight() == 34);
+    }
 }
 
 #include <MainWindowQml_test.moc>

--- a/src/contour/test/MultiWindow_test.cpp
+++ b/src/contour/test/MultiWindow_test.cpp
@@ -87,6 +87,96 @@ TEST_CASE("two controllers adapt distinct model windows with independent tab row
     CHECK(windowB->count() == 3);
 }
 
+TEST_CASE("tab strip Multiple gate tracks the live tab count and re-notifies QML", "[contour][multiwindow]")
+{
+    using contour::config::TabBarVisibility;
+
+    // Model-only tabs (createTab / closeTabsToRight): they drive the same onTabAdded / onTabClosed
+    // hooks synchronously without needing a backing session (closeTabAtIndex on a session-less tab is
+    // an async session-teardown path, so it is not used here).
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController window { manager };
+    REQUIRE(window.controller != nullptr);
+
+    window->seedTabBarVisibility(TabBarVisibility::Multiple);
+    // The seed itself emits the change once (mode is one input to the resolved gate). Spy AFTER seeding
+    // so the counts below reflect only the count-driven add/close notifications.
+    QSignalSpy shouldShowSpy(window.controller, &contour::WindowController::tabBarShouldShowChanged);
+
+    // One tab: Multiple hides the strip.
+    createTabs(manager, *window, 1);
+    CHECK(window->count() == 1);
+    CHECK_FALSE(window->tabBarShouldShow());
+
+    // Second tab: the strip shows, and the add fired the gate notification.
+    createTabs(manager, *window, 1);
+    CHECK(window->count() == 2);
+    CHECK(window->tabBarShouldShow());
+
+    // Back to one tab: the strip hides again, and the close fired the notification too.
+    window->closeTabsToRight(0);
+    CHECK(window->count() == 1);
+    CHECK_FALSE(window->tabBarShouldShow());
+
+    // Two adds + one close each drove tabBarShouldShowChanged (the onTabAdded / onTabClosed wiring);
+    // without those emits the QML `visible` binding would go stale.
+    CHECK(shouldShowSpy.count() == 3);
+}
+
+TEST_CASE("tab strip seeds are first-write-wins per window", "[contour][multiwindow]")
+{
+    using contour::config::TabBarPosition;
+    using contour::config::TabBarVisibility;
+
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController window { manager };
+    REQUIRE(window.controller != nullptr);
+
+    // Defaults before any seed (mirror the ConfigEntry defaults: Top / Always).
+    CHECK(window->tabBarPosition() == static_cast<int>(TabBarPosition::Top));
+    CHECK(window->tabBarVisibility() == static_cast<int>(TabBarVisibility::Always));
+
+    // First seed takes effect...
+    window->seedTabBarPosition(TabBarPosition::Bottom);
+    window->seedTabBarVisibility(TabBarVisibility::Never);
+    CHECK(window->tabBarPosition() == static_cast<int>(TabBarPosition::Bottom));
+    CHECK(window->tabBarVisibility() == static_cast<int>(TabBarVisibility::Never));
+
+    // ...a later seed (arriving on every session rebind in production) is a no-op, so a runtime state
+    // is never reset by a tab switch or split collapse.
+    window->seedTabBarPosition(TabBarPosition::Top);
+    window->seedTabBarVisibility(TabBarVisibility::Always);
+    CHECK(window->tabBarPosition() == static_cast<int>(TabBarPosition::Bottom));
+    CHECK(window->tabBarVisibility() == static_cast<int>(TabBarVisibility::Never));
+}
+
+TEST_CASE("tab strip Always/Never gates ignore the tab count", "[contour][multiwindow]")
+{
+    using contour::config::TabBarVisibility;
+
+    TestApp app;
+    auto& manager = app.manager();
+
+    SECTION("Always -> shown even with zero or one tab")
+    {
+        ScopedController window { manager };
+        window->seedTabBarVisibility(TabBarVisibility::Always);
+        CHECK(window->tabBarShouldShow()); // no tabs yet
+        createTabs(manager, *window, 1);
+        CHECK(window->tabBarShouldShow()); // one tab
+    }
+
+    SECTION("Never -> hidden even with multiple tabs")
+    {
+        ScopedController window { manager };
+        window->seedTabBarVisibility(TabBarVisibility::Never);
+        createTabs(manager, *window, 3);
+        CHECK_FALSE(window->tabBarShouldShow());
+    }
+}
+
 TEST_CASE("REGRESSION: tab operations from a second window target that window, not the first",
           "[contour][multiwindow]")
 {

--- a/src/contour/test/e2e/cli-surface.sh
+++ b/src/contour/test/e2e/cli-surface.sh
@@ -26,6 +26,12 @@ trap 'rm -rf "$OUT"' EXIT
 "$CONTOUR" documentation configuration global > "$OUT/doc-config-global.txt"
 "$CONTOUR" documentation configuration profile > "$OUT/doc-config-profile.txt"
 "$CONTOUR" generate config to "$OUT/generated-config.yml"
+# The generated sample config must carry the tab-bar options (guards the reflection-driven
+# serialization + the doc-template keys against a silent regression).
+for key in tab_bar_position tab_bar_visibility; do
+    grep -q "$key:" "$OUT/generated-config.yml" \
+        || { echo "error: generated config is missing '$key:'" >&2; exit 1; }
+done
 "$CONTOUR" generate terminfo to "$OUT/generated.terminfo"
 "$CONTOUR" generate integration shell zsh to "$OUT/integration.zsh"
 "$CONTOUR" generate integration shell fish to "$OUT/integration.fish"

--- a/src/contour/test/e2e/coverage-config.yml.in
+++ b/src/contour/test/e2e/coverage-config.yml.in
@@ -20,6 +20,8 @@ profiles:
         arguments: []
         initial_working_directory: "~"
         show_title_bar: true
+        tab_bar_position: Bottom
+        tab_bar_visibility: Multiple
         dim_unfocused: 0.3
         size_indicator_on_resize: true
         fullscreen: false

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -39,7 +39,16 @@ ApplicationWindow
     // The custom tab strip is shown regardless of the decoration mode — only the window controls inside
     // it are dropped when the native frame provides them (see TitleBar.useCustomWindowControls). Tabs
     // remain reachable whether or not the native title bar is used.
-    property bool showCustomTitleBar: true
+    //
+    // Tab-strip placement + visibility come from the profile via the window controller (win). Both are
+    // aliased to window-level properties here so the `win`-null startup guard (and its default) lives in
+    // ONE place; the TitleBar/content bindings below read these, never `win` directly.
+    //   - tabBarPosition: 0 = Top (above the terminal content), 1 = Bottom (below it). Mirrors the
+    //     config::TabBarPosition enumerator order; defaults to Top before `win` resolves.
+    //   - tabBarShouldShow: the resolved Always / Never / Multiple gate (against the live tab count);
+    //     defaults to shown before `win` resolves.
+    property int tabBarPosition: win ? win.tabBarPosition : 0
+    property bool tabBarShouldShow: win ? win.tabBarShouldShow : true
 
     // Diagnostic lifecycle/notification traces below are routed through a category that is off by
     // default (Warning floor), so they stay silent during normal use (closing a window and firing a
@@ -88,10 +97,17 @@ ApplicationWindow
     // {{{ Custom title bar + terminal content
     TitleBar {
         id: titleBar
-        anchors.top: parent.top
+        objectName: "titleBar" // so offscreen layout tests can findChild() this item
+        // Pinned to the top OR the bottom edge depending on tabBarPosition (never both — assigning
+        // `undefined` detaches an anchor). left/right always span the window.
+        anchors.top: appWindow.tabBarPosition === 0 ? parent.top : undefined
+        anchors.bottom: appWindow.tabBarPosition === 1 ? parent.bottom : undefined
         anchors.left: parent.left
         anchors.right: parent.right
-        visible: appWindow.showCustomTitleBar
+        // Shown per the profile's tab_bar_visibility, resolved against the live tab count by the
+        // controller (Always / Never / Multiple). When hidden, height/effectiveHeight collapse to 0 so
+        // the content area (and the declared chrome height feeding the geometry authority) reclaim it.
+        visible: appWindow.tabBarShouldShow
         height: visible ? implicitHeight : 0
         property real effectiveHeight: visible ? implicitHeight : 0
         // Declared after the content area below, so a positive z keeps the bar above it. The terminal now
@@ -112,10 +128,15 @@ ApplicationWindow
     // startup session exists).
     Item {
         id: content
-        anchors.top: titleBar.bottom
+        objectName: "content" // so offscreen layout tests can findChild() this item
+        // Fills the window edge-to-edge on the axis the tab strip does NOT occupy: with the strip at
+        // the top, content runs from titleBar.bottom to the window bottom; with the strip at the bottom,
+        // content runs from the window top to titleBar.top. When the strip is hidden, titleBar's height
+        // is 0, so content reclaims the full window either way.
+        anchors.top: appWindow.tabBarPosition === 0 ? titleBar.bottom : parent.top
+        anchors.bottom: appWindow.tabBarPosition === 1 ? titleBar.top : parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.bottom: parent.bottom
 
         Loader {
             id: paneContentLoader


### PR DESCRIPTION
closes #1968 

The GUI tab strip is currently always shown and always at the top of the window. This adds two per-profile options so users can move it to the bottom, hide it entirely, or auto-hide it when only one tab is open.

- `tab_bar_position`: `Top` (default) or `Bottom` — places the tab bar above or below the terminal content.
- `tab_bar_visibility`: `Always` (default), `Never`, or `Multiple` — always shown, never shown, or shown only when the window has more than one tab.

## Changes

- Both options flow through the established Config → WindowController → QML pipeline, mirroring the existing `show_title_bar`/`titleBarVisible` mechanism: window-scoped state seeded first-write-wins from the profile, so a session rebind (tab switch, split collapse) never resets it.
- `WindowController` exposes `tabBarPosition` as an int and a computed `tabBarShouldShow` gate that resolves `Always`/`Never`/`Multiple` against the live tab count; the gate re-notifies on every tab add/close so `Multiple` mode stays in sync.
- `main.qml` flips the title-bar/content anchors on position (no `ColumnLayout` rewrite) and binds the tab bar's visibility to the resolved gate, riding the existing `chromeHeight` collapse chain — window sizing math is unchanged, and a hidden or bottom strap participates in sizing correctly.
- Defaults (`Top`/`Always`) reproduce the current behavior exactly, so existing users are unaffected.

Covered by unit tests across the config parser, the offscreen `main.qml` layout, the `WindowController` gate (including the count-driven re-notification), and an end-to-end run of the real binary with the options set.