### PR TITLE
vtbackend: do not scroll to bottom on key/char release events

### DIFF
--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -933,7 +933,11 @@ Handled Terminal::sendKeyEvent(Key key,
     if (success)
     {
         flushInput();
-        if (!isModifierKey(key))
+        // A key release is never "typed content": under win32-input-mode / the Kitty keyboard
+        // protocol the release of a viewport-scroll shortcut (e.g. the Up in Shift+Up) still
+        // generates PTY input, and snapping to the bottom here would undo the scroll the press just
+        // performed. Only press/repeat reveal the cursor.
+        if (!isModifierKey(key) && eventType != KeyboardEventType::Release)
             scrollToBottomOnInput();
     }
     return Handled { success };
@@ -976,7 +980,10 @@ Handled Terminal::sendCharEvent(char32_t ch,
     if (success)
     {
         flushInput();
-        scrollToBottomOnInput();
+        // See sendKeyEvent(): key releases are not typed content, so they must not snap the viewport
+        // back to the bottom even when the protocol reports them to the application.
+        if (eventType != KeyboardEventType::Release)
+            scrollToBottomOnInput();
     }
     return Handled { success };
 }

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1501,10 +1501,14 @@ class Terminal
     void forceAutoScrollToBottomIfEnabled();
 
     /// Scrolls the viewport to the bottom in response to *user input* (a key or character
-    /// forwarded to the application). Intentionally independent of
-    /// `settings().autoScrollOnUpdate`, which gates only *output*-driven scrolling: typing must
-    /// always reveal the cursor and the resulting output regardless of that setting. Honors the
-    /// viewport's own alt-screen guard (`scrollToBottom()` no-ops when scrolling is disabled).
+    /// forwarded to the application). Called only for key/char *press and repeat* events, never for
+    /// releases: a release is not typed content, and snapping on it would undo a viewport-scroll
+    /// shortcut whose press was consumed by the GUI (e.g. Shift+Up) once the protocol reports key
+    /// releases to the application (win32-input-mode, Kitty keyboard protocol). Intentionally
+    /// independent of `settings().autoScrollOnUpdate`, which gates only *output*-driven scrolling:
+    /// typing must always reveal the cursor and the resulting output regardless of that setting.
+    /// Honors the viewport's own alt-screen guard (`scrollToBottom()` no-ops when scrolling is
+    /// disabled).
     void scrollToBottomOnInput();
 
     void mainLoop();

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -349,6 +349,56 @@ TEST_CASE("Terminal.AutoScrollOnUpdate", "[terminal]")
         CHECK(!terminal.viewport().scrolled());
     }
 
+    // A key/char *release* is never typed content. When the active keyboard protocol reports
+    // releases to the application (win32-input-mode here, or the Kitty keyboard protocol) the release
+    // still produces PTY input, but it must NOT snap the viewport back to the bottom -- otherwise
+    // releasing a viewport-scroll shortcut such as Shift+Up (whose press the GUI already consumed as
+    // a ScrollOneUp action) would immediately undo the scroll. See Terminal::scrollToBottomOnInput().
+    SECTION("key release does not scroll to bottom even when it generates input")
+    {
+        // Win32 input mode reports both presses and releases to the application, so the release below
+        // actually reaches the input generator (in legacy mode releases generate nothing at all).
+        terminal.setMode(vtbackend::DECMode::Win32InputMode, true);
+
+        // Sanity check: a *press* in this mode really does generate input and snap to the bottom, so
+        // the release assertion below is not vacuous.
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        terminal.sendKeyEvent(vtbackend::Key::UpArrow,
+                              anyModifiers,
+                              vtbackend::KeyboardEventType::Press,
+                              std::chrono::steady_clock::now());
+        REQUIRE(!terminal.viewport().scrolled());
+
+        // The release generates input too, but must leave the viewport parked where the user put it.
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        terminal.sendKeyEvent(vtbackend::Key::UpArrow,
+                              anyModifiers,
+                              vtbackend::KeyboardEventType::Release,
+                              std::chrono::steady_clock::now());
+
+        CHECK(terminal.viewport().scrolled());
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
+    SECTION("char release does not scroll to bottom even when it generates input")
+    {
+        terminal.setMode(vtbackend::DECMode::Win32InputMode, true);
+
+        terminal.viewport().scrollUp(LineCount(2));
+        REQUIRE(terminal.viewport().scrolled());
+        auto const offsetBefore = terminal.viewport().scrollOffset();
+
+        terminal.sendCharEvent(
+            U'a', 0, anyModifiers, vtbackend::KeyboardEventType::Release, std::chrono::steady_clock::now());
+
+        CHECK(terminal.viewport().scrolled());
+        CHECK(terminal.viewport().scrollOffset() == offsetBefore);
+    }
+
     SECTION("scrollbackBufferCleared (CSI 3 J) honors autoScrollOnUpdate=false")
     {
         terminal.settings().autoScrollOnUpdate = false;


### PR DESCRIPTION
quick regression fix I accidentally slipped through in #1980.