### PR TITLE
Reach SaveLayout from the command palette via a name prompt

### DIFF
--- a/docs/configuration/layouts.md
+++ b/docs/configuration/layouts.md
@@ -106,7 +106,7 @@ launched the window itself.
 
 ## Opening a layout
 
-There are three ways to open a layout:
+There are four ways to open a layout:
 
 ### At startup
 
@@ -137,6 +137,12 @@ input_mapping:
 Unlike the startup and CLI cases, `LaunchLayout` **appends** the layout's tabs to the
 current window rather than opening a new one.
 
+### From the command palette
+
+Open the command palette (`Ctrl+Shift+P` by default) and pick the **Launch Layout: _name_**
+entry — one is listed for every saved layout, so no keybinding is required. Picking one
+appends that layout's tabs to the current window, exactly like the `LaunchLayout` action.
+
 ## Saving the current window as a layout
 
 The `SaveLayout` action captures the active window's current tabs and panes — their
@@ -153,3 +159,8 @@ machine-managed `layouts.yml` file next to your main configuration file, in the 
 directory. Layouts from `layouts.yml` are merged with any `layouts` defined inline in
 your main configuration; if a name exists in both, the `layouts.yml` version wins, since
 it reflects the most recently saved state.
+
+You don't need a keybinding to save: open the command palette (`Ctrl+Shift+P`) and pick
+**Save Layout**. Because saving needs a name, that entry opens a small prompt for you to
+type one in, then saves exactly as the `SaveLayout` action does. A key bound to
+`SaveLayout` with no `name` opens the same prompt.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,7 @@
     <release version="0.7.0" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Adds a Save Layout entry to the command palette that prompts for a name, so a window's tabs can be saved as a layout — and thereby launched — without a keybinding; a key bound to SaveLayout with no name opens the same prompt</li>
           <li>Adds a right-click context menu to the terminal: copy, paste, select all, the hyperlink under the cursor, opening the current folder, splitting and closing panes, switching profile, and a soft or hard terminal reset. It opens exactly when a selection drag would have worked, so an application that asked for the mouse (vim, tmux) still receives its right-click; hold Shift to open the menu anyway. Bind OpenContextMenu in input_mapping to move it to another button</li>
           <li>Adds the actions SelectAll, SoftReset (DECSTR), CopyHyperlink, and CopyLastCommandPrompt, CopyLastCommandOutput and CopyLastCommandBlock for copying the most recently finished command straight from the scrollback</li>
           <li>The bundled shell integration now emits OSC 133 prompt marks (A, C and D), so Contour can tell a prompt apart from a command's output. This is what makes "copy last command output" work; previously those marks were only recorded while the opt-in semantic-block protocol (DEC mode 2034) was enabled, which no shell turns on</li>

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -314,7 +314,11 @@ concept NonRepeatableActionConcept = crispy::one_of<T,
 ///
 /// Deliberately excluded: CopySelection, PasteClipboard, PasteSelection, NewTerminal and ReloadConfig
 /// all default to a meaningful argument (copy as text, paste unstripped, current profile), so they
-/// run as-is.
+/// run as-is. SetTabColor and SaveLayout are excluded for the same reason from the other direction:
+/// a bare SetTabColor opens the color picker and a bare SaveLayout opens the save-as name prompt, so
+/// the bare form is a meaningful gesture the palette SHOULD offer from the catalog. LaunchLayout
+/// stays in the list — a nameless "launch which layout?" has no default; its per-name rows already
+/// reach the palette through the saved-layout source.
 template <typename T>
 concept ParameterizedActionConcept = crispy::one_of<T,
                                                     ChangeProfile,
@@ -325,8 +329,7 @@ concept ParameterizedActionConcept = crispy::one_of<T,
                                                     MoveTabTo,
                                                     SwitchToTab,
                                                     ResizePane,
-                                                    LaunchLayout,
-                                                    SaveLayout>;
+                                                    LaunchLayout>;
 
 /// @returns true if @p action requires an argument that a bare catalog entry cannot supply (a
 /// ParameterizedActionConcept member), false if it is runnable as-is.
