### PR TITLE
Fix screenshots being saved upside down on OpenGL

### DIFF
--- a/src/contour/display/RhiRenderer.cpp
+++ b/src/contour/display/RhiRenderer.cpp
@@ -1076,6 +1076,15 @@ void RhiRenderer::recordScreenshotPass(QRhi* rhi, QRhiCommandBuffer* cb)
     cb->resourceUpdate(batch);
     _screenshotReadbackPending = true;
     _screenshotSize = size;
+
+    // Readback hands back the texture's texel rows in index order. For a texture we RENDERED into, which row
+    // is texel row 0 follows the backend's framebuffer origin: bottom-left on OpenGL (isYUpInFramebuffer(),
+    // whose readBackTexture() is a plain glReadPixels off an FBO), so the image arrives bottom-up and its
+    // rows must be reversed; top-left on D3D/Vulkan/Metal, where it already matches. (The glyph atlas is
+    // UPLOADED rather than rendered into, so it round-trips in the row order we wrote it and readAtlas()
+    // rightly never flips.) The orientation is a property of THIS capture, so it is recorded with it —
+    // deliverScreenshot() then reverses the rows without re-deriving it.
+    _screenshotFlipRows = rhi->isYUpInFramebuffer();
     displayLog()("Screenshot: scheduled offscreen capture ({}).", size);
 }
 
@@ -1092,14 +1101,12 @@ void RhiRenderer::deliverScreenshot()
     auto const width = unbox<int>(_screenshotSize.width);
     auto const height = unbox<int>(_screenshotSize.height);
 
-    // Offscreen-texture readback is top-left origin on every backend, so no vertical flip is needed. (The
-    // capturedFromTexture=true short-circuit makes the backend framebuffer orientation irrelevant, so we
-    // don't consult _rhi here — keeping deliverScreenshot independent of a live per-frame RHI handle.)
-    auto const flip = screenshotNeedsVerticalFlip(/*capturedFromTexture*/ true, /*framebufferIsYUp*/ false);
+    // Normalize the raw readback into a tightly-packed, top-left-origin RGBA8 buffer, reversing the rows
+    // iff the capture came off a Y-up (bottom-left origin) framebuffer — recorded with the capture.
     auto const* bytes = reinterpret_cast<uint8_t const*>(_screenshotReadbackResult.data.constData());
     auto const source =
         std::span<uint8_t const>(bytes, static_cast<size_t>(_screenshotReadbackResult.data.size()));
-    auto buffer = normalizeScreenshotBuffer(source, width, height, flip);
+    auto buffer = normalizeScreenshotBuffer(source, width, height, _screenshotFlipRows);
 
     displayLog()("Screenshot: delivering captured frame ({}).", _screenshotSize);
     _pendingScreenshotCallback.value()(buffer, _screenshotSize);

--- a/src/contour/display/RhiRenderer.h
+++ b/src/contour/display/RhiRenderer.h
@@ -552,6 +552,11 @@ class RhiRenderer final: public vtrasterizer::RenderTarget, public vtrasterizer:
     ImageSize _screenshotSize {};            ///< Device-pixel size the pending/last capture was taken at.
     bool _screenshotReadbackPending = false; ///< A readback is scheduled and awaiting completion delivery.
 
+    /// Whether the pending capture's readback rows arrive bottom-up and must be reversed to yield a
+    /// top-left-origin image. Recorded with the capture it describes (recordScreenshotPass, from
+    /// QRhi::isYUpInFramebuffer()), since the row order is a property of the frame that produced it.
+    bool _screenshotFlipRows = false;
+
     QRhiResourcePtr<QRhiTexture> _screenshotTexture; ///< Owned RGBA8 color target (readback source).
     QRhiResourcePtr<QRhiRenderBuffer> _screenshotDepthStencil; ///< Depth-stencil for the offscreen pass.
     QRhiResourcePtr<QRhiTextureRenderTarget> _screenshotRenderTarget; ///< The offscreen render target.

