### PR TITLE
Fix scrollbar spanning the whole pane instead of hugging its edge

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -155,6 +155,7 @@ qmljsdebugger
 qobject
 QPalette
 qputenv
+QRegular
 qrhi
 qrhigles
 qsb
@@ -164,6 +165,7 @@ QSignal
 qsizetype
 QTemporary
 QTest
+QText
 qtwaylandscanner
 qulonglong
 qunsetenv

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -166,6 +166,7 @@
           <li>Adds the dim_unfocused profile option: dims a pane while it is not the focused one (an inactive pane of a split, or any pane of an unfocused window) by blending it toward its background color; 0.0 (default) disables dimming</li>
           <li>Fixes the input-method (IME) candidate window opening at the wrong position: the reported cursor rectangle now honors the configured window margin and the pane's position inside a split, and widens over double-width (CJK) characters</li>
           <li>Changes the window to use a custom client-side-decorated title bar (tab strip plus window controls) by default on all platforms; set show_title_bar: true to use the native server-side window decoration instead, in which case the tab strip is kept but its window controls defer to the OS frame</li>
+          <li>Fixes profile settings that only took effect after a restart: changing background_image, its blur or opacity, the background color, or the scrollbar position now applies as soon as the config is reloaded or the profile is switched</li>
         </ul>
       </description>
     </release>

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -35,6 +35,7 @@
 #include <QtNetwork/QHostInfo>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -2366,6 +2367,32 @@ void TerminalSession::spawnNewTerminal(string const& profileName)
     }
 }
 