@@ -523,7 +526,8 @@ namespace documentation
         "Opens a named layout, appending its tabs to the current window."
     };
     constexpr inline std::string_view SaveLayout {
-        "Saves the current window's tabs as a named layout in layouts.yml."
+        "Saves the current window's tabs as a named layout in layouts.yml. Without a name it opens a "
+        "prompt to type one in (which is how the command palette offers it)."
     };
     constexpr inline std::string_view OpenContextMenu {
         "Opens the terminal pane's context menu. Bound to the right mouse button by default, and only "
@@ -802,7 +806,11 @@ struct std::formatter<contour::actions::Direction>: std::formatter<std::string_v
             [](WriteScreen const& a) { return std::format(", chars: '{}'", a.chars); },
             [](CreateSelection const& a) { return std::format(", delimiters: '{}'", a.delimiters); },
             [](LaunchLayout const& a) { return std::format(", name: '{}'", a.name); },
-            [](SaveLayout const& a) { return std::format(", name: '{}'", a.name); },
+            [](SaveLayout const& a) {
+                // A nameless SaveLayout opens the save-as prompt, so — like a colorless SetTabColor below
+                // — it has no argument to write; a named one round-trips its name.
+                return a.name.empty() ? std::string {} : std::format(", name: '{}'", a.name);
+            },
             [](SetTabColor const& a) {
                 // A colorless SetTabColor opens the picker, so it has no argument to write. The color
                 // needs no hand-quoting: std::formatter<RGBColor> already renders it as '#RRGGBB', and

--- a/src/contour/Command.cpp
+++ b/src/contour/Command.cpp
@@ -106,6 +106,12 @@ CommandArguments commandArguments(actions::Action const& action)
                 return { .id = std::move(hex), .title = std::move(title) };
             },
             [](SaveLayout const& a) -> CommandArguments {
+                // A nameless SaveLayout opens the save-as prompt (the same shape as a colorless
+                // SetTabColor above), so it carries no arguments: the row keeps the plain "SaveLayout"
+                // id and the palette can offer it straight from the catalog. A bound instance that
+                // already names a layout is a different command, and says so.
+                if (a.name.empty())
+                    return {};
                 return { .id = a.name, .title = std::format(": {}", a.name) };
             },
             // The defaulted-argument actions. Their argument only enters the identity when it is NOT the

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -2569,9 +2569,12 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
 
         if (holds_alternative<actions::SaveLayout>(action))
         {
+            // The name is OPTIONAL, unlike LaunchLayout above: with one, SaveLayout saves straight to it;
+            // without, it opens the save-as prompt (the mirror of a colorless SetTabColor). So a nameless
+            // binding is kept, not dropped.
             if (auto name = node["name"]; name && name.IsScalar())
                 return actions::SaveLayout { name.as<std::string>() };
-            return std::nullopt;
+            return actions::SaveLayout {};
         }
 
         if (holds_alternative<actions::CreateSelection>(action))

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2404,7 +2404,12 @@ bool TerminalSession::operator()(actions::LaunchLayout const& event)
 
 bool TerminalSession::operator()(actions::SaveLayout const& event)
 {
-    _manager->saveLayout(event.name, this);
+    // Naming no layout means "ask me for one": open the save-as prompt (the mirror of a colorless
+    // SetTabColor opening the color picker). Naming one means the user already decided, so save directly.
+    if (event.name.empty())
+        _manager->beginSaveLayoutPrompt(/*acting*/ this);
+    else
+        _manager->saveLayout(event.name, this);
     return true;
 }
 

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -611,6 +611,12 @@ void TerminalSessionManager::beginTabColorPick(TerminalSession* acting)
         controller->beginActiveTabColorPick();
 }
 
+void TerminalSessionManager::beginSaveLayoutPrompt(TerminalSession* acting)
+{
+    if (auto* controller = controllerHostingSession(acting); controller != nullptr)
+        controller->beginSaveLayoutPrompt();
+}
+
 void TerminalSessionManager::setActiveTabColor(vtbackend::RGBColor color, TerminalSession* acting)
 {
     if (auto* controller = controllerHostingSession(acting); controller != nullptr)

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -116,6 +116,12 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     /// @param acting The session that triggered the action; its hosting window is serialized.
     void saveLayout(std::string const& name, TerminalSession* acting);
 
+    /// Opens the save-as name prompt over the window hosting @p acting (a nameless `SaveLayout` action),
+    /// routed exactly like beginTabColorPick(). The window then calls back into saveLayout() with the
+    /// name the user typed. No-ops if @p acting has no hosting window.
+    /// @param acting The session that triggered the action; its hosting window shows the prompt.
+    void beginSaveLayoutPrompt(TerminalSession* acting);
+
     /// Serializes @p window's live tab/pane tree into a config::Layout, persists it through the
     /// injected LayoutStore, and — only once the store has accepted it, so runtime state can never
     /// claim more than what is actually saved — stores it under @p name in the app's in-memory config.

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -314,6 +314,26 @@ void WindowController::beginActiveTabColorPick()
     emit tabColorPickRequested(index);
 }
 
+void WindowController::beginSaveLayoutPrompt()
+{
+    // Window-scoped, not tab-scoped: the layout is the whole window's tab set, so unlike the tab-title /
+    // tab-color prompts there is no row to name — the dialog just opens over this window.
+    emit saveLayoutRequested();
+}
+
+void WindowController::saveLayoutAs(QString const& name)
+{
+    // A blank prompt must never write a nameless layout (see the header). Trim first, so trailing
+    // whitespace neither passes the guard nor lands in the saved key.
+    auto const trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return;
+    // Route through the same manager entry point the SaveLayout keybinding uses, targeting THIS window's
+    // active session — saveLayout() resolves the hosting window from it and serializes that window.
+    if (auto* session = activeSession(); session != nullptr)
+        _manager.saveLayout(trimmed.toStdString(), session);
+}
+
 // Both of these route through the row-based setters the color flyout already uses, so the keyboard and
 // the mouse write the identical TabColorSource::User slot. With no active tab the row is -1, which
 // tabAtRow() bounds-checks into a null tab — the no-op the header promises, without a second guard.

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -141,6 +141,15 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     /// SetTabColor action when it names no color). No-op when this window has no active tab. Emits
     /// tabColorPickRequested() with the active tab's row so exactly that TabItem opens its flyout.
     Q_INVOKABLE void beginActiveTabColorPick();