--- a/src/contour/display/ScreenshotReadback.h
+++ b/src/contour/display/ScreenshotReadback.h
@@ -26,27 +26,6 @@ inline constexpr std::size_t ScreenshotBytesPerPixel = 4;
     return static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * ScreenshotBytesPerPixel;
 }
 
-/// Decides whether a captured framebuffer buffer must be vertically flipped to land in a top-left-origin
-/// image (as QImage expects).
-///
-/// The RHI normalizes *texture* readback to a top-left origin on every backend, so an offscreen-texture
-/// capture needs no flip. A *swapchain backbuffer* readback, by contrast, follows the backend's framebuffer
-/// origin: bottom-left on OpenGL (QRhi::isYUpInFramebuffer() == true), which must be flipped. Expressing the
-/// policy as data (two booleans) keeps it unit-testable without a GL context and documents exactly when the
-/// flip applies.
-/// @param capturedFromTexture true if the pixels came from an offscreen QRhiTexture readback (top-left
-/// origin,
-///                            no flip); false if from the swapchain backbuffer.
-/// @param framebufferIsYUp    QRhi::isYUpInFramebuffer() for the active backend (only consulted for a
-///                            backbuffer capture).
-/// @return true if the buffer's rows must be reversed to obtain a top-left-origin image.
-[[nodiscard]] constexpr bool screenshotNeedsVerticalFlip(bool capturedFromTexture,
-                                                         bool framebufferIsYUp) noexcept
-{
-    // Offscreen texture readback is already top-left; only a Y-up backbuffer needs flipping.
-    return !capturedFromTexture && framebufferIsYUp;
-}
-
 /// Copies a readback buffer into a tightly-packed, top-left-origin RGBA8 image buffer of the expected size,
 /// optionally reversing rows (vertical flip) and defensively padding/truncating to the exact expected length.
 ///
@@ -57,7 +36,8 @@ inline constexpr std::size_t ScreenshotBytesPerPixel = 4;
 /// @param source     The raw readback bytes (may be shorter or longer than expected; may be empty).
 /// @param width      Target image width in pixels.
 /// @param height     Target image height in pixels.