+void TerminalSession::emitProfileDerivedPropertiesChanged()
+{
+    // One row per Q_PROPERTY that is read out of the profile — directly (opacity, dim_unfocused,
+    // scrollbar.*) or out of the color palette that configureTerminal() re-seeds from it (the background
+    // image/blur/color). Adding a profile-derived property means adding a row here, rather than
+    // remembering to hand-write another `emit` at every site that swaps the profile.
+    //
+    // These signals carry no C++ slots: they exist purely so the QML bindings in TerminalPane.qml and
+    // SessionChrome.qml re-read the now-current profile. Emitting one whose value did not actually change
+    // therefore costs a binding re-evaluation and nothing else.
+    static constexpr auto Notifiers = std::array {
+        &TerminalSession::opacityChanged,
+        &TerminalSession::dimUnfocusedChanged,
+        &TerminalSession::pathToBackgroundChanged,
+        &TerminalSession::opacityBackgroundChanged,
+        &TerminalSession::isImageBackgroundChanged,
+        &TerminalSession::isBlurBackgroundChanged,
+        &TerminalSession::backgroundColorChanged,
+        &TerminalSession::isScrollbarRightChanged,
+        &TerminalSession::isScrollbarVisibleChanged,
+    };
+
+    for (auto const notify: Notifiers)
+        (this->*notify)();
+}
+
 void TerminalSession::activateProfile(string const& newProfileName, ProfileWindowSizePolicy windowSizePolicy)
 {
     // findProfile() (not profile()): the name comes from runtime input (a keybinding or the
@@ -2383,9 +2410,8 @@ void TerminalSession::activateProfile(string const& newProfileName, ProfileWindo
     _profile = *newProfile;
     configureTerminal();
 
-    // The unfocused-dim amount lives in the profile; a reload/switch may change it, and
-    // TerminalPane.qml's overlay binds to the property.
-    emit dimUnfocusedChanged();
+    // _profile was just replaced, so every QML binding reading a profile-derived property is now stale.
+    emitProfileDerivedPropertiesChanged();
 
     // An EXPLICIT profile switch (keybinding / OSC request) may change the configured grid
     // (terminal_size); ask the window to fit it — a content-driven grid->window request through the

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -572,6 +572,13 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     int executeAllActions(std::vector<actions::Action> const& actions);
     void spawnNewTerminal(std::string const& profileName);
 
+    /// Re-announces every Q_PROPERTY whose value is derived from the profile, so the QML bindings that
+    /// read them re-evaluate against the profile that was just swapped in. Call after every assignment
+    /// to _profile; without it a property keeps reporting the OLD profile's value until the app is
+    /// restarted (the signal is declared, simply never emitted), which is what made a reload of
+    /// scrollbar.position — and still, background_image and friends — a no-op.
+    void emitProfileDerivedPropertiesChanged();
+
     /// Whether activating a profile should also resize the window to the profile's configured
     /// terminal_size. Data-driven so the resize is tied to the *intent* of the activation, not to
     /// the activation itself: an explicit profile switch (a keybinding / OSC request) should fit the

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -19,9 +19,13 @@
 
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDirIterator>
 #include <QtCore/QEvent>
+#include <QtCore/QFile>
 #include <QtCore/QObject>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QStringList>
+#include <QtCore/QTextStream>
 #include <QtGui/QColor>
 #include <QtGui/QGuiApplication>
 #include <QtQml/QQmlComponent>
@@ -202,15 +206,17 @@ class MockSession: public QObject
     Q_OBJECT
     Q_PROPERTY(int pageLineCount READ pageLineCount NOTIFY lineCountChanged)
     Q_PROPERTY(int pageColumnsCount READ pageColumnsCount NOTIFY columnsCountChanged)
-    Q_PROPERTY(int historyLineCount READ historyLineCount CONSTANT)
+    Q_PROPERTY(int historyLineCount READ historyLineCount NOTIFY historyLineCountChanged)
     Q_PROPERTY(bool showResizeIndicator READ showResizeIndicator CONSTANT)
     Q_PROPERTY(int upTime READ upTime CONSTANT)
     Q_PROPERTY(float opacity READ opacity NOTIFY opacityChanged)
     Q_PROPERTY(float dimUnfocused READ dimUnfocused NOTIFY dimUnfocusedChanged)
     Q_PROPERTY(QColor backgroundColor READ backgroundColor CONSTANT)
     Q_PROPERTY(QString bellSource READ bellSource CONSTANT)
-    Q_PROPERTY(bool isScrollbarRight READ isScrollbarRight CONSTANT)
-    Q_PROPERTY(bool isScrollbarVisible READ isScrollbarVisible CONSTANT)
+    // Mirrors TerminalSession's profile-derived scrollbar properties: both are NOTIFY-driven (a config
+    // reload flips them live), so the mock must be able to drive that transition too.
+    Q_PROPERTY(bool isScrollbarRight READ isScrollbarRight NOTIFY isScrollbarRightChanged)
+    Q_PROPERTY(bool isScrollbarVisible READ isScrollbarVisible NOTIFY isScrollbarVisibleChanged)
     Q_PROPERTY(bool isImageBackground READ isImageBackground CONSTANT)
     Q_PROPERTY(bool isBlurBackground READ isBlurBackground CONSTANT)
     Q_PROPERTY(float opacityBackground READ opacityBackground CONSTANT)
@@ -219,7 +225,7 @@ class MockSession: public QObject
   public:
     [[nodiscard]] int pageLineCount() const { return _lines; }
     [[nodiscard]] int pageColumnsCount() const { return _columns; }
-    [[nodiscard]] int historyLineCount() const { return 0; }
+    [[nodiscard]] int historyLineCount() const { return _historyLineCount; }
     [[nodiscard]] bool showResizeIndicator() const { return true; }
     [[nodiscard]] int upTime() const { return 5; } // > 1.0 so the resize popup path is exercised
     [[nodiscard]] float opacity() const { return _opacity; }
@@ -230,8 +236,8 @@ class MockSession: public QObject
     [[nodiscard]] QString pathToBackground() const { return QString(); }
     [[nodiscard]] QColor backgroundColor() const { return QColor(Qt::black); }
     [[nodiscard]] QString bellSource() const { return QString(); }
-    [[nodiscard]] bool isScrollbarRight() const { return true; }
-    [[nodiscard]] bool isScrollbarVisible() const { return false; }
+    [[nodiscard]] bool isScrollbarRight() const { return _scrollbarRight; }
+    [[nodiscard]] bool isScrollbarVisible() const { return _scrollbarVisible; }
 
     // Drivers: mutate state and fire the NOTIFY the QML binds to, reproducing a live resize / opacity change.
     void setPageSize(int columns, int lines)
@@ -240,6 +246,26 @@ class MockSession: public QObject
         _lines = lines;
         emit columnsCountChanged();
         emit lineCountChanged();
+    }
+    /// Give the session scrollback, so SessionChrome's `hasScrollback` (thumb size < 1.0) turns true and
+    /// the scrollbar is actually shown.
+    void setHistoryLineCount(int lines)
+    {
+        _historyLineCount = lines;
+        emit historyLineCountChanged();
+    }
+    /// Move the bar to the other edge, as a profile reload / switch does (TerminalSession::activateProfile
+    /// emits isScrollbarRightChanged for exactly this).
+    void setScrollbarRight(bool right)
+    {
+        _scrollbarRight = right;
+        emit isScrollbarRightChanged();
+    }
+    /// Show or hide the bar, as scrollbar.position: Hidden — or hide_in_alt_screen on the alt screen — does.
+    void setScrollbarVisible(bool visible)
+    {
+        _scrollbarVisible = visible;
+        emit isScrollbarVisibleChanged();
     }
     void setOpacity(float o)
     {
@@ -261,6 +287,9 @@ class MockSession: public QObject
   signals:
     void lineCountChanged();
     void columnsCountChanged();
+    void historyLineCountChanged();
+    void isScrollbarRightChanged();
+    void isScrollbarVisibleChanged();
     void opacityChanged();
     void dimUnfocusedChanged();
     void onBell();
@@ -275,6 +304,9 @@ class MockSession: public QObject
   private:
     int _columns = 80;
     int _lines = 25;
+    int _historyLineCount = 0;
+    bool _scrollbarRight = true;
+    bool _scrollbarVisible = false;
     float _opacity = 1.0F;
     float _dimUnfocused = 0.0F;
 };
@@ -729,9 +761,205 @@ TEST_CASE("SessionChrome scrollbar renders as a styled grabbable overlay (offscr
     // A comfortable, easy-to-grab hit target rather than the thin Fusion default.
     CHECK(bar->property("implicitWidth").toReal() >= 12.0);
 
+    // The bar is sized by its implicitWidth and nothing else. Asserting only implicitWidth (as this case
+    // originally did) is blind to the real defect: an anchor pair can stretch the actual width while
+    // implicitWidth stays a truthful 12. The rebind case below drives that transition.
+    CHECK(bar->width() == Catch::Approx(bar->property("implicitWidth").toReal()));
+
     // Explicit, style-independent handle + track items (the fix), not the inherited defaults.
     CHECK(bar->property("contentItem").value<QQuickItem*>() != nullptr);
     CHECK(bar->property("background").value<QQuickItem*>() != nullptr);
+}
+
+namespace
+{
+/// A SessionChrome hosted in a sized, visible offscreen Window, with its scrollbar already resolved.
+struct ChromeHost
+{
+    std::unique_ptr<QObject> window;
+    QQuickItem* chrome {};
+    QQuickItem* bar {};
+    qreal paneWidth {};
+    /// The bar's natural (unstretched) width — the value an anchor pair used to latch away.
+    qreal thin {};
+};
+
+/// Hosts a bare SessionChrome, bound to a NULL session, in a sized Window — so the scrollbar's real
+/// geometry (x/width against a known parent width) is observable, and so the null->session rebind that
+/// every split / tab switch / teardown performs can be driven from the test. Passing the session as an
+/// initial property instead would defeat the purpose: a session that is non-null on the first binding
+/// pass never armed the anchor latch these cases guard.
+[[nodiscard]] ChromeHost createChromeInWindow(QQmlEngine& engine)
+{
+    QQmlComponent component(&engine);
+    component.setData(QByteArrayLiteral("import QtQuick\n"
+                                        "import QtQuick.Window\n"
+                                        "import \"qrc:/contour/ui\"\n"
+                                        "Window {\n"
+                                        "  width: 400; height: 300; visible: true\n"
+                                        "  property alias chrome: chromeItem\n"
+                                        "  SessionChrome { id: chromeItem; session: null }\n"
+                                        "}\n"),
+                      QUrl(QStringLiteral("qrc:/contour/ui/ScrollBarWrapper.qml")));
+    while (component.status() == QQmlComponent::Loading)
+        QCoreApplication::processEvents();
+    INFO("wrapper errors: " << component.errorString().toStdString());
+    REQUIRE(component.isReady());
+
+    auto host = ChromeHost { .window = std::unique_ptr<QObject>(component.create()) };
+    REQUIRE(host.window != nullptr);
+    QCoreApplication::processEvents();
+
+    host.chrome = host.window->property("chrome").value<QQuickItem*>();
+    REQUIRE(host.chrome != nullptr);
+    host.bar = host.chrome->findChild<QQuickItem*>(QStringLiteral("verticalScrollBar"));
+    REQUIRE(host.bar != nullptr);
+    host.paneWidth = host.chrome->width(); // SessionChrome fills the window
+    host.thin = host.bar->property("implicitWidth").toReal();
+    return host;
+}
+
+/// A Right-placed session with scrollback, so the bar is genuinely shown rather than merely laid out.
+[[nodiscard]] std::unique_ptr<MockSession> createScrollableSession()
+{
+    auto session = std::make_unique<MockSession>();
+    session->setScrollbarVisible(true);
+    session->setHistoryLineCount(1000);
+    return session;
+}
+} // namespace
+
+TEST_CASE("SessionChrome scrollbar stays a thin edge overlay, whatever the session does (offscreen)",
+          "[contour][gui][qml][scrollbar]")
+{
+    // THE regression guard: the bar used to span the WHOLE pane width.
+    //
+    // Placement was expressed as TWO conditional anchor bindings over one condition (anchors.right =
+    // atRightEdge ? parent.right : undefined, plus the mirrored anchors.left). QML re-evaluates them one
+    // at a time, and the null-session fallback anchored LEFT — so a null->Right rebind set `right` while
+    // `left` was still bound. QQuickAnchors answers a left+right pair by stretching the item:
+    // setItemWidth(parent.width) -> QQuickItem::setWidth() -> widthValid latches. Resetting `left` an
+    // instant later does NOT restore the width, so implicitWidth never re-applied and the bar stayed
+    // parent-wide at x == 0 forever. Placement is a single `x` binding now, so no anchor can size the bar
+    // horizontally — and every section below asserts the width, which is what the styling case above
+    // (implicitWidth only) was blind to: implicitWidth stayed a truthful 12 throughout the bug.
+    QQmlEngine engine;
+    MockTabController controller;
+    engine.rootContext()->setContextProperty("terminalSessions", &controller);
+    contour::test::QmlMessageCapture warnings;
+
+    auto host = createChromeInWindow(engine);
+    auto session = createScrollableSession();
+
+    SECTION("a null->session rebind (every split / tab switch) leaves it thin and right-aligned")
+    {
+        host.chrome->setProperty("session", QVariant::fromValue(static_cast<QObject*>(session.get())));
+        QCoreApplication::processEvents();
+
+        // Pre-fix this read width == 400 (the whole pane) and x == 0.
+        CHECK(host.bar->width() == Catch::Approx(host.thin));
+        CHECK(host.bar->x() == Catch::Approx(host.paneWidth - host.thin));
+        CHECK(host.bar->height() == Catch::Approx(host.chrome->height())); // vertical anchors still span
+        CHECK(host.bar->isVisible());
+
+        // Rebinding back to null (pane teardown) must not stretch it either.
+        host.chrome->setProperty("session", QVariant::fromValue(static_cast<QObject*>(nullptr)));
+        QCoreApplication::processEvents();
+        CHECK(host.bar->width() == Catch::Approx(host.thin));
+    }
+
+    SECTION("the configured edge is honored, and a live profile flip only ever moves it")
+    {
+        // scrollbar.position is profile state, so a config reload can move the bar between edges at
+        // runtime (TerminalSession::activateProfile re-announces it; the signal used to be declared and
+        // never emitted, so the setting needed a restart). A flip is the second way into the old latch:
+        // whichever direction set an anchor before the opposite one was reset stretched the bar. So both
+        // directions are asserted, and each asserts the width, not just the position.
+        session->setScrollbarRight(false); // position: Left
+        host.chrome->setProperty("session", QVariant::fromValue(static_cast<QObject*>(session.get())));
+        QCoreApplication::processEvents();
+        CHECK(host.bar->x() == Catch::Approx(0.0));
+        CHECK(host.bar->width() == Catch::Approx(host.thin));
+
+        session->setScrollbarRight(true); // Left -> Right
+        QCoreApplication::processEvents();
+        CHECK(host.bar->x() == Catch::Approx(host.paneWidth - host.thin));
+        CHECK(host.bar->width() == Catch::Approx(host.thin));
+
+        session->setScrollbarRight(false); // Right -> Left
+        QCoreApplication::processEvents();
+        CHECK(host.bar->x() == Catch::Approx(0.0));
+        CHECK(host.bar->width() == Catch::Approx(host.thin));
+    }
+
+    SECTION("hiding it live (position: Hidden, or hide_in_alt_screen on the alt screen) is honored")
+    {
+        host.chrome->setProperty("session", QVariant::fromValue(static_cast<QObject*>(session.get())));
+        QCoreApplication::processEvents();
+        REQUIRE(host.bar->isVisible());
+
+        session->setScrollbarVisible(false);
+        QCoreApplication::processEvents();
+        CHECK_FALSE(host.bar->isVisible());
+    }
+
+    INFO("QML messages:\n" << warnings.messages().join(QStringLiteral("\n")).toStdString());
+    CHECK(warnings.count(contour::test::isQmlDiagnostic) == 0);
+}
+
+TEST_CASE("No QML detaches an anchor conditionally (the full-pane-scrollbar trap)", "[contour][gui][qml]")
+{
+    // A source tripwire for the bug class the scrollbar shipped, because no runtime assertion can catch its
+    // reintroduction in a component no test happens to instantiate.
+    //
+    // `anchors.<edge>: cond ? parent.<edge> : undefined` is only ever written as one half of a pair that
+    // switches an item between two opposite edges. The two bindings re-evaluate ONE AT A TIME, so a flip
+    // transiently leaves both edges anchored; QQuickAnchors then stretches the item across its parent and
+    // latches that as an explicit width/height (QQuickItem::setWidth marks widthValid), which the implicit
+    // size can never undo. The item stays parent-sized for good. Bind `x`/`y` instead — see the vbar in
+    // SessionChrome.qml and the TitleBar in main.qml.
+    //
+    // Comment lines are skipped: the two fix sites document the trap using the very syntax it flags.
+    //
+    // The leading word boundary is spelled (?<!\w) rather than the usual backslash-b escape: identical
+    // zero-width meaning, but check-spelling tokenizes this pattern as prose and would glue that escape
+    // onto the word behind it, then demand the resulting nonsense token be added to the dictionary.
+    static auto const conditionalDetach = QRegularExpression(QStringLiteral(
+        R"(anchors\.(left|right|top|bottom|horizontalCenter|verticalCenter)\s*:.*(?<!\w)undefined\b)"));
+    REQUIRE(conditionalDetach.isValid()); // an invalid pattern matches nothing and guards nothing
+
+    auto offenders = QStringList {};
+    auto scanned = 0;
+    auto it = QDirIterator(QStringLiteral(":/contour/ui"),
+                           QStringList { QStringLiteral("*.qml") },
+                           QDir::Files,
+                           QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        auto file = QFile(it.next());
+        REQUIRE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+        ++scanned;
+        auto lineNumber = 0;
+        auto stream = QTextStream(&file);
+        while (!stream.atEnd())
+        {
+            auto const line = stream.readLine();
+            ++lineNumber;
+            if (line.trimmed().startsWith(QStringLiteral("//")))
+                continue;
+            if (conditionalDetach.match(line).hasMatch())
+                offenders
+                    << QStringLiteral("%1:%2: %3").arg(file.fileName()).arg(lineNumber).arg(line.trimmed());
+        }
+    }
+
+    REQUIRE(scanned > 0); // a zero-file scan would pass vacuously
+
+    // ONE ScopedMessage covering the CHECK: an INFO raised inside a loop is destroyed on each iteration
+    // and never survives to the assertion, so a failure would name no file at all.
+    INFO("conditionally detached anchors (bind x/y instead):\n"
+         << offenders.join(QStringLiteral("\n")).toStdString());
+    CHECK(offenders.isEmpty());
 }
 
 TEST_CASE("Tab color flyout offers a dependency-free arbitrary-color entry (offscreen)",

--- a/src/contour/ui/SessionChrome.qml
+++ b/src/contour/ui/SessionChrome.qml
@@ -49,10 +49,22 @@ Item {
     ScrollBar {
         id: vbar
         objectName: "verticalScrollBar"
+
+        // Which edge the bar floats against. ONE binding drives `x` — deliberately NOT a pair of
+        // conditional left/right anchors, which is what used to make the bar span the WHOLE pane:
+        //
+        // QML re-evaluates two such bindings one at a time, and the null-session fallback anchored left,
+        // so every null->Right rebind (a split, a tab switch, a teardown) transiently left BOTH edges
+        // anchored. QQuickAnchors answers a left+right pair by *stretching* the item — setItemWidth(),
+        // which routes through QQuickItem::setWidth() and latches widthValid. Resetting the other anchor
+        // an instant later does not undo that: implicitWidth could never re-apply, and a right-only anchor
+        // merely repositions a bar that is still parent-wide. Binding `x` leaves the width purely implicit,
+        // so no anchor can ever size this item horizontally.
+        readonly property bool atRightEdge: chrome.session ? chrome.session.isScrollbarRight : true
+
         anchors.top: parent.top
         anchors.bottom: parent.bottom
-        anchors.right: (chrome.session && chrome.session.isScrollbarRight) ? parent.right : undefined
-        anchors.left: (chrome.session && chrome.session.isScrollbarRight) ? undefined : parent.left
+        x: vbar.atRightEdge ? parent.width - vbar.width : 0
         visible: (chrome.session ? chrome.session.isScrollbarVisible : false) && vbar.hasScrollback
         orientation: Qt.Vertical
         policy: visible ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -99,12 +99,14 @@ ApplicationWindow
     TitleBar {
         id: titleBar
         objectName: "titleBar" // so offscreen layout tests can findChild() this item
-        // Pinned to the top OR the bottom edge depending on tabBarPosition (never both — assigning
-        // `undefined` detaches an anchor). left/right always span the window.
-        anchors.top: appWindow.tabBarPosition === 0 ? parent.top : undefined
-        anchors.bottom: appWindow.tabBarPosition === 1 ? parent.bottom : undefined
+        // Pinned to the top OR the bottom edge via a single `y` binding — never a pair of conditional
+        // top/bottom anchors, which a Bottom->Top flip would leave BOTH set for an instant, stretching the
+        // bar to the window's height and overriding the `height` binding below for good. See the scrollbar
+        // in SessionChrome.qml for the full mechanism; it shipped that bug as a full-pane-wide bar.
+        // left/right stay anchored: that pair is unconditional, so sizing the width is intended.
         anchors.left: parent.left
         anchors.right: parent.right
+        y: appWindow.tabBarPosition === 0 ? 0 : parent.height - titleBar.height
         // Shown per the profile's tab_bar_visibility, resolved against the live tab count by the
         // controller (Always / Never / Multiple). When hidden, height/effectiveHeight collapse to 0 so
         // the content area (and the declared chrome height feeding the geometry authority) reclaim it.


### PR DESCRIPTION
The vertical scrollbar intermittently rendered as a bar across the entire pane instead of a thin strip on the configured edge. It looked random, but it was a permanent Qt anchor latch — once a pane hit it, that pane's bar stayed parent-wide for good.

`SessionChrome.qml` expressed "anchored left OR right, never both" as two independent bindings over one condition. QML re-evaluates such bindings **one at a time, in declaration order**, and the null-session fallback anchored *left* — so a null→Right rebind applied `anchors.right` while `anchors.left` was still bound. For that instant both edges were anchored, and `QQuickAnchors` answers a left+right pair by *stretching* the item: `setItemWidth(parent.width)` → `QQuickItem::setWidth()`, which latches `widthValid`. Resetting the left anchor a moment later does not restore the width, `implicitWidth` can never re-apply, and a right-only anchor repositions without resizing.

That explains the "sometimes": anchors are batched until `componentComplete`, so only a *post-construction* session flip arms it — `PaneNode.qml` binds `session: root.node ? root.node.session : null`, so splits, tab switches and teardowns arm it, while a pane whose session is non-null on the first binding pass escapes. It only ever bit `position: Right`. Commit 93528f38 (the custom `contentItem`) is what made the stale stretch *visible*; Fusion's own handle delegate had ignored the control's width.

## Changes

- Place the scrollbar with a single `x` binding instead of a conditional anchor pair, leaving the width purely implicit so no anchor can size it horizontally.
- Harden `main.qml`'s `TitleBar`, which carried the identical latent latch on the vertical axis (conditional top/bottom anchors on `tabBarPosition`): a Bottom→Top flip would have stretched it to the window height and permanently overridden its `height` binding.
- Re-announce profile-derived properties on a profile change. `TerminalSession` declares a NOTIFY signal for every `Q_PROPERTY` QML reads out of the profile, but `activateProfile()` emitted almost none of them — so `scrollbar.position`, `background_image`, its blur and opacity, and the background color all silently required a restart. Replaced the hand-maintained emit list with one data-driven table of the profile-derived notifiers. This half fixes a bug present in shipped releases, hence the release note.

Reviewer's note: the profile-notify commit must follow the anchor fix — against the previous conditional anchor pair, a live edge flip would have triggered the very width latch being removed.

Regression coverage asserts the real `width` (the previous case checked only `implicitWidth`, which stayed a truthful 12 throughout the bug) and drives the null→session rebind that arms the latch. A source tripwire scans the qrc'd QML for the conditional-detach idiom so the class cannot re-enter the tree.