+    /// Asks the QML to open this window's "save layout as" name prompt (the keyboard/palette entry point
+    /// for a nameless SaveLayout action). Emits saveLayoutRequested(); the dialog calls saveLayoutAs()
+    /// back with the name the user types.
+    Q_INVOKABLE void beginSaveLayoutPrompt();
+    /// Saves this window's tabs as the layout named @p name (the "save layout as" prompt's accept), via
+    /// the manager's saveLayout(). A blank name or a window with no active session is a no-op, so an
+    /// empty prompt never writes a nameless layout.
+    /// @param name The layout name the user typed.
+    Q_INVOKABLE void saveLayoutAs(QString const& name);
     /// Colors the ACTIVE tab (the keyboard entry point for `SetTabColor` carrying a color). Recorded
     /// as the user's own choice, so it outranks any color the application assigned via DECAC.
     /// @param color The color to apply.
@@ -445,6 +454,9 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     /// Requests that this window show its command palette. Per-window (like tabTitleEditRequested), so
     /// the popup opens over the window the user pressed the chord in — not over every open window.
     void commandPaletteRequested();
+    /// Requests that this window open its "save layout as" name prompt. Per-window, exactly like
+    /// commandPaletteRequested: the prompt opens over the window the SaveLayout action fired in.
+    void saveLayoutRequested();
     /// The context menu's rows changed. Emitted before contextMenuRequested(), so the QML has already
     /// rebuilt the menu by the time it is asked to pop it.
     void contextMenuModelChanged();

--- a/src/contour/resources.qrc
+++ b/src/contour/resources.qrc
@@ -22,6 +22,7 @@
         <file>ui/TerminalPane.qml</file>
         <file>ui/TerminalContextMenu.qml</file>
         <file>ui/CommandPalette.qml</file>
+        <file>ui/SaveLayoutDialog.qml</file>
         <file>ui/main.qml</file>
     </qresource>
 </RCC>

--- a/src/contour/test/Actions_test.cpp
+++ b/src/contour/test/Actions_test.cpp
@@ -195,6 +195,13 @@ TEST_CASE("actions::isParameterized marks the actions the palette cannot run bar
     CHECK_FALSE(isParameterized(Action { SetTabColor {} }));
     CHECK_FALSE(isParameterized(Action { SetTabColor { vtbackend::RGBColor { 0xFF, 0x00, 0x00 } } }));
     CHECK_FALSE(isParameterized(Action { ResetTabColor {} }));
+
+    // SaveLayout is the layout-side mirror of SetTabColor: a nameless instance opens the save-as name
+    // prompt rather than doing nothing, so it too stays out of this set and the palette offers it
+    // straight from the catalog. (LaunchLayout above stays IN — a nameless "launch which layout?" has no
+    // default, and its per-name rows already reach the palette from the saved-layout source.)
+    CHECK_FALSE(isParameterized(Action { SaveLayout {} }));
+    CHECK_FALSE(isParameterized(Action { SaveLayout { "dev" } }));
 }
 
 TEST_CASE("actions: every catalog row sits at its own variant index", "[actions][catalog]")

--- a/src/contour/test/CommandCatalog_test.cpp
+++ b/src/contour/test/CommandCatalog_test.cpp
@@ -93,6 +93,13 @@ TEST_CASE("A command's id encodes everything that distinguishes it", "[contour][
               == "Set Tab Color: #FF0000");
         CHECK(commandId(actions::SetTabColor { vtbackend::RGBColor { 0x00, 0x80, 0xFF } })
               == "SetTabColor:#0080FF");
+
+        // SaveLayout mirrors SetTabColor from the layout side: a nameless instance opens the save-as
+        // prompt and keeps the bare id, while a named one is a genuinely different command.
+        CHECK(commandId(actions::SaveLayout {}) == "SaveLayout");
+        CHECK(commandTitle(actions::SaveLayout {}) == "Save Layout");
+        CHECK(commandId(actions::SaveLayout { .name = "dev" }) == "SaveLayout:dev");
+        CHECK(commandTitle(actions::SaveLayout { .name = "dev" }) == "Save Layout: dev");
     }
 }
 
@@ -114,6 +121,12 @@ TEST_CASE("ActionCommandSource offers every action that can run without an argum
         // without the user having bound anything.
         CHECK(hasCommand(commands, "SetTabColor"));
         CHECK(hasCommand(commands, "ResetTabColor"));
+
+        // Saving a layout had no palette entry at all before this — SaveLayout needed a name and so was
+        // skipped like any parameterized action. Bare, it now opens the save-as name prompt, so the
+        // palette offers it from the catalog. That is what lets a user create the FIRST layout (and hence
+        // any LaunchLayout rows) from the palette rather than only from a hand-written key binding.
+        CHECK(hasCommand(commands, "SaveLayout"));
     }
 
     SECTION("an action needing an argument is NOT offered bare")