-/// @param flip       Whether to reverse the row order (see screenshotNeedsVerticalFlip()).
+/// @param flip       Whether to reverse the row order. Whose call this is depends on how the captured
+///                   surface got its pixels; RhiRenderer::recordScreenshotPass() decides it.
 /// @return A buffer of exactly screenshotBufferSize(width, height) bytes. Rows beyond what @p source supplies
 ///         are left zero-filled.
 [[nodiscard]] inline std::vector<uint8_t> normalizeScreenshotBuffer(std::span<uint8_t const> source,

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1451,9 +1451,10 @@ void TerminalDisplay::doDumpState()
 QImage TerminalDisplay::screenshotImageFromBuffer(std::vector<uint8_t> const& rgbaBuffer,
                                                   vtbackend::ImageSize pixelSize)
 {
-    // The offscreen-texture readback delivers a top-left-origin RGBA8 buffer, so — unlike the old
-    // glReadPixels backbuffer path — no vertical flip is applied here. copy() detaches from the (transient)
-    // source buffer so the returned image stays valid after it is freed.
+    // The buffer arrives already normalized to a top-left-origin, tightly-packed RGBA8 image (the renderer's
+    // deliverScreenshot() reverses the rows when the capture came off a Y-up framebuffer), so this wrapper
+    // only adopts it. copy() detaches from the (transient) source buffer so the returned image stays valid
+    // after it is freed.
     return QImage(rgbaBuffer.data(),
                   pixelSize.width.as<int>(),
                   pixelSize.height.as<int>(),

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -311,8 +311,8 @@ class TerminalDisplay: public QQuickItem
     /// @param onReady Receives the captured QImage once the readback completes.
     void requestScreenshot(std::function<void(QImage)> onReady);
 
-    /// Wraps a raw RGBA8 readback buffer (top-left origin, as the offscreen-texture readback delivers) into a
-    /// QImage that owns a copy of the pixels.
+    /// Wraps a raw RGBA8 readback buffer (tightly packed, top-left origin — as RenderTarget's
+    /// ScreenshotCallback guarantees) into a QImage that owns a copy of the pixels.
     /// @param rgbaBuffer Tightly-packed RGBA8 pixels, width*height*4 bytes.
     /// @param pixelSize  The image size in pixels.
     /// @return A QImage owning a deep copy of the pixels (safe after @p rgbaBuffer is freed).

--- a/src/contour/test/ScreenshotReadback_test.cpp
+++ b/src/contour/test/ScreenshotReadback_test.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Unit tests for the pure, GPU-free screenshot-readback helpers (ScreenshotReadback.h): the buffer-size
-// arithmetic, the vertical-flip policy (offscreen-texture readback is top-left origin; only a Y-up
-// swapchain backbuffer needs flipping), and the normalization of a raw RHI readback buffer into a
-// deterministic, correctly-sized, correctly-oriented RGBA8 image buffer.
+// arithmetic and the normalization of a raw RHI readback buffer into a deterministic, correctly-sized,
+// correctly-oriented RGBA8 image buffer (including the row reversal a Y-up framebuffer capture needs).
 //
 // These govern how RhiRenderer's deferred offscreen screenshot readback is turned into a QImage without a
-// GPU/RHI context, so they are pinned here.
+// GPU/RHI context, so they are pinned here. Which of the two orientations a real capture actually needs is
+// a property of the live RHI backend, so it is pinned end-to-end in ScreenshotRhiReadback_test instead.
 
 #include <contour/display/ScreenshotReadback.h>
 
@@ -33,24 +33,6 @@ TEST_CASE("screenshotBufferSize: non-positive dimensions yield zero", "[screensh
     CHECK(screenshotBufferSize(100, 0) == 0);
     CHECK(screenshotBufferSize(-1, 10) == 0);
     CHECK(screenshotBufferSize(10, -1) == 0);
-}
-// }}}
-
-// {{{ screenshotNeedsVerticalFlip
-TEST_CASE("screenshotNeedsVerticalFlip: offscreen texture capture never flips", "[screenshot]")
-{
-    // Texture readback is normalized to a top-left origin on every backend, so no flip regardless of the
-    // backend framebuffer orientation.
-    CHECK_FALSE(screenshotNeedsVerticalFlip(/*capturedFromTexture*/ true, /*framebufferIsYUp*/ true));
-    CHECK_FALSE(screenshotNeedsVerticalFlip(/*capturedFromTexture*/ true, /*framebufferIsYUp*/ false));
-}
-
-TEST_CASE("screenshotNeedsVerticalFlip: only a Y-up backbuffer capture flips", "[screenshot]")
-{
-    // A swapchain backbuffer follows the backend origin: OpenGL (Y-up) needs a flip; a top-left backend
-    // does not.
-    CHECK(screenshotNeedsVerticalFlip(/*capturedFromTexture*/ false, /*framebufferIsYUp*/ true));
-    CHECK_FALSE(screenshotNeedsVerticalFlip(/*capturedFromTexture*/ false, /*framebufferIsYUp*/ false));
 }
 // }}}
 

--- a/src/contour/test/ScreenshotRhiReadback_test.cpp
+++ b/src/contour/test/ScreenshotRhiReadback_test.cpp
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// End-to-end RHI readback test for the screenshot path. Where a (software) OpenGL RHI can be created in the
-// test environment, this exercises the REAL Qt RHI readback contract the screenshot capture depends on:
-// render into an owned RGBA8 texture render target, schedule readBackTexture(), and verify the pixels come
-// back correctly through normalizeScreenshotBuffer() — the same buffer transform
-// RhiRenderer::deliverScreenshot applies. This guards the offscreen-texture-readback assumptions (top-left
-// origin, RGBA8, deferred completion) that the pure ScreenshotReadback_test cannot cover.
+// End-to-end RHI readback tests for the screenshot path. Where a (software) OpenGL RHI can be created in the
+// test environment, these exercise the REAL Qt RHI readback contract the screenshot capture depends on —
+// including the one thing a pure test cannot know: which row of the readback buffer is the TOP row of the
+// image. That is a property of the live backend (see RhiRenderer::recordScreenshotPass), and getting it
+// wrong saved every screenshot upside down (#1986).
 //
-// The test SKIPS (does not fail) when no GL context / RHI is available (common in headless CI without a
-// software GL stack), so it hardens coverage where possible without becoming a flaky gate.
+// The tests SKIP (do not fail) when no GL context / RHI is available (common in headless CI without a
+// software GL stack), so they harden coverage where possible without becoming a flaky gate.
 
+#include <contour/display/RhiRenderer.h>
 #include <contour/display/ScreenshotReadback.h>
 
+#include <vtbackend/Color.h>
+#include <vtbackend/primitives.h>
+
+#include <QtGui/QColor>
 #include <QtGui/QOffscreenSurface>
 #include <QtGui/QOpenGLContext>
 
@@ -22,9 +26,20 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <ranges>
+#include <span>
+#include <vector>
 
 using namespace contour::display;
+
+using vtbackend::Height;
+using vtbackend::ImageSize;
+using vtbackend::RGBAColor;
+using vtbackend::Width;
 
 namespace
 {
@@ -66,6 +81,65 @@ OffscreenRhi makeOffscreenRhi()
     return out;
 }
 
+/// A color + depth-stencil texture render target, mirroring the layout RhiRenderer::ensureScreenshotTarget()
+/// builds for its offscreen screenshot pass — so pipelines baked against this target's render-pass descriptor
+/// stay compatible with the one the renderer creates internally. Owns its resources; the caller keeps it
+/// alive for as long as those pipelines are used.
+struct TextureTarget
+{
+    QRhiResourcePtr<QRhiTexture> texture;
+    QRhiResourcePtr<QRhiRenderBuffer> depthStencil;
+    QRhiResourcePtr<QRhiTextureRenderTarget> renderTarget;
+    QRhiResourcePtr<QRhiRenderPassDescriptor> rpDesc;
+
+    [[nodiscard]] bool valid() const noexcept { return renderTarget != nullptr; }
+};
+
+/// Creates an RGBA8 color texture (render target + readback source) with a depth-stencil buffer and its
+/// render target, or an invalid TextureTarget if any resource fails to build.
+/// @param rhi  The RHI to create the resources on.
+/// @param size Pixel size of the target.
+TextureTarget makeTextureTarget(QRhi* rhi, QSize size)
+{
+    TextureTarget out;
+    out.texture.reset(rhi->newTexture(
+        QRhiTexture::RGBA8, size, 1, QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource));
+    if (!out.texture->create())
+        return {};
+
+    out.depthStencil.reset(rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, size, 1));
+    if (!out.depthStencil->create())
+        return {};
+
+    QRhiTextureRenderTargetDescription rtDesc({ QRhiColorAttachment(out.texture.get()) });
+    rtDesc.setDepthStencilBuffer(out.depthStencil.get());
+    out.renderTarget.reset(rhi->newTextureRenderTarget(rtDesc));
+    out.rpDesc.reset(out.renderTarget->newCompatibleRenderPassDescriptor());
+    out.renderTarget->setRenderPassDescriptor(out.rpDesc.get());
+    if (!out.renderTarget->create())
+        return {};
+
+    return out;
+}
+
+/// @return @p color as the QColor an RHI clear takes.
+[[nodiscard]] QColor asQColor(RGBAColor color)
+{
+    return { color.red(), color.green(), color.blue(), color.alpha() };
+}
+
+/// @return the color of pixel (@p x, @p y) in a tightly-packed, top-left-origin RGBA8 image buffer — the
+/// layout RenderTarget's ScreenshotCallback guarantees.
+/// @param image  The delivered screenshot buffer.
+/// @param width  The image width in pixels (its row stride in pixels).
+[[nodiscard]] RGBAColor pixelAt(std::span<uint8_t const> image, int width, int x, int y)
+{
+    auto const offset = (static_cast<size_t>(y) * static_cast<size_t>(width) + static_cast<size_t>(x))
+                        * ScreenshotBytesPerPixel;
+    auto const px = image.subspan(offset, ScreenshotBytesPerPixel);
+    return { px[0], px[1], px[2], px[3] };
+}
+
 } // namespace
 
 TEST_CASE("RHI readback: an offscreen texture cleared to a known color reads back correctly",
@@ -73,73 +147,115 @@ TEST_CASE("RHI readback: an offscreen texture cleared to a known color reads bac
 {
     auto env = makeOffscreenRhi();
     if (!env.valid())
-    {
-        WARN("Skipping RHI readback test: no usable OpenGL context in this environment.");
-        SUCCEED("no GL context; skipped");
-        return;
-    }
+        SKIP("no usable OpenGL context in this environment");
 
     auto* rhi = env.rhi.get();
     constexpr int W = 8;
     constexpr int H = 6;
-    QSize const size(W, H);
 
-    // Owned color texture usable as a render target and readback source (as RhiRenderer's screenshot target).
-    std::unique_ptr<QRhiTexture> tex(rhi->newTexture(
-        QRhiTexture::RGBA8, size, 1, QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource));
-    REQUIRE(tex->create());
+    auto const target = makeTextureTarget(rhi, QSize(W, H));
+    if (!target.valid())
+        SKIP("could not create a texture render target");
 
-    std::unique_ptr<QRhiTextureRenderTarget> rt(
-        rhi->newTextureRenderTarget(QRhiTextureRenderTargetDescription({ QRhiColorAttachment(tex.get()) })));
-    std::unique_ptr<QRhiRenderPassDescriptor> rp(rt->newCompatibleRenderPassDescriptor());
-    rt->setRenderPassDescriptor(rp.get());
-    REQUIRE(rt->create());
-
-    // A distinctive opaque color so channel order (RGBA) and correctness are both observable.
-    // R=0x11, G=0x22, B=0x33, A=0xFF.
-    QColor const clearColor(0x11, 0x22, 0x33, 0xFF);
+    // A color with four distinct channels, so the RGBA byte order is fully observable.
+    auto constexpr Clear = RGBAColor { 0x11, 0x22, 0x33, 0xFF };
 
     QRhiCommandBuffer* cb = nullptr;
     if (rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
-    {
-        WARN("Skipping RHI readback test: beginOffscreenFrame failed.");
-        SUCCEED("offscreen frame unavailable; skipped");
-        return;
-    }
+        SKIP("beginOffscreenFrame failed");
 
-    cb->beginPass(rt.get(), clearColor, { 1.0f, 0 });
+    cb->beginPass(target.renderTarget.get(), asQColor(Clear), { 1.0f, 0 });
     cb->endPass();
 
     QRhiReadbackResult readback;
     auto* batch = rhi->nextResourceUpdateBatch();
-    batch->readBackTexture(QRhiReadbackDescription(tex.get()), &readback);
+    batch->readBackTexture(QRhiReadbackDescription(target.texture.get()), &readback);
     cb->resourceUpdate(batch);
 
     rhi->endOffscreenFrame(); // submits + completes the readback
 
     REQUIRE_FALSE(readback.data.isEmpty());
-    CHECK(readback.pixelSize == size);
+    CHECK(readback.pixelSize == QSize(W, H));
 
     auto const* bytes = reinterpret_cast<uint8_t const*>(readback.data.constData());
     auto const source = std::span<uint8_t const>(bytes, static_cast<size_t>(readback.data.size()));
 
-    // Offscreen-texture readback is top-left origin => no flip, matching RhiRenderer::deliverScreenshot.
-    auto const flip = screenshotNeedsVerticalFlip(/*capturedFromTexture*/ true, rhi->isYUpInFramebuffer());
-    CHECK_FALSE(flip);
-
-    auto const image = normalizeScreenshotBuffer(source, W, H, flip);
+    // A flat clear color is orientation-blind by construction, so this case pins the channel order and the
+    // deferred-completion contract only; the row order is pinned by the case below.
+    auto const image = normalizeScreenshotBuffer(source, W, H, /*flip*/ rhi->isYUpInFramebuffer());
     REQUIRE(image.size() == screenshotBufferSize(W, H));
 
-    // Every pixel must be the clear color, in RGBA byte order.
-    bool allMatch = true;
-    for (size_t px = 0; px < static_cast<size_t>(W) * H; ++px)
-    {
-        auto const i = px * 4;
-        if (image[i + 0] != 0x11 || image[i + 1] != 0x22 || image[i + 2] != 0x33 || image[i + 3] != 0xFF)
-        {
-            allMatch = false;
-            break;
-        }
-    }
-    CHECK(allMatch);
+    CHECK(std::ranges::all_of(std::views::iota(0, W * H),
+                              [&](int i) { return pixelAt(image, W, i % W, i / W) == Clear; }));
+}
+
+TEST_CASE("RHI readback: a captured screenshot is delivered top-left origin, not upside down",
+          "[screenshot][rhi]")
+{
+    // Regression pin for #1986 (screenshots saved vertically flipped). This drives the REAL RhiRenderer —
+    // production shaders, the production offscreen transform, and the production flip decision — over a live
+    // OpenGL RHI, which is the Y-up-framebuffer backend Qt picks by default on Linux. A rectangle is filled
+    // across the TOP half of the item, so the delivered image is only correct if its first rows are the
+    // image's top rows. Before the fix, RhiRenderer::deliverScreenshot() never reversed the rows (it assumed
+    // texture readback is top-left on every backend, which OpenGL's plain glReadPixels is not), and this
+    // capture came back with the rectangle in the BOTTOM half.
+    auto env = makeOffscreenRhi();
+    if (!env.valid())
+        SKIP("no usable OpenGL context in this environment");
+
+    auto* rhi = env.rhi.get();
+    constexpr int W = 16;
+    constexpr int H = 8;
+    constexpr int TopHalf = H / 2;
+
+    // The frame's render target: the renderer's pipelines are baked against its render-pass descriptor.
+    auto const frameTarget = makeTextureTarget(rhi, QSize(W, H));
+    if (!frameTarget.valid())
+        SKIP("could not create a texture render target");
+
+    auto const captureSize = ImageSize { Width(W), Height(H) };
+    auto renderer = RhiRenderer(captureSize, ImageSize { Width(4), Height(4) });
+    renderer.initialize();
+    renderer.createPipelines(rhi, frameTarget.rpDesc.get());
+    if (!renderer.pipelinesReady())
+        SKIP("the RHI pipelines could not be built");
+
+    // An opaque red band across the top half of the item; the rest stays the pass's transparent clear.
+    auto constexpr Red = RGBAColor { 0xFF, 0x00, 0x00, 0xFF };
+    auto constexpr Transparent = RGBAColor { 0x00, 0x00, 0x00, 0x00 };
+
+    auto captured = std::vector<uint8_t> {};
+    auto capturedSize = ImageSize {};
+
+    QRhiCommandBuffer* cb = nullptr;
+    if (rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+        SKIP("beginOffscreenFrame failed");
+
+    // Drive one frame exactly as the render node's prepare() does: stage the geometry, arm the capture,
+    // flush the uploads, then replay the staged draws into the offscreen screenshot target.
+    renderer.beginFrame(rhi, cb, frameTarget.renderTarget.get());
+    renderer.renderRectangle(0, 0, Width(W), Height(TopHalf), Red); // item coords: y=0 is the TOP
+    renderer.execute(std::chrono::steady_clock::now());
+    renderer.scheduleScreenshot([&](std::vector<uint8_t> const& rgba, ImageSize pixelSize) {
+        captured = rgba;
+        capturedSize = pixelSize;
+    });
+    renderer.flushFrame();
+    REQUIRE(renderer.screenshotRequested());
+    renderer.recordScreenshotPass(rhi, cb);
+
+    rhi->endOffscreenFrame(); // submits the frame + completes the deferred readback
+
+    renderer.deliverScreenshot();
+
+    REQUIRE(capturedSize == captureSize);
+    REQUIRE(captured.size() == screenshotBufferSize(W, H));
+
+    // The delivered buffer is top-left origin: the red band occupies the FIRST rows, and the untouched
+    // (transparent) clear the last ones. An unflipped Y-up readback would have these exactly swapped.
+    auto const image = std::span<uint8_t const>(captured);
+    CHECK(pixelAt(image, W, 0, 0) == Red);                 // top-left: inside the band
+    CHECK(pixelAt(image, W, W - 1, TopHalf - 1) == Red);   // last row of the band
+    CHECK(pixelAt(image, W, 0, TopHalf) == Transparent);   // first row below it
+    CHECK(pixelAt(image, W, W - 1, H - 1) == Transparent); // bottom-right: outside the band
 }

--- a/src/vtrasterizer/RenderTarget.h
+++ b/src/vtrasterizer/RenderTarget.h
@@ -112,10 +112,16 @@ class RenderTarget
     /// Fills a rectangular area with the given solid color.
     virtual void renderRectangle(int x, int y, Width, Height, RGBAColor color) = 0;
 
+    /// Receives a captured screenshot as tightly-packed RGBA8 pixels of exactly width*height*4 bytes, in
+    /// TOP-LEFT origin row order (row 0 is the top of the image) — the render target normalizes whatever
+    /// orientation its graphics backend reads back in, so consumers never flip. Note this is the opposite
+    /// convention to setScissorRect() below, which is bottom-left by the graphics APIs' own contract.
     using ScreenshotCallback =
         std::function<void(std::vector<uint8_t> const& /*_rgbaBuffer*/, ImageSize /*_pixelSize*/)>;
 
     /// Schedules taking a screenshot of the current scene and forwards it to the given callback.
+    /// The capture may complete asynchronously (a deferred GPU readback), so the callback can run on a
+    /// later frame rather than before this returns.
     virtual void scheduleScreenshot(ScreenshotCallback callback) = 0;
 
     /// Enables scissor testing and restricts rendering to the given rectangle.


### PR DESCRIPTION
`SaveScreenshot` / `CopyScreenshot` wrote a vertically flipped PNG on OpenGL — Qt's default RHI backend on Linux. Fixes #1986.

The RHI port assumed Qt normalizes texture readback to a top-left origin on every backend and so hardcoded the vertical flip off. It does not: the OpenGL backend reads a texture back with a plain `glReadPixels` off an FBO, so a surface we rendered into arrives bottom-up. `QRhi::isYUpInFramebuffer()` — the flag that says exactly this — was called nowhere in production code. D3D11/Metal report a top-left origin, which is why the bug only ever showed on Linux.

## Changes

- `RhiRenderer::recordScreenshotPass()` records `isYUpInFramebuffer()` with the capture; `deliverScreenshot()` reverses the rows when it is set.
- Drop `screenshotNeedsVerticalFlip()`. Its texture-vs-backbuffer axis is not the real one: what decides row order is how the surface got its pixels. A surface we *render into* follows the backend's framebuffer origin, whereas an *uploaded* texture round-trips in the row order we wrote it — which is why the glyph-atlas readback rightly never flips.
- Document the delivered buffer's contract (tightly packed RGBA8, top-left origin) on `RenderTarget::ScreenshotCallback`, the interface where it crosses from `contour` into `vtrasterizer`.
- The existing RHI readback test cleared its texture to one flat color, so an upside-down result was invisible to it — which is how this shipped. It now drives the real `RhiRenderer` over a live OpenGL RHI and asserts that a band filled across the top half of the item lands in the *first* rows of the delivered buffer. The two unit tests that asserted the old (wrong) policy are removed.

No performance impact: the capture path is only entered when a screenshot is pending, and `normalizeScreenshotBuffer()` already copied row by row — flipping only changes the destination row index.