### PR TITLE
Improve command palette and terminal context-menu UX

### DIFF
--- a/src/contour/CommandPaletteModel.cpp
+++ b/src/contour/CommandPaletteModel.cpp
@@ -4,8 +4,10 @@
 #include <contour/FuzzyFilter.h>
 
 #include <algorithm>
+#include <optional>
 #include <ranges>
 #include <utility>
+#include <vector>
 
 namespace contour
 {
@@ -81,11 +83,11 @@ void CommandPaletteModel::rebuildRows()
         // entry simply stops appearing, with no stale row and no migration of the stored file.
         for (auto const& id: _history.recent())
             if (auto const* command = commandById(id))
-                _rows.push_back(Row { .command = command, .section = Section::Recent });
+                _rows.push_back(Row { .command = command, .section = Section::Recent, .titleMatches = {} });
 
         auto const firstAll = _rows.size();
         for (auto const& command: _commands)
-            _rows.push_back(Row { .command = &command, .section = Section::All });
+            _rows.push_back(Row { .command = &command, .section = Section::All, .titleMatches = {} });
 
         // Sort just the freshly-appended stretch, leaving the recent rows pinned above it.
         std::ranges::sort(_rows.begin() + static_cast<std::ptrdiff_t>(firstAll),
@@ -101,6 +103,7 @@ void CommandPaletteModel::rebuildRows()
             Command const* command;
             int score;
             int recency; //!< Position in the MRU list; lower is more recent. Absent -> past the end.
+            std::vector<int> titleMatches; //!< Title indices this query matched; empty if matched via id.
         };
 
         auto const recencyOf = [this](std::string const& id) {
@@ -116,15 +119,27 @@ void CommandPaletteModel::rebuildRows()
         for (auto const& command: _commands)
         {
             // Match against the title (what the user sees and therefore types at), falling back to the
-            // id — so "splitv" still finds "Split Vertical" even though its title has a space there.
-            auto score = fuzzyScore(query, command.title);
-            if (!score)
+            // id — so "splitv" still finds "Split Vertical" even though its title has a space there. A
+            // title hit also hands back the matched positions, so QML can bold exactly those characters;
+            // an id-only hit highlights nothing, there being no id text on screen to mark.
+            auto score = std::optional<int> {};
+            auto titleMatches = std::vector<int> {};
+            if (auto match = fuzzyMatch(query, command.title))
+            {
+                score = match->score;
+                titleMatches = std::move(match->positions);
+            }
+            else
+            {
                 score = fuzzyScore(query, command.id);
+            }
             if (!score)
                 continue;
 
-            scored.push_back(
-                Scored { .command = &command, .score = *score, .recency = recencyOf(command.id) });
+            scored.push_back(Scored { .command = &command,
+                                      .score = *score,
+                                      .recency = recencyOf(command.id),
+                                      .titleMatches = std::move(titleMatches) });
         }
 
         std::ranges::stable_sort(scored, [](Scored const& a, Scored const& b) {
@@ -135,8 +150,10 @@ void CommandPaletteModel::rebuildRows()
             return byTitle(*a.command, *b.command);
         });
 
-        for (auto const& entry: scored)
-            _rows.push_back(Row { .command = entry.command, .section = Section::All });
+        for (auto& entry: scored)
+            _rows.push_back(Row { .command = entry.command,
+                                  .section = Section::All,
+                                  .titleMatches = std::move(entry.titleMatches) });
     }
 
     endResetModel();
@@ -177,6 +194,15 @@ QVariant CommandPaletteModel::data(QModelIndex const& index, int role) const
             return QString::fromStdString(shortcut->second);
         }
         case SectionRole: return static_cast<int>(entry.section);
+        case TitleMatchesRole: {
+            // The matched title indices as a plain list of ints, which QML reads as a JS array to decide
+            // which characters to bold. Empty on an unfiltered or id-only-matched row.
+            auto matches = QVariantList {};
+            matches.reserve(static_cast<qsizetype>(entry.titleMatches.size()));
+            for (auto const position: entry.titleMatches)
+                matches.append(position);
+            return matches;
+        }
         case SectionStartRole:
             // Answers the whole question the view asks — "draw a header above this row?" — rather than
             // half of it. A filtered list has no sections, so no row starts one; otherwise a header goes
@@ -192,8 +218,13 @@ QVariant CommandPaletteModel::data(QModelIndex const& index, int role) const
 QHash<int, QByteArray> CommandPaletteModel::roleNames() const
 {
     return {
-        { IdRole, "commandId" },      { TitleRole, "title" },     { DescriptionRole, "description" },
-        { ShortcutRole, "shortcut" }, { SectionRole, "section" }, { SectionStartRole, "sectionStart" },
+        { IdRole, "commandId" },
+        { TitleRole, "title" },
+        { DescriptionRole, "description" },
+        { ShortcutRole, "shortcut" },
+        { SectionRole, "section" },
+        { SectionStartRole, "sectionStart" },
+        { TitleMatchesRole, "titleMatches" },
     };
 }
 

--- a/src/contour/CommandPaletteModel.h
+++ b/src/contour/CommandPaletteModel.h
@@ -58,6 +58,7 @@ class CommandPaletteModel: public QAbstractListModel
         ShortcutRole,              //!< Rendered key binding ("Ctrl+Shift+E"), or empty if unbound.
         SectionRole,               //!< The row's Section, as an int.
         SectionStartRole,          //!< True on the FIRST row of a section, so QML draws one header for it.
+        TitleMatchesRole,          //!< Title character indices the current filter matched, for highlighting.
     };
 
     /// @param history The app-wide most-recently-used list. Must outlive this model.
@@ -114,6 +115,10 @@ class CommandPaletteModel: public QAbstractListModel
     {
         Command const* command;
         Section section;
+        /// Byte offsets into the command's title that the active filter matched, ascending — what QML
+        /// bolds. Empty when there is no filter, or when the row matched only through its id (there is
+        /// nothing in the visible title to highlight then).
+        std::vector<int> titleMatches;
     };
 
     /// Rebuilds _rows from _commands, applying the current filter and ordering (see the class comment).

--- a/src/contour/ContextMenu.cpp
+++ b/src/contour/ContextMenu.cpp
@@ -52,6 +52,11 @@ namespace
     {
         return !state.profileNames.empty();
     }
+
+    bool inputProtected(ContextMenuState const& state) noexcept
+    {
+        return state.inputProtected;
+    }
     // }}}
 
     using Predicate = bool (*)(ContextMenuState const&) noexcept;
@@ -78,6 +83,7 @@ namespace
         std::string_view title {};         ///< Empty on a Command row => commandTitle(action).
         Predicate visible = always;        ///< When false, the row is not in the menu at all.
         Predicate enabled = always;        ///< When false, the row is in the menu but grayed out.
+        Predicate checked = nullptr;       ///< When set, the row is checkable; checked when it holds.
         ChildBuilder children = nullptr;   ///< Submenu rows: what is inside.
         ActionBinder bindAction = nullptr; ///< When set, supplies the action in place of @ref action.
 
@@ -94,6 +100,14 @@ namespace
         {
             auto row = *this;
             row.enabled = predicate;
+            return row;
+        }
+
+        /// This row, drawn with a check column that is ticked exactly when @p predicate holds.
+        [[nodiscard]] Row checkedWhen(Predicate predicate) const
+        {
+            auto row = *this;
+            row.checked = predicate;
             return row;
         }
 
@@ -237,6 +251,12 @@ namespace
 
             separator(),
 
+            // Read-only == input protection (KAM). The check reflects the pane's state at open time;
+            // picking it runs ToggleInputProtection, which flips it for the next open.
+            command(ToggleInputProtection {}, "Read-Only Mode").checkedWhen(inputProtected),
+
+            separator(),
+
             submenu("Change Profile", profileRows).shownWhen(hasProfiles),
             submenu("Advanced", advancedRows),
         };
@@ -288,8 +308,8 @@ namespace
                         .title = row.title.empty() ? commandTitle(action) : std::string(row.title),
                         .action = std::move(action),
                         .enabled = row.enabled(state),
-                        .checkable = false,
-                        .checked = false,
+                        .checkable = row.checked != nullptr,
+                        .checked = row.checked != nullptr && row.checked(state),
                         .children = {} });
                     break;
                 }

--- a/src/contour/ContextMenu.cpp
+++ b/src/contour/ContextMenu.cpp
@@ -38,9 +38,9 @@ namespace
         return !state.hyperlinkUnderCursor.empty();
     }
 
-    bool hasWorkingDirectory(ContextMenuState const& state) noexcept
+    bool hasLocalWorkingDirectory(ContextMenuState const& state) noexcept
     {
-        return state.hasWorkingDirectory;
+        return state.hasLocalWorkingDirectory;
     }
 
     bool hasSplits(ContextMenuState const& state) noexcept
@@ -238,7 +238,7 @@ namespace
 
             hyperlinkCommand<FollowHyperlink>("Open Link"),
             hyperlinkCommand<CopyHyperlink>("Copy Link Address"),
-            command(OpenFileManager {}, "Open Current Folder").enabledWhen(hasWorkingDirectory),
+            command(OpenFileManager {}, "Open Current Folder").enabledWhen(hasLocalWorkingDirectory),
 
             separator(),
 

--- a/src/contour/ContextMenu.h
+++ b/src/contour/ContextMenu.h
@@ -23,6 +23,7 @@ struct ContextMenuState
     bool hasLastCommand = false;      ///< A finished OSC 133 command block sits in the scrollback.
     bool hasWorkingDirectory = false; ///< The shell reported a working directory (OSC 7).
     bool hasSplits = false;           ///< This tab holds more than one pane.
+    bool inputProtected = false;      ///< Input protection (KAM / read-only) is on for this pane.
 
     /// The OSC 8 hyperlink the user right-clicked, empty if there was none.
     ///

--- a/src/contour/ContextMenu.h
+++ b/src/contour/ContextMenu.h
@@ -18,12 +18,12 @@ namespace contour
 /// with no terminal, no window, no clipboard and no Qt behind it.
 struct ContextMenuState
 {
-    bool hasSelection = false;        ///< Some grid cells are selected.
-    bool clipboardHasText = false;    ///< The system clipboard holds text.
-    bool hasLastCommand = false;      ///< A finished OSC 133 command block sits in the scrollback.
-    bool hasWorkingDirectory = false; ///< The shell reported a working directory (OSC 7).
-    bool hasSplits = false;           ///< This tab holds more than one pane.
-    bool inputProtected = false;      ///< Input protection (KAM / read-only) is on for this pane.
+    bool hasSelection = false;             ///< Some grid cells are selected.
+    bool clipboardHasText = false;         ///< The system clipboard holds text.
+    bool hasLastCommand = false;           ///< A finished OSC 133 command block sits in the scrollback.
+    bool hasLocalWorkingDirectory = false; ///< OSC 7 reported a working directory on THIS host (openable).
+    bool hasSplits = false;                ///< This tab holds more than one pane.
+    bool inputProtected = false;           ///< Input protection (KAM / read-only) is on for this pane.
 
     /// The OSC 8 hyperlink the user right-clicked, empty if there was none.
     ///

--- a/src/contour/FuzzyFilter.cpp
+++ b/src/contour/FuzzyFilter.cpp
@@ -59,6 +59,120 @@ namespace
         }
         return wanted == query.end();
     }
+
+    /// Fills the alignment table for @p query against @p candidate, and — when @p parents is non-null —
+    /// the predecessor column that produced each cell, so callers that need the matched characters can
+    /// backtrack. This is the single DP both fuzzyScore() and fuzzyMatch() share; keeping it in one
+    /// place is what guarantees the score fuzzyMatch() reports is byte-for-byte the one fuzzyScore()
+    /// ranks by.
+    ///
+    /// A full alignment rather than a greedy left-to-right scan. Greedy matching cannot rank. Preferring
+    /// a word-start occurrence over an earlier mid-word one is what makes the ranking good ("spl" should
+    /// find "Split Vertical", where it is a literal prefix, rather than "Toggle Split Orientation", where
+    /// it only appears mid-title) — but a greedy scan that jumps ahead to a word start can jump PAST the
+    /// only positions from which the rest of the query still fits, and would then report "no match" for a
+    /// query that plainly matches. Concretely: typing the whole of "Toggle Status Line" with the spaces
+    /// left out, the 'l' of "toggle" would bind to the 'L' of "Line", stranding the rest of the query
+    /// with nothing left of the title to match against.
+    ///
+    /// So: score every way the query could align to the candidate and keep the best. best[i][j] is the
+    /// score of the best alignment of query[0..i] in which query[i] lands on candidate[j].
+    ///
+    /// Cost is O(query * candidate) — a few thousand operations against a ~40-character title, and only
+    /// for the candidates that survive the subsequence pre-check. It is not on any render path.
+    ///
+    /// @param query     Precondition: non-empty and a subsequence of @p candidate (both checked by the
+    ///                  callers), and no longer than @p candidate.
+    /// @param candidate The text being matched against.
+    /// @param weights   How to score the match.
+    /// @param best      Filled with the alignment scores; must be pre-sized query*candidate to Unreachable.
+    /// @param parents   When non-null, filled (same size) with each cell's predecessor column, or -1.
+    void computeAlignment(std::string_view query,
+                          std::string_view candidate,
+                          FuzzyWeights const& weights,
+                          std::vector<int>& best,
+                          std::vector<int>* parents)
+    {
+        auto const queryLength = query.size();
+        auto const candidateLength = candidate.size();
+
+        for (auto const i: std::views::iota(std::size_t { 0 }, queryLength))
+        {
+            auto const wanted = ascii::fold(query[i]);
+
+            // Running best over all predecessors j' < j of (best[i-1][j'] - gap * j'), plus the column
+            // that achieves it so a backtrack can recover the matched characters.
+            //
+            // The gap penalty is linear, so max over j' of (best[i-1][j'] + gap * (j - j' - 1)) factors
+            // into (max over j' of (best[i-1][j'] - gap * j')) + gap * (j - 1). Carrying that maximum
+            // forward turns the inner search over predecessors into O(1), which is what keeps the whole
+            // thing quadratic rather than cubic.
+            auto reachBest = Unreachable;
+            auto reachArg = -1;
+
+            for (auto const j: std::views::iota(std::size_t { 0 }, candidateLength))
+            {
+                // Fold predecessor j-1 into the running maximum BEFORE using it for j, so it covers
+                // exactly the j' < j the recurrence quantifies over.
+                if (i > 0 && j > 0)
+                {
+                    auto const previous = best[((i - 1) * candidateLength) + (j - 1)];
+                    if (previous != Unreachable)
+                    {
+                        auto const reach = previous - (weights.gap * static_cast<int>(j - 1));
+                        if (reachBest == Unreachable || reach > reachBest)
+                        {
+                            reachBest = reach;
+                            reachArg = static_cast<int>(j - 1);
+                        }
+                    }
+                }
+
+                if (ascii::fold(candidate[j]) != wanted)
+                    continue;
+
+                auto score = 0;
+                auto parent = -1;
+
+                if (i == 0)
+                {
+                    // A match deep inside the candidate is a weaker one than a match up front, but the
+                    // penalty is capped: past a handful of characters "further in" stops carrying
+                    // information, and an uncapped penalty would just punish long titles.
+                    auto const skipped = std::min(j, static_cast<std::size_t>(weights.leadingGapMax));
+                    score = weights.leadingGap * static_cast<int>(skipped);
+                }
+                else
+                {
+                    if (reachBest == Unreachable)
+                        continue; // query[i-1] cannot land anywhere before j: this cell is unreachable
+
+                    score = reachBest + (weights.gap * static_cast<int>(j - 1));
+                    parent = reachArg;
+
+                    // Landing immediately after the previous match is worth more than any gapped
+                    // alternative of equal reach, so it is scored separately rather than folded into the
+                    // linear gap term.
+                    if (j > 0)
+                    {
+                        auto const adjacent = best[((i - 1) * candidateLength) + (j - 1)];
+                        if (adjacent != Unreachable && adjacent + weights.consecutive > score)
+                        {
+                            score = adjacent + weights.consecutive;
+                            parent = static_cast<int>(j - 1);
+                        }
+                    }
+                }
+
+                if (isWordStart(candidate, j))
+                    score += weights.wordStart;
+
+                best[(i * candidateLength) + j] = score;
+                if (parents != nullptr)
+                    (*parents)[(i * candidateLength) + j] = parent;
+            }
+        }
+    }
 } // namespace
 
 std::optional<int> fuzzyScore(std::string_view query, std::string_view candidate, FuzzyWeights const& weights)
@@ -72,93 +186,54 @@ std::optional<int> fuzzyScore(std::string_view query, std::string_view candidate
     if (queryLength > candidateLength || !isSubsequence(query, candidate))
         return std::nullopt;
 
-    // A full alignment rather than a greedy left-to-right scan.
-    //
-    // Greedy matching cannot rank. Preferring a word-start occurrence over an earlier mid-word one is
-    // what makes the ranking good ("spl" should find "Split Vertical", where it is a literal prefix,
-    // rather than "Toggle Split Orientation", where it only appears mid-title) — but a greedy scan that
-    // jumps ahead to a word start can jump PAST the only positions from which the rest of the query
-    // still fits, and would then report "no match" for a query that plainly matches. Concretely: typing
-    // the whole of "Toggle Status Line" with the spaces left out, the 'l' of "toggle" would bind to the
-    // 'L' of "Line", stranding the rest of the query with nothing left of the title to match against.
-    //
-    // So: score every way the query could align to the candidate and keep the best. best[i][j] is the
-    // score of the best alignment of query[0..i] in which query[i] lands on candidate[j].
-    //
-    // Cost is O(query * candidate) — a few thousand operations against a ~40-character title, and only
-    // for the candidates that survive the pre-check above. It is not on any render path.
     auto best = std::vector<int>(queryLength * candidateLength, Unreachable);
-
-    for (auto const i: std::views::iota(std::size_t { 0 }, queryLength))
-    {
-        auto const wanted = ascii::fold(query[i]);
-
-        // Running best over all predecessors j' < j of (best[i-1][j'] - gap * j').
-        //
-        // The gap penalty is linear, so max over j' of (best[i-1][j'] + gap * (j - j' - 1)) factors
-        // into (max over j' of (best[i-1][j'] - gap * j')) + gap * (j - 1). Carrying that maximum
-        // forward turns the inner search over predecessors into O(1), which is what keeps the whole
-        // thing quadratic rather than cubic.
-        auto reachBest = Unreachable;
-
-        for (auto const j: std::views::iota(std::size_t { 0 }, candidateLength))
-        {
-            // Fold predecessor j-1 into the running maximum BEFORE using it for j, so it covers exactly
-            // the j' < j the recurrence quantifies over.
-            if (i > 0 && j > 0)
-            {
-                auto const previous = best[((i - 1) * candidateLength) + (j - 1)];
-                if (previous != Unreachable)
-                {
-                    auto const reach = previous - (weights.gap * static_cast<int>(j - 1));
-                    reachBest = reachBest == Unreachable ? reach : std::max(reachBest, reach);
-                }
-            }
-
-            if (ascii::fold(candidate[j]) != wanted)
-                continue;
-
-            auto score = 0;
-
-            if (i == 0)
-            {
-                // A match deep inside the candidate is a weaker one than a match up front, but the
-                // penalty is capped: past a handful of characters "further in" stops carrying
-                // information, and an uncapped penalty would just punish long titles.
-                auto const skipped = std::min(j, static_cast<std::size_t>(weights.leadingGapMax));
-                score = weights.leadingGap * static_cast<int>(skipped);
-            }
-            else
-            {
-                if (reachBest == Unreachable)
-                    continue; // query[i-1] cannot land anywhere before j: this cell is unreachable
-
-                score = reachBest + (weights.gap * static_cast<int>(j - 1));
-
-                // Landing immediately after the previous match is worth more than any gapped
-                // alternative of equal reach, so it is scored separately rather than folded into the
-                // linear gap term.
-                if (j > 0)
-                {
-                    auto const adjacent = best[((i - 1) * candidateLength) + (j - 1)];
-                    if (adjacent != Unreachable)
-                        score = std::max(score, adjacent + weights.consecutive);
-                }
-            }
-
-            if (isWordStart(candidate, j))
-                score += weights.wordStart;
-
-            best[(i * candidateLength) + j] = score;
-        }
-    }
+    computeAlignment(query, candidate, weights, best, nullptr);
 
     // The best place for the query's LAST character to land decides the alignment.
     auto const lastRow = std::span(best).subspan((queryLength - 1) * candidateLength, candidateLength);
-    auto const bestScore = std::ranges::max(lastRow);
 
     // The pre-check already established that the query IS a subsequence, so some alignment exists.
-    return bestScore;
+    return std::ranges::max(lastRow);
+}
+
+std::optional<FuzzyMatch> fuzzyMatch(std::string_view query,
+                                     std::string_view candidate,
+                                     FuzzyWeights const& weights)
+{
+    if (query.empty())
+        return FuzzyMatch { .score = 0, .positions = {} };
+
+    auto const queryLength = query.size();
+    auto const candidateLength = candidate.size();
+
+    if (queryLength > candidateLength || !isSubsequence(query, candidate))
+        return std::nullopt;
+
+    auto best = std::vector<int>(queryLength * candidateLength, Unreachable);
+    auto parents = std::vector<int>(queryLength * candidateLength, -1);
+    computeAlignment(query, candidate, weights, best, &parents);
+
+    // The column the query's last character lands on decides the whole alignment; take the best-scoring
+    // one, the same "best cell of the last row" fuzzyScore ranks by. max_element keeps the FIRST of equal
+    // maxima, i.e. the earliest column on a tie (Unreachable is INT_MIN, so it never wins).
+    auto const lastRow = std::span(best).subspan((queryLength - 1) * candidateLength, candidateLength);
+    auto const bestCell = std::ranges::max_element(lastRow);
+    auto const bestScore = *bestCell;
+    auto const lastColumn = static_cast<std::size_t>(bestCell - lastRow.begin());
+
+    // Walk the predecessor chain from that column back to the first query character. Each parent is a
+    // strictly smaller column (see computeAlignment), so the positions come out ascending.
+    auto positions = std::vector<int>(queryLength);
+    auto column = static_cast<int>(lastColumn);
+    for (auto i = static_cast<int>(queryLength) - 1; i >= 0; --i)
+    {
+        positions[static_cast<std::size_t>(i)] = column;
+        if (i > 0)
+            column =
+                parents[(static_cast<std::size_t>(i) * candidateLength) + static_cast<std::size_t>(column)];
+    }
+
+    return FuzzyMatch { .score = bestScore, .positions = std::move(positions) };
 }
 
 } // namespace contour

--- a/src/contour/FuzzyFilter.h
+++ b/src/contour/FuzzyFilter.h
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string_view>
+#include <vector>
 
 namespace contour
 {
@@ -46,5 +47,31 @@ struct FuzzyWeights
 [[nodiscard]] std::optional<int> fuzzyScore(std::string_view query,
                                             std::string_view candidate,
                                             FuzzyWeights const& weights = {});
+
+/// The score of a fuzzy match together with the exact characters it landed on.
+///
+/// @c positions carries one candidate index per query character, in ascending order — the winning
+/// alignment fuzzyScore() ranks by. That is what lets the command palette bold the very characters
+/// that earned the ranking, rather than guessing at them with a second, possibly different, scan.
+struct FuzzyMatch
+{
+    int score;                  ///< Identical to what fuzzyScore() returns for the same arguments.
+    std::vector<int> positions; ///< Candidate index each query character matched, strictly ascending.
+};
+
+/// Scores @p query against @p candidate exactly as fuzzyScore() does, and additionally reports which
+/// characters of @p candidate the best alignment matched.
+///
+/// Shares the alignment with fuzzyScore() (the score is byte-for-byte identical); the extra work is a
+/// single backtrack over the alignment table, so it is only paid by callers that need the positions.
+///
+/// @param query     What the user typed.
+/// @param candidate The text to match against.
+/// @param weights   How to score the match.
+/// @return The score and the matched positions, or nullopt when @p query is not a subsequence of
+///         @p candidate. An empty @p query yields score 0 and no positions.
+[[nodiscard]] std::optional<FuzzyMatch> fuzzyMatch(std::string_view query,
+                                                   std::string_view candidate,
+                                                   FuzzyWeights const& weights = {});
 
 } // namespace contour

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1577,6 +1577,7 @@ ContextMenuState TerminalSession::contextMenuState()
             // Left for the window to fill in: whether this tab holds more than one pane is not something
             // a session knows about itself.
             .hasSplits = false,
+            .inputProtected = !terminal().allowInput(),
             // Taken now, while the pointer is still on the cell the user clicked. The rows built from this
             // carry the URI with them, because by the time one is picked the pointer has moved to the menu.
             .hyperlinkUnderCursor = hyperlink ? hyperlink->uri : std::string {},

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1559,6 +1559,10 @@ ContextMenuState TerminalSession::contextMenuState()
     auto const* mimeData = clipboard != nullptr ? clipboard->mimeData(QClipboard::Clipboard) : nullptr;
     auto const clipboardHasText = mimeData != nullptr && mimeData->hasText();
 
+    // This machine's host name, so the working-directory row can be grayed out for a remote (SSH) cwd
+    // whose path the local file manager cannot open. Read outside the terminal lock (it is not grid state).
+    auto const localHost = QHostInfo::localHostName().toStdString();
+
     // One lock for the whole snapshot. The parser thread mutates the grid concurrently, so a menu that
     // asked the terminal a fresh question per row would be reading a moving target — and a QML binding
     // that reached into the terminal on its own schedule would be a plain data race.
@@ -1573,7 +1577,10 @@ ContextMenuState TerminalSession::contextMenuState()
             // cannot guard against that in an alias) reports a command that never ran, with no text to
             // copy — offering the user three rows that would all yield nothing.
             .hasLastCommand = block.has_value() && !(block->prompt.empty() && block->output.empty()),
-            .hasWorkingDirectory = !terminal().currentWorkingDirectory().empty(),
+            // Only a working directory on this host can be opened by the local file manager. OSC 7 gives a
+            // file://HOST/PATH; a remote (SSH) cwd resolves to nullopt and grays the "Open Current Folder".
+            .hasLocalWorkingDirectory =
+                vtbackend::localWorkingDirectory(terminal().currentWorkingDirectory(), localHost).has_value(),
             // Left for the window to fill in: whether this tab holds more than one pane is not something
             // a session knows about itself.
             .hasSplits = false,
@@ -1871,10 +1878,22 @@ bool TerminalSession::operator()(actions::OpenConfiguration)
 
 bool TerminalSession::operator()(actions::OpenFileManager)
 {
-    auto const l = scoped_lock { terminal() };
-    auto const& cwd = terminal().currentWorkingDirectory();
-    if (!_app.externalLauncher().openUrl(QUrl(QString::fromUtf8(cwd.c_str()))))
-        errorLog()("Could not open file \"{}\".", cwd);
+    // OSC 7 advertises the cwd as a file://HOST/PATH URL. Hand the raw URL to the file manager and its
+    // host authority is read as a network share ("//fedora/home/..."), which does not exist locally.
+    // Resolve it to a plain local path first, and only when it is on THIS host — a remote (SSH) cwd is
+    // not openable here (its menu row is grayed out, but a keybinding could still reach this handler).
+    auto const localHost = QHostInfo::localHostName().toStdString();
+    auto localPath = std::optional<std::string> {};
+    {
+        auto const l = scoped_lock { terminal() };
+        localPath = vtbackend::localWorkingDirectory(terminal().currentWorkingDirectory(), localHost);
+    }
+
+    if (!localPath)
+        return true;
+
+    if (!_app.externalLauncher().openUrl(QUrl::fromLocalFile(QString::fromStdString(*localPath))))
+        errorLog()("Could not open folder \"{}\".", *localPath);
 
     return true;
 }

--- a/src/contour/test/CommandPaletteModel_test.cpp
+++ b/src/contour/test/CommandPaletteModel_test.cpp
@@ -47,6 +47,24 @@ namespace
     return roleAt(model, row, CommandPaletteModel::SectionRole).toInt();
 }
 
+/// The title character indices the current filter matched on a row, as the QML delegate reads them.
+[[nodiscard]] std::vector<int> titleMatchesAt(CommandPaletteModel const& model, int row)
+{
+    auto result = std::vector<int> {};
+    for (auto const& entry: roleAt(model, row, CommandPaletteModel::TitleMatchesRole).toList())
+        result.push_back(entry.toInt());
+    return result;
+}
+
+/// The row index of the command with @p id, or -1 if it is not present.
+[[nodiscard]] int rowOf(CommandPaletteModel const& model, std::string const& id)
+{
+    for (auto row = 0; row < model.rowCount(); ++row)
+        if (idAt(model, row) == id)
+            return row;
+    return -1;
+}
+
 /// The ids of the rows in the Recent section, in order.
 [[nodiscard]] std::vector<std::string> recentRows(CommandPaletteModel const& model)
 {
@@ -204,6 +222,46 @@ TEST_CASE("Typing collapses the sections into one ranked list", "[contour][palet
     {
         model.setFilter(QStringLiteral("zzzznotacommand"));
         CHECK(model.rowCount() == 0);
+    }
+}
+
+TEST_CASE("The palette reports which title characters the filter matched", "[contour][palette]")
+{
+    // These indices are what QML bolds; they must point at the characters the filter actually landed on.
+    auto history = CommandHistory { 3 };
+    auto const actionCommands = ActionCommandSource {};
+
+    auto model = CommandPaletteModel { history };
+    model.setSources({ &actionCommands });
+    model.refresh();
+
+    SECTION("an unfiltered row highlights nothing")
+    {
+        REQUIRE(model.rowCount() > 0);
+        CHECK(titleMatchesAt(model, 0).empty());
+    }
+
+    SECTION("a filtered row marks exactly the matched title characters")
+    {
+        model.setFilter(QStringLiteral("splitv"));
+        auto const row = rowOf(model, "SplitVertical");
+        REQUIRE(row >= 0);
+        REQUIRE(titleAt(model, row) == "Split Vertical");
+        // "splitv" over "Split Vertical": S p l i t (0..4), then V (6) past the space.
+        CHECK(titleMatchesAt(model, row) == std::vector<int> { 0, 1, 2, 3, 4, 6 });
+    }
+
+    SECTION("clearing the filter clears the highlight again")
+    {
+        model.setFilter(QStringLiteral("split"));
+        auto const filtered = rowOf(model, "SplitVertical");
+        REQUIRE(filtered >= 0);
+        REQUIRE_FALSE(titleMatchesAt(model, filtered).empty());
+
+        model.setFilter(QString {});
+        auto const cleared = rowOf(model, "SplitVertical");
+        REQUIRE(cleared >= 0);
+        CHECK(titleMatchesAt(model, cleared).empty());
     }
 }
 

--- a/src/contour/test/ContextMenu_test.cpp
+++ b/src/contour/test/ContextMenu_test.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <string>
+#include <variant>
 #include <vector>
 
 using namespace contour;
@@ -206,6 +207,37 @@ TEST_CASE("ContextMenu.profiles.oneRowEachWithTheActiveOneChecked", "[contextmen
         CHECK(child.checked == (child.title == "light"));
         // The row carries the concrete, argument-bearing action; nothing has to re-parse its name later.
         CHECK(commandId(child.action) == "ChangeProfile:" + child.title);
+    }
+}
+
+TEST_CASE("ContextMenu.readOnly.reflectsInputProtection", "[contextmenu]")
+{
+    // The row is always present and always checkable; its check mirrors the pane's input-protection
+    // (read-only) state at the moment the menu was opened.
+    SECTION("unchecked while input is allowed")
+    {
+        auto state = fullyEnabledState();
+        state.inputProtected = false;
+
+        auto const menu = buildContextMenu(state);
+        auto const* readOnly = find(menu, "Read-Only Mode");
+        REQUIRE(readOnly != nullptr);
+        CHECK(readOnly->checkable);
+        CHECK_FALSE(readOnly->checked);
+        // Picking it flips the very state the check reflects.
+        CHECK(std::holds_alternative<actions::ToggleInputProtection>(readOnly->action));
+    }
+
+    SECTION("checked while input is protected")
+    {
+        auto state = fullyEnabledState();
+        state.inputProtected = true;
+
+        auto const menu = buildContextMenu(state);
+        auto const* readOnly = find(menu, "Read-Only Mode");
+        REQUIRE(readOnly != nullptr);
+        CHECK(readOnly->checkable);
+        CHECK(readOnly->checked);
     }
 }
 