@@ -194,6 +207,30 @@ TEST_CASE("A bound SetTabColor reaches the palette as its own concrete row", "[c
 
     // And it did NOT collapse onto the colorless row: they are two commands, not one.
     CHECK_FALSE(hasCommand(commands, "SetTabColor"));
+}
+
+TEST_CASE("A bound SaveLayout with a name reaches the palette as its own concrete row", "[contour][palette]")
+{
+    // The layout-side mirror of the SetTabColor case above. The catalog offers the nameless SaveLayout
+    // (it opens the save-as prompt); a user who bound SaveLayout to a SPECIFIC name gets a SECOND,
+    // distinct row that saves straight to that name without the prompt.
+    auto mappings = config::InputMappings {};
+    mappings.keyMappings.push_back(
+        config::KeyInputMapping { .modes { vtbackend::MatchModes {} },
+                                  .modifiers { vtbackend::Modifiers { vtbackend::Modifier::Control } },
+                                  .input = vtbackend::Key::F6,
+                                  .binding = { { actions::SaveLayout { .name = "dev" } } } });
+
+    auto const commands = BoundCommandSource { mappings }.commands();
+
+    REQUIRE(hasCommand(commands, "SaveLayout:dev"));
+    auto const* dev = find(commands, "SaveLayout:dev");
+    REQUIRE(dev != nullptr);
+    CHECK(dev->title == "Save Layout: dev");
+    CHECK_FALSE(dev->description.empty());
+
+    // And it did NOT collapse onto the nameless row: they are two commands, not one.
+    CHECK_FALSE(hasCommand(commands, "SaveLayout"));
 }
 
 TEST_CASE("The live-state sources offer what actually exists right now", "[contour][palette]")

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -1015,6 +1015,41 @@ input_mapping:
     CHECK(std::get<SetTabColor>(action).color == red); // what went out came back
 }
 
+TEST_CASE("Config: a nameless SaveLayout binding is kept and round-trips as 'SaveLayout'", "[config]")
+{
+    // The layout-side mirror of the SetTabColor round-trip. A nameless SaveLayout opens the save-as prompt,
+    // so — like a colorless SetTabColor — it writes no argument, must survive the config it writes, and
+    // (unlike a nameless LaunchLayout) must NOT be dropped on parse. A named one still carries its name.
+    using namespace contour::actions;
+
+    CHECK(std::format("{}", Action { SaveLayout {} }) == "SaveLayout"); // the prompt writes no name
+    CHECK(std::format("{}", Action { SaveLayout { .name = "dev" } }) == "SaveLayout, name: 'dev'");
+
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+input_mapping:
+    - { mods: [Control, Shift], key: F2, action: SaveLayout }
+    - { mods: [Control, Shift], key: F3, action: SaveLayout, name: dev }
+)"sv);
+
+    auto const& mappings = config.inputMappings.value().keyMappings;
+    // Both bindings survived: the nameless one is no longer dropped for want of a name.
+    auto const nameless = std::ranges::any_of(mappings, [](auto const& m) {
+        auto const* s = std::get_if<SaveLayout>(&m.binding.at(0));
+        return s != nullptr && s->name.empty();
+    });
+    auto const named = std::ranges::any_of(mappings, [](auto const& m) {
+        auto const* s = std::get_if<SaveLayout>(&m.binding.at(0));
+        return s != nullptr && s->name == "dev";
+    });
+    CHECK(nameless);
+    CHECK(named);
+}
+
 TEST_CASE("Config: font features, text shaping engine, frozen DEC modes and hint patterns load", "[config]")
 {
     QTemporaryDir dir;

--- a/src/contour/test/KeyboardRouting_test.cpp
+++ b/src/contour/test/KeyboardRouting_test.cpp
@@ -296,6 +296,8 @@ class RoutingMockController: public QAbstractListModel
     Q_INVOKABLE void resetTabTitle(int) {}
     Q_INVOKABLE void beginActiveTabTitleEdit() { emit tabTitleEditRequested(_activeTabIndex); }
     Q_INVOKABLE void beginActiveTabColorPick() { emit tabColorPickRequested(_activeTabIndex); }
+    Q_INVOKABLE void beginSaveLayoutPrompt() { emit saveLayoutRequested(); }
+    Q_INVOKABLE void saveLayoutAs(QString const&) {}
     Q_INVOKABLE void setTabColor(int, QColor const&) {}
     Q_INVOKABLE void resetTabColor(int) {}
     Q_INVOKABLE void closeTabAtIndex(int) {}
@@ -343,6 +345,9 @@ class RoutingMockController: public QAbstractListModel
     void tabTitleEditRequested(int index);
     // Matches TabItem's Connections handler; a missing signal here is a QML warning, not a silent no-op.
     void tabColorPickRequested(int index);
+    // Matches main.qml's Connections handler for the save-layout prompt; a missing signal here is a QML
+    // warning the run-wide gate turns into a suite failure.
+    void saveLayoutRequested();
 
   private:
     int _chromeHeight = 0;

--- a/src/contour/test/MainWindowQml_test.cpp
+++ b/src/contour/test/MainWindowQml_test.cpp
@@ -195,6 +195,8 @@ class MockMainController: public QAbstractListModel
     Q_INVOKABLE void resetTabTitle(int) {}
     Q_INVOKABLE void beginActiveTabTitleEdit() { emit tabTitleEditRequested(0); }
     Q_INVOKABLE void beginActiveTabColorPick() { emit tabColorPickRequested(0); }
+    Q_INVOKABLE void beginSaveLayoutPrompt() { emit saveLayoutRequested(); }
+    Q_INVOKABLE void saveLayoutAs(QString const&) {}
     Q_INVOKABLE void setTabColor(int, QColor const&) {}
     Q_INVOKABLE void resetTabColor(int) {}
     Q_INVOKABLE void closeTabAtIndex(int) {}
@@ -244,6 +246,9 @@ class MockMainController: public QAbstractListModel
     void tabTitleEditRequested(int index);
     // Matches TabItem's Connections handler; a missing signal here is a QML warning, not a silent no-op.
     void tabColorPickRequested(int index);
+    // Matches main.qml's Connections handler for the save-layout prompt; a missing signal here is a QML
+    // warning, and the run-wide gate turns that into a failure of the whole suite.
+    void saveLayoutRequested();
 
   private:
     int _chromeHeight = 0;

--- a/src/contour/test/MultiWindow_test.cpp
+++ b/src/contour/test/MultiWindow_test.cpp
@@ -573,6 +573,82 @@ TEST_CASE("beginActiveTabColorPick requests the active tab's picker, per window"
     }
 }
 
+TEST_CASE("the SaveLayout action saves the acting window, and nameless opens the prompt",
+          "[contour][multiwindow][layout]")
+{
+    // The layout-side mirror of the SetTabColor chain: a named SaveLayout runs the whole keybinding path
+    // headless (action -> TerminalSession::operator() -> the manager -> the injected LayoutStore), while a
+    // nameless one opens the save-as prompt instead of saving anything — exactly as a colorless SetTabColor
+    // opens the picker rather than coloring.
+    auto factoryOwned = std::make_unique<contour::test::MockPtySessionFactory>();
+    auto storeOwned = std::make_unique<contour::test::InMemoryLayoutStore>();
+    auto* store = storeOwned.get();
+    contour::test::TestApp app { std::move(factoryOwned), std::move(storeOwned) };
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    window->createNewTab();
+    REQUIRE(window->count() == 1);
+
+    auto* tab = manager.model().window(window.id)->tabAt(0);
+    REQUIRE(tab != nullptr);
+    auto* session = manager.sessionForId(tab->activePane()->session());
+    REQUIRE(session != nullptr);
+
+    SECTION("a named SaveLayout persists the window's tabs through the store")
+    {
+        CHECK((*session)(contour::actions::SaveLayout { .name = "dev" }));
+
+        REQUIRE(store->savedPaths.size() == 1);
+        CHECK(store->layouts.contains("dev"));
+        // The live config sees it too, so a LaunchLayout later in this run finds it.
+        CHECK(app.app().config().layouts.value().contains("dev"));
+    }
+
+    SECTION("a nameless SaveLayout opens the save-as prompt instead of saving anything")
+    {
+        auto spy = QSignalSpy(window.controller, &contour::WindowController::saveLayoutRequested);
+
+        CHECK((*session)(contour::actions::SaveLayout {}));
+
+        CHECK(spy.count() == 1);          // it asked for a name
+        CHECK(store->savedPaths.empty()); // and wrote nothing until it has one
+    }
+
+    SECTION("saveLayoutAs persists under the typed name, and a blank name is a no-op")
+    {
+        window->saveLayoutAs(QStringLiteral("  from-dialog  ")); // the prompt's accept, whitespace and all
+        REQUIRE(store->savedPaths.size() == 1);
+        CHECK(store->layouts.contains("from-dialog")); // trimmed before it lands as the key
+
+        window->saveLayoutAs(QStringLiteral("   ")); // a blank field must never write a nameless layout
+        CHECK(store->savedPaths.size() == 1);        // still just the one save
+    }
+
+    for (int row = window->count() - 1; row >= 0; --row)
+        window->closeTabAtIndex(row);
+}
+
+TEST_CASE("beginSaveLayoutPrompt requests the save-as prompt, per window", "[contour][multiwindow]")
+{
+    // The same per-window routing the color picker gets: the request must reach only the window whose
+    // controller was asked, or a chord pressed in window B pops a prompt over window A.
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController windowA { manager };
+    ScopedController windowB { manager };
+    createTabs(manager, *windowA, 2);
+    createTabs(manager, *windowB, 1);
+
+    auto spyB = QSignalSpy(windowB.controller, &contour::WindowController::saveLayoutRequested);
+    auto spyA = QSignalSpy(windowA.controller, &contour::WindowController::saveLayoutRequested);
+
+    windowB->beginSaveLayoutPrompt();
+
+    CHECK(spyB.count() == 1);
+    CHECK(spyA.count() == 0);
+}
+
 TEST_CASE("a user's tab color outranks DECAC and survives a terminal reset", "[contour][multiwindow][model]")
 {
     // The user's choice always wins, and no escape sequence can take it away: a DECAC reset — which is

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -511,6 +511,7 @@ TEST_CASE("GUI QML tab components load without errors (offscreen)", "[contour][g
         QStringLiteral("qrc:/contour/ui/TitleBar.qml"),
         QStringLiteral("qrc:/contour/ui/SessionChrome.qml"),
         QStringLiteral("qrc:/contour/ui/CommandPalette.qml"),
+        QStringLiteral("qrc:/contour/ui/SaveLayoutDialog.qml"),
         QStringLiteral("qrc:/contour/ui/TerminalContextMenu.qml"),
     };
 
@@ -2807,6 +2808,229 @@ TEST_CASE("The palette survives controller destruction without QML errors (offsc
     host.palette->setProperty("controller", QVariant::fromValue<QObject*>(nullptr));
     QCoreApplication::processEvents();
     engine.rootContext()->setContextProperty("paletteController", nullptr);
+    controller.reset();
+    QCoreApplication::processEvents();
+
+    CHECK(capture.count([](QString const& m) { return m.contains(QStringLiteral("TypeError")); }) == 0);
+
+    host.window.reset();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents();
+}
+
+// ============================================================================================
+// SaveLayoutDialog: the "save layout as" name prompt a nameless SaveLayout action opens. The exact
+// mirror of the TabColorFlyout tests above — a bare action opens a surface that supplies the
+// argument — and of the command-palette focus tests: the prompt hands the keyboard back on close.
+// ============================================================================================
+
+namespace
+{
+
+/// A stand-in for WindowController exposing exactly the save-layout surface SaveLayoutDialog.qml binds:
+/// the saveLayoutRequested signal main.qml opens the dialog on, and the saveLayoutAs() the dialog calls
+/// back with the typed name.
+class MockSaveLayoutController: public QObject
+{
+    Q_OBJECT
+
+  public:
+    /// Mirrors WindowController::beginSaveLayoutPrompt(): what the manager calls for a nameless
+    /// SaveLayout action, and what makes main.qml's prompt appear.
+    Q_INVOKABLE void beginSaveLayoutPrompt() { emit saveLayoutRequested(); }
+
+    /// Records the name the dialog accepted, so a test can assert the accept routed through with it.
+    Q_INVOKABLE void saveLayoutAs(QString const& name) { saved << name; }
+    QStringList saved;
+
+  signals:
+    /// What WindowController raises to ask its window to open the prompt; main.qml answers with open().
+    void saveLayoutRequested();
+};
+
+/// Hosts SaveLayoutDialog.qml in a Window mirroring main.qml's ApplicationWindow — it declares
+/// restoreTerminalFocus() (which the dialog calls on close) and wires saveLayoutRequested -> open(),
+/// exactly as main.qml does, so the open path and the focus-restore contract are both exercised.
+struct SaveLayoutHost
+{
+    std::unique_ptr<QObject> window; //!< The wrapper Window.
+    QObject* dialog = nullptr;       //!< The SaveLayoutDialog inside it (owned by the window).
+
+    [[nodiscard]] int focusRestores() const { return window->property("focusRestores").toInt(); }
+    [[nodiscard]] bool opened() const { return dialog != nullptr && dialog->property("opened").toBool(); }
+    [[nodiscard]] QQuickItem* nameField() const
+    {
+        return dialog != nullptr ? dialog->findChild<QQuickItem*>(QStringLiteral("saveLayoutNameField"))
+                                 : nullptr;
+    }
+};
+
+/// Builds the host and locates the dialog (not yet opened — the tests open it via the controller's
+/// request, which is the path main.qml takes).
+[[nodiscard]] SaveLayoutHost makeSaveLayoutHost(QQmlEngine& engine, MockSaveLayoutController& controller)
+{
+    engine.rootContext()->setContextProperty("saveLayoutController", &controller);
+
+    QQmlComponent component(&engine);
+    component.setData(QByteArrayLiteral("import QtQuick\n"
+                                        "import QtQuick.Window\n"
+                                        "import \"qrc:/contour/ui\"\n"
+                                        "Window {\n"
+                                        "  id: host\n"
+                                        "  width: 800; height: 600; visible: true\n"
+                                        "  property int focusRestores: 0\n"
+                                        "  property alias saveLayoutDialogItem: dialogItem\n"
+                                        "  function restoreTerminalFocus() { host.focusRestores++; }\n"
+                                        "  SaveLayoutDialog {\n"
+                                        "    id: dialogItem\n"
+                                        "    controller: saveLayoutController\n"
+                                        "    window: host\n"
+                                        "  }\n"
+                                        // main.qml's wiring, verbatim: the controller asks, the window
+                                        // opens the prompt.
+                                        "  Connections {\n"
+                                        "    target: saveLayoutController\n"
+                                        "    function onSaveLayoutRequested() { dialogItem.open(); }\n"
+                                        "  }\n"
+                                        "}\n"),
+                      QUrl(QStringLiteral("qrc:/contour/ui/SaveLayoutTestHost.qml")));
+    while (component.status() == QQmlComponent::Loading)
+        QCoreApplication::processEvents();
+
+    auto host = SaveLayoutHost {};
+    {
+        INFO("SaveLayoutTestHost errors: " << component.errorString().toStdString());
+        if (!component.isReady())
+            return host;
+    }
+
+    host.window.reset(component.create());
+    if (host.window == nullptr)
+        return host;
+
+    host.dialog = host.window->property("saveLayoutDialogItem").value<QObject*>();
+    return host;
+}
+
+/// Opens the dialog the way a nameless SaveLayout action does (controller request -> main.qml open()) and
+/// pumps the loop so the Popup materializes its field.
+void openSaveLayoutPrompt(MockSaveLayoutController& controller)
+{
+    controller.beginSaveLayoutPrompt();
+    QCoreApplication::processEvents();
+}
+
+} // namespace
+
+TEST_CASE("The save-layout prompt opens on the controller's request (offscreen)",
+          "[contour][gui][qml][layout]")
+{
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockSaveLayoutController controller;
+
+    auto host = makeSaveLayoutHost(engine, controller);
+    REQUIRE(host.dialog != nullptr);
+    REQUIRE_FALSE(host.opened()); // nothing has asked for it yet
+
+    openSaveLayoutPrompt(controller);
+    CHECK(host.opened());
+    CHECK(host.nameField() != nullptr);
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
+TEST_CASE("Accepting the save-layout prompt saves the typed name and gives the keyboard back (offscreen)",
+          "[contour][gui][qml][layout]")
+{
+    // The typed name has to route all the way to the controller — the field is decoration otherwise — and
+    // the terminal has to get the keyboard back, or the user is left typing into a dismissed prompt.
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockSaveLayoutController controller;
+
+    auto host = makeSaveLayoutHost(engine, controller);
+    REQUIRE(host.dialog != nullptr);
+    openSaveLayoutPrompt(controller);
+    REQUIRE(host.opened());
+    REQUIRE(host.nameField() != nullptr);
+
+    host.nameField()->setProperty("text", QStringLiteral("dev"));
+    QMetaObject::invokeMethod(host.dialog, "accept");
+    QCoreApplication::processEvents();
+
+    REQUIRE(controller.saved.size() == 1);
+    CHECK(controller.saved.front() == QStringLiteral("dev"));
+    CHECK_FALSE(host.opened());
+    CHECK(host.focusRestores() == 1);
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
+TEST_CASE("A blank save-layout name is a no-op that keeps the prompt open (offscreen)",
+          "[contour][gui][qml][layout]")
+{
+    // Enter on an empty (or whitespace-only) field must neither save a nameless layout nor silently
+    // dismiss the dialog — the user is asked to type a name or press Escape.
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockSaveLayoutController controller;
+
+    auto host = makeSaveLayoutHost(engine, controller);
+    REQUIRE(host.dialog != nullptr);
+    openSaveLayoutPrompt(controller);
+    REQUIRE(host.opened());
+    REQUIRE(host.nameField() != nullptr);
+
+    host.nameField()->setProperty("text", QStringLiteral("   "));
+    QMetaObject::invokeMethod(host.dialog, "accept");
+    QCoreApplication::processEvents();
+
+    CHECK(controller.saved.isEmpty());
+    CHECK(host.opened()); // still up, nothing saved
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
+TEST_CASE("Dismissing the save-layout prompt saves nothing and gives the keyboard back (offscreen)",
+          "[contour][gui][qml][layout]")
+{
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockSaveLayoutController controller;
+
+    auto host = makeSaveLayoutHost(engine, controller);
+    REQUIRE(host.dialog != nullptr);
+    openSaveLayoutPrompt(controller);
+    REQUIRE(host.opened());
+
+    QMetaObject::invokeMethod(host.dialog, "close");
+    QCoreApplication::processEvents();
+
+    CHECK(controller.saved.isEmpty());
+    CHECK_FALSE(host.opened());
+    CHECK(host.focusRestores() == 1);
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
+TEST_CASE("The save-layout prompt survives controller destruction without QML errors (offscreen)",
+          "[contour][gui][qml][layout]")
+{
+    // Same teardown hazard the command palette guards against: the C++ controller is destroyed before the
+    // QML tree on window close, and an unguarded `controller.` in the dialog would raise a TypeError that
+    // the run-wide gate turns into a failure of the whole suite.
+    contour::test::QmlMessageCapture capture;
+    QQmlEngine engine;
+    auto controller = std::make_unique<MockSaveLayoutController>();
+
+    auto host = makeSaveLayoutHost(engine, *controller);
+    REQUIRE(host.dialog != nullptr);
+    openSaveLayoutPrompt(*controller);
+
+    host.dialog->setProperty("controller", QVariant::fromValue<QObject*>(nullptr));
+    QCoreApplication::processEvents();
+    engine.rootContext()->setContextProperty("saveLayoutController", nullptr);
     controller.reset();
     QCoreApplication::processEvents();
 

--- a/src/contour/ui/SaveLayoutDialog.qml
+++ b/src/contour/ui/SaveLayoutDialog.qml
@@ -1,0 +1,97 @@
+// vim:syntax=qml
+// The "save layout as" name prompt: a small modal popup with a single text field.
+//
+// Opened by a nameless SaveLayout action — the row the command palette offers, or a key bound to bare
+// SaveLayout. Both route through the session manager to THIS window's WindowController, whose
+// `saveLayoutRequested` signal main.qml connects to open(). This is the exact mirror of how a colorless
+// SetTabColor opens TabColorFlyout: the bare action opens a surface that supplies the argument.
+//
+// The user types a layout name and presses Enter; the dialog hands it to WindowController::saveLayoutAs,
+// which persists the current window's tabs to layouts.yml. A blank name or Escape cancels.
+import QtQuick
+import QtQuick.Controls
+
+Popup {
+    id: root
+
+    // The WindowController. Null-guarded EVERYWHERE below, for the same reason CommandPalette.qml guards
+    // its controller: it is destroyed before the QML tree on window close, and QML re-evaluates dependent
+    // bindings once more against null during teardown — an unguarded `controller.` would raise a TypeError.
+    required property var controller
+    // The ApplicationWindow, so closing the prompt can hand keyboard focus back to the terminal.
+    required property var window
+
+    modal: true
+    focus: true
+    // Insets the content (the label + field) from the border. On the Popup rather than the Column, since a
+    // Column is a bare positioner with no padding of its own; the Popup resizes its contentItem to the
+    // area left inside this padding.
+    padding: 12
+
+    // Centered and fixed-width: the prompt holds one short field, so it need not track the window size the
+    // way the command palette's list does.
+    anchors.centerIn: Overlay.overlay
+    width: Math.min(420, root.window ? root.window.width * 0.8 : 420)
+
+    // Live OS palette handle so the popup follows dark/light in realtime (see CommandPalette).
+    SystemPalette {
+        id: systemPalette
+        colorGroup: SystemPalette.Active
+    }
+
+    background: Rectangle {
+        color: systemPalette.window
+        border.color: systemPalette.mid
+        border.width: 1
+        radius: 6
+    }
+
+    // Start empty with the caret already in the field on every open, so the user can type immediately.
+    onOpened: {
+        nameField.clear();
+        nameField.forceActiveFocus();
+    }
+
+    // Whatever closed the prompt — Enter, Escape, a click outside — the terminal must get the keyboard
+    // back, or the user is left typing into nothing (same law as CommandPalette.qml's onClosed). The save
+    // itself has already happened synchronously in accept(); nothing is deferred here because, unlike the
+    // palette, this prompt opens no further keyboard-driven surface for a restore to fight over.
+    onClosed: {
+        if (root.window)
+            root.window.restoreTerminalFocus();
+    }
+
+    // Saves under the typed name and closes. A blank field is a no-op that keeps the prompt open, so Enter
+    // on an empty name never silently dismisses the dialog without saving — the user must type a name or
+    // press Escape. WindowController::saveLayoutAs trims and re-checks, so this is a UX guard, not the
+    // authority on emptiness.
+    function accept() {
+        if (nameField.text.trim().length === 0)
+            return;
+        if (root.controller)
+            root.controller.saveLayoutAs(nameField.text);
+        root.close();
+    }
+
+    contentItem: Column {
+        spacing: 6
+
+        Label {
+            text: qsTr("Save layout as:")
+            color: systemPalette.windowText
+        }
+
+        TextField {
+            id: nameField
+            objectName: "saveLayoutNameField"
+            // The Popup sizes this Column to the area inside its padding, so `parent.width` is that inset
+            // width — the field spans it without a second margin calculation.
+            width: parent.width
+            placeholderText: qsTr("Layout name…")
+
+            Keys.onReturnPressed: root.accept()
+            Keys.onEnterPressed: root.accept()
+            Keys.onEscapePressed: root.close()
+        }
+    }
+}

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -161,6 +161,15 @@ ApplicationWindow
         window: appWindow
     }
 
+    // The "save layout as" name prompt. Opened by a nameless SaveLayout action (the command-palette row
+    // or a key bound to bare SaveLayout), routed per-window exactly like the command palette above, so
+    // the prompt appears over the window the action fired in.
+    SaveLayoutDialog {
+        id: saveLayoutDialog
+        controller: appWindow.win
+        window: appWindow
+    }
+
     // The terminal pane's right-click menu. Per-window like the command palette: the OpenContextMenu
     // action routes through the session manager to THIS window's controller, which first makes the
     // right-clicked pane active, then republishes the model for the state under the cursor and asks us to
@@ -175,6 +184,7 @@ ApplicationWindow
     Connections {
         target: appWindow.win
         function onCommandPaletteRequested() { commandPalette.open(); }
+        function onSaveLayoutRequested() { saveLayoutDialog.open(); }
         function onContextMenuRequested() { terminalContextMenu.popup(); }
     }
 


### PR DESCRIPTION
The command palette could neither save nor, in practice, launch a layout. Both actions are parameterized (they need a `name:`), and the palette's catalog floor skips parameterized actions — so `LaunchLayout` only re-entered as one row per already-saved layout, while `SaveLayout` had no source at all and was reachable only from a hand-written keybinding. That left a chicken-and-egg: you couldn't save from the palette, so you never had a layout to launch either.

A nameless `SaveLayout` is now a meaningful, non-parameterized action that opens a small name-input prompt — the exact mirror of how a colorless `SetTabColor` opens the color picker. It appears on the catalog floor; picking it (or a key bound to bare `SaveLayout`) opens the prompt, and the typed name is saved through the existing manager/LayoutStore path. Once a layout exists, the per-name `LaunchLayout` rows follow, closing the loop.

## Changes

- Drop `SaveLayout` from `ParameterizedActionConcept`; a nameless instance now keeps the bare `SaveLayout` id and writes no config argument, and its binding is kept on parse rather than dropped. `LaunchLayout` stays parameterized — a nameless "launch which layout?" has no default.
- Route a nameless `SaveLayout` to a new `WindowController::beginSaveLayoutPrompt()` / `saveLayoutRequested` signal (per window, like the tab-color picker); the dialog calls back into `saveLayoutAs()`, which saves through the existing `TerminalSessionManager::saveLayout`.
- Add `SaveLayoutDialog.qml`, wired into `main.qml`, mirroring the command palette's focus discipline (restores terminal focus on close).
- Document both palette entry points on the layouts page and add a release note.