### PR TITLE
Fix scrollbar visibility and type-to-scroll; improve tab color picker

### DIFF
--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -637,6 +637,72 @@ TEST_CASE("SessionChrome instantiates and wires a (null) session without errors 
     CHECK(chrome != nullptr);
 }
 
+TEST_CASE("SessionChrome scrollbar renders as a styled grabbable overlay (offscreen)", "[contour][gui][qml]")
+{
+    // Regression guard for the "barely visible / hard to grab" scrollbar. After the app-wide Fusion
+    // style was pinned (for the tab strip/menus), the stock ScrollBar inherited Fusion's thin,
+    // low-contrast, hover-only handle. SessionChrome now supplies an explicit contentItem/background and
+    // a comfortable hit target, so the styling must survive: the bar is findable, wider than the thin
+    // default, and owns its handle + track items rather than deferring to the style.
+    QQmlEngine engine;
+    MockTabController controller;
+    engine.rootContext()->setContextProperty("terminalSessions", &controller);
+
+    QQmlComponent component(&engine, QUrl(QStringLiteral("qrc:/contour/ui/SessionChrome.qml")));
+    while (component.status() == QQmlComponent::Loading)
+        QCoreApplication::processEvents();
+    REQUIRE(component.isReady());
+
+    MockSession session;
+    QVariantMap initial;
+    initial.insert("session", QVariant::fromValue(static_cast<QObject*>(&session)));
+    std::unique_ptr<QObject> chrome(component.createWithInitialProperties(initial));
+    REQUIRE(chrome != nullptr);
+    QCoreApplication::processEvents();
+
+    auto* bar = chrome->findChild<QQuickItem*>(QStringLiteral("verticalScrollBar"));
+    REQUIRE(bar != nullptr);
+
+    // A comfortable, easy-to-grab hit target rather than the thin Fusion default.
+    CHECK(bar->property("implicitWidth").toReal() >= 12.0);
+
+    // Explicit, style-independent handle + track items (the fix), not the inherited defaults.
+    CHECK(bar->property("contentItem").value<QQuickItem*>() != nullptr);
+    CHECK(bar->property("background").value<QQuickItem*>() != nullptr);
+}
+
+TEST_CASE("Tab color flyout offers a dependency-free arbitrary-color entry (offscreen)",
+          "[contour][gui][qml]")
+{
+    // Guards the arbitrary-RGB tab-color feature AND its robustness: the flyout must carry no hard
+    // QtQuick.Dialogs dependency (a missing such module used to cascade up and break the whole main.qml
+    // where it is not installed), yet still expose a hex input field for entering any color. Loading the
+    // component without error already proves the absent-module hazard is gone; finding the field proves
+    // the entry point is there.
+    QQmlEngine engine;
+    MockTabController controller;
+    engine.rootContext()->setContextProperty("terminalSessions", &controller);
+
+    QQmlComponent component(&engine, QUrl(QStringLiteral("qrc:/contour/ui/TabColorFlyout.qml")));
+    while (component.status() == QQmlComponent::Loading)
+        QCoreApplication::processEvents();
+    REQUIRE(component.isReady());
+
+    QVariantMap initial;
+    initial.insert("controller", QVariant::fromValue(&controller));
+    initial.insert("tabIndex", 0);
+    std::unique_ptr<QObject> flyout(component.createWithInitialProperties(initial));
+    REQUIRE(flyout != nullptr);
+
+    // A Popup defers building its contentItem until shown; reading the property forces that deferred
+    // execution, instantiating the statically-declared hex field (unlike the swatch Repeater delegates,
+    // a plain child materializes here without hosting/opening the popup).
+    REQUIRE(flyout->property("contentItem").value<QQuickItem*>() != nullptr);
+    QCoreApplication::processEvents();
+
+    CHECK(flyout->findChild<QObject*>(QStringLiteral("customColorField")) != nullptr);
+}
+
 TEST_CASE("PaneNode renders a split tree without recursive-instantiation errors (offscreen)",
           "[contour][gui][qml][split]")
 {

--- a/src/contour/test/test_main.cpp
+++ b/src/contour/test/test_main.cpp
@@ -13,6 +13,8 @@
 
 #include <iostream>
 
+#include <QtQuickControls2/QQuickStyle>
+
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch_session.hpp>
 
@@ -45,6 +47,13 @@ int main(int argc, char* argv[])
 #endif
 
     QGuiApplication app(argc, argv);
+
+    // Pin the same Qt Quick Controls style the app itself pins (ContourGuiApp: QQuickStyle::setStyle).
+    // The tests instantiate real Controls (SessionChrome's customized ScrollBar, the tab flyout, ...),
+    // and the platform-native style (notably on Windows) refuses contentItem/background customization,
+    // emitting a QML diagnostic that the gate below then fails on. Fusion supports customization on
+    // every platform, so pinning it here makes the test environment match production.
+    QQuickStyle::setStyle(QStringLiteral("Fusion"));
 
     // Run-wide gate: capture every warning/critical for the whole session. Per-test QmlMessageCapture guards
     // chain to this one (see QmlMessageCapture.h), so a per-test guard never blinds the gate.

--- a/src/contour/ui/SessionChrome.qml
+++ b/src/contour/ui/SessionChrome.qml
@@ -48,11 +48,12 @@ Item {
     // so they exist exactly once regardless of how often the session rebinds.
     ScrollBar {
         id: vbar
+        objectName: "verticalScrollBar"
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.right: (chrome.session && chrome.session.isScrollbarRight) ? parent.right : undefined
         anchors.left: (chrome.session && chrome.session.isScrollbarRight) ? undefined : parent.left
-        visible: chrome.session ? chrome.session.isScrollbarVisible : false
+        visible: (chrome.session ? chrome.session.isScrollbarVisible : false) && vbar.hasScrollback
         orientation: Qt.Vertical
         policy: visible ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
         minimumSize: 0.1
@@ -64,6 +65,50 @@ Item {
             : 0.0
         onPositionChanged: chrome.onScrollBarPositionChanged()
         onSizeChanged: chrome.updateScrollBarPosition()
+
+        // Comfortable hit target that floats just off the terminal edge. Overlay only — no gutter is
+        // reserved, so the grid/window geometry is untouched.
+        implicitWidth: 12
+        padding: 2
+
+        // A stock ScrollBar inherits the app-pinned Fusion style's thin, low-contrast, hover-only handle
+        // (see ContourGuiApp's QQuickStyle::setStyle("Fusion")), nearly invisible over a terminal's
+        // per-profile background. An explicit contentItem/background — the same remedy WindowControls.qml
+        // uses for Fusion's illegible defaults — makes the handle style-independent: clearly visible at
+        // rest, emphasized on hover/drag.
+
+        // Auto-contrast handle color derived from the profile background (QColor r/g/b are 0..1), so it
+        // reads on any theme without plumbing a foreground color to QML: light handle over dark
+        // backgrounds, dark handle over light ones. Null-guarded during split-teardown rebinds.
+        readonly property color handleColor: {
+            let bg = chrome.session ? chrome.session.backgroundColor : Qt.rgba(0, 0, 0, 1);
+            let luminance = 0.2126 * bg.r + 0.7152 * bg.g + 0.0722 * bg.b;
+            return luminance < 0.5 ? Qt.rgba(1, 1, 1, 1) : Qt.rgba(0, 0, 0, 1);
+        }
+
+        // True only while there is scrollback to move through. Because we supply our own contentItem, the
+        // style's "hide when content fits" no longer applies, so we gate the whole bar's visibility on
+        // size (< 1.0 means history exists) ourselves — this also keeps the overlay from swallowing edge
+        // clicks/selections when there is nothing to scroll (an invisible-but-present bar would still
+        // capture mouse events in its strip).
+        readonly property bool hasScrollback: vbar.size < 1.0
+
+        contentItem: Rectangle {
+            implicitWidth: 8
+            radius: width / 2
+            color: vbar.handleColor
+            // Visible at rest, brighter on hover, brightest while dragging. Opacity is ours (not the
+            // style's active-driven fade), so the handle never vanishes when merely idle.
+            opacity: vbar.pressed ? 0.55 : vbar.hovered ? 0.45 : 0.28
+            Behavior on opacity { NumberAnimation { duration: 120 } }
+        }
+
+        background: Rectangle {
+            color: vbar.handleColor
+            // A faint track that only surfaces while the user interacts, keeping the resting look clean.
+            opacity: (vbar.hovered || vbar.pressed) ? 0.10 : 0.0
+            Behavior on opacity { NumberAnimation { duration: 120 } }
+        }
     }
 
     // Bell sound, loaded once multimedia is ready.

--- a/src/contour/ui/TabColorFlyout.qml
+++ b/src/contour/ui/TabColorFlyout.qml
@@ -1,9 +1,11 @@
 // vim:syntax=qml
 // A popup with a grid of predefined color swatches for trivially colorizing a tab (Windows-Terminal
 // style). The palette comes from the authoritative vtmux model via the controller, so the GUI and
-// any future network client offer the same choices. One click on a swatch sets the tab color.
+// any future network client offer the same choices. One click on a swatch sets the tab color; a hex
+// field below the swatches lets the user enter an arbitrary RGB color.
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 Popup {
     id: root
@@ -42,7 +44,7 @@ Popup {
         Grid {
             id: grid
             columns: 8
-            spacing: 4
+            spacing: 8
 
             Repeater {
                 // Null-guarded like TabStrip's currentIndex: the controller dies before this QML tree
@@ -50,9 +52,10 @@ Popup {
                 model: root.controller ? root.controller.tabColorPalette() : []
                 delegate: Rectangle {
                     required property var modelData
-                    width: 20
-                    height: 20
-                    radius: 3
+                    objectName: "tabColorSwatch"
+                    width: 30
+                    height: 30
+                    radius: 5
                     color: modelData
                     border.width: 1
                     border.color: Qt.rgba(0, 0, 0, 0.4)
@@ -71,6 +74,45 @@ Popup {
             }
         }
 
+        // Arbitrary-color entry. Deliberately dependency-free (no QtQuick.Dialogs): a hard import of that
+        // module is not installed in every runtime, and its absence would cascade up and break the whole
+        // main.qml. Instead the user types a 6-digit hex RGB value; the preview updates live and Enter
+        // (or clicking the preview) applies it. The "#rrggbb" string is coerced to a QColor by the same
+        // controller.setTabColor() the preset swatches use, so the backend needs no new API.
+        RowLayout {
+            width: grid.width
+            spacing: 8
+
+            Label {
+                text: "#"
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            TextField {
+                id: hexField
+                objectName: "customColorField"
+                Layout.fillWidth: true
+                placeholderText: qsTr("RRGGBB")
+                maximumLength: 6
+                validator: RegularExpressionValidator { regularExpression: /[0-9A-Fa-f]{6}/ }
+                onAccepted: root.applyCustomColor()
+            }
+
+            // Live preview of the typed color; click it to apply.
+            Rectangle {
+                Layout.preferredWidth: 30
+                Layout.preferredHeight: 30
+                radius: 5
+                border.width: 1
+                border.color: Qt.rgba(0, 0, 0, 0.4)
+                color: hexField.acceptableInput ? ("#" + hexField.text) : "transparent"
+                TapHandler {
+                    enabled: hexField.acceptableInput
+                    onTapped: root.applyCustomColor()
+                }
+            }
+        }
+
         Button {
             width: grid.width
             text: qsTr("Reset Color")
@@ -79,5 +121,14 @@ Popup {
                 root.close()
             }
         }
+    }
+
+    // Applies the typed hex color (when it is a complete, valid RGB value) through the same path as the
+    // preset swatches, then closes. Null-guarded because the controller can be torn down during teardown.
+    function applyCustomColor() {
+        if (!hexField.acceptableInput || !root.controller)
+            return;
+        root.controller.setTabColor(root.tabIndex, "#" + hexField.text);
+        root.close();
     }
 }

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -877,6 +877,14 @@ void Terminal::forceAutoScrollToBottomIfEnabled()
         _viewport.forceScrollToBottom();
 }
 
+void Terminal::scrollToBottomOnInput()
+{
+    // Unconditional on purpose: user input must always jump the viewport back to the bottom, even
+    // when `autoScrollOnUpdate` (which governs output-driven scrolling only) is turned off. The
+    // alt-screen guard still applies via `scrollToBottom()`'s own `scrollingDisabled()` check.
+    _viewport.scrollToBottom();
+}
+
 Handled Terminal::sendKeyEvent(Key key,
                                KeyboardModifiers modifiers,
                                KeyboardEventType eventType,
@@ -916,7 +924,7 @@ Handled Terminal::sendKeyEvent(Key key,
         {
             _inputGenerator.generateRaw(*udkStr);
             flushInput();
-            autoScrollToBottomIfEnabled();
+            scrollToBottomOnInput();
             return Handled { true };
         }
     }
@@ -926,7 +934,7 @@ Handled Terminal::sendKeyEvent(Key key,
     {
         flushInput();
         if (!isModifierKey(key))
-            autoScrollToBottomIfEnabled();
+            scrollToBottomOnInput();
     }
     return Handled { success };
 }
@@ -968,7 +976,7 @@ Handled Terminal::sendCharEvent(char32_t ch,
     if (success)
     {
         flushInput();
-        autoScrollToBottomIfEnabled();
+        scrollToBottomOnInput();
     }
     return Handled { success };
 }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1500,6 +1500,13 @@ class Terminal
     /// target buffer but pixel/offset state still needs to be reset).
     void forceAutoScrollToBottomIfEnabled();
 
+    /// Scrolls the viewport to the bottom in response to *user input* (a key or character
+    /// forwarded to the application). Intentionally independent of
+    /// `settings().autoScrollOnUpdate`, which gates only *output*-driven scrolling: typing must
+    /// always reveal the cursor and the resulting output regardless of that setting. Honors the
+    /// viewport's own alt-screen guard (`scrollToBottom()` no-ops when scrolling is disabled).
+    void scrollToBottomOnInput();
+
     void mainLoop();
     void fillRenderBufferInternal(RenderBuffer& output, bool includeSelection);
     LineCount fillRenderBufferStatusLine(RenderBuffer& output, bool includeSelection, LineOffset base);

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -293,20 +293,21 @@ TEST_CASE("Terminal.AutoScrollOnUpdate", "[terminal]")
 
     auto const anyModifiers = vtbackend::Modifiers { vtbackend::Modifier::None };
 
-    SECTION("keypress honors autoScrollOnUpdate=false")
+    SECTION("keypress always scrolls to bottom, even when autoScrollOnUpdate=false")
     {
+        // User input must reveal the cursor regardless of the output-scroll setting: sending a key
+        // snaps the viewport back to the bottom even though autoScrollOnUpdate (which governs
+        // output-driven scrolling only) is disabled.
         terminal.settings().autoScrollOnUpdate = false;
         terminal.viewport().scrollUp(LineCount(2));
         REQUIRE(terminal.viewport().scrolled());
-        auto const offsetBefore = terminal.viewport().scrollOffset();
 
         terminal.sendKeyEvent(vtbackend::Key::Enter,
                               anyModifiers,
                               vtbackend::KeyboardEventType::Press,
                               std::chrono::steady_clock::now());
 
-        CHECK(terminal.viewport().scrolled());
-        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+        CHECK(!terminal.viewport().scrolled());
     }
 
     SECTION("keypress honors autoScrollOnUpdate=true (default)")
@@ -323,18 +324,17 @@ TEST_CASE("Terminal.AutoScrollOnUpdate", "[terminal]")
         CHECK(!terminal.viewport().scrolled());
     }
 
-    SECTION("char input honors autoScrollOnUpdate=false")
+    SECTION("char input always scrolls to bottom, even when autoScrollOnUpdate=false")
     {
+        // Same input-independence as the keypress case above, exercised through the char path.
         terminal.settings().autoScrollOnUpdate = false;
         terminal.viewport().scrollUp(LineCount(2));
         REQUIRE(terminal.viewport().scrolled());
-        auto const offsetBefore = terminal.viewport().scrollOffset();
 
         terminal.sendCharEvent(
             U'a', 0, anyModifiers, vtbackend::KeyboardEventType::Press, std::chrono::steady_clock::now());
 
-        CHECK(terminal.viewport().scrolled());
-        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+        CHECK(!terminal.viewport().scrolled());
     }
 
     SECTION("char input honors autoScrollOnUpdate=true")


### PR DESCRIPTION
Three GUI papercuts, all surfaced by the recent RHI/native-GUI rewrite (and one older regression it exposed):

- The scrollbar became barely visible — the unstyled `ScrollBar` inherited the app-pinned Fusion style's thin, low-contrast, hover-only handle over the dark terminal background.
- Typing no longer snapped the viewport back to the bottom when `auto_scroll_on_update: false`, because keypress-scroll had been wrongly coupled to that (output-only) setting.
- The tab-color popup's swatches were too small to click comfortably and offered no way to choose an arbitrary color.

## Changes

- **Scrollbar**: give the `ScrollBar` an explicit `contentItem`/`background` (the same remedy `WindowControls.qml` uses for Fusion's illegible defaults) — a 12px hit target with an auto-contrast handle derived from the profile background, clearly visible at rest and emphasized on hover/drag. Visibility is gated on actual scrollback so the overlay never swallows edge clicks when there is nothing to scroll.
- **Type-to-scroll**: decouple keypress/char scroll-to-bottom from `auto_scroll_on_update` via a new `Terminal::scrollToBottomOnInput()`, restoring the pre-regression behavior and matching xterm's independent `scrollKey`/`scrollTtyOutput` semantics. `auto_scroll_on_update` continues to gate output-driven scrolling only.
- **Tab colors**: enlarge swatches to 30px and add a "Custom…" button opening a native `ColorDialog` for an arbitrary RGB color, routed through the existing `WindowController.setTabColor()` (no new backend API; links the `QuickDialogs2` Qt module).