--- a/src/contour/test/ContextMenu_test.cpp
+++ b/src/contour/test/ContextMenu_test.cpp
@@ -51,7 +51,7 @@ namespace
         .hasSelection = true,
         .clipboardHasText = true,
         .hasLastCommand = true,
-        .hasWorkingDirectory = true,
+        .hasLocalWorkingDirectory = true,
         .hasSplits = true,
         .hyperlinkUnderCursor = "https://contour-terminal.org/",
         .activeProfile = "dark",
@@ -147,17 +147,19 @@ TEST_CASE("ContextMenu.hyperlink.onlyUnderTheCursor", "[contextmenu]")
     CHECK(find(elsewhere, "Copy Link Address") == nullptr);
 }
 
-TEST_CASE("ContextMenu.openCurrentFolder.requiresWorkingDirectory", "[contextmenu]")
+TEST_CASE("ContextMenu.openCurrentFolder.requiresLocalWorkingDirectory", "[contextmenu]")
 {
+    // Grayed out unless the cwd is on this host: a remote (SSH) working directory cannot be opened by the
+    // local file manager, so resolving it to a local path is what gates the row (see localWorkingDirectory).
     auto state = fullyEnabledState();
 
-    state.hasWorkingDirectory = false;
+    state.hasLocalWorkingDirectory = false;
     auto const unknown = buildContextMenu(state);
     auto const* whenUnknown = find(unknown, "Open Current Folder");
     REQUIRE(whenUnknown != nullptr);
     CHECK_FALSE(whenUnknown->enabled);
 
-    state.hasWorkingDirectory = true;
+    state.hasLocalWorkingDirectory = true;
     auto const known = buildContextMenu(state);
     auto const* whenKnown = find(known, "Open Current Folder");
     REQUIRE(whenKnown != nullptr);
@@ -319,7 +321,7 @@ TEST_CASE("ContextMenu.separators.neverLeadingTrailingOrDoubled", "[contextmenu]
                                 .hasSelection = selection,
                                 .clipboardHasText = clipboard,
                                 .hasLastCommand = lastCommand,
-                                .hasWorkingDirectory = true,
+                                .hasLocalWorkingDirectory = true,
                                 .hasSplits = splits,
                                 .hyperlinkUnderCursor = hyperlink ? "https://example.org/" : "",
                                 .activeProfile = profiles ? "dark" : "",

--- a/src/contour/test/FuzzyFilter_test.cpp
+++ b/src/contour/test/FuzzyFilter_test.cpp
@@ -8,6 +8,9 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -129,5 +132,84 @@ TEST_CASE("fuzzyScore ranks the command the user meant first", "[contour][palett
         auto const order = ranked("close", { "Cancel Long Selection Everywhere", "Close Tab" });
         REQUIRE(order.size() == 2);
         CHECK(order.front() == "Close Tab");
+    }
+}
+
+TEST_CASE("fuzzyMatch reports the exact characters the best alignment landed on", "[contour][palette]")
+{
+    // The palette bolds these positions, so they must be the SAME alignment fuzzyScore ranks by — a
+    // second, differently-scored scan could highlight characters that had nothing to do with the rank.
+
+    SECTION("initials land on the word starts they stand for")
+    {
+        auto const match = fuzzyMatch("sv", "Split Vertical");
+        REQUIRE(match.has_value());
+        CHECK(match->positions == std::vector<int> { 0, 6 });
+    }
+
+    SECTION("a contiguous prefix lands on adjacent characters")
+    {
+        auto const match = fuzzyMatch("spl", "Split Vertical");
+        REQUIRE(match.has_value());
+        CHECK(match->positions == std::vector<int> { 0, 1, 2 });
+    }
+
+    SECTION("a query straddling a space skips the gap")
+    {
+        // "splitv" is "Split V…" with the space typed through: the last char lands past the space.
+        auto const match = fuzzyMatch("splitv", "Split Vertical");
+        REQUIRE(match.has_value());
+        CHECK(match->positions == std::vector<int> { 0, 1, 2, 3, 4, 6 });
+    }
+
+    SECTION("the reported score is byte-for-byte the one fuzzyScore ranks by")
+    {
+        for (auto const candidate: { "Toggle Pane Zoom", "Split Vertical", "Toggle Status Line" })
+        {
+            auto const match = fuzzyMatch("tpz", candidate);
+            auto const score = fuzzyScore("tpz", candidate);
+            CHECK(match.has_value() == score.has_value());
+            if (match && score)
+                CHECK(match->score == *score);
+        }
+    }
+
+    SECTION("positions are strictly ascending and each lands on the query's character")
+    {
+        // The regression shape from fuzzyScore's own tests: nothing greedy may strand the tail.
+        auto const query = std::string { "togglestatusline" };
+        auto const candidate = std::string { "Toggle Status Line" };
+        auto const match = fuzzyMatch(query, candidate);
+        REQUIRE(match.has_value());
+        REQUIRE(match->positions.size() == query.size());
+
+        auto previous = -1;
+        for (auto const i: std::views::iota(std::size_t { 0 }, query.size()))
+        {
+            auto const at = match->positions[i];
+            INFO("query[" << i << "]='" << query[i] << "' -> candidate index " << at);
+            CHECK(at > previous); // strictly ascending
+            REQUIRE(at >= 0);
+            REQUIRE(at < static_cast<int>(candidate.size()));
+            auto const folded = [](char c) {
+                return std::tolower(static_cast<unsigned char>(c));
+            };
+            CHECK(folded(candidate[static_cast<std::size_t>(at)]) == folded(query[i]));
+            previous = at;
+        }
+    }
+
+    SECTION("a non-subsequence yields nullopt, exactly like fuzzyScore")
+    {
+        CHECK_FALSE(fuzzyMatch("vs", "Split Vertical").has_value());
+        CHECK_FALSE(fuzzyMatch("quit", "Split Vertical").has_value());
+    }
+
+    SECTION("an empty query matches with score 0 and no positions to highlight")
+    {
+        auto const match = fuzzyMatch("", "Split Vertical");
+        REQUIRE(match.has_value());
+        CHECK(match->score == 0);
+        CHECK(match->positions.empty());
     }
 }

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -3041,4 +3041,98 @@ TEST_CASE("The save-layout prompt survives controller destruction without QML er
     QCoreApplication::processEvents();
 }
 
+TEST_CASE("Ctrl+J and Ctrl+K walk the palette selection, vim-style (offscreen)",
+          "[contour][gui][qml][palette]")
+{
+    // The keyboard-only path: Ctrl+J/Ctrl+K move the selection down/up without the caret ever leaving
+    // the filter box, mirroring the arrow keys the palette already handled.
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockPaletteController controller;
+
+    auto const host = openPalette(engine, controller);
+    REQUIRE(host.palette != nullptr);
+
+    auto* filter = host.palette->findChild<QQuickItem*>(QStringLiteral("commandPaletteFilter"));
+    REQUIRE(filter != nullptr);
+    auto* list = host.palette->findChild<QQuickItem*>(QStringLiteral("commandPaletteList"));
+    REQUIRE(list != nullptr);
+    REQUIRE(list->property("count").toInt() > 2);
+
+    // The chords are handled on the filter field, so the caret must be there — as it is on open. Key
+    // events route to the window's focus item, which forceActiveFocus makes the filter.
+    QMetaObject::invokeMethod(filter, "forceActiveFocus");
+    QCoreApplication::processEvents();
+    REQUIRE(list->property("currentIndex").toInt() == 0);
+    auto* const keyWindow = filter->window();
+    REQUIRE(keyWindow != nullptr);
+
+    QTest::keyClick(keyWindow, Qt::Key_J, Qt::ControlModifier);
+    QCoreApplication::processEvents();
+    CHECK(list->property("currentIndex").toInt() == 1);
+
+    QTest::keyClick(keyWindow, Qt::Key_J, Qt::ControlModifier);
+    QCoreApplication::processEvents();
+    CHECK(list->property("currentIndex").toInt() == 2);
+
+    QTest::keyClick(keyWindow, Qt::Key_K, Qt::ControlModifier);
+    QCoreApplication::processEvents();
+    CHECK(list->property("currentIndex").toInt() == 1);
+
+    // The chord drives the list, it must not leak a character into the filter text.
+    CHECK(filter->property("text").toString().isEmpty());
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
+TEST_CASE("The palette bolds matched characters and tints only unselected rows (offscreen)",
+          "[contour][gui][qml][palette]")
+{
+    // The title label renders StyledText so the filter's matches stand out: bold everywhere, and accent
+    // coloured too — except on the selected row, whose accent background would swallow the tint.
+    contour::test::QmlMessageCapture warnings;
+    QQmlEngine engine;
+    MockPaletteController controller;
+
+    auto const host = openPalette(engine, controller);
+    REQUIRE(host.palette != nullptr);
+
+    auto* filter = host.palette->findChild<QQuickItem*>(QStringLiteral("commandPaletteFilter"));
+    REQUIRE(filter != nullptr);
+    auto* list = host.palette->findChild<QQuickItem*>(QStringLiteral("commandPaletteList"));
+    REQUIRE(list != nullptr);
+
+    // "spl" keeps several title-matched rows, the two Split commands on top; row 0 is the selection.
+    filter->setProperty("text", QStringLiteral("spl"));
+    QCoreApplication::processEvents();
+    QMetaObject::invokeMethod(list, "forceLayout");
+    QCoreApplication::processEvents();
+    REQUIRE(list->property("count").toInt() > 1);
+    REQUIRE(list->property("currentIndex").toInt() == 0);
+
+    auto titleTextAt = [&](int index) -> QString {
+        QQuickItem* rowItem = nullptr;
+        QMetaObject::invokeMethod(list, "itemAtIndex", Q_RETURN_ARG(QQuickItem*, rowItem), Q_ARG(int, index));
+        if (rowItem == nullptr)
+            return {};
+        auto* title = rowItem->findChild<QQuickItem*>(QStringLiteral("commandPaletteTitle"));
+        return title != nullptr ? title->property("text").toString() : QString {};
+    };
+
+    auto const selectedTitle = titleTextAt(0);   // the current row
+    auto const unselectedTitle = titleTextAt(1); // another matched row
+    INFO("row0='" << selectedTitle.toStdString() << "' row1='" << unselectedTitle.toStdString() << "'");
+    REQUIRE_FALSE(selectedTitle.isEmpty());
+    REQUIRE_FALSE(unselectedTitle.isEmpty());
+
+    // Both rows bold their matched characters...
+    CHECK(selectedTitle.contains(QStringLiteral("<b>")));
+    CHECK(unselectedTitle.contains(QStringLiteral("<b>")));
+    // ...but only the unselected row tints them with the accent colour.
+    CHECK(unselectedTitle.contains(QStringLiteral("<font color=\"")));
+    CHECK_FALSE(selectedTitle.contains(QStringLiteral("<font color=\"")));
+
+    CHECK(warnings.count([](QString const& w) { return w.contains("TypeError"); }) == 0);
+}
+
 #include <QmlComponents_test.moc>

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -572,7 +572,7 @@ TEST_CASE("Terminal context menu builds its rows from the C++ model (offscreen)"
         .hasSelection = false, // Copy must come out present-but-disabled
         .clipboardHasText = true,
         .hasLastCommand = false, // the three "last command" rows must be absent
-        .hasWorkingDirectory = true,
+        .hasLocalWorkingDirectory = true,
         .hasSplits = false,
         .hyperlinkUnderCursor = "", // the two hyperlink rows must be absent
         .activeProfile = "dark",

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -518,11 +518,17 @@ TEST_CASE("TerminalSession: opener, paste and reload actions run without a displ
     namespace actions = contour::actions;
     auto& launcher = testApp.launcher();
 
+    // A working directory on this host, so OpenFileManager has a local folder to open (it now refuses a
+    // remote or absent one).
+    session->terminal().setCurrentWorkingDirectory("file://" + QHostInfo::localHostName().toStdString()
+                                                   + "/tmp");
+
     // The document/URL openers route through the injected ExternalLauncher (no desktop touched).
     CHECK((*session)(actions::OpenConfiguration {}));
     CHECK((*session)(actions::OpenFileManager {}));
     CHECK((*session)(actions::OpenSelection {}));
-    // OpenConfiguration opens the config file URL; the other two open the (empty) cwd/selection.
+    // OpenConfiguration opens the config file URL, OpenFileManager the local cwd, OpenSelection the
+    // (empty) selection.
     CHECK(launcher.openedUrls.size() == 3);
 
     // FollowHyperlink with nothing hovered/selected returns false (no target).
@@ -1523,10 +1529,45 @@ TEST_CASE("TerminalSession: the opener actions log (do not crash) when the launc
     namespace actions = contour::actions;
     testApp.launcher().openUrlResult = false;
 
+    // A local cwd, so OpenFileManager reaches its openUrl() (and thus the failure branch) rather than
+    // short-circuiting on an absent/remote directory.
+    session->terminal().setCurrentWorkingDirectory("file://" + QHostInfo::localHostName().toStdString()
+                                                   + "/tmp");
+
     CHECK((*session)(actions::OpenConfiguration {}));
     CHECK((*session)(actions::OpenFileManager {}));
     CHECK((*session)(actions::OpenSelection {}));
     CHECK(testApp.launcher().openedUrls.size() == 3); // all attempted despite the failure
+}
+
+TEST_CASE("TerminalSession: OpenFileManager strips the OSC 7 host and skips remote directories",
+          "[contour][session][actions]")
+{
+    // OSC 7 reports the cwd as file://HOST/PATH. Handing that raw URL to the file manager makes its host
+    // authority read as a network share ("//host/path"); it must be resolved to a plain local path, and
+    // only for a directory on THIS host — a remote (SSH) cwd is not openable here.
+    contour::test::TestApp testApp;
+    auto session = makeDisplaylessSession(testApp.app());
+    namespace actions = contour::actions;
+    auto& launcher = testApp.launcher();
+
+    SECTION("a working directory on this host opens as a plain local path")
+    {
+        session->terminal().setCurrentWorkingDirectory("file://" + QHostInfo::localHostName().toStdString()
+                                                       + "/home/user/proj");
+        CHECK((*session)(actions::OpenFileManager {}));
+        REQUIRE(launcher.openedUrls.size() == 1);
+        // The host authority is gone: a local file URL, not a //host network path.
+        CHECK(launcher.openedUrls.back().isLocalFile());
+        CHECK(launcher.openedUrls.back().toLocalFile() == QStringLiteral("/home/user/proj"));
+    }
+
+    SECTION("a remote (SSH) working directory is not opened")
+    {
+        session->terminal().setCurrentWorkingDirectory("file://some-remote-host/home/user");
+        CHECK((*session)(actions::OpenFileManager {}));
+        CHECK(launcher.openedUrls.empty()); // nothing local to open
+    }
 }
 
 TEST_CASE("TerminalSessionManager::setFocusedSession moves terminal focus symmetrically",

--- a/src/contour/ui/CommandPalette.qml
+++ b/src/contour/ui/CommandPalette.qml
@@ -101,6 +101,41 @@ Popup {
         root.close();
     }
 
+    // Renders a command title as StyledText with the filter's matched characters emphasized, so the user
+    // sees WHY a row matched. `matches` is the ascending list of title indices the model's fuzzy filter
+    // landed on (empty when unfiltered). Matched characters are always bold; on an unselected row they
+    // also take the accent colour, but on the SELECTED row — whose background is already that accent —
+    // bold alone is used, since a tint there would wash out. The colour is chosen here, in the view,
+    // because only QML knows the live OS accent and which row is current.
+    //
+    // The whole string is HTML-escaped (a live tab title can contain & < >), so it is always valid
+    // StyledText. Indices are byte offsets from the model, exact for the ASCII command titles shown.
+    function highlightedTitle(text, matches, selected) {
+        var open = selected ? "<b>" : "<b><font color=\"" + systemPalette.highlight.toString() + "\">";
+        var close = selected ? "</b>" : "</font></b>";
+        var next = 0;
+        var result = "";
+        for (var i = 0; i < text.length; ++i) {
+            var hit = matches && next < matches.length && matches[next] === i;
+            if (hit) {
+                result += open;
+                ++next;
+            }
+            var c = text.charAt(i);
+            if (c === "&")
+                result += "&amp;";
+            else if (c === "<")
+                result += "&lt;";
+            else if (c === ">")
+                result += "&gt;";
+            else
+                result += c;
+            if (hit)
+                result += close;
+        }
+        return result;
+    }
+
     contentItem: Column {
         spacing: 0
 
@@ -132,6 +167,22 @@ Popup {
                 Keys.onReturnPressed: root.acceptCurrent()
                 Keys.onEnterPressed: root.acceptCurrent()
                 Keys.onEscapePressed: root.close()
+
+                // Vim-style navigation: Ctrl+J/Ctrl+K move the selection down/up, the same as the arrow
+                // keys, so a home-row user never reaches for them. Accepted explicitly so Ctrl+J cannot
+                // fall through as a line feed into the filter text. Other keys are left unaccepted here
+                // and reach the named handlers above and normal text entry.
+                Keys.onPressed: (event) => {
+                    if (event.modifiers & Qt.ControlModifier) {
+                        if (event.key === Qt.Key_J) {
+                            list.incrementCurrentIndex();
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_K) {
+                            list.decrementCurrentIndex();
+                            event.accepted = true;
+                        }
+                    }
+                }
             }
         }
 
@@ -171,6 +222,7 @@ Popup {
                 required property string shortcut
                 required property int section
                 required property bool sectionStart
+                required property var titleMatches
 
                 width: ListView.view.width
                 height: header.height + entry.height
@@ -218,7 +270,13 @@ Popup {
                         // Yields to the shortcut rather than overrunning it: the shortcut is short and
                         // fixed, the title is the part that can be arbitrarily long.
                         width: parent.width - 24 - shortcutLabel.width - 8
-                        text: row.title
+                        // StyledText so the filter's matched characters can be bolded/accented; the raw
+                        // title and its matched indices come from the model, the styling is chosen here.
+                        // Re-evaluates when the selection moves, flipping the accent tint off the current
+                        // row (see highlightedTitle).
+                        textFormat: Text.StyledText
+                        text: root.highlightedTitle(row.title, row.titleMatches,
+                                                    row.index === list.currentIndex)
                         elide: Text.ElideRight
                         color: entry.textColor
                     }

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -298,4 +298,47 @@ auto extractPathFromFileUrl(std::string const& url) -> std::string
     return std::string(remainder);
 }
 
+namespace
+{
+    /// The DNS label before the first '.', lower-cased: the bare machine name of a possibly-qualified
+    /// host, so "fedora" and "fedora.localdomain" compare equal.
+    [[nodiscard]] std::string bareHostLabel(std::string_view host)
+    {
+        auto label = std::string(host.substr(0, host.find('.')));
+        std::ranges::transform(
+            label, label.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        return label;
+    }
+} // namespace
+
+auto localWorkingDirectory(std::string const& url, std::string_view localHost) -> std::optional<std::string>
+{
+    constexpr auto Prefix = std::string_view("file://");
+    if (url.starts_with(Prefix))
+    {
+        auto const remainder = std::string_view(url).substr(Prefix.size());
+
+        // The host is the authority up to the first '/'. file:///path is rooted (no host), and a Windows
+        // drive-letter authority (file://C:/path) is a path, not a host.
+        auto const isDriveLetter = remainder.size() >= 2
+                                   && (std::isalpha(static_cast<unsigned char>(remainder[0])) != 0)
+                                   && remainder[1] == ':';
+        auto host = std::string_view {};
+        if (!remainder.empty() && remainder.front() != '/' && !isDriveLetter)
+            host = remainder.substr(0, remainder.find('/'));
+
+        if (!host.empty())
+        {
+            auto const label = bareHostLabel(host);
+            if (label != "localhost" && label != bareHostLabel(localHost))
+                return std::nullopt; // a different host: this is a remote working directory
+        }
+    }
+
+    auto path = extractPathFromFileUrl(url);
+    if (path.empty())
+        return std::nullopt;
+    return path;
+}
+
 } // namespace vtbackend

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -301,7 +301,7 @@ auto extractPathFromFileUrl(std::string const& url) -> std::string
 namespace
 {
     /// The DNS label before the first '.', lower-cased: the bare machine name of a possibly-qualified
-    /// host, so "fedora" and "fedora.localdomain" compare equal.
+    /// host, so "fedora" and "fedora.corp.example" compare equal.
     [[nodiscard]] std::string bareHostLabel(std::string_view host)
     {
         auto label = std::string(host.substr(0, host.find('.')));

--- a/src/vtbackend/HintModeHandler.h
+++ b/src/vtbackend/HintModeHandler.h
@@ -4,6 +4,7 @@
 #include <vtbackend/primitives.h>
 
 #include <functional>
+#include <optional>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -141,6 +142,24 @@ class HintModeHandler
 /// Extracts a local filesystem path from a file:// URL (as set by OSC 7).
 /// Returns the URL unchanged if it does not start with "file://".
 [[nodiscard]] auto extractPathFromFileUrl(std::string const& url) -> std::string;
+
+/// The local filesystem path a working-directory URL points at, or nullopt when the URL names a host
+/// other than @p localHost — a remote (e.g. SSH) working directory that does not exist on this machine.
+///
+/// OSC 7 reports the working directory as file://HOST/PATH. A host that is empty, "localhost", or that
+/// shares its first DNS label with @p localHost — case-insensitively, so "host" matches "host.example.com"
+/// — is this machine; the returned path has the file:// scheme, the host authority and the leading "//"
+/// stripped (see @ref extractPathFromFileUrl). Any other host is remote and yields nullopt, as does a URL
+/// that carries no path at all.
+///
+/// The local host name is a parameter rather than read here so the decision stays pure and unit-testable;
+/// the caller injects it (QHostInfo::localHostName() in the GUI).
+///
+/// @param url       The working-directory URL: an OSC 7 file:// URL, or a bare local path.
+/// @param localHost This machine's host name.
+/// @return The local path to open, or nullopt when @p url is remote or path-less.
+[[nodiscard]] auto localWorkingDirectory(std::string const& url, std::string_view localHost)
+    -> std::optional<std::string>;
 
 /// Converts a UTF-8 byte offset within @p text to the corresponding codepoint index.
 ///

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -576,6 +576,42 @@ TEST_CASE("extractPathFromFileUrl.WindowsDriveLetterWithHost", "[hintmode]")
     CHECK(extractPathFromFileUrl("file://MYPC/d:/temp/x") == "d:/temp/x");
 }
 
+TEST_CASE("localWorkingDirectory.localHostIsOpenable", "[hintmode]")
+{
+    // The pane's own host: strip the scheme and authority down to a plain local path.
+    CHECK(localWorkingDirectory("file://fedora/home/user/proj", "fedora") == "/home/user/proj");
+    // Case-insensitively, and tolerant of a fully-qualified name on either side (same machine).
+    CHECK(localWorkingDirectory("file://FEDORA/home/user", "fedora") == "/home/user");
+    CHECK(localWorkingDirectory("file://fedora.localdomain/home/user", "fedora") == "/home/user");
+    CHECK(localWorkingDirectory("file://fedora/home/user", "fedora.corp.example") == "/home/user");
+    // An empty authority (file:///path) and an explicit "localhost" are this machine too.
+    CHECK(localWorkingDirectory("file:///home/user", "fedora") == "/home/user");
+    CHECK(localWorkingDirectory("file://localhost/home/user", "fedora") == "/home/user");
+    // A bare path (a shell that emits OSC 7 without the file:// wrapper) is local as-is.
+    CHECK(localWorkingDirectory("/home/user", "fedora") == "/home/user");
+}
+
+TEST_CASE("localWorkingDirectory.remoteHostIsRejected", "[hintmode]")
+{
+    // A different host is a remote (e.g. SSH) working directory: its path does not exist here.
+    CHECK(localWorkingDirectory("file://remotebox/home/user", "fedora") == std::nullopt);
+    CHECK(localWorkingDirectory("file://remotebox/C:/Users/user", "fedora") == std::nullopt);
+    // A host with no path at all has nothing to open.
+    CHECK(localWorkingDirectory("file://fedora", "fedora") == std::nullopt);
+    // Nothing reported yet.
+    CHECK(localWorkingDirectory("", "fedora") == std::nullopt);
+}
+
+TEST_CASE("localWorkingDirectory.windowsDriveLetterIsLocal", "[hintmode]")
+{
+    // A drive-letter authority is a path, not a host, so it is this machine's.
+    CHECK(localWorkingDirectory("file://C:/Users/user", "mypc") == "C:/Users/user");
+    CHECK(localWorkingDirectory("file:///C:/Users/user", "mypc") == "C:/Users/user");
+    // A real host in front of a drive path is still local only when the host matches.
+    CHECK(localWorkingDirectory("file://mypc/C:/Users/user", "mypc") == "C:/Users/user");
+    CHECK(localWorkingDirectory("file://otherpc/C:/Users/user", "mypc") == std::nullopt);
+}
+
 TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")
 {
     namespace fs = std::filesystem;

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -582,7 +582,7 @@ TEST_CASE("localWorkingDirectory.localHostIsOpenable", "[hintmode]")
     CHECK(localWorkingDirectory("file://fedora/home/user/proj", "fedora") == "/home/user/proj");
     // Case-insensitively, and tolerant of a fully-qualified name on either side (same machine).
     CHECK(localWorkingDirectory("file://FEDORA/home/user", "fedora") == "/home/user");
-    CHECK(localWorkingDirectory("file://fedora.localdomain/home/user", "fedora") == "/home/user");
+    CHECK(localWorkingDirectory("file://fedora.corp.example/home/user", "fedora") == "/home/user");
     CHECK(localWorkingDirectory("file://fedora/home/user", "fedora.corp.example") == "/home/user");
     // An empty authority (file:///path) and an explicit "localhost" are this machine too.
     CHECK(localWorkingDirectory("file:///home/user", "fedora") == "/home/user");
@@ -594,8 +594,8 @@ TEST_CASE("localWorkingDirectory.localHostIsOpenable", "[hintmode]")
 TEST_CASE("localWorkingDirectory.remoteHostIsRejected", "[hintmode]")
 {
     // A different host is a remote (e.g. SSH) working directory: its path does not exist here.
-    CHECK(localWorkingDirectory("file://remotebox/home/user", "fedora") == std::nullopt);
-    CHECK(localWorkingDirectory("file://remotebox/C:/Users/user", "fedora") == std::nullopt);
+    CHECK(localWorkingDirectory("file://remotehost/home/user", "fedora") == std::nullopt);
+    CHECK(localWorkingDirectory("file://remotehost/C:/Users/user", "fedora") == std::nullopt);
     // A host with no path at all has nothing to open.
     CHECK(localWorkingDirectory("file://fedora", "fedora") == std::nullopt);
     // Nothing reported yet.
@@ -605,11 +605,11 @@ TEST_CASE("localWorkingDirectory.remoteHostIsRejected", "[hintmode]")
 TEST_CASE("localWorkingDirectory.windowsDriveLetterIsLocal", "[hintmode]")
 {
     // A drive-letter authority is a path, not a host, so it is this machine's.
-    CHECK(localWorkingDirectory("file://C:/Users/user", "mypc") == "C:/Users/user");
-    CHECK(localWorkingDirectory("file:///C:/Users/user", "mypc") == "C:/Users/user");
+    CHECK(localWorkingDirectory("file://C:/Users/user", "laptop") == "C:/Users/user");
+    CHECK(localWorkingDirectory("file:///C:/Users/user", "laptop") == "C:/Users/user");
     // A real host in front of a drive path is still local only when the host matches.
-    CHECK(localWorkingDirectory("file://mypc/C:/Users/user", "mypc") == "C:/Users/user");
-    CHECK(localWorkingDirectory("file://otherpc/C:/Users/user", "mypc") == std::nullopt);
+    CHECK(localWorkingDirectory("file://laptop/C:/Users/user", "laptop") == "C:/Users/user");
+    CHECK(localWorkingDirectory("file://desktop/C:/Users/user", "laptop") == std::nullopt);
 }
 
 TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")


### PR DESCRIPTION
Several keyboard- and mouse-driven UX improvements to the command palette and the terminal right-click context menu.

## Changes

- **Command palette: vim navigation + match highlighting.** `Ctrl+J` / `Ctrl+K` move the selection down/up without the caret leaving the filter box, and the characters a fuzzy query matched are emphasized — bold everywhere, plus an accent tint on all but the selected row (whose accent background would otherwise swallow it). A shared `fuzzyMatch()` reports the exact matched positions, so the highlight is precisely what the score ranked by.
- **Context menu: Read-Only Mode toggle.** A checkable "Read-Only Mode" item reflects and toggles the terminal's input-protection state — its checkbox is ticked when input is protected — reusing the existing `ToggleInputProtection` action and the menu's data-driven checkable-row path.
- **Context menu: "Open Current Folder" respects the local host.** OSC 7 reports the working directory as `file://HOST/PATH`; the raw URL was handed to the file manager, so an SSH session's remote host was read as a network share (`//host/path`) and failed to open. The directory is now resolved to a plain local path, and the item is grayed out unless the cwd is on this host.