### PR TITLE
Add a Windows-Terminal-style in-app GUI settings page

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -9,6 +9,7 @@ actionlint
 affordance
 agentic
 argless
+asprintf
 AWriter
 axb
 backbuffer
@@ -62,6 +63,7 @@ dri
 drv
 Dscs
 ecmascript
+editability
 eeeh
 EGL
 ellips
@@ -77,6 +79,7 @@ FDiag
 FFFFF
 FFFFFFC
 fiddliest
+flyouts
 FRENCHCANADIAN
 GGGGG
 gitbranch
@@ -85,11 +88,13 @@ Gles
 HCenter
 headlessly
 HHHHH
+HHHHHH
 HTP
 imagesize
 invokables
 isakbm
 journalctl
+keysym
 libcuda
 libva
 LMENU
@@ -156,6 +161,7 @@ qmljsdebugger
 qobject
 QPalette
 qputenv
+qqmlregistration
 QRegular
 qrhi
 qrhigles
@@ -214,6 +220,7 @@ templ
 TOCTOU
 togglestatusline
 tpz
+trashcan
 tso
 UBO
 ubuf

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -68,6 +68,7 @@ struct NewTerminal{ std::optional<std::string> profileName; };
 struct NoSearchHighlight{};
 struct OpenCommandPalette{};
 struct OpenConfiguration{};
+struct OpenSettings{};            // open the in-app settings page as a tab in this window
 struct OpenFileManager{};
 struct OpenSelection{};
 struct PasteClipboard{ bool strip = false; };
@@ -164,6 +165,7 @@ using Action = std::variant<CancelSelection,
                             NoSearchHighlight,
                             OpenCommandPalette,
                             OpenConfiguration,
+                            OpenSettings,
                             OpenFileManager,
                             OpenSelection,
                             PasteClipboard,
@@ -391,6 +393,10 @@ namespace documentation
         "alphabetically."
     };
     constexpr inline std::string_view OpenConfiguration { "Opens the configuration file." };
+    constexpr inline std::string_view OpenSettings {
+        "Opens the in-app settings page as a tab in the current window, where profiles, color schemes "
+        "and the default profile can be edited via the GUI."
+    };
     constexpr inline std::string_view OpenFileManager {
         "Opens the current working directory in a system file manager."
     };
@@ -620,6 +626,7 @@ struct ActionCatalogEntry
             "OpenCommandPalette", Action { OpenCommandPalette {} }, documentation::OpenCommandPalette },
         ActionCatalogEntry {
             "OpenConfiguration", Action { OpenConfiguration {} }, documentation::OpenConfiguration },
+        ActionCatalogEntry { "OpenSettings", Action { OpenSettings {} }, documentation::OpenSettings },
         ActionCatalogEntry {
             "OpenFileManager", Action { OpenFileManager {} }, documentation::OpenFileManager },
         ActionCatalogEntry { "OpenSelection", Action { OpenSelection {} }, documentation::OpenSelection },

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -67,8 +67,7 @@ struct IncreaseOpacity{};
 struct NewTerminal{ std::optional<std::string> profileName; };
 struct NoSearchHighlight{};
 struct OpenCommandPalette{};
-struct OpenConfiguration{};
-struct OpenSettings{};            // open the in-app settings page as a tab in this window
+struct OpenConfiguration{ bool inEditor = false; }; // GUI settings page by default; in_editor opens the file
 struct OpenFileManager{};
 struct OpenSelection{};
 struct PasteClipboard{ bool strip = false; };
@@ -165,7 +164,6 @@ using Action = std::variant<CancelSelection,
                             NoSearchHighlight,
                             OpenCommandPalette,
                             OpenConfiguration,
-                            OpenSettings,
                             OpenFileManager,
                             OpenSelection,
                             PasteClipboard,
@@ -392,10 +390,9 @@ namespace documentation
         "description and key binding. Recently used commands are listed first, then all commands "
         "alphabetically."
     };
-    constexpr inline std::string_view OpenConfiguration { "Opens the configuration file." };
-    constexpr inline std::string_view OpenSettings {
-        "Opens the in-app settings page as a tab in the current window, where profiles, color schemes "
-        "and the default profile can be edited via the GUI."
+    constexpr inline std::string_view OpenConfiguration {
+        "Opens the in-app settings page (profiles, color schemes, global settings). Set `in_editor: true` "
+        "on the binding to instead open the configuration file in an external editor."
     };
     constexpr inline std::string_view OpenFileManager {
         "Opens the current working directory in a system file manager."
@@ -626,7 +623,6 @@ struct ActionCatalogEntry
             "OpenCommandPalette", Action { OpenCommandPalette {} }, documentation::OpenCommandPalette },
         ActionCatalogEntry {
             "OpenConfiguration", Action { OpenConfiguration {} }, documentation::OpenConfiguration },
-        ActionCatalogEntry { "OpenSettings", Action { OpenSettings {} }, documentation::OpenSettings },
         ActionCatalogEntry {
             "OpenFileManager", Action { OpenFileManager {} }, documentation::OpenFileManager },
         ActionCatalogEntry { "OpenSelection", Action { OpenSelection {} }, documentation::OpenSelection },

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -56,6 +56,7 @@ set(_header_files
     ContextMenuModel.h
     ContourApp.h
     FuzzyFilter.h
+    GuiConfigStore.h
     Shortcut.h
     TabLabel.h
 )
@@ -79,6 +80,7 @@ set(_core_source_files
     ContextMenuModel.cpp
     ContourApp.cpp
     FuzzyFilter.cpp
+    GuiConfigStore.cpp
     Shortcut.cpp
     TabLabel.cpp
 )

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -106,6 +106,7 @@ if(CONTOUR_FRONTEND_GUI)
         PaneProxy.h
         QtExternalLauncher.h
         SessionFactory.h
+        SettingsController.h
         TerminalSession.h
         TerminalSessionManager.h
         helper.h
@@ -121,6 +122,7 @@ if(CONTOUR_FRONTEND_GUI)
         LayoutBuilder.cpp
         LayoutStore.cpp
         SessionFactory.cpp
+        SettingsController.cpp
         TerminalSession.cpp
         TerminalSessionManager.cpp
         WindowController.cpp
@@ -313,6 +315,7 @@ if(CONTOUR_FRONTEND_GUI)
             test/CommandHistory_test.cpp
             test/CommandPaletteModel_test.cpp
             test/Config_test.cpp
+            test/SettingsController_test.cpp
             test/ContextMenu_test.cpp
             test/FuzzyFilter_test.cpp
             test/Shortcut_test.cpp

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -316,6 +316,7 @@ if(CONTOUR_FRONTEND_GUI)
             test/CommandPaletteModel_test.cpp
             test/Config_test.cpp
             test/SettingsController_test.cpp
+            test/SettingsPageQml_test.cpp
             test/ContextMenu_test.cpp
             test/FuzzyFilter_test.cpp
             test/Shortcut_test.cpp

--- a/src/contour/CommandPaletteModel.cpp
+++ b/src/contour/CommandPaletteModel.cpp
@@ -4,8 +4,10 @@
 #include <contour/FuzzyFilter.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <optional>
 #include <ranges>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -22,6 +24,48 @@ namespace
     [[nodiscard]] bool byTitle(Command const& a, Command const& b) noexcept
     {
         return a.title < b.title;
+    }
+
+    /// Translates fuzzy-match offsets from UTF-8 byte positions (what FuzzyFilter reports) to UTF-16
+    /// code-unit indices (what a QML string is indexed by). For an all-ASCII title the two coincide, but a
+    /// multibyte character shifts every later index, so without this the palette would bold the wrong
+    /// characters of a non-ASCII title (e.g. a shell-set tab title). @p title is the UTF-8 title; @p
+    /// byteOffsets are ascending byte offsets at code-point boundaries. @return the same-count ascending
+    /// UTF-16 indices; an offset past the string end (or not on a boundary) is dropped, matching the view's
+    /// prior silent handling of out-of-range indices.
+    [[nodiscard]] std::vector<int> byteOffsetsToUtf16(std::string_view title,
+                                                      std::vector<int> const& byteOffsets)
+    {
+        auto result = std::vector<int> {};
+        result.reserve(byteOffsets.size());
+
+        auto bytePos = std::size_t { 0 };
+        auto utf16Pos = 0;
+        for (auto const offset: byteOffsets)
+        {
+            if (offset < 0)
+                continue; // defensive: ignore a nonsensical offset rather than loop on it
+            auto const target = static_cast<std::size_t>(offset);
+            // Offsets are ascending, so bytePos only ever moves forward: walk to the target byte position
+            // one whole UTF-8 code point at a time, accumulating each one's UTF-16 width (2 for a code
+            // point encoded as 4 bytes, which is a surrogate pair, else 1).
+            while (bytePos < target && bytePos < title.size())
+            {
+                auto const lead = static_cast<unsigned char>(title[bytePos]);
+                auto seqLen = 1;
+                if (lead >= 0xF0)
+                    seqLen = 4;
+                else if (lead >= 0xE0)
+                    seqLen = 3;
+                else if (lead >= 0x80)
+                    seqLen = 2;
+                bytePos += static_cast<std::size_t>(seqLen);
+                utf16Pos += seqLen == 4 ? 2 : 1; // a 4-byte code point maps to a UTF-16 surrogate pair
+            }
+            if (bytePos == target)
+                result.push_back(utf16Pos);
+        }
+        return result;
     }
 } // namespace
 
@@ -196,10 +240,13 @@ QVariant CommandPaletteModel::data(QModelIndex const& index, int role) const
         case SectionRole: return static_cast<int>(entry.section);
         case TitleMatchesRole: {
             // The matched title indices as a plain list of ints, which QML reads as a JS array to decide
-            // which characters to bold. Empty on an unfiltered or id-only-matched row.
+            // which characters to bold. Empty on an unfiltered or id-only-matched row. FuzzyFilter reports
+            // these as UTF-8 byte offsets, but QML indexes the title by UTF-16 code unit; translate here,
+            // where the UTF-8 title is known, so a title with any multibyte character bolds correctly.
+            auto const utf16Matches = byteOffsetsToUtf16(entry.command->title, entry.titleMatches);
             auto matches = QVariantList {};
-            matches.reserve(static_cast<qsizetype>(entry.titleMatches.size()));
-            for (auto const position: entry.titleMatches)
+            matches.reserve(static_cast<qsizetype>(utf16Matches.size()));
+            for (auto const position: utf16Matches)
                 matches.append(position);
             return matches;
         }

--- a/src/contour/CommandPaletteModel.h
+++ b/src/contour/CommandPaletteModel.h
@@ -58,7 +58,7 @@ class CommandPaletteModel: public QAbstractListModel
         ShortcutRole,              //!< Rendered key binding ("Ctrl+Shift+E"), or empty if unbound.
         SectionRole,               //!< The row's Section, as an int.
         SectionStartRole,          //!< True on the FIRST row of a section, so QML draws one header for it.
-        TitleMatchesRole,          //!< Title character indices the current filter matched, for highlighting.
+        TitleMatchesRole,          //!< Matched title indices (UTF-16 code units) for highlighting.
     };
 
     /// @param history The app-wide most-recently-used list. Must outlive this model.
@@ -115,9 +115,10 @@ class CommandPaletteModel: public QAbstractListModel
     {
         Command const* command;
         Section section;
-        /// Byte offsets into the command's title that the active filter matched, ascending — what QML
-        /// bolds. Empty when there is no filter, or when the row matched only through its id (there is
-        /// nothing in the visible title to highlight then).
+        /// UTF-8 byte offsets into the command's title that the active filter matched, ascending. These
+        /// are converted to UTF-16 code-unit indices at the TitleMatchesRole boundary (what QML bolds).
+        /// Empty when there is no filter, or when the row matched only through its id (there is nothing in
+        /// the visible title to highlight then).
         std::vector<int> titleMatches;
     };
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -3251,6 +3251,26 @@ std::string emitGuiSettingsYaml(GuiManagedSettings const& settings)
     return std::string { out.c_str() } + '\n';
 }
 
+std::optional<vtbackend::ColorPalette> loadColorSchemeFile(std::filesystem::path const& path)
+{
+    auto const contents = readFile(path);
+    if (!contents)
+        return std::nullopt;
+
+    try
+    {
+        auto reader = YAMLConfigReader(path.string(), configLog);
+        auto palette = vtbackend::ColorPalette {};
+        reader.loadFromEntry(YAML::Load(*contents), palette);
+        return palette;
+    }
+    catch (std::exception const& e)
+    {
+        configLog()("Could not read color scheme {}: {}", path.string(), e.what());
+        return std::nullopt;
+    }
+}
+
 std::expected<GuiManagedSettings, std::string> loadGuiSettingsFile(std::filesystem::path const& path)
 {
     auto settings = GuiManagedSettings {};

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -2655,6 +2655,14 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
             }
         }
 
+        if (holds_alternative<actions::OpenConfiguration>(action))
+        {
+            // Default opens the in-app settings page; `in_editor: true` opens the config file instead.
+            if (auto inEditor = node["in_editor"]; inEditor && inEditor.IsScalar())
+                return actions::OpenConfiguration { inEditor.as<bool>() };
+            return action;
+        }
+
         if (holds_alternative<actions::PasteSelection>(action))
         {
             if (auto eval = node["evaluate_in_shell"]; eval && eval.IsScalar())

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -325,6 +325,92 @@ void compareEntries(Config& config, auto const& output)
     }
 }
 
+/// Records the provenance of every profile and color scheme the main parse produced, so that anything
+/// the GUI side-file scan adds on top is distinguishable as GUI-owned (and therefore editable in the
+/// settings page) from the hand-maintained inline entries, which stay read-only there.
+/// @param config The just-parsed configuration to annotate.
+void recordMainConfigOrigins(Config& config)
+{
+    for (auto const& [name, _]: config.profiles.value())
+        config.profileOrigins.emplace(name, SettingsOrigin::MainConfig);
+    for (auto const& [name, _]: config.colorschemes.value())
+        config.colorSchemeOrigins.emplace(
+            name, name == "default" ? SettingsOrigin::Builtin : SettingsOrigin::MainConfig);
+}
+
+/// Merges the GUI-managed side files over the just-parsed configuration, mirroring the layouts.yml
+/// merge: the freshest (GUI) content wins, and a broken file is logged and skipped rather than taking
+/// the whole configuration down. Color scheme side files (colorschemes/<name>.yml) are already
+/// resolved lazily by the reader when a profile references them, so only the per-profile files and the
+/// global settings.yml are handled here.
+/// @param config The configuration to augment in place (its @c configFile locates the side files).
+/// @param reader The reader used for the main config; reused to parse profile bodies (it carries the
+///               logger and ${VAR} replacer, and loadProfileBody takes its node explicitly).
+void mergeGuiManagedSideFiles(Config& config, YAMLConfigReader& reader)
+{
+    auto const dir = config.configFile.parent_path();
+
+    // Inheritance base for GUI profiles: the resolved default profile, captured BEFORE any side file
+    // can replace it in the map, so a GUI profile inherits the same defaults an inline one would.
+    auto base = TerminalProfile {};
+    if (auto const* def = config.findProfile(config.defaultProfileName.value()))
+        base = *def;
+
+    auto const profilesDir = dir / "profiles";
+    std::error_code ec;
+    if (std::filesystem::is_directory(profilesDir, ec))
+    {
+        auto files = std::vector<std::filesystem::path> {};
+        for (auto const& entry: std::filesystem::directory_iterator(profilesDir, ec))
+            if (entry.is_regular_file() && entry.path().extension() == ".yml")
+                files.push_back(entry.path());
+        std::ranges::sort(files); // deterministic load order across filesystems
+
+        for (auto const& path: files)
+        {
+            auto const name = path.stem().string();
+            auto const contents = readFile(path);
+            if (!contents)
+            {
+                configLog()("Skipping unreadable profile side file: {}", path.string());
+                continue;
+            }
+            auto root = YAML::Node {};
+            try
+            {
+                root = YAML::Load(*contents);
+            }
+            catch (std::exception const& e)
+            {
+                configLog()("Skipping malformed profile side file {}: {}", path.string(), e.what());
+                continue;
+            }
+            auto profile = base; // inherit the default profile's values, then overlay the file's keys
+            reader.loadProfileBody(root, profile);
+            config.profiles.value()[name] = std::move(profile);
+            config.profileOrigins[name] = SettingsOrigin::SideFile;
+        }
+    }
+
+    // settings.yml — GUI-owned global overrides (currently only default_profile). Applied last so it
+    // can select a profile the scan above just introduced.
+    if (auto loaded = loadGuiSettingsFile(dir / "settings.yml"))
+    {
+        config.guiManagedSettings = *loaded;
+        if (auto const& defaultProfile = loaded->defaultProfile)
+        {
+            if (config.findProfile(*defaultProfile))
+                config.defaultProfileName = *defaultProfile;
+            else
+                configLog()("settings.yml default_profile '{}' is not a known profile; keeping '{}'.",
+                            *defaultProfile,
+                            config.defaultProfileName.value());
+        }
+    }
+    else
+        configLog()("Failed to load settings.yml: {}", loaded.error());
+}
+
 /**
  * @return success or failure of loading the config file.
  */
@@ -349,6 +435,11 @@ void loadConfigFromFile(Config& config, fs::path const& fileName)
     }
     else
         logger()("Failed to load layouts.yml: {}", fileLayouts.error());
+
+    // Provenance first, then the GUI side files (profiles/*.yml, settings.yml) on top — the same
+    // freshest-wins, broken-file-tolerant merge philosophy the layouts.yml merge above uses.
+    recordMainConfigOrigins(config);
+    mergeGuiManagedSideFiles(config, yamlVisitor);
 
     compareEntries(config, logger);
 }
@@ -487,6 +578,7 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("early_exit_threshold", c.earlyExitThreshold);
         loadFromEntry("spawn_new_process", c.spawnNewProcess);
         loadFromEntry("reflow_on_resize", c.reflowOnResize);
+        loadFromEntry("gui_config_locked", c.guiConfigLocked);
         loadFromEntry("experimental", c.experimentalFeatures);
         loadFromEntry("bypass_mouse_protocol_modifier", c.bypassMouseProtocolModifiers);
         loadFromEntry("on_mouse_select", c.onMouseSelection);
@@ -515,7 +607,11 @@ void YAMLConfigReader::load(Config& c)
 void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& entry, TerminalProfile& where)
 {
     logger()("loading profile {}\n", entry);
-    auto const child = node[entry];
+    loadProfileBody(node[entry], where);
+}
+
+void YAMLConfigReader::loadProfileBody(YAML::Node const& child, TerminalProfile& where)
+{
     if (child)
     {
         if (child["ssh"])
@@ -2859,12 +2955,17 @@ std::string createForGlobal(Config const& c)
     return doc;
 }
 
+/// Appends one profile's body (every ConfigEntry member, walked via reflection) to @p doc using
+/// @p writer. The single source of truth for profile serialization, shared by createForProfile
+/// (which wraps it in `profiles:`/name scopes) and createForSingleProfile (which emits it bare for a
+/// profiles/<name>.yml side file). Because it is a reflection walk, a newly-added profile field is
+/// serialized here automatically — there is nothing to hand-list.
+/// @param writer The writer providing indentation and value formatting.
+/// @param doc The output buffer to append to.
+/// @param profile The profile to serialize.
 template <typename Writer>
-std::string createForProfile(Config const& c)
+void emitProfileBody(Writer& writer, std::string& doc, TerminalProfile const& profile)
 {
-    auto doc = std::string {};
-    Writer writer;
-
     auto const processConfigEntry =
         [&]<typename T, documentation::StringLiteral ConfigDoc, documentation::StringLiteral WebDoc>(
             auto name,
@@ -2902,6 +3003,26 @@ std::string createForProfile(Config const& c)
         [&]([[maybe_unused]] auto name, [[maybe_unused]] auto const& v) {},
     };
 
+    Reflection::CallOnMembers(profile, completeOverload);
+}
+
+/// Serializes one profile's body as a bare top-level map for a `profiles/<name>.yml` GUI side file
+/// (no `profiles:`/name wrapper), so the same reader that parses an inline profile parses it back.
+template <typename Writer>
+std::string createForSingleProfile(TerminalProfile const& profile)
+{
+    auto doc = std::string {};
+    Writer writer;
+    emitProfileBody(writer, doc, profile);
+    return doc;
+}
+
+template <typename Writer>
+std::string createForProfile(Config const& c)
+{
+    auto doc = std::string {};
+    Writer writer;
+
     // inside profiles:
     doc.append(writer.replaceCommentPlaceholder(std::string { writer.whichDoc(c.profiles) }));
     {
@@ -2911,9 +3032,140 @@ std::string createForProfile(Config const& c)
             if constexpr (std::same_as<Writer, YAMLConfigWriter>)
                 doc.append(std::format("    {}: \n", name));
 
-            writer.scoped([&]() { Reflection::CallOnMembers(entry, completeOverload); });
+            writer.scoped([&]() { emitProfileBody(writer, doc, entry); });
         }
     }
+    return doc;
+}
+
+/// Appends one color palette's body (every colored slot: defaults, decorations, highlights, the
+/// 3×8 ANSI colors) to @p doc via @p writer. The single source of truth for palette serialization,
+/// shared by createForColorScheme (which wraps it in `color_schemes:`/name scopes) and
+/// createForSingleColorScheme (which emits it bare for a colorschemes/<name>.yml side file), so a new
+/// palette slot is added in exactly one place.
+/// @param writer The writer providing indentation and value formatting.
+/// @param doc The output buffer to append to.
+/// @param entry The palette to serialize.
+template <typename Writer>
+void emitColorPaletteBody(Writer& writer, std::string& doc, vtbackend::ColorPalette const& entry)
+{
+    auto const processWithDoc = [&](auto&& docString, auto... val) {
+        doc.append(writer.replaceCommentPlaceholder(writer.process(writer.whichDoc(docString), val...)));
+    };
+
+    processWithDoc(documentation::DefaultColors {},
+                   entry.defaultBackground,
+                   entry.defaultForeground,
+                   entry.defaultForegroundBright,
+                   entry.defaultForegroundDimmed);
+
+    processWithDoc(documentation::HyperlinkDecoration {},
+                   entry.hyperlinkDecoration.normal,
+                   entry.hyperlinkDecoration.hover);
+
+    processWithDoc(documentation::YankHighlight {},
+                   entry.yankHighlight.foreground,
+                   entry.yankHighlight.foregroundAlpha,
+                   entry.yankHighlight.background,
+                   entry.yankHighlight.backgroundAlpha);
+
+    processWithDoc(documentation::NormalModeCursorline {},
+                   entry.normalModeCursorline.foreground,
+                   entry.normalModeCursorline.foregroundAlpha,
+                   entry.normalModeCursorline.background,
+                   entry.normalModeCursorline.backgroundAlpha);
+
+    processWithDoc(documentation::Selection {},
+                   entry.selection.foreground,
+                   entry.selection.foregroundAlpha,
+                   entry.selection.background,
+                   entry.selection.backgroundAlpha);
+
+    processWithDoc(documentation::SearchHighlight {},
+                   entry.searchHighlight.foreground,
+                   entry.searchHighlight.foregroundAlpha,
+                   entry.searchHighlight.background,
+                   entry.searchHighlight.backgroundAlpha);
+
+    processWithDoc(documentation::SearchHighlightFocused {},
+                   entry.searchHighlightFocused.foreground,
+                   entry.searchHighlightFocused.foregroundAlpha,
+                   entry.searchHighlightFocused.background,
+                   entry.searchHighlightFocused.backgroundAlpha);
+
+    processWithDoc(documentation::WordHighlightCurrent {},
+                   entry.wordHighlightCurrent.foreground,
+                   entry.wordHighlightCurrent.foregroundAlpha,
+                   entry.wordHighlightCurrent.background,
+                   entry.wordHighlightCurrent.backgroundAlpha);
+
+    processWithDoc(documentation::WordHighlight {},
+                   entry.wordHighlight.foreground,
+                   entry.wordHighlight.foregroundAlpha,
+                   entry.wordHighlight.background,
+                   entry.wordHighlight.backgroundAlpha);
+
+    processWithDoc(documentation::HintLabel {},
+                   entry.hintLabel.foreground,
+                   entry.hintLabel.foregroundAlpha,
+                   entry.hintLabel.background,
+                   entry.hintLabel.backgroundAlpha);
+
+    processWithDoc(documentation::HintMatch {},
+                   entry.hintMatch.foreground,
+                   entry.hintMatch.foregroundAlpha,
+                   entry.hintMatch.background,
+                   entry.hintMatch.backgroundAlpha);
+
+    processWithDoc(documentation::IndicatorStatusLine {},
+                   entry.indicatorStatusLineInsertMode.foreground,
+                   entry.indicatorStatusLineInsertMode.background,
+                   entry.indicatorStatusLineInactive.foreground,
+                   entry.indicatorStatusLineInactive.background);
+
+    processWithDoc(documentation::InputMethodEditor {},
+                   entry.inputMethodEditor.foreground,
+                   entry.inputMethodEditor.background);
+
+    processWithDoc(documentation::NormalColors {},
+                   entry.normalColor(0),
+                   entry.normalColor(1),
+                   entry.normalColor(2),
+                   entry.normalColor(3),
+                   entry.normalColor(4),
+                   entry.normalColor(5),
+                   entry.normalColor(6),
+                   entry.normalColor(7));
+
+    processWithDoc(documentation::BrightColors {},
+                   entry.brightColor(0),
+                   entry.brightColor(1),
+                   entry.brightColor(2),
+                   entry.brightColor(3),
+                   entry.brightColor(4),
+                   entry.brightColor(5),
+                   entry.brightColor(6),
+                   entry.brightColor(7));
+
+    processWithDoc(documentation::DimColors {},
+                   entry.dimColor(0),
+                   entry.dimColor(1),
+                   entry.dimColor(2),
+                   entry.dimColor(3),
+                   entry.dimColor(4),
+                   entry.dimColor(5),
+                   entry.dimColor(6),
+                   entry.dimColor(7));
+}
+
+/// Serializes one color palette as a bare top-level body for a `colorschemes/<name>.yml` GUI side
+/// file (no `color_schemes:`/name wrapper), matching that file's lazy read path.
+template <typename Writer>
+std::string createForSingleColorScheme(vtbackend::ColorPalette const& palette)
+{
+    auto doc = std::string {};
+    Writer writer;
+    emitColorPaletteBody(writer, doc, palette);
     return doc;
 }
 
@@ -2923,10 +3175,6 @@ std::string createForColorScheme(Config const& c)
     auto doc = std::string {};
     Writer writer;
 
-    auto const processWithDoc = [&](auto&& docString, auto... val) {
-        doc.append(writer.replaceCommentPlaceholder(writer.process(writer.whichDoc(docString), val...)));
-    };
-
     doc.append(writer.replaceCommentPlaceholder(c.colorschemes.documentation));
     writer.scoped([&]() {
         for (auto&& [name, entry]: c.colorschemes.value())
@@ -2934,139 +3182,7 @@ std::string createForColorScheme(Config const& c)
             doc.append(std::format("    {}: \n", name));
             {
                 const auto _ = typename Writer::Offset {};
-                processWithDoc(documentation::DefaultColors {},
-                               entry.defaultBackground,
-                               entry.defaultForeground,
-                               entry.defaultForegroundBright,
-                               entry.defaultForegroundDimmed);
-
-                // processWithDoc("# Background image support.\n"
-                //                "background_image:\n"
-                //                "    # Full path to the image to use as background.\n"
-                //                "    #\n"
-                //                "    # Default: empty string (disabled)\n"
-                //                "    # path: '/Users/trapni/Pictures/bg.png'\n"
-                //                "\n"
-                //                "    # Image opacity to be applied to make the image not look to
-                //                intense\n" "    # and not get too distracted by the background
-                //                image.\n" "    opacity: {}\n"
-                //                "\n"
-                //                "    # Optionally blurs background image to make it less
-                //                distracting\n" "    # and keep the focus on the actual terminal
-                //                contents.\n" "    #\n" "    blur: {}\n",
-                //                entry.backgroundImage->opacity,
-                //                entry.backgroundImage->blur);
-
-                // processWithDoc("# Mandates the color of the cursor and potentially overridden
-                // text.\n"
-                //                "#\n"
-                //                "# The color can be specified in RGB as usual, plus\n"
-                //                "# - CellForeground: Selects the cell's foreground color.\n"
-                //                "# - CellBackground: Selects the cell's background color.\n"
-                //                "cursor:\n"
-                //                "    # Specifies the color to be used for the actual cursor
-                //                shape.\n" "    #\n" "    default: {}\n" "    # Specifies the
-                //                color to be used for the characters that would\n" "    # be
-                //                covered otherwise.\n" "    #\n" "    text: {}\n",
-                //                entry.cursor.color, entry.cursor.textOverrideColor);
-
-                processWithDoc(documentation::HyperlinkDecoration {},
-                               entry.hyperlinkDecoration.normal,
-                               entry.hyperlinkDecoration.hover);
-
-                processWithDoc(documentation::YankHighlight {},
-                               entry.yankHighlight.foreground,
-                               entry.yankHighlight.foregroundAlpha,
-                               entry.yankHighlight.background,
-                               entry.yankHighlight.backgroundAlpha);
-
-                processWithDoc(documentation::NormalModeCursorline {},
-                               entry.normalModeCursorline.foreground,
-                               entry.normalModeCursorline.foregroundAlpha,
-                               entry.normalModeCursorline.background,
-                               entry.normalModeCursorline.backgroundAlpha);
-
-                processWithDoc(documentation::Selection {},
-                               entry.selection.foreground,
-                               entry.selection.foregroundAlpha,
-                               entry.selection.background,
-                               entry.selection.backgroundAlpha);
-
-                processWithDoc(documentation::SearchHighlight {},
-                               entry.searchHighlight.foreground,
-                               entry.searchHighlight.foregroundAlpha,
-                               entry.searchHighlight.background,
-                               entry.searchHighlight.backgroundAlpha);
-
-                processWithDoc(documentation::SearchHighlightFocused {},
-                               entry.searchHighlightFocused.foreground,
-                               entry.searchHighlightFocused.foregroundAlpha,
-                               entry.searchHighlightFocused.background,
-                               entry.searchHighlightFocused.backgroundAlpha);
-
-                processWithDoc(documentation::WordHighlightCurrent {},
-                               entry.wordHighlightCurrent.foreground,
-                               entry.wordHighlightCurrent.foregroundAlpha,
-                               entry.wordHighlightCurrent.background,
-                               entry.wordHighlightCurrent.backgroundAlpha);
-
-                processWithDoc(documentation::WordHighlight {},
-                               entry.wordHighlight.foreground,
-                               entry.wordHighlight.foregroundAlpha,
-                               entry.wordHighlight.background,
-                               entry.wordHighlight.backgroundAlpha);
-
-                processWithDoc(documentation::HintLabel {},
-                               entry.hintLabel.foreground,
-                               entry.hintLabel.foregroundAlpha,
-                               entry.hintLabel.background,
-                               entry.hintLabel.backgroundAlpha);
-
-                processWithDoc(documentation::HintMatch {},
-                               entry.hintMatch.foreground,
-                               entry.hintMatch.foregroundAlpha,
-                               entry.hintMatch.background,
-                               entry.hintMatch.backgroundAlpha);
-
-                processWithDoc(documentation::IndicatorStatusLine {},
-                               entry.indicatorStatusLineInsertMode.foreground,
-                               entry.indicatorStatusLineInsertMode.background,
-                               entry.indicatorStatusLineInactive.foreground,
-                               entry.indicatorStatusLineInactive.background);
-
-                processWithDoc(documentation::InputMethodEditor {},
-                               entry.inputMethodEditor.foreground,
-                               entry.inputMethodEditor.background);
-
-                processWithDoc(documentation::NormalColors {},
-                               entry.normalColor(0),
-                               entry.normalColor(1),
-                               entry.normalColor(2),
-                               entry.normalColor(3),
-                               entry.normalColor(4),
-                               entry.normalColor(5),
-                               entry.normalColor(6),
-                               entry.normalColor(7));
-
-                processWithDoc(documentation::BrightColors {},
-                               entry.brightColor(0),
-                               entry.brightColor(1),
-                               entry.brightColor(2),
-                               entry.brightColor(3),
-                               entry.brightColor(4),
-                               entry.brightColor(5),
-                               entry.brightColor(6),
-                               entry.brightColor(7));
-
-                processWithDoc(documentation::DimColors {},
-                               entry.dimColor(0),
-                               entry.dimColor(1),
-                               entry.dimColor(2),
-                               entry.dimColor(3),
-                               entry.dimColor(4),
-                               entry.dimColor(5),
-                               entry.dimColor(6),
-                               entry.dimColor(7));
+                emitColorPaletteBody(writer, doc, entry);
             }
         }
     });
@@ -3113,6 +3229,50 @@ std::string createString(Config const& c)
 {
     return createForGlobal<Writer>(c) + createForProfile<Writer>(c) + createForColorScheme<Writer>(c)
            + createKeyMapping<Writer>(c);
+}
+
+std::string emitProfileYaml(TerminalProfile const& profile)
+{
+    return createForSingleProfile<YAMLConfigWriter>(profile);
+}
+
+std::string emitColorSchemeYaml(vtbackend::ColorPalette const& palette)
+{
+    return createForSingleColorScheme<YAMLConfigWriter>(palette);
+}
+
+std::string emitGuiSettingsYaml(GuiManagedSettings const& settings)
+{
+    YAML::Emitter out;
+    out << YAML::BeginMap;
+    if (settings.defaultProfile)
+        out << YAML::Key << "default_profile" << YAML::Value << *settings.defaultProfile;
+    out << YAML::EndMap;
+    return std::string { out.c_str() } + '\n';
+}
+
+std::expected<GuiManagedSettings, std::string> loadGuiSettingsFile(std::filesystem::path const& path)
+{
+    auto settings = GuiManagedSettings {};
+
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec) || ec)
+        return settings; // nothing saved yet is not an error
+
+    auto doc = YAML::Node {};
+    try
+    {
+        doc = YAML::LoadFile(path.string());
+    }
+    catch (std::exception const& e)
+    {
+        return std::unexpected(std::string(e.what()));
+    }
+
+    if (auto const node = doc["default_profile"]; node && node.IsScalar())
+        settings.defaultProfile = node.as<std::string>();
+
+    return settings;
 }
 
 } // namespace contour::config

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -117,7 +117,10 @@ namespace
         if (!fs::exists(path))
             return nullopt;
 
-        auto ifs = ifstream(path.string());
+        // Binary mode is mandatory here: the read below is sized by fs::file_size(), so any text-mode
+        // CRLF->LF translation (Windows) would make read() fall short of that byte count and leave a
+        // trailing NUL that corrupts the parse.
+        auto ifs = ifstream(path, std::ios::binary);
         if (!ifs.good())
             return nullopt;
 
@@ -125,6 +128,12 @@ namespace
         auto text = string {};
         text.resize(size);
         ifs.read(text.data(), static_cast<std::streamsize>(size));
+
+        // Normalize CRLF -> LF. Files saved by Windows editors carry '\r' bytes that our YAML parser
+        // keeps as trailing characters on plain scalar values ("true\r"), which then fail typed
+        // conversion. Stripping them makes side files parse identically regardless of how they were
+        // saved; every caller here consumes the result as text, so this is always safe.
+        std::erase(text, '\r');
         return { text };
     }
 

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -392,9 +392,10 @@ void mergeGuiManagedSideFiles(Config& config, YAMLConfigReader& reader)
         }
     }
 
-    // settings.yml — GUI-owned global overrides (currently only default_profile). Applied last so it
-    // can select a profile the scan above just introduced.
-    if (auto loaded = loadGuiSettingsFile(dir / "settings.yml"))
+    // settings.yml — GUI-owned globals. Applied last so a default_profile can name a profile the scan
+    // above just introduced.
+    auto const settingsPath = dir / "settings.yml";
+    if (auto loaded = loadGuiSettingsFile(settingsPath))
     {
         config.guiManagedSettings = *loaded;
         if (auto const& defaultProfile = loaded->defaultProfile)
@@ -405,6 +406,22 @@ void mergeGuiManagedSideFiles(Config& config, YAMLConfigReader& reader)
                 configLog()("settings.yml default_profile '{}' is not a known profile; keeping '{}'.",
                             *defaultProfile,
                             config.defaultProfileName.value());
+        }
+
+        // Apply any GUI global overrides present in settings.yml through the SAME typed per-key loaders
+        // contour.yml uses (an absent key is a no-op), so the GUI never needs its own parse logic and a
+        // new overridable global is just another loadFromEntry line here.
+        std::error_code ec;
+        if (!loaded->globalOverrides.empty() && std::filesystem::exists(settingsPath, ec) && !ec)
+        {
+            auto overrides = YAMLConfigReader(settingsPath.string(), configLog);
+            overrides.loadFromEntry("word_delimiters", config.wordDelimiters);
+            overrides.loadFromEntry("read_buffer_size", config.ptyReadBufferSize);
+            overrides.loadFromEntry("pty_buffer_size", config.ptyBufferObjectSize);
+            overrides.loadFromEntry("command_palette_recent_count", config.commandPaletteRecentCount);
+            overrides.loadFromEntry("spawn_new_process", config.spawnNewProcess);
+            overrides.loadFromEntry("reflow_on_resize", config.reflowOnResize);
+            overrides.loadFromEntry("early_exit_threshold", config.earlyExitThreshold);
         }
     }
     else
@@ -3247,6 +3264,8 @@ std::string emitGuiSettingsYaml(GuiManagedSettings const& settings)
     out << YAML::BeginMap;
     if (settings.defaultProfile)
         out << YAML::Key << "default_profile" << YAML::Value << *settings.defaultProfile;
+    for (auto const& [key, value]: settings.globalOverrides)
+        out << YAML::Key << key << YAML::Value << value;
     out << YAML::EndMap;
     return std::string { out.c_str() } + '\n';
 }
@@ -3291,6 +3310,16 @@ std::expected<GuiManagedSettings, std::string> loadGuiSettingsFile(std::filesyst
 
     if (auto const node = doc["default_profile"]; node && node.IsScalar())
         settings.defaultProfile = node.as<std::string>();
+
+    // Every other top-level scalar is a GUI global override, kept as its YAML scalar text so it can be
+    // re-emitted verbatim and re-applied through the typed per-key loader on the next load.
+    if (doc.IsMap())
+        for (auto const& entry: doc)
+        {
+            auto const key = entry.first.as<std::string>();
+            if (key != "default_profile" && entry.second.IsScalar())
+                settings.globalOverrides[key] = entry.second.as<std::string>();
+        }
 
     return settings;
 }

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -338,13 +338,27 @@ void compareEntries(Config& config, auto const& output)
 /// the GUI side-file scan adds on top is distinguishable as GUI-owned (and therefore editable in the
 /// settings page) from the hand-maintained inline entries, which stay read-only there.
 /// @param config The just-parsed configuration to annotate.
-void recordMainConfigOrigins(Config& config)
+/// @param reader The reader that parsed contour.yml; its @c doc supplies the inline `color_schemes:` node.
+void recordMainConfigOrigins(Config& config, YAMLConfigReader const& reader)
 {
     for (auto const& [name, _]: config.profiles.value())
         config.profileOrigins.emplace(name, SettingsOrigin::MainConfig);
     for (auto const& [name, _]: config.colorschemes.value())
         config.colorSchemeOrigins.emplace(
             name, name == "default" ? SettingsOrigin::Builtin : SettingsOrigin::MainConfig);
+
+    // Inline color schemes are resolved lazily INTO the referencing profile, not into the colorschemes
+    // map, so their names never reach the loop above. Record them straight from the contour.yml
+    // `color_schemes:` node: without this the settings page cannot tell that a GUI scheme name collides
+    // with a hand-maintained inline scheme (which shadows a side file at load), and would let the user
+    // write a dead colorschemes/<name>.yml that never takes effect.
+    if (auto const node = reader.doc["color_schemes"]; node && node.IsMap())
+        for (auto const& entry: node)
+        {
+            auto const name = entry.first.as<std::string>();
+            config.colorSchemeOrigins.emplace(
+                name, name == "default" ? SettingsOrigin::Builtin : SettingsOrigin::MainConfig);
+        }
 }
 
 /// Merges the GUI-managed side files over the just-parsed configuration, mirroring the layouts.yml
@@ -447,6 +461,18 @@ void loadConfigFromFile(Config& config, fs::path const& fileName)
     config.configFile = fileName;
     createFileIfNotExists(config.configFile);
 
+    // A live reload reuses the same Config object rather than a fresh one (see reloadAllSessions), so the
+    // collections rebuilt wholesale from the file plus the GUI side-file scan below must be reset to their
+    // default-constructed starting state first. Otherwise a profile or color scheme that was deleted from
+    // disk (e.g. a GUI entity removed in the settings page) would linger from the previous load, and its
+    // stale provenance would keep the settings page treating a contour.yml entry as GUI-owned. The loaders
+    // assume the built-in seeds exist (the "main" profile is the inheritance base; the "default" color
+    // palette is the fallback), so restore those — exactly a first load's initial Config state.
+    config.profiles.value() = { { "main", TerminalProfile {} } };
+    config.colorschemes.value() = { { "default", vtbackend::ColorPalette {} } };
+    config.profileOrigins.clear();
+    config.colorSchemeOrigins.clear();
+
     auto yamlVisitor = YAMLConfigReader(config.configFile.string(), logger);
     yamlVisitor.load(config);
 
@@ -464,7 +490,7 @@ void loadConfigFromFile(Config& config, fs::path const& fileName)
 
     // Provenance first, then the GUI side files (profiles/*.yml, settings.yml) on top — the same
     // freshest-wins, broken-file-tolerant merge philosophy the layouts.yml merge above uses.
-    recordMainConfigOrigins(config);
+    recordMainConfigOrigins(config, yamlVisitor);
     mergeGuiManagedSideFiles(config, yamlVisitor);
 
     compareEntries(config, logger);
@@ -521,7 +547,16 @@ YAMLConfigReader::YAMLConfigReader(std::string const& filename,
     }
     try
     {
-        doc = YAML::LoadFile(configFile.string());
+        // Read through readFile (binary + CRLF->LF normalization) rather than YAML::LoadFile, so every
+        // config document — contour.yml, the settings.yml global-override reader, and the color-scheme
+        // files — is parsed identically regardless of how it was saved. YAML::LoadFile is CRLF-safe only
+        // on Windows (its text-mode ifstream strips '\r' at the OS layer); a CRLF file synced onto
+        // Linux/macOS would otherwise leave a trailing '\r' on plain scalar values and fail typed
+        // conversion. This is the same normalization the GUI profile side files already rely on.
+        if (auto const contents = readFile(configFile))
+            doc = YAML::Load(*contents);
+        else
+            errorLog()("Configuration file could not be read.\nDefault config will be loaded.");
     }
     catch (std::exception const& e)
     {
@@ -3315,10 +3350,17 @@ std::expected<GuiManagedSettings, std::string> loadGuiSettingsFile(std::filesyst
     if (!std::filesystem::exists(path, ec) || ec)
         return settings; // nothing saved yet is not an error
 
+    // Read through readFile (binary + CRLF->LF normalization) so a settings.yml saved with Windows line
+    // endings parses identically on every platform — matching the profile side files, and closing the
+    // cross-platform CRLF gap YAML::LoadFile leaves open off Windows.
+    auto const contents = readFile(path);
+    if (!contents)
+        return std::unexpected(std::string("Could not read settings file: ") + path.string());
+
     auto doc = YAML::Node {};
     try
     {
-        doc = YAML::LoadFile(path.string());
+        doc = YAML::Load(*contents);
     }
     catch (std::exception const& e)
     {

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -1934,6 +1934,13 @@ std::expected<std::unordered_map<std::string, Layout>, std::string> loadLayoutsF
 /// @return The complete YAML document text.
 [[nodiscard]] std::string emitGuiSettingsYaml(GuiManagedSettings const& settings);
 
+/// Loads a single bare-body `colorschemes/<name>.yml` palette file at @p path (the same file the lazy
+/// scheme resolver reads). Used by the GUI scheme editor to load an existing scheme's colors for
+/// editing, independently of whether any profile currently references it.
+/// @param path The color scheme file to read.
+/// @return The parsed palette, or nullopt if the file is missing or unreadable.
+[[nodiscard]] std::optional<vtbackend::ColorPalette> loadColorSchemeFile(std::filesystem::path const& path);
+
 /// Loads ONLY the GUI-owned `settings.yml` at @p path (no merge). A missing file yields default
 /// (all-unset) settings — nothing saved yet is not an error; a file that fails to parse yields the
 /// parse error, so a caller about to rewrite it can refuse rather than destroy it.

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -302,6 +302,12 @@ enum class SettingsOrigin : uint8_t
 struct GuiManagedSettings
 {
     std::optional<std::string> defaultProfile; //!< Overrides contour.yml's `default_profile` when set.
+
+    /// GUI-set global overrides, keyed by the contour.yml top-level key, valued as the YAML scalar to
+    /// write (e.g. "reflow_on_resize" -> "false"). Present here == overridden by the GUI; the on-load
+    /// merge re-applies each through the same per-key loader contour.yml uses, so the value is typed
+    /// correctly. Absent keys defer to contour.yml.
+    std::map<std::string, std::string> globalOverrides;
 };
 
 /// Selects which Qt RHI graphics API drives the terminal display.

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -282,6 +282,28 @@ struct SimpleColorConfig
 
 using ColorConfig = std::variant<SimpleColorConfig, DualColorConfig>;
 
+/// Where a named profile or color scheme was defined, so the GUI can decide whether it may edit it.
+///
+/// contour.yml-defined and built-in entities are shown but read-only in the settings page (editing
+/// them would mean the GUI silently shadowing the hand-maintained file); only @ref SideFile entities,
+/// which the GUI itself created, are editable.
+enum class SettingsOrigin : uint8_t
+{
+    Builtin,    //!< A built-in default (e.g. the "default" color palette shipped with Contour).
+    MainConfig, //!< Defined inline in the hand-maintained contour.yml.
+    SideFile,   //!< Stored in a GUI-managed side file (profiles/<name>.yml, colorschemes/<name>.yml).
+};
+
+/// GUI-owned global overrides, persisted to the sibling `settings.yml` and merged over the
+/// hand-maintained contour.yml at load (freshest wins, exactly like `layouts.yml`).
+///
+/// Kept deliberately small: it holds only what the settings page can currently edit at global scope,
+/// and grows a field at a time as that surface widens. An unset optional means "defer to contour.yml".
+struct GuiManagedSettings
+{
+    std::optional<std::string> defaultProfile; //!< Overrides contour.yml's `default_profile` when set.
+};
+
 /// Selects which Qt RHI graphics API drives the terminal display.
 ///
 /// @c Auto lets Qt resolve the platform-native backend (Direct3D 11 on Windows, Metal on macOS,
@@ -997,6 +1019,7 @@ struct Config
     };
     ConfigEntry<bool, documentation::SpawnNewProcess> spawnNewProcess { false };
     ConfigEntry<bool, documentation::ReflowOnResize> reflowOnResize { true };
+    ConfigEntry<bool, documentation::GuiConfigLocked> guiConfigLocked { false };
     ConfigEntry<vtbackend::Modifiers, documentation::BypassMouseProtocolModifiers>
         bypassMouseProtocolModifiers { vtbackend::Modifier::Shift };
     ConfigEntry<vtbackend::Modifiers, documentation::MouseBlockSelectionModifiers>
@@ -1015,6 +1038,19 @@ struct Config
     ConfigEntry<std::string, documentation::DefaultLayout> defaultLayoutName { "" };
     ConfigEntry<std::unordered_map<std::string, vtbackend::ColorPalette>, documentation::ColorSchemes>
         colorschemes { { { "default", vtbackend::ColorPalette {} } } };
+
+    /// Runtime-only provenance of each entry in @ref profiles / @ref colorschemes, populated by the
+    /// loader (never serialized). The GUI consults these to gate editability: a name absent from the
+    /// map, or mapped to anything other than SettingsOrigin::SideFile, is read-only in the settings page.
+    /// @{
+    std::unordered_map<std::string, SettingsOrigin> profileOrigins {};
+    std::unordered_map<std::string, SettingsOrigin> colorSchemeOrigins {};
+    /// @}
+
+    /// GUI-owned global overrides loaded from the sibling `settings.yml` (see GuiManagedSettings).
+    /// Runtime-only mirror of that file; the resolved values have already been applied to the fields
+    /// above (e.g. @ref defaultProfileName), this simply records what the GUI had persisted.
+    GuiManagedSettings guiManagedSettings {};
 
     ConfigEntry<InputMappings, documentation::InputMappings> inputMappings { defaultInputMappings };
     ConfigEntry<vtrasterizer::BoxDrawingRenderer::GitDrawingsStyle, documentation::GitDrawings>
@@ -1279,6 +1315,15 @@ struct YAMLConfigReader
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtbackend::ColorPalette& where);
     void loadFromEntry(YAML::Node const& node, vtbackend::ColorPalette& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, TerminalProfile& where);
+
+    /// Parses a profile body map (a profile's `shell`, `font`, `colors`, ... keys) directly into
+    /// @p where. This is the shared core of profile parsing: the `loadFromEntry(node, entry, profile)`
+    /// overload above resolves `node[entry]` to the body and delegates here, and the GUI side-file
+    /// loader (whose `profiles/<name>.yml` document root IS the body) calls it directly.
+    /// @param profileNode The profile body map; a null node is a no-op (@p where keeps its base values).
+    /// @param where The profile to populate; pre-seed it with an inheritance base before calling.
+    void loadProfileBody(YAML::Node const& profileNode, TerminalProfile& where);
+
     void loadFromEntry(YAML::Node const& node, std::string const& entry, RendererConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ImagesConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, HistoryConfig& where);
@@ -1867,6 +1912,34 @@ void compareEntries(Config& config, auto const& output);
 /// Used by SaveLayout to read back layouts.yml's own prior contents before appending the new one,
 /// so the file is never overwritten with the merged (inline + file) in-memory view.
 std::expected<std::unordered_map<std::string, Layout>, std::string> loadLayoutsFile(
+    std::filesystem::path const& path);
+
+/// Serializes a single profile's body as the exact text written to a `profiles/<name>.yml` GUI side
+/// file: a bare top-level map of the profile's fields (no `profiles:`/name wrapper), so the same
+/// reader that parses an inline profile parses it back. Produced by the reflection-driven config
+/// writer, so every profile field serializes here identically to how it appears in contour.yml and is
+/// covered without hand-listing.
+/// @param profile The profile to serialize.
+/// @return The complete YAML document text for the side file.
+[[nodiscard]] std::string emitProfileYaml(TerminalProfile const& profile);
+
+/// Serializes a single color palette as the exact text written to a `colorschemes/<name>.yml` GUI
+/// side file: a bare top-level palette body, matching the existing lazy read path for that file.
+/// @param palette The palette to serialize.
+/// @return The complete YAML document text for the side file.
+[[nodiscard]] std::string emitColorSchemeYaml(vtbackend::ColorPalette const& palette);
+
+/// Serializes the GUI-owned global overrides as the text written to the sibling `settings.yml`.
+/// @param settings The overrides to persist (unset fields are omitted, i.e. "defer to contour.yml").
+/// @return The complete YAML document text.
+[[nodiscard]] std::string emitGuiSettingsYaml(GuiManagedSettings const& settings);
+
+/// Loads ONLY the GUI-owned `settings.yml` at @p path (no merge). A missing file yields default
+/// (all-unset) settings — nothing saved yet is not an error; a file that fails to parse yields the
+/// parse error, so a caller about to rewrite it can refuse rather than destroy it.
+/// @param path The `settings.yml` path (sibling of contour.yml).
+/// @return The parsed overrides, or a human-readable parse error.
+[[nodiscard]] std::expected<GuiManagedSettings, std::string> loadGuiSettingsFile(
     std::filesystem::path const& path);
 
 /// Splits a command line into tokens the way a shell would: whitespace separates tokens; single quotes

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -677,6 +677,14 @@ constexpr StringLiteral ReflowOnResizeConfig {
     "reflow_on_resize: {}\n"
 };
 
+constexpr StringLiteral GuiConfigLockedConfig {
+    "\n"
+    "{comment} When set to true, the in-app graphical settings page is opened read-only and Contour\n"
+    "{comment} will not write any GUI-managed side files (profiles/, colorschemes/, settings.yml).\n"
+    "{comment} Use this to keep this hand-maintained configuration the single source of truth.\n"
+    "gui_config_locked: {}\n"
+};
+
 constexpr StringLiteral ColorSchemesConfig {
     "{comment} Color Profiles\n"
     "{comment} --------------\n"
@@ -1304,6 +1312,12 @@ constexpr StringLiteral SpawnNewProcessWeb { "flag determines whether a new proc
 constexpr StringLiteral ReflowOnResizeWeb {
     "option controls whether or not the lines in the terminal should be reflowed when a resize event occurs. "
     "The default value is `true`."
+};
+
+constexpr StringLiteral GuiConfigLockedWeb {
+    "flag, when `true`, opens the in-app settings page read-only and prevents the GUI from writing any "
+    "of its side files (`profiles/`, `colorschemes/`, `settings.yml`), so this hand-maintained "
+    "configuration file stays the single source of truth. The default value is `false`."
 };
 
 constexpr StringLiteral BypassMouseProtocolModifiersWeb {
@@ -2178,6 +2192,7 @@ using CommandPaletteRecentCount =
 using PTYReadBufferSize = DocumentationEntry<PTYReadBufferSizeConfig, PTYReadBufferSizeWeb>;
 using PTYBufferObjectSize = DocumentationEntry<PTYBufferObjectSizeConfig, PTYBufferObjectSizeWeb>;
 using ReflowOnResize = DocumentationEntry<ReflowOnResizeConfig, ReflowOnResizeWeb>;
+using GuiConfigLocked = DocumentationEntry<GuiConfigLockedConfig, GuiConfigLockedWeb>;
 using ColorSchemes = DocumentationEntry<ColorSchemesConfig, Dummy>;
 using Profiles = DocumentationEntry<ProfilesConfig, ProfilesWeb>;
 using DefaultProfiles = DocumentationEntry<StringLiteral { "default_profile: {}\n" }, DefaultProfilesWeb>;

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -6,6 +6,7 @@
 #include <contour/QtExternalLauncher.h>
 #include <contour/RenderingBackendSelection.h>
 #include <contour/SessionFactory.h>
+#include <contour/SettingsController.h>
 #include <contour/WindowController.h>
 #include <contour/display/ContentScale.h>
 #include <contour/display/TerminalDisplay.h>
@@ -541,10 +542,12 @@ int ContourGuiApp::terminalGuiAction()
     qmlRegisterUncreatableType<PaneProxy>("Contour.Terminal", 1, 0, "PaneProxy", "Created by the session manager.");
     qmlRegisterUncreatableType<WindowController>("Contour.Terminal", 1, 0, "WindowController", "Created by the session manager.");
     qmlRegisterUncreatableType<CommandPaletteModel>("Contour.Terminal", 1, 0, "CommandPaletteModel", "Created by the window controller.");
+    qmlRegisterUncreatableType<SettingsController>("Contour.Terminal", 1, 0, "SettingsController", "Created by the window controller.");
     qRegisterMetaType<TerminalSession*>("TerminalSession*");
     qRegisterMetaType<PaneProxy*>("PaneProxy*");
     qRegisterMetaType<WindowController*>("WindowController*");
     qRegisterMetaType<CommandPaletteModel*>("CommandPaletteModel*");
+    qRegisterMetaType<SettingsController*>("SettingsController*");
     // clang-format on
 
     {

--- a/src/contour/GuiConfigStore.cpp
+++ b/src/contour/GuiConfigStore.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <contour/AtomicFileWrite.h>
+#include <contour/GuiConfigStore.h>
+
+#include <format>
+#include <system_error>
+#include <utility>
+
+namespace contour
+{
+
+namespace
+{
+    /// Removes @p path, treating an already-absent file as success (the desired post-state either way).
+    /// @param path The file to remove.
+    /// @return Nothing on success, or a human-readable error when removal actually failed.
+    std::expected<void, std::string> removeFile(std::filesystem::path const& path)
+    {
+        auto ec = std::error_code {};
+        std::filesystem::remove(path, ec); // a missing file yields false with ec clear: still success
+        if (ec)
+            return std::unexpected(std::format("could not remove {}: {}", path.string(), ec.message()));
+        return {};
+    }
+} // namespace
+
+FileGuiConfigStore::FileGuiConfigStore(std::filesystem::path configDir): _configDir { std::move(configDir) }
+{
+}
+
+std::expected<void, std::string> FileGuiConfigStore::saveProfile(std::string const& name,
+                                                                 config::TerminalProfile const& profile)
+{
+    return atomicWriteFile(_configDir / "profiles" / (name + ".yml"), config::emitProfileYaml(profile));
+}
+
+std::expected<void, std::string> FileGuiConfigStore::deleteProfile(std::string const& name)
+{
+    return removeFile(_configDir / "profiles" / (name + ".yml"));
+}
+
+std::expected<void, std::string> FileGuiConfigStore::saveColorScheme(std::string const& name,
+                                                                     vtbackend::ColorPalette const& palette)
+{
+    return atomicWriteFile(_configDir / "colorschemes" / (name + ".yml"),
+                           config::emitColorSchemeYaml(palette));
+}
+
+std::expected<void, std::string> FileGuiConfigStore::deleteColorScheme(std::string const& name)
+{
+    return removeFile(_configDir / "colorschemes" / (name + ".yml"));
+}
+
+std::expected<void, std::string> FileGuiConfigStore::saveGuiSettings(
+    config::GuiManagedSettings const& settings)
+{
+    return atomicWriteFile(_configDir / "settings.yml", config::emitGuiSettingsYaml(settings));
+}
+
+} // namespace contour

--- a/src/contour/GuiConfigStore.h
+++ b/src/contour/GuiConfigStore.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <contour/Config.h>
+
+#include <vtbackend/Color.h>
+
+#include <expected>
+#include <filesystem>
+#include <string>
+
+namespace contour
+{
+
+/// Persistence for the GUI-managed configuration side files — the write-side counterpart to the
+/// loader's side-file merge (see mergeGuiManagedSideFiles in Config.cpp). The settings page creates
+/// and edits its own `profiles/<name>.yml` and `colorschemes/<name>.yml`, plus the global
+/// `settings.yml`, and never touches the hand-maintained `contour.yml`.
+///
+/// It is an interface per the project's dependency-injection principle (this is filesystem I/O): the
+/// settings-page logic and its tests drive save/delete end to end against an in-memory store, and no
+/// caller holds knowledge of paths, temp files, or atomic renames.
+class GuiConfigStore
+{
+  public:
+    virtual ~GuiConfigStore() = default;
+
+    /// Writes @p profile to its `profiles/<name>.yml` side file, atomically, creating the `profiles/`
+    /// directory if needed.
+    /// @param name The profile name (also the file stem).
+    /// @param profile The profile to persist.
+    /// @return Nothing on success, or a human-readable error describing why the write failed.
+    [[nodiscard]] virtual std::expected<void, std::string> saveProfile(
+        std::string const& name, config::TerminalProfile const& profile) = 0;
+
+    /// Removes a profile's `profiles/<name>.yml` side file. A file that is already gone is success.
+    /// @param name The profile name whose side file to remove.
+    /// @return Nothing on success, or a human-readable error.
+    [[nodiscard]] virtual std::expected<void, std::string> deleteProfile(std::string const& name) = 0;
+
+    /// Writes @p palette to its `colorschemes/<name>.yml` side file, atomically.
+    /// @param name The color scheme name (also the file stem).
+    /// @param palette The palette to persist.
+    /// @return Nothing on success, or a human-readable error.
+    [[nodiscard]] virtual std::expected<void, std::string> saveColorScheme(
+        std::string const& name, vtbackend::ColorPalette const& palette) = 0;
+
+    /// Removes a color scheme's `colorschemes/<name>.yml` side file. A file already gone is success.
+    /// @param name The color scheme name whose side file to remove.
+    /// @return Nothing on success, or a human-readable error.
+    [[nodiscard]] virtual std::expected<void, std::string> deleteColorScheme(std::string const& name) = 0;
+
+    /// Writes the GUI-owned global overrides to `settings.yml`, atomically.
+    /// @param settings The overrides to persist.
+    /// @return Nothing on success, or a human-readable error.
+    [[nodiscard]] virtual std::expected<void, std::string> saveGuiSettings(
+        config::GuiManagedSettings const& settings) = 0;
+};
+
+/// The production GuiConfigStore: side files under the directory holding `contour.yml`, each replaced
+/// atomically (write a temp sibling, then rename over the target) so an interrupted or failing write
+/// can never leave a truncated file behind — see contour::atomicWriteFile.
+class FileGuiConfigStore final: public GuiConfigStore
+{
+  public:
+    /// @param configDir The directory that holds `contour.yml`; every side file lives beside or under
+    ///                  it, matching where the loader's side-file merge reads them back from.
+    explicit FileGuiConfigStore(std::filesystem::path configDir);
+
+    [[nodiscard]] std::expected<void, std::string> saveProfile(
+        std::string const& name, config::TerminalProfile const& profile) override;
+    [[nodiscard]] std::expected<void, std::string> deleteProfile(std::string const& name) override;
+    [[nodiscard]] std::expected<void, std::string> saveColorScheme(
+        std::string const& name, vtbackend::ColorPalette const& palette) override;
+    [[nodiscard]] std::expected<void, std::string> deleteColorScheme(std::string const& name) override;
+    [[nodiscard]] std::expected<void, std::string> saveGuiSettings(
+        config::GuiManagedSettings const& settings) override;
+
+  private:
+    std::filesystem::path _configDir;
+};
+
+} // namespace contour

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -105,9 +105,12 @@ namespace
               },
               [](TerminalProfile& p, QVariant const& v) {
                   auto const s = v.toString();
-                  p.tabBarVisibility = s == "Never"      ? config::TabBarVisibility::Never
-                                       : s == "Multiple" ? config::TabBarVisibility::Multiple
-                                                         : config::TabBarVisibility::Always;
+                  if (s == "Never")
+                      p.tabBarVisibility = config::TabBarVisibility::Never;
+                  else if (s == "Multiple")
+                      p.tabBarVisibility = config::TabBarVisibility::Multiple;
+                  else
+                      p.tabBarVisibility = config::TabBarVisibility::Always;
               },
               { "Always", "Never", "Multiple" } },
             // }}}
@@ -236,17 +239,17 @@ namespace
                              "Foreground",
                              [](auto const& p) { return p.defaultForeground; },
                              [](auto& p, auto c) { p.defaultForeground = c; } });
-            static constexpr auto ansiNames =
+            static constexpr auto AnsiNames =
                 std::array<std::string_view, 8> { "black", "red",     "green", "yellow",
                                                   "blue",  "magenta", "cyan",  "white" };
             for (auto const bright: { false, true })
-                for (auto i = size_t { 0 }; i < ansiNames.size(); ++i)
+                for (auto i = size_t { 0 }; i < AnsiNames.size(); ++i)
                 {
                     auto const slot = bright ? i + 8 : i;
                     list.push_back({ QString::fromStdString((bright ? "bright_" : "normal_")
-                                                            + std::string(ansiNames[i])),
+                                                            + std::string(AnsiNames[i])),
                                      QString::fromStdString((bright ? "Bright " : "Normal ")
-                                                            + std::string(ansiNames[i])),
+                                                            + std::string(AnsiNames[i])),
                                      [slot](auto const& p) { return p.palette.at(slot); },
                                      [slot](auto& p, auto c) { p.palette.at(slot) = c; } });
                 }

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <contour/SettingsController.h>
+
+#include <text_shaper/font.h>
+
+#include <QtGui/QColor>
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <set>
+#include <utility>
+
+namespace contour
+{
+
+using config::SettingsOrigin;
+using config::TerminalProfile;
+
+namespace
+{
+    /// A data-driven descriptor for one editable scalar profile field: adding a field to the settings
+    /// page is adding a row here, not editing logic in three places.
+    struct ProfileFieldDescriptor
+    {
+        QString key;                                                //!< Stable identifier / QML key.
+        QString label;                                              //!< Human-readable label.
+        QString help;                                               //!< One-line help text.
+        QString type;                                               //!< "bool" | "double" | "string".
+        std::function<QVariant(TerminalProfile const&)> get;        //!< Reads the field as a QVariant.
+        std::function<void(TerminalProfile&, QVariant const&)> set; //!< Writes the field from QVariant.
+    };
+
+    /// The editable scalar profile fields. Kept intentionally small for the first version; it grows one
+    /// row at a time toward full parity without touching any other code.
+    std::vector<ProfileFieldDescriptor> const& profileFieldDescriptors()
+    {
+        static auto const descriptors = std::vector<ProfileFieldDescriptor> {
+            { "show_title_bar",
+              "Show title bar",
+              "Whether the window shows its title bar.",
+              "bool",
+              [](TerminalProfile const& p) { return QVariant(p.showTitleBar.value()); },
+              [](TerminalProfile& p, QVariant const& v) { p.showTitleBar = v.toBool(); } },
+            { "dim_unfocused",
+              "Dim when unfocused",
+              "How much to dim a pane while it is not focused (0.0 = off, 1.0 = fully dimmed).",
+              "double",
+              [](TerminalProfile const& p) { return QVariant(p.dimUnfocused.value()); },
+              [](TerminalProfile& p, QVariant const& v) { p.dimUnfocused = v.toDouble(); } },
+            { "font_family",
+              "Font family",
+              "The regular font family name.",
+              "string",
+              [](TerminalProfile const& p) {
+                  return QVariant(QString::fromStdString(p.fonts.value().regular.familyName));
+              },
+              [](TerminalProfile& p, QVariant const& v) {
+                  p.fonts.value().regular.familyName = v.toString().toStdString();
+              } },
+            { "font_size",
+              "Font size (pt)",
+              "The font size in points.",
+              "double",
+              [](TerminalProfile const& p) { return QVariant(p.fonts.value().size.pt); },
+              [](TerminalProfile& p, QVariant const& v) {
+                  p.fonts.value().size = text::font_size { v.toDouble() };
+              } },
+            { "size_indicator_on_resize",
+              "Show size on resize",
+              "Briefly show the terminal dimensions when the window is resized.",
+              "bool",
+              [](TerminalProfile const& p) { return QVariant(p.sizeIndicatorOnResize.value()); },
+              [](TerminalProfile& p, QVariant const& v) { p.sizeIndicatorOnResize = v.toBool(); } },
+        };
+        return descriptors;
+    }
+
+    /// A data-driven descriptor for one editable color slot of a palette.
+    struct SchemeColorDescriptor
+    {
+        QString key;
+        QString label;
+        std::function<vtbackend::RGBColor(vtbackend::ColorPalette const&)> get;
+        std::function<void(vtbackend::ColorPalette&, vtbackend::RGBColor)> set;
+    };
+
+    /// The color slots the scheme editor exposes: the default fg/bg plus the 8 normal and 8 bright
+    /// ANSI colors. Generated once from the ANSI names so the two 8-color banks are not hand-listed.
+    std::vector<SchemeColorDescriptor> const& schemeColorDescriptors()
+    {
+        static auto const descriptors = [] {
+            auto list = std::vector<SchemeColorDescriptor> {};
+            list.push_back({ "background",
+                             "Background",
+                             [](auto const& p) { return p.defaultBackground; },
+                             [](auto& p, auto c) { p.defaultBackground = c; } });
+            list.push_back({ "foreground",
+                             "Foreground",
+                             [](auto const& p) { return p.defaultForeground; },
+                             [](auto& p, auto c) { p.defaultForeground = c; } });
+            static constexpr auto ansiNames =
+                std::array<std::string_view, 8> { "black", "red",     "green", "yellow",
+                                                  "blue",  "magenta", "cyan",  "white" };
+            for (auto const bright: { false, true })
+                for (auto i = size_t { 0 }; i < ansiNames.size(); ++i)
+                {
+                    auto const slot = bright ? i + 8 : i;
+                    list.push_back({ QString::fromStdString((bright ? "bright_" : "normal_")
+                                                            + std::string(ansiNames[i])),
+                                     QString::fromStdString((bright ? "Bright " : "Normal ")
+                                                            + std::string(ansiNames[i])),
+                                     [slot](auto const& p) { return p.palette.at(slot); },
+                                     [slot](auto& p, auto c) { p.palette.at(slot) = c; } });
+                }
+            return list;
+        }();
+        return descriptors;
+    }
+
+    /// "#rrggbb" for @p color, the format the QML color pickers exchange.
+    QString rgbToHex(vtbackend::RGBColor color)
+    {
+        return QString::asprintf("#%02x%02x%02x", color.red, color.green, color.blue);
+    }
+
+    /// Parses "#rrggbb" (or any Qt-recognized color string) into an RGBColor, black on a parse failure.
+    vtbackend::RGBColor hexToRgb(QString const& hex)
+    {
+        auto const color = QColor(hex);
+        return vtbackend::RGBColor { static_cast<uint8_t>(color.red()),
+                                     static_cast<uint8_t>(color.green()),
+                                     static_cast<uint8_t>(color.blue()) };
+    }
+
+    /// The QML-facing token for a provenance value.
+    QString originString(SettingsOrigin origin)
+    {
+        switch (origin)
+        {
+            case SettingsOrigin::Builtin: return QStringLiteral("builtin");
+            case SettingsOrigin::MainConfig: return QStringLiteral("main");
+            case SettingsOrigin::SideFile: return QStringLiteral("side");
+        }
+        return QStringLiteral("builtin");
+    }
+} // namespace
+
+SettingsController::SettingsController(ConfigAccessor config,
+                                       std::shared_ptr<GuiConfigStore> store,
+                                       ApplyCallback apply,
+                                       QObject* parent):
+    QObject { parent },
+    _config { std::move(config) },
+    _store { std::move(store) },
+    _apply { std::move(apply) }
+{
+    refresh();
+}
+
+SettingsOrigin SettingsController::profileOrigin(std::string const& name) const
+{
+    auto const& origins = _config().profileOrigins;
+    auto const it = origins.find(name);
+    return it != origins.end() ? it->second : SettingsOrigin::Builtin;
+}
+
+bool SettingsController::fail(std::string const& error)
+{
+    emit errorOccurred(QString::fromStdString(error));
+    return false;
+}
+
+void SettingsController::refresh()
+{
+    auto const& cfg = _config();
+    _locked = cfg.guiConfigLocked.value();
+    _defaultProfile = QString::fromStdString(cfg.defaultProfileName.value());
+
+    // Profiles, name-sorted for a stable list.
+    auto profileNames = std::vector<std::string> {};
+    for (auto const& [name, _]: cfg.profiles.value())
+        profileNames.push_back(name);
+    std::ranges::sort(profileNames);
+
+    _profiles.clear();
+    for (auto const& name: profileNames)
+    {
+        auto const origin = profileOrigin(name);
+        auto row = QVariantMap {};
+        row[QStringLiteral("name")] = QString::fromStdString(name);
+        row[QStringLiteral("origin")] = originString(origin);
+        row[QStringLiteral("editable")] = (!_locked && origin == SettingsOrigin::SideFile);
+        row[QStringLiteral("isDefault")] = (name == cfg.defaultProfileName.value());
+        _profiles.push_back(row);
+    }
+
+    // Color schemes: those the config knows about, unioned with any colorschemes/*.yml on disk.
+    auto schemeNames = std::set<std::string> {};
+    for (auto const& [name, _]: cfg.colorschemes.value())
+        schemeNames.insert(name);
+    auto const schemesDir = cfg.configFile.parent_path() / "colorschemes";
+    auto onDisk = std::set<std::string> {};
+    auto ec = std::error_code {};
+    if (std::filesystem::is_directory(schemesDir, ec))
+        for (auto const& entry: std::filesystem::directory_iterator(schemesDir, ec))
+            if (entry.is_regular_file() && entry.path().extension() == ".yml")
+            {
+                schemeNames.insert(entry.path().stem().string());
+                onDisk.insert(entry.path().stem().string());
+            }
+
+    _colorSchemes.clear();
+    for (auto const& name: schemeNames)
+    {
+        auto row = QVariantMap {};
+        row[QStringLiteral("name")] = QString::fromStdString(name);
+        row[QStringLiteral("editable")] = (!_locked && onDisk.contains(name));
+        _colorSchemes.push_back(row);
+    }
+
+    emit changed();
+}
+
+// {{{ Profile draft
+
+QVariantList SettingsController::profileFields() const
+{
+    auto fields = QVariantList {};
+    if (!_hasDraft)
+        return fields;
+    for (auto const& descriptor: profileFieldDescriptors())
+    {
+        auto row = QVariantMap {};
+        row[QStringLiteral("key")] = descriptor.key;
+        row[QStringLiteral("label")] = descriptor.label;
+        row[QStringLiteral("help")] = descriptor.help;
+        row[QStringLiteral("type")] = descriptor.type;
+        row[QStringLiteral("value")] = descriptor.get(_draft);
+        fields.push_back(row);
+    }
+    return fields;
+}
+
+void SettingsController::editProfile(QString const& name)
+{
+    auto const& cfg = _config();
+    auto const* profile = cfg.findProfile(name.toStdString());
+    if (profile == nullptr)
+        return;
+    _draft = *profile;
+    _editingProfile = name;
+    _hasDraft = true;
+    _editingReadOnly = _locked || profileOrigin(name.toStdString()) != SettingsOrigin::SideFile;
+    emit draftChanged();
+}
+
+void SettingsController::newProfile(QString const& basedOn)
+{
+    auto const& cfg = _config();
+    auto const* base = cfg.findProfile(basedOn.toStdString());
+    if (base == nullptr)
+        base = cfg.findProfile(cfg.defaultProfileName.value());
+    _draft = base != nullptr ? *base : TerminalProfile {};
+    _editingProfile.clear(); // unsaved: needs Save As
+    _hasDraft = true;
+    _editingReadOnly = _locked;
+    emit draftChanged();
+}
+
+void SettingsController::setProfileField(QString const& key, QVariant const& value)
+{
+    if (!_hasDraft)
+        return;
+    for (auto const& descriptor: profileFieldDescriptors())
+        if (descriptor.key == key)
+        {
+            descriptor.set(_draft, value);
+            emit draftChanged();
+            return;
+        }
+}
+
+QString SettingsController::colorSchemeMode() const
+{
+    if (_hasDraft && std::holds_alternative<config::DualColorConfig>(_draft.colors.value()))
+        return QStringLiteral("dual");
+    return QStringLiteral("simple");
+}
+
+QString SettingsController::colorScheme() const
+{
+    if (_hasDraft)
+        if (auto const* simple = std::get_if<config::SimpleColorConfig>(&_draft.colors.value()))
+            return QString::fromStdString(simple->colorScheme);
+    return {};
+}
+
+QString SettingsController::colorSchemeLight() const
+{
+    if (_hasDraft)
+        if (auto const* dual = std::get_if<config::DualColorConfig>(&_draft.colors.value()))
+            return QString::fromStdString(dual->colorSchemeLight);
+    return {};
+}
+
+QString SettingsController::colorSchemeDark() const
+{
+    if (_hasDraft)
+        if (auto const* dual = std::get_if<config::DualColorConfig>(&_draft.colors.value()))
+            return QString::fromStdString(dual->colorSchemeDark);
+    return {};
+}
+
+void SettingsController::setColorSchemeMode(QString const& mode)
+{
+    if (!_hasDraft)
+        return;
+    auto& colors = _draft.colors.value();
+    if (mode == QStringLiteral("dual") && std::holds_alternative<config::SimpleColorConfig>(colors))
+    {
+        auto const name = std::get<config::SimpleColorConfig>(colors).colorScheme;
+        colors = config::DualColorConfig { .colorSchemeLight = name, .colorSchemeDark = name };
+        emit draftChanged();
+    }
+    else if (mode == QStringLiteral("simple") && std::holds_alternative<config::DualColorConfig>(colors))
+    {
+        auto const name = std::get<config::DualColorConfig>(colors).colorSchemeDark;
+        colors = config::SimpleColorConfig { .colorScheme = name };
+        emit draftChanged();
+    }
+}
+
+void SettingsController::setColorScheme(QString const& name)
+{
+    if (!_hasDraft)
+        return;
+    if (auto* simple = std::get_if<config::SimpleColorConfig>(&_draft.colors.value()))
+    {
+        simple->colorScheme = name.toStdString();
+        emit draftChanged();
+    }
+}
+
+void SettingsController::setColorSchemeLight(QString const& name)
+{
+    if (!_hasDraft)
+        return;
+    if (auto* dual = std::get_if<config::DualColorConfig>(&_draft.colors.value()))
+    {
+        dual->colorSchemeLight = name.toStdString();
+        emit draftChanged();
+    }
+}
+
+void SettingsController::setColorSchemeDark(QString const& name)
+{
+    if (!_hasDraft)
+        return;
+    if (auto* dual = std::get_if<config::DualColorConfig>(&_draft.colors.value()))
+    {
+        dual->colorSchemeDark = name.toStdString();
+        emit draftChanged();
+    }
+}
+
+bool SettingsController::saveProfile()
+{
+    if (!_hasDraft || _locked)
+        return fail("The settings page is read-only.");
+    if (_editingProfile.isEmpty())
+        return fail("This profile has no name yet — use \"Save As\".");
+    if (_editingReadOnly)
+        return fail("This profile is defined in contour.yml and cannot be overwritten — use \"Save As\".");
+
+    if (auto const result = _store->saveProfile(_editingProfile.toStdString(), _draft); !result)
+        return fail(result.error());
+
+    _apply();
+    refresh();
+    editProfile(_editingProfile); // re-seed from the reloaded config
+    return true;
+}
+
+bool SettingsController::saveProfileAs(QString const& newName)
+{
+    if (!_hasDraft || _locked)
+        return fail("The settings page is read-only.");
+    if (newName.trimmed().isEmpty())
+        return fail("Enter a name for the new profile.");
+    if (profileOrigin(newName.toStdString()) == SettingsOrigin::MainConfig)
+        return fail("A profile with that name is defined in contour.yml; choose another name.");
+
+    if (auto const result = _store->saveProfile(newName.toStdString(), _draft); !result)
+        return fail(result.error());
+
+    _apply();
+    refresh();
+    editProfile(newName);
+    return true;
+}
+
+bool SettingsController::deleteProfile(QString const& name)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+    if (profileOrigin(name.toStdString()) != SettingsOrigin::SideFile)
+        return fail("Only GUI-created profiles can be deleted here.");
+
+    if (auto const result = _store->deleteProfile(name.toStdString()); !result)
+        return fail(result.error());
+
+    if (_editingProfile == name)
+    {
+        _hasDraft = false;
+        _editingProfile.clear();
+        emit draftChanged();
+    }
+    _apply();
+    refresh();
+    return true;
+}
+
+// }}}
+
+bool SettingsController::setDefaultProfile(QString const& name)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+
+    auto settings = _config().guiManagedSettings;
+    settings.defaultProfile = name.toStdString();
+    if (auto const result = _store->saveGuiSettings(settings); !result)
+        return fail(result.error());
+
+    _apply();
+    refresh();
+    return true;
+}
+
+// {{{ Color-scheme draft
+
+QVariantList SettingsController::schemeColors() const
+{
+    auto colors = QVariantList {};
+    if (!_hasSchemeDraft)
+        return colors;
+    for (auto const& descriptor: schemeColorDescriptors())
+    {
+        auto row = QVariantMap {};
+        row[QStringLiteral("key")] = descriptor.key;
+        row[QStringLiteral("label")] = descriptor.label;
+        row[QStringLiteral("color")] = rgbToHex(descriptor.get(_schemeDraft));
+        colors.push_back(row);
+    }
+    return colors;
+}
+
+void SettingsController::editColorScheme(QString const& name)
+{
+    auto const& cfg = _config();
+    auto palette = vtbackend::ColorPalette {};
+    if (auto const it = cfg.colorschemes.value().find(name.toStdString());
+        it != cfg.colorschemes.value().end())
+        palette = it->second;
+    else if (auto const loaded = config::loadColorSchemeFile(cfg.configFile.parent_path() / "colorschemes"
+                                                             / (name.toStdString() + ".yml")))
+        palette = *loaded;
+
+    _schemeDraft = palette;
+    _editingScheme = name;
+    _hasSchemeDraft = true;
+    emit schemeDraftChanged();
+}
+
+void SettingsController::newColorScheme(QString const& basedOn)
+{
+    auto const& cfg = _config();
+    auto palette = vtbackend::ColorPalette {};
+    if (auto const it = cfg.colorschemes.value().find(basedOn.toStdString());
+        it != cfg.colorschemes.value().end())
+        palette = it->second;
+
+    _schemeDraft = palette;
+    _editingScheme.clear();
+    _hasSchemeDraft = true;
+    emit schemeDraftChanged();
+}
+
+void SettingsController::setSchemeColor(QString const& key, QString const& color)
+{
+    if (!_hasSchemeDraft)
+        return;
+    for (auto const& descriptor: schemeColorDescriptors())
+        if (descriptor.key == key)
+        {
+            descriptor.set(_schemeDraft, hexToRgb(color));
+            emit schemeDraftChanged();
+            return;
+        }
+}
+
+bool SettingsController::saveColorScheme(QString const& name)
+{
+    if (!_hasSchemeDraft || _locked)
+        return fail("The settings page is read-only.");
+    if (name.trimmed().isEmpty())
+        return fail("Enter a name for the color scheme.");
+
+    if (auto const result = _store->saveColorScheme(name.toStdString(), _schemeDraft); !result)
+        return fail(result.error());
+
+    _apply();
+    refresh();
+    _editingScheme = name;
+    emit schemeDraftChanged();
+    return true;
+}
+
+bool SettingsController::deleteColorScheme(QString const& name)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+
+    if (auto const result = _store->deleteColorScheme(name.toStdString()); !result)
+        return fail(result.error());
+
+    if (_editingScheme == name)
+    {
+        _hasSchemeDraft = false;
+        _editingScheme.clear();
+        emit schemeDraftChanged();
+    }
+    _apply();
+    refresh();
+    return true;
+}
+
+// }}}
+
+} // namespace contour

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -669,6 +669,46 @@ bool SettingsController::deleteProfile(QString const& name)
 
 // }}}
 
+bool SettingsController::renameProfile(QString const& oldName, QString const& newName)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+    if (profileOrigin(oldName.toStdString()) != SettingsOrigin::SideFile)
+        return fail("Only GUI-created profiles can be renamed here.");
+    auto const trimmed = newName.trimmed();
+    if (trimmed.isEmpty())
+        return fail("Enter a name for the profile.");
+    if (trimmed == oldName)
+        return true; // nothing to do
+    if (_config().findProfile(trimmed.toStdString()) != nullptr)
+        return fail("A profile with that name already exists.");
+
+    // Copy the profile out: findProfile's pointer is invalidated by _apply()'s in-place config reload.
+    auto const* profile = _config().findProfile(oldName.toStdString());
+    if (profile == nullptr)
+        return fail("Profile not found.");
+    auto const profileCopy = *profile;
+    bool const wasDefault = (_defaultProfile == oldName);
+
+    if (auto const result = _store->saveProfile(trimmed.toStdString(), profileCopy); !result)
+        return fail(result.error());
+    if (auto const result = _store->deleteProfile(oldName.toStdString()); !result)
+        return fail(result.error());
+    if (wasDefault)
+    {
+        auto settings = _config().guiManagedSettings;
+        settings.defaultProfile = trimmed.toStdString();
+        if (auto const result = _store->saveGuiSettings(settings); !result)
+            return fail(result.error());
+    }
+
+    _apply();
+    refresh();
+    if (_editingProfile == oldName)
+        editProfile(trimmed);
+    return true;
+}
+
 bool SettingsController::setDefaultProfile(QString const& name)
 {
     if (_locked)
@@ -795,6 +835,41 @@ void SettingsController::setSchemeColor(QString const& key, QString const& color
             emit schemeDraftChanged();
             return;
         }
+}
+
+bool SettingsController::renameColorScheme(QString const& oldName, QString const& newName)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+    auto const schemesDir = _config().configFile.parent_path() / "colorschemes";
+    if (!std::filesystem::exists(schemesDir / (oldName.toStdString() + ".yml")))
+        return fail("Only GUI-created color schemes can be renamed here.");
+    auto const trimmed = newName.trimmed();
+    if (trimmed.isEmpty())
+        return fail("Enter a name for the color scheme.");
+    if (trimmed == oldName)
+        return true; // nothing to do
+    if (std::filesystem::exists(schemesDir / (trimmed.toStdString() + ".yml")))
+        return fail("A color scheme with that name already exists.");
+
+    // Load the old palette (config-known or from its side file), then write it under the new name.
+    auto palette = vtbackend::ColorPalette {};
+    if (auto const it = _config().colorschemes.value().find(oldName.toStdString());
+        it != _config().colorschemes.value().end())
+        palette = it->second;
+    else if (auto const loaded = config::loadColorSchemeFile(schemesDir / (oldName.toStdString() + ".yml")))
+        palette = *loaded;
+
+    if (auto const result = _store->saveColorScheme(trimmed.toStdString(), palette); !result)
+        return fail(result.error());
+    if (auto const result = _store->deleteColorScheme(oldName.toStdString()); !result)
+        return fail(result.error());
+
+    _apply();
+    refresh();
+    if (_editingScheme == oldName)
+        editColorScheme(trimmed);
+    return true;
 }
 
 bool SettingsController::saveColorScheme(QString const& name)

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -3,11 +3,13 @@
 
 #include <text_shaper/font.h>
 
+#include <QtCore/QStringList>
 #include <QtGui/QColor>
 
 #include <algorithm>
 #include <array>
 #include <filesystem>
+#include <format>
 #include <set>
 #include <utility>
 
@@ -23,31 +25,93 @@ namespace
     /// page is adding a row here, not editing logic in three places.
     struct ProfileFieldDescriptor
     {
-        QString key;                                                //!< Stable identifier / QML key.
-        QString label;                                              //!< Human-readable label.
-        QString help;                                               //!< One-line help text.
-        QString type;                                               //!< "bool" | "double" | "string".
+        QString key;   //!< Stable identifier / QML key.
+        QString label; //!< Human-readable label.
+        QString help;  //!< One-line help text.
+        QString type;  //!< "bool" | "int" | "double" | "string" | "enum".
         std::function<QVariant(TerminalProfile const&)> get;        //!< Reads the field as a QVariant.
         std::function<void(TerminalProfile&, QVariant const&)> set; //!< Writes the field from QVariant.
+        QStringList options {}; //!< For "enum": the allowed values (the combo model + accepted set).
     };
 
-    /// The editable scalar profile fields. Kept intentionally small for the first version; it grows one
-    /// row at a time toward full parity without touching any other code.
+    /// Builds a bool profile-field descriptor from a ConfigEntry member accessor.
+    template <typename Accessor>
+    ProfileFieldDescriptor boolField(QString key, QString label, QString help, Accessor accessor)
+    {
+        return { std::move(key),
+                 std::move(label),
+                 std::move(help),
+                 "bool",
+                 [accessor](TerminalProfile const& p) { return QVariant(accessor(p).value()); },
+                 [accessor](TerminalProfile& p, QVariant const& v) { accessor(p) = v.toBool(); } };
+    }
+
+    /// The editable scalar profile fields. Data-driven: it grows one row at a time toward full parity
+    /// without touching any other code (the QML renders each row by its `type`).
     std::vector<ProfileFieldDescriptor> const& profileFieldDescriptors()
     {
+        using vtbackend::LineCount;
+        using vtbackend::LineOffset;
+        using Ms = std::chrono::milliseconds;
         static auto const descriptors = std::vector<ProfileFieldDescriptor> {
-            { "show_title_bar",
-              "Show title bar",
-              "Whether the window shows its title bar.",
-              "bool",
-              [](TerminalProfile const& p) { return QVariant(p.showTitleBar.value()); },
-              [](TerminalProfile& p, QVariant const& v) { p.showTitleBar = v.toBool(); } },
+            // {{{ Appearance / window
+            boolField("show_title_bar",
+                      "Show title bar",
+                      "Whether the window shows its title bar.",
+                      [](auto& p) -> auto& { return p.showTitleBar; }),
+            boolField("maximized",
+                      "Start maximized",
+                      "Open the window maximized.",
+                      [](auto& p) -> auto& { return p.maximized; }),
+            boolField("fullscreen",
+                      "Start fullscreen",
+                      "Open the window in fullscreen.",
+                      [](auto& p) -> auto& { return p.fullscreen; }),
+            boolField("size_indicator_on_resize",
+                      "Show size on resize",
+                      "Briefly show the terminal dimensions when the window is resized.",
+                      [](auto& p) -> auto& { return p.sizeIndicatorOnResize; }),
             { "dim_unfocused",
               "Dim when unfocused",
               "How much to dim a pane while it is not focused (0.0 = off, 1.0 = fully dimmed).",
               "double",
               [](TerminalProfile const& p) { return QVariant(p.dimUnfocused.value()); },
               [](TerminalProfile& p, QVariant const& v) { p.dimUnfocused = v.toDouble(); } },
+            { "tab_bar_position",
+              "Tab bar position",
+              "Where the tab strip sits relative to the terminal content.",
+              "enum",
+              [](TerminalProfile const& p) {
+                  return QVariant(p.tabBarPosition.value() == config::TabBarPosition::Bottom ? "Bottom"
+                                                                                             : "Top");
+              },
+              [](TerminalProfile& p, QVariant const& v) {
+                  p.tabBarPosition =
+                      v.toString() == "Bottom" ? config::TabBarPosition::Bottom : config::TabBarPosition::Top;
+              },
+              { "Top", "Bottom" } },
+            { "tab_bar_visibility",
+              "Tab bar visibility",
+              "When the tab strip is shown.",
+              "enum",
+              [](TerminalProfile const& p) {
+                  switch (p.tabBarVisibility.value())
+                  {
+                      case config::TabBarVisibility::Never: return QVariant("Never");
+                      case config::TabBarVisibility::Multiple: return QVariant("Multiple");
+                      case config::TabBarVisibility::Always: break;
+                  }
+                  return QVariant("Always");
+              },
+              [](TerminalProfile& p, QVariant const& v) {
+                  auto const s = v.toString();
+                  p.tabBarVisibility = s == "Never"      ? config::TabBarVisibility::Never
+                                       : s == "Multiple" ? config::TabBarVisibility::Multiple
+                                                         : config::TabBarVisibility::Always;
+              },
+              { "Always", "Never", "Multiple" } },
+            // }}}
+            // {{{ Font
             { "font_family",
               "Font family",
               "The regular font family name.",
@@ -66,12 +130,85 @@ namespace
               [](TerminalProfile& p, QVariant const& v) {
                   p.fonts.value().size = text::font_size { v.toDouble() };
               } },
-            { "size_indicator_on_resize",
-              "Show size on resize",
-              "Briefly show the terminal dimensions when the window is resized.",
-              "bool",
-              [](TerminalProfile const& p) { return QVariant(p.sizeIndicatorOnResize.value()); },
-              [](TerminalProfile& p, QVariant const& v) { p.sizeIndicatorOnResize = v.toBool(); } },
+            boolField("draw_bold_text_with_bright_colors",
+                      "Bold text uses bright colors",
+                      "Render bold text using the bright ANSI colors.",
+                      [](auto& p) -> auto& { return p.drawBoldTextWithBrightColors; }),
+            // }}}
+            // {{{ Scrolling
+            boolField("smooth_scrolling",
+                      "Smooth scrolling",
+                      "Animate scrolling between lines.",
+                      [](auto& p) -> auto& { return p.smoothScrolling; }),
+            boolField("momentum_scrolling",
+                      "Momentum scrolling",
+                      "Continue scrolling with momentum.",
+                      [](auto& p) -> auto& { return p.momentumScrolling; }),
+            { "slow_scrolling_time",
+              "Slow scrolling time (ms)",
+              "Duration of one smooth line-scroll step, in milliseconds.",
+              "int",
+              [](TerminalProfile const& p) {
+                  return QVariant(static_cast<int>(p.smoothLineScrolling.value().count()));
+              },
+              [](TerminalProfile& p, QVariant const& v) { p.smoothLineScrolling = Ms { v.toInt() }; } },
+            { "vi_mode_scrolloff",
+              "Vi mode scroll-off",
+              "Minimum lines kept above/below the cursor while scrolling in Vi mode.",
+              "int",
+              [](TerminalProfile const& p) {
+                  return QVariant(static_cast<int>(unbox(p.modalCursorScrollOff.value())));
+              },
+              [](TerminalProfile& p, QVariant const& v) { p.modalCursorScrollOff = LineCount(v.toInt()); } },
+            { "copy_last_mark_range_offset",
+              "Copy last-mark range offset",
+              "Line offset applied to the CopyPreviousMarkRange action.",
+              "int",
+              [](TerminalProfile const& p) {
+                  return QVariant(static_cast<int>(unbox(p.copyLastMarkRangeOffset.value())));
+              },
+              [](TerminalProfile& p, QVariant const& v) {
+                  p.copyLastMarkRangeOffset = LineOffset(v.toInt());
+              } },
+            // }}}
+            // {{{ Behavior / timings
+            boolField("escape_sandbox",
+                      "Escape sandbox",
+                      "Escape a Flatpak/Snap sandbox when spawning.",
+                      [](auto& p) -> auto& { return p.escapeSandbox; }),
+            boolField("search_mode_switch",
+                      "Search mode switch",
+                      "Switch to Vi normal mode when a search starts.",
+                      [](auto& p) -> auto& { return p.searchModeSwitch; }),
+            boolField("insert_after_yank",
+                      "Insert after yank",
+                      "Enter insert mode after yanking in Vi mode.",
+                      [](auto& p) -> auto& { return p.insertAfterYank; }),
+            boolField("input_method_editor",
+                      "Input method editor",
+                      "Enable IME (input method) support.",
+                      [](auto& p) -> auto& { return p.inputMethodEditor; }),
+            boolField("highlight_word_and_matches_on_double_click",
+                      "Highlight word on double-click",
+                      "Highlight the double-clicked word and its other occurrences.",
+                      [](auto& p) -> auto& { return p.highlightDoubleClickedWord; }),
+            { "vi_mode_highlight_timeout",
+              "Vi highlight timeout (ms)",
+              "How long a Vi-mode yank highlight stays visible, in milliseconds.",
+              "int",
+              [](TerminalProfile const& p) {
+                  return QVariant(static_cast<int>(p.highlightTimeout.value().count()));
+              },
+              [](TerminalProfile& p, QVariant const& v) { p.highlightTimeout = Ms { v.toInt() }; } },
+            { "screen_transition_duration",
+              "Screen transition (ms)",
+              "Duration of the alt-screen transition animation, in milliseconds.",
+              "int",
+              [](TerminalProfile const& p) {
+                  return QVariant(static_cast<int>(p.screenTransitionDuration.value().count()));
+              },
+              [](TerminalProfile& p, QVariant const& v) { p.screenTransitionDuration = Ms { v.toInt() }; } },
+            // }}}
         };
         return descriptors;
     }
@@ -118,6 +255,65 @@ namespace
         return descriptors;
     }
 
+    /// A data-driven descriptor for one editable global (application-scope) setting. `toYaml` turns the
+    /// edited value into the YAML scalar written to settings.yml; the load-time merge re-applies it
+    /// through the typed per-key loader, so this side needs no parsing.
+    struct GlobalFieldDescriptor
+    {
+        QString key;
+        QString label;
+        QString help;
+        QString type;
+        std::function<QVariant(config::Config const&)> get;
+        std::function<std::string(QVariant const&)> toYaml;
+    };
+
+    QString boolToYaml(QVariant const& v)
+    {
+        return v.toBool() ? "true" : "false";
+    }
+
+    /// The editable global settings. The keys match contour.yml's top-level keys AND the loader lines in
+    /// mergeGuiManagedSideFiles, so an override round-trips as the right type.
+    std::vector<GlobalFieldDescriptor> const& globalFieldDescriptors()
+    {
+        static auto const descriptors = std::vector<GlobalFieldDescriptor> {
+            { "reflow_on_resize",
+              "Reflow on resize",
+              "Reflow lines when the terminal is resized.",
+              "bool",
+              [](config::Config const& c) { return QVariant(c.reflowOnResize.value()); },
+              [](QVariant const& v) { return boolToYaml(v).toStdString(); } },
+            { "spawn_new_process",
+              "Spawn new process",
+              "Spawn a separate process for each new terminal window.",
+              "bool",
+              [](config::Config const& c) { return QVariant(c.spawnNewProcess.value()); },
+              [](QVariant const& v) { return boolToYaml(v).toStdString(); } },
+            { "read_buffer_size",
+              "PTY read buffer size",
+              "Number of bytes read from the pseudo-terminal per read.",
+              "int",
+              [](config::Config const& c) { return QVariant(c.ptyReadBufferSize.value()); },
+              [](QVariant const& v) { return std::to_string(v.toInt()); } },
+            { "command_palette_recent_count",
+              "Recent commands",
+              "How many recently-used commands the command palette lists first.",
+              "int",
+              [](config::Config const& c) { return QVariant(c.commandPaletteRecentCount.value()); },
+              [](QVariant const& v) { return std::to_string(v.toInt()); } },
+            { "word_delimiters",
+              "Word delimiters",
+              "Characters that separate words when selecting by double-click.",
+              "string",
+              [](config::Config const& c) {
+                  return QVariant(QString::fromStdString(c.wordDelimiters.value()));
+              },
+              [](QVariant const& v) { return v.toString().toStdString(); } },
+        };
+        return descriptors;
+    }
+
     /// "#rrggbb" for @p color, the format the QML color pickers exchange.
     QString rgbToHex(vtbackend::RGBColor color)
     {
@@ -131,6 +327,39 @@ namespace
         return vtbackend::RGBColor { static_cast<uint8_t>(color.red()),
                                      static_cast<uint8_t>(color.green()),
                                      static_cast<uint8_t>(color.blue()) };
+    }
+
+    /// Formats a modifier chord as "Ctrl+Shift" (the individual Modifier has a formatter, the set does
+    /// not), mirroring the config writer's bit walk.
+    QString formatModifiers(vtbackend::Modifiers modifiers)
+    {
+        auto parts = QStringList {};
+        for (auto bit = 0u; bit < sizeof(vtbackend::Modifier) * 8; ++bit)
+        {
+            auto const flag = static_cast<vtbackend::Modifier>(1u << bit);
+            if (!modifiers.test(flag))
+                continue;
+            auto const name = std::format("{}", flag);
+            if (!name.empty())
+                parts << QString::fromStdString(name);
+        }
+        return parts.join('+');
+    }
+
+    /// Builds a read-only display row { trigger, action, mode } for one input binding, or an empty map
+    /// when the binding carries no action.
+    template <typename Binding>
+    QVariantMap keybindingRow(Binding const& binding, QString const& inputLabel)
+    {
+        if (binding.binding.empty())
+            return {};
+        auto const mods = formatModifiers(binding.modifiers);
+        auto row = QVariantMap {};
+        row[QStringLiteral("trigger")] = mods.isEmpty() ? inputLabel : mods + '+' + inputLabel;
+        row[QStringLiteral("action")] = QString::fromStdString(std::format("{}", binding.binding.front()));
+        row[QStringLiteral("mode")] =
+            binding.modes.any() ? QString::fromStdString(std::format("{}", binding.modes)) : QString {};
+        return row;
     }
 
     /// The QML-facing token for a provenance value.
@@ -219,6 +448,22 @@ void SettingsController::refresh()
         _colorSchemes.push_back(row);
     }
 
+    // Keybindings (read-only): key, character and mouse mappings, each as { trigger, action, mode }.
+    _keybindings.clear();
+    auto const& mappings = cfg.inputMappings.value();
+    for (auto const& binding: mappings.keyMappings)
+        if (auto row = keybindingRow(binding, QString::fromStdString(std::format("{}", binding.input)));
+            !row.isEmpty())
+            _keybindings.push_back(row);
+    for (auto const& binding: mappings.charMappings)
+        if (auto row = keybindingRow(binding, QString(QChar(static_cast<char16_t>(binding.input))));
+            !row.isEmpty())
+            _keybindings.push_back(row);
+    for (auto const& binding: mappings.mouseMappings)
+        if (auto row = keybindingRow(binding, QString::fromStdString(std::format("{}", binding.input)));
+            !row.isEmpty())
+            _keybindings.push_back(row);
+
     emit changed();
 }
 
@@ -237,6 +482,7 @@ QVariantList SettingsController::profileFields() const
         row[QStringLiteral("help")] = descriptor.help;
         row[QStringLiteral("type")] = descriptor.type;
         row[QStringLiteral("value")] = descriptor.get(_draft);
+        row[QStringLiteral("options")] = descriptor.options;
         fields.push_back(row);
     }
     return fields;
@@ -433,6 +679,57 @@ bool SettingsController::setDefaultProfile(QString const& name)
     if (auto const result = _store->saveGuiSettings(settings); !result)
         return fail(result.error());
 
+    _apply();
+    refresh();
+    return true;
+}
+
+QVariantList SettingsController::globalFields() const
+{
+    auto const& cfg = _config();
+    auto const& overrides = cfg.guiManagedSettings.globalOverrides;
+    auto fields = QVariantList {};
+    for (auto const& descriptor: globalFieldDescriptors())
+    {
+        auto row = QVariantMap {};
+        row[QStringLiteral("key")] = descriptor.key;
+        row[QStringLiteral("label")] = descriptor.label;
+        row[QStringLiteral("help")] = descriptor.help;
+        row[QStringLiteral("type")] = descriptor.type;
+        row[QStringLiteral("value")] = descriptor.get(cfg);
+        row[QStringLiteral("options")] = QStringList {};
+        row[QStringLiteral("overridden")] = overrides.contains(descriptor.key.toStdString());
+        fields.push_back(row);
+    }
+    return fields;
+}
+
+bool SettingsController::setGlobalField(QString const& key, QVariant const& value)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+    for (auto const& descriptor: globalFieldDescriptors())
+        if (descriptor.key == key)
+        {
+            auto settings = _config().guiManagedSettings;
+            settings.globalOverrides[key.toStdString()] = descriptor.toYaml(value);
+            if (auto const result = _store->saveGuiSettings(settings); !result)
+                return fail(result.error());
+            _apply();
+            refresh();
+            return true;
+        }
+    return fail("Unknown global setting.");
+}
+
+bool SettingsController::resetGlobalField(QString const& key)
+{
+    if (_locked)
+        return fail("The settings page is read-only.");
+    auto settings = _config().guiManagedSettings;
+    settings.globalOverrides.erase(key.toStdString());
+    if (auto const result = _store->saveGuiSettings(settings); !result)
+        return fail(result.error());
     _apply();
     refresh();
     return true;

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -397,6 +397,24 @@ SettingsOrigin SettingsController::profileOrigin(std::string const& name) const
     return it != origins.end() ? it->second : SettingsOrigin::Builtin;
 }
 
+bool SettingsController::colorSchemeSideFileExists(std::string const& name) const
+{
+    auto ec = std::error_code {};
+    auto const path = _config().configFile.parent_path() / "colorschemes" / (name + ".yml");
+    return std::filesystem::exists(path, ec) && !ec;
+}
+
+bool SettingsController::isInlineColorScheme(std::string const& name) const
+{
+    // "Inline" means declared in contour.yml (origin MainConfig) with no GUI side file backing it. A side
+    // file always wins editability regardless of a stale MainConfig marking (a side-file scheme referenced
+    // by a profile is loaded into the config map and recorded MainConfig), so exclude it explicitly.
+    auto const& origins = _config().colorSchemeOrigins;
+    auto const it = origins.find(name);
+    return it != origins.end() && it->second == SettingsOrigin::MainConfig
+           && !colorSchemeSideFileExists(name);
+}
+
 bool SettingsController::fail(std::string const& error)
 {
     emit errorOccurred(QString::fromStdString(error));
@@ -635,17 +653,21 @@ bool SettingsController::saveProfileAs(QString const& newName)
 {
     if (!_hasDraft || _locked)
         return fail("The settings page is read-only.");
-    if (newName.trimmed().isEmpty())
+    auto const trimmed = newName.trimmed();
+    if (trimmed.isEmpty())
         return fail("Enter a name for the new profile.");
-    if (profileOrigin(newName.toStdString()) == SettingsOrigin::MainConfig)
-        return fail("A profile with that name is defined in contour.yml; choose another name.");
+    // Reject ANY existing name, not just contour.yml ones: an existing GUI (side-file) profile of the
+    // same name would otherwise be silently overwritten with the current draft. findProfile covers both
+    // inline and side-file profiles, matching renameProfile's collision guard.
+    if (_config().findProfile(trimmed.toStdString()) != nullptr)
+        return fail("A profile with that name already exists; choose another name.");
 
-    if (auto const result = _store->saveProfile(newName.toStdString(), _draft); !result)
+    if (auto const result = _store->saveProfile(trimmed.toStdString(), _draft); !result)
         return fail(result.error());
 
     _apply();
     refresh();
-    editProfile(newName);
+    editProfile(trimmed);
     return true;
 }
 
@@ -811,6 +833,7 @@ void SettingsController::editColorScheme(QString const& name)
     _editingScheme = name;
     _hasSchemeDraft = true;
     emit schemeDraftChanged();
+    emit editingSchemeChanged();
 }
 
 void SettingsController::newColorScheme(QString const& basedOn)
@@ -825,6 +848,7 @@ void SettingsController::newColorScheme(QString const& basedOn)
     _editingScheme.clear();
     _hasSchemeDraft = true;
     emit schemeDraftChanged();
+    emit editingSchemeChanged();
 }
 
 void SettingsController::setSchemeColor(QString const& key, QString const& color)
@@ -845,14 +869,19 @@ bool SettingsController::renameColorScheme(QString const& oldName, QString const
     if (_locked)
         return fail("The settings page is read-only.");
     auto const schemesDir = _config().configFile.parent_path() / "colorschemes";
-    if (!std::filesystem::exists(schemesDir / (oldName.toStdString() + ".yml")))
+    if (!colorSchemeSideFileExists(oldName.toStdString()))
         return fail("Only GUI-created color schemes can be renamed here.");
     auto const trimmed = newName.trimmed();
     if (trimmed.isEmpty())
         return fail("Enter a name for the color scheme.");
     if (trimmed == oldName)
         return true; // nothing to do
-    if (std::filesystem::exists(schemesDir / (trimmed.toStdString() + ".yml")))
+    // Reject a destination naming ANY existing scheme: a side file, a contour.yml inline scheme (which
+    // would shadow the written side file at load, leaving a dead file), or a config-known scheme such as
+    // the builtin "default". Mirrors renameProfile's guard, and uses the non-throwing exists() overload
+    // (via the helper) so an I/O error cannot throw out of a slot.
+    if (colorSchemeSideFileExists(trimmed.toStdString()) || isInlineColorScheme(trimmed.toStdString())
+        || _config().colorschemes.value().contains(trimmed.toStdString()))
         return fail("A color scheme with that name already exists.");
 
     // Load the old palette (config-known or from its side file), then write it under the new name.
@@ -881,6 +910,10 @@ bool SettingsController::saveColorScheme(QString const& name)
         return fail("The settings page is read-only.");
     if (name.trimmed().isEmpty())
         return fail("Enter a name for the color scheme.");
+    // A contour.yml inline scheme of the same name shadows a side file at load (the inline node wins), so
+    // writing one would silently have no effect. Refuse it, mirroring saveProfileAs's contour.yml guard.
+    if (isInlineColorScheme(name.trimmed().toStdString()))
+        return fail("A color scheme with that name is defined in contour.yml; choose another name.");
 
     if (auto const result = _store->saveColorScheme(name.toStdString(), _schemeDraft); !result)
         return fail(result.error());
@@ -889,6 +922,7 @@ bool SettingsController::saveColorScheme(QString const& name)
     refresh();
     _editingScheme = name;
     emit schemeDraftChanged();
+    emit editingSchemeChanged();
     return true;
 }
 
@@ -896,6 +930,11 @@ bool SettingsController::deleteColorScheme(QString const& name)
 {
     if (_locked)
         return fail("The settings page is read-only.");
+    // Only GUI-created (side-file) schemes can be deleted; a builtin/inline scheme has no side file, and
+    // removeFile treats an absent file as success, so without this guard we would report a false delete of
+    // a scheme that is actually still present. Mirrors deleteProfile's origin guard.
+    if (!colorSchemeSideFileExists(name.toStdString()))
+        return fail("Only GUI-created color schemes can be deleted here.");
 
     if (auto const result = _store->deleteColorScheme(name.toStdString()); !result)
         return fail(result.error());
@@ -905,6 +944,7 @@ bool SettingsController::deleteColorScheme(QString const& name)
         _hasSchemeDraft = false;
         _editingScheme.clear();
         emit schemeDraftChanged();
+        emit editingSchemeChanged();
     }
     _apply();
     refresh();

--- a/src/contour/SettingsController.h
+++ b/src/contour/SettingsController.h
@@ -143,6 +143,9 @@ class SettingsController: public QObject
     Q_INVOKABLE bool saveProfileAs(QString const& newName);
     /// Removes profile @p name's side file. @return true on success.
     Q_INVOKABLE bool deleteProfile(QString const& name);
+    /// Renames a GUI-created profile's side file from @p oldName to @p newName, moving the default-profile
+    /// pointer and the open draft with it. Only side-file profiles can be renamed. @return success.
+    Q_INVOKABLE bool renameProfile(QString const& oldName, QString const& newName);
     // }}}
 
     /// Sets the default profile (persisted to settings.yml, overriding contour.yml). @return success.
@@ -164,6 +167,9 @@ class SettingsController: public QObject
     Q_INVOKABLE bool saveColorScheme(QString const& name);
     /// Removes color scheme @p name's side file. @return true on success.
     Q_INVOKABLE bool deleteColorScheme(QString const& name);
+    /// Renames a GUI-created color scheme's side file from @p oldName to @p newName, moving the open
+    /// scheme draft with it. Only side-file schemes can be renamed. @return success.
+    Q_INVOKABLE bool renameColorScheme(QString const& oldName, QString const& newName);
     // }}}
 
   signals:

--- a/src/contour/SettingsController.h
+++ b/src/contour/SettingsController.h
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <contour/Config.h>
+#include <contour/GuiConfigStore.h>
+
+#include <QtCore/QObject>
+#include <QtCore/QVariantList>
+#include <QtCore/QVariantMap>
+#include <QtQml/qqmlregistration.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace contour
+{
+
+/// The editable bridge between the GUI settings page and the configuration.
+///
+/// It follows Windows Terminal's "edit a clone, then Save" model: the controller never mutates the
+/// live @ref config::Config, it edits an in-memory *draft* of one profile (or one color scheme) and
+/// persists that draft to a GUI-owned side file on Save, then asks the host to reload so the change
+/// takes effect. It NEVER writes the hand-maintained `contour.yml`; profiles and schemes defined there
+/// are surfaced read-only (see @ref config::SettingsOrigin), and only the GUI's own side-file entities
+/// are editable.
+///
+/// Every collaborator it touches is injected (per the project's DI principle), so the whole
+/// create/edit/save/delete workflow is driven headlessly in tests against an in-memory store:
+///   - a *config accessor* returning the current, already-merged configuration (re-read on refresh),
+///   - a @ref GuiConfigStore for the actual side-file writes/deletes,
+///   - an *apply* callback the host wires to a live config reload.
+class SettingsController: public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("Created by the WindowController")
+
+    /// True when `gui_config_locked` is set in contour.yml: the page opens read-only and no Save,
+    /// Save-As or Delete is offered.
+    Q_PROPERTY(bool locked READ locked NOTIFY changed)
+
+    /// The profiles the page lists: one QVariantMap per profile
+    /// { name, origin ("main"|"side"|"builtin"), editable (bool), isDefault (bool) }.
+    Q_PROPERTY(QVariantList profiles READ profiles NOTIFY changed)
+
+    /// The color schemes the page lists: one QVariantMap per scheme { name, editable (bool) }.
+    Q_PROPERTY(QVariantList colorSchemes READ colorSchemes NOTIFY changed)
+
+    /// The name of the current default profile (settings.yml override, else contour.yml).
+    Q_PROPERTY(QString defaultProfile READ defaultProfile NOTIFY changed)
+
+    /// The scalar fields of the profile currently being edited: one QVariantMap per field
+    /// { key, label, help, type ("bool"|"int"|"double"|"string"), value }. Empty when nothing is open.
+    Q_PROPERTY(QVariantList profileFields READ profileFields NOTIFY draftChanged)
+
+    /// The name of the profile draft being edited ("" for an unsaved new profile).
+    Q_PROPERTY(QString editingProfile READ editingProfile NOTIFY draftChanged)
+
+    /// True when the open profile draft cannot be saved in place (it is a contour.yml/builtin profile,
+    /// or the page is locked): the UI offers "Save As" / "Duplicate" instead of "Save".
+    Q_PROPERTY(bool editingReadOnly READ editingReadOnly NOTIFY draftChanged)
+
+    /// The color-scheme selection of the profile draft: "simple" (one scheme) or "dual" (light+dark).
+    Q_PROPERTY(QString colorSchemeMode READ colorSchemeMode NOTIFY draftChanged)
+    /// The scheme name for "simple" mode.
+    Q_PROPERTY(QString colorScheme READ colorScheme NOTIFY draftChanged)
+    /// The light/dark scheme names for "dual" mode.
+    Q_PROPERTY(QString colorSchemeLight READ colorSchemeLight NOTIFY draftChanged)
+    Q_PROPERTY(QString colorSchemeDark READ colorSchemeDark NOTIFY draftChanged)
+
+    /// The colors of the color-scheme draft being edited: one QVariantMap per slot
+    /// { key, label, color ("#rrggbb") }. Empty when no scheme is open for editing.
+    Q_PROPERTY(QVariantList schemeColors READ schemeColors NOTIFY schemeDraftChanged)
+    /// The name of the color-scheme draft being edited ("" for an unsaved new scheme).
+    Q_PROPERTY(QString editingScheme READ editingScheme NOTIFY schemeDraftChanged)
+
+  public:
+    /// Returns the current, already-side-file-merged configuration. Called on every refresh, so a
+    /// reload is reflected the next time the page is opened or refreshed.
+    using ConfigAccessor = std::function<config::Config const&()>;
+
+    /// Applies persisted changes to the running program (the host wires this to a live config reload).
+    using ApplyCallback = std::function<void()>;
+
+    /// @param config Accessor for the live configuration (read-only; edits go through @p store).
+    /// @param store  Where side files are written/removed (injected for testability).
+    /// @param apply  Invoked after a successful save/delete so the change takes effect immediately.
+    /// @param parent Optional QObject parent.
+    SettingsController(ConfigAccessor config,
+                       std::shared_ptr<GuiConfigStore> store,
+                       ApplyCallback apply,
+                       QObject* parent = nullptr);
+
+    [[nodiscard]] bool locked() const noexcept { return _locked; }
+    [[nodiscard]] QVariantList profiles() const { return _profiles; }
+    [[nodiscard]] QVariantList colorSchemes() const { return _colorSchemes; }
+    [[nodiscard]] QString defaultProfile() const { return _defaultProfile; }
+
+    [[nodiscard]] QVariantList profileFields() const;
+    [[nodiscard]] QString editingProfile() const { return _editingProfile; }
+    [[nodiscard]] bool editingReadOnly() const noexcept { return _editingReadOnly; }
+    [[nodiscard]] QString colorSchemeMode() const;
+    [[nodiscard]] QString colorScheme() const;
+    [[nodiscard]] QString colorSchemeLight() const;
+    [[nodiscard]] QString colorSchemeDark() const;
+
+    [[nodiscard]] QVariantList schemeColors() const;
+    [[nodiscard]] QString editingScheme() const { return _editingScheme; }
+
+    /// Rebuilds the list models (profiles, color schemes, default) from the current configuration.
+    /// Called by the host whenever the settings page is shown, so stale rows never linger.
+    Q_INVOKABLE void refresh();
+
+    // {{{ Profile draft
+    /// Opens @p name for editing (loads its values into the draft). Read-only if it is not a side file.
+    Q_INVOKABLE void editProfile(QString const& name);
+    /// Starts a new profile draft seeded from @p basedOn (or the default profile if empty/unknown).
+    Q_INVOKABLE void newProfile(QString const& basedOn);
+    /// Sets a scalar profile field on the draft (see @ref profileFields for keys/types).
+    Q_INVOKABLE void setProfileField(QString const& key, QVariant const& value);
+    /// Switches the draft's color selection between "simple" and "dual".
+    Q_INVOKABLE void setColorSchemeMode(QString const& mode);
+    /// Sets the simple-mode scheme name / the dual-mode light/dark scheme names on the draft.
+    Q_INVOKABLE void setColorScheme(QString const& name);
+    Q_INVOKABLE void setColorSchemeLight(QString const& name);
+    Q_INVOKABLE void setColorSchemeDark(QString const& name);
+    /// Persists the draft to its own side file (its current name). @return true on success.
+    Q_INVOKABLE bool saveProfile();
+    /// Persists the draft under @p newName (a new side file), then continues editing it.
+    /// @return true on success.
+    Q_INVOKABLE bool saveProfileAs(QString const& newName);
+    /// Removes profile @p name's side file. @return true on success.
+    Q_INVOKABLE bool deleteProfile(QString const& name);
+    // }}}
+
+    /// Sets the default profile (persisted to settings.yml, overriding contour.yml). @return success.
+    Q_INVOKABLE bool setDefaultProfile(QString const& name);
+
+    // {{{ Color-scheme draft
+    /// Opens color scheme @p name for editing (loads its colors into the scheme draft).
+    Q_INVOKABLE void editColorScheme(QString const& name);
+    /// Starts a new color-scheme draft seeded from @p basedOn (or a default palette).
+    Q_INVOKABLE void newColorScheme(QString const& basedOn);
+    /// Sets one color slot on the scheme draft (see @ref schemeColors for keys). @p color is "#rrggbb".
+    Q_INVOKABLE void setSchemeColor(QString const& key, QString const& color);
+    /// Persists the scheme draft under @p name (a `colorschemes/<name>.yml` side file). @return success.
+    Q_INVOKABLE bool saveColorScheme(QString const& name);
+    /// Removes color scheme @p name's side file. @return true on success.
+    Q_INVOKABLE bool deleteColorScheme(QString const& name);
+    // }}}
+
+  signals:
+    /// The list models (profiles, color schemes, default profile, locked) changed.
+    void changed();
+    /// The profile draft changed (opened, a field edited, saved).
+    void draftChanged();
+    /// The color-scheme draft changed.
+    void schemeDraftChanged();
+    /// A user-facing error occurred (e.g. a write failed); @p message is human-readable.
+    void errorOccurred(QString const& message);
+
+  private:
+    /// The origin of @p name among the current profiles, defaulting to Builtin if unknown.
+    [[nodiscard]] config::SettingsOrigin profileOrigin(std::string const& name) const;
+    /// Reports @p error to the UI and returns false, for the `return fail(...)` idiom on write errors.
+    bool fail(std::string const& error);
+
+    ConfigAccessor _config;
+    std::shared_ptr<GuiConfigStore> _store;
+    ApplyCallback _apply;
+
+    bool _locked = false;
+    QVariantList _profiles;
+    QVariantList _colorSchemes;
+    QString _defaultProfile;
+
+    // The profile draft (Windows-Terminal "edit a clone").
+    config::TerminalProfile _draft;
+    QString _editingProfile; //!< "" while editing an unsaved new profile.
+    bool _hasDraft = false;
+    bool _editingReadOnly = false;
+
+    // The color-scheme draft.
+    vtbackend::ColorPalette _schemeDraft;
+    QString _editingScheme; //!< "" while editing an unsaved new scheme.
+    bool _hasSchemeDraft = false;
+};
+
+} // namespace contour

--- a/src/contour/SettingsController.h
+++ b/src/contour/SettingsController.h
@@ -50,6 +50,15 @@ class SettingsController: public QObject
     /// The name of the current default profile (settings.yml override, else contour.yml).
     Q_PROPERTY(QString defaultProfile READ defaultProfile NOTIFY changed)
 
+    /// The configured key/mouse bindings, read-only: one QVariantMap per binding
+    /// { trigger, action, mode }. Editing bindings stays in contour.yml for now (this is a viewer).
+    Q_PROPERTY(QVariantList keybindings READ keybindings NOTIFY changed)
+
+    /// The editable global (application-scope) settings: one QVariantMap per field
+    /// { key, label, help, type, value, options, overridden }. Edits are written to settings.yml as
+    /// overrides on contour.yml — the same side-file discipline the rest of the page uses.
+    Q_PROPERTY(QVariantList globalFields READ globalFields NOTIFY changed)
+
     /// The scalar fields of the profile currently being edited: one QVariantMap per field
     /// { key, label, help, type ("bool"|"int"|"double"|"string"), value }. Empty when nothing is open.
     Q_PROPERTY(QVariantList profileFields READ profileFields NOTIFY draftChanged)
@@ -96,6 +105,8 @@ class SettingsController: public QObject
     [[nodiscard]] QVariantList profiles() const { return _profiles; }
     [[nodiscard]] QVariantList colorSchemes() const { return _colorSchemes; }
     [[nodiscard]] QString defaultProfile() const { return _defaultProfile; }
+    [[nodiscard]] QVariantList keybindings() const { return _keybindings; }
+    [[nodiscard]] QVariantList globalFields() const;
 
     [[nodiscard]] QVariantList profileFields() const;
     [[nodiscard]] QString editingProfile() const { return _editingProfile; }
@@ -137,6 +148,11 @@ class SettingsController: public QObject
     /// Sets the default profile (persisted to settings.yml, overriding contour.yml). @return success.
     Q_INVOKABLE bool setDefaultProfile(QString const& name);
 
+    /// Overrides a global setting (persisted to settings.yml over contour.yml). @return success.
+    Q_INVOKABLE bool setGlobalField(QString const& key, QVariant const& value);
+    /// Clears a global override, so the setting falls back to contour.yml/default. @return success.
+    Q_INVOKABLE bool resetGlobalField(QString const& key);
+
     // {{{ Color-scheme draft
     /// Opens color scheme @p name for editing (loads its colors into the scheme draft).
     Q_INVOKABLE void editColorScheme(QString const& name);
@@ -173,6 +189,7 @@ class SettingsController: public QObject
     bool _locked = false;
     QVariantList _profiles;
     QVariantList _colorSchemes;
+    QVariantList _keybindings;
     QString _defaultProfile;
 
     // The profile draft (Windows-Terminal "edit a clone").

--- a/src/contour/SettingsController.h
+++ b/src/contour/SettingsController.h
@@ -82,7 +82,7 @@ class SettingsController: public QObject
     /// { key, label, color ("#rrggbb") }. Empty when no scheme is open for editing.
     Q_PROPERTY(QVariantList schemeColors READ schemeColors NOTIFY schemeDraftChanged)
     /// The name of the color-scheme draft being edited ("" for an unsaved new scheme).
-    Q_PROPERTY(QString editingScheme READ editingScheme NOTIFY schemeDraftChanged)
+    Q_PROPERTY(QString editingScheme READ editingScheme NOTIFY editingSchemeChanged)
 
   public:
     /// Returns the current, already-side-file-merged configuration. Called on every refresh, so a
@@ -179,12 +179,25 @@ class SettingsController: public QObject
     void draftChanged();
     /// The color-scheme draft changed.
     void schemeDraftChanged();
+    /// The IDENTITY of the color scheme being edited changed (a different scheme selected, a new one
+    /// started, or the current one saved/deleted) — but NOT a mere color tweak. Kept separate from
+    /// @ref schemeDraftChanged so the editor's name field can re-seed on an identity change without being
+    /// wiped every time the user adjusts a color while typing a new name.
+    void editingSchemeChanged();
     /// A user-facing error occurred (e.g. a write failed); @p message is human-readable.
     void errorOccurred(QString const& message);
 
   private:
     /// The origin of @p name among the current profiles, defaulting to Builtin if unknown.
     [[nodiscard]] config::SettingsOrigin profileOrigin(std::string const& name) const;
+    /// Whether a GUI-owned side file @c colorschemes/<name>.yml exists on disk. This is the editability
+    /// ground truth the color-scheme list uses: only such schemes can be edited, renamed or deleted.
+    /// @param name The color scheme name. @return true if the side file exists.
+    [[nodiscard]] bool colorSchemeSideFileExists(std::string const& name) const;
+    /// Whether @p name is a color scheme declared inline in contour.yml with no GUI side file backing it.
+    /// Such a name would shadow a @c colorschemes/<name>.yml side file at load time (the inline node wins),
+    /// so the GUI must refuse to write one. @param name The color scheme name. @return true if inline.
+    [[nodiscard]] bool isInlineColorScheme(std::string const& name) const;
     /// Reports @p error to the UI and returns false, for the `return fail(...)` idiom on write errors.
     bool fail(std::string const& error);
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1343,10 +1343,20 @@ void TerminalSession::sendCharEvent(char32_t value,
 
     if (eventType != KeyboardEventType::Release)
     {
-        // find if action exist for the given key, and ignore if editing search prompt
-        if (auto const* actions = config::apply(
-                _config.inputMappings.value().charMappings, value, modifiers.chord, matchModeFlags());
-            actions && !_terminal.inputHandler().isEditingSearch())
+        // Find a char binding for this key (ignored while editing the search prompt).
+        auto const& charMappings = _config.inputMappings.value().charMappings;
+        auto const flags = matchModeFlags();
+        auto const* actions = config::apply(charMappings, value, modifiers.chord, flags);
+
+        // A shortcut written with the base key label (e.g. `Ctrl+Shift+,`) is stored under the base
+        // character, but Qt delivers a Shift+punctuation chord as the *shifted* symbol ('<' here). When
+        // the direct lookup misses and Shift is held, retry under the un-shifted base so the binding
+        // fires as the user intended — letters already match (their codepoint is shift-invariant).
+        if (actions == nullptr && modifiers.chord.test(vtbackend::Modifier::Shift))
+            if (auto const base = unshiftedCodepoint(value); base != value)
+                actions = config::apply(charMappings, base, modifiers.chord, flags);
+
+        if (actions != nullptr && !_terminal.inputHandler().isEditingSearch())
         {
             auto executionCount = 0;
             handleAction(actions, eventType, [&](auto const& actions) {

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2263,6 +2263,14 @@ bool TerminalSession::operator()(actions::OpenCommandPalette)
     return true;
 }
 
+bool TerminalSession::operator()(actions::OpenSettings)
+{
+    // Show the in-app settings page over this session's window. Routed through the manager (like the
+    // command palette) so it targets the window this session actually lives in.
+    _manager->openSettings(/*acting*/ this);
+    return true;
+}
+
 bool TerminalSession::operator()(actions::SetTabTitle)
 {
     // Open the GUI-native inline tab-title editor for the active tab. Routed through the manager

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1868,8 +1868,17 @@ bool TerminalSession::operator()(actions::NoSearchHighlight)
     return true;
 }
 
-bool TerminalSession::operator()(actions::OpenConfiguration)
+bool TerminalSession::operator()(actions::OpenConfiguration event)
 {
+    // By default open the in-app settings page over this session's window (routed through the manager
+    // like every window-scoped op). The explicit `in_editor: true` opt-in instead opens the raw
+    // configuration file in the OS's external editor — the historical behavior.
+    if (!event.inEditor)
+    {
+        _manager->openSettings(/*acting*/ this);
+        return true;
+    }
+
     if (!_app.externalLauncher().openUrl(QUrl(QString::fromUtf8(_config.configFile.string().c_str()))))
         errorLog()("Could not open configuration file \"{}\".", _config.configFile.generic_string());
 
@@ -2260,14 +2269,6 @@ bool TerminalSession::operator()(actions::OpenCommandPalette)
     // Open the GUI-native command palette over this session's window. Routed through the manager like
     // every other window-scoped op so it targets the window this session is actually in.
     _manager->openCommandPalette(/*acting*/ this);
-    return true;
-}
-
-bool TerminalSession::operator()(actions::OpenSettings)
-{
-    // Show the in-app settings page over this session's window. Routed through the manager (like the
-    // command palette) so it targets the window this session actually lives in.
-    _manager->openSettings(/*acting*/ this);
     return true;
 }
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1903,13 +1903,21 @@ bool TerminalSession::operator()(actions::OpenFileManager)
     // not openable here (its menu row is grayed out, but a keybinding could still reach this handler).
     auto const localHost = QHostInfo::localHostName().toStdString();
     auto localPath = std::optional<std::string> {};
+    auto cwd = std::string {};
     {
         auto const l = scoped_lock { terminal() };
-        localPath = vtbackend::localWorkingDirectory(terminal().currentWorkingDirectory(), localHost);
+        cwd = terminal().currentWorkingDirectory();
+        localPath = vtbackend::localWorkingDirectory(cwd, localHost);
     }
 
     if (!localPath)
+    {
+        // A remote (SSH) or otherwise non-local cwd cannot be opened in this host's file manager. The
+        // context-menu row for this is grayed out, but a keybinding can still reach this handler — so
+        // report why nothing happened rather than silently swallowing the request.
+        errorLog()("Cannot open file manager: working directory \"{}\" is not on the local host.", cwd);
         return true;
+    }
 
     if (!_app.externalLauncher().openUrl(QUrl::fromLocalFile(QString::fromStdString(*localPath))))
         errorLog()("Could not open folder \"{}\".", *localPath);
@@ -2902,7 +2910,17 @@ void TerminalSession::followHyperlink(vtbackend::HyperlinkInfo const& hyperlink)
 
 void TerminalSession::onConfigReload()
 {
-    _display->post([this]() { reloadConfigWithProfile(_profileName); });
+    // reloadAllSessions() fans this out to EVERY session, including background tabs/split panes whose
+    // display was detached on the last tab switch (_display == nullptr) — the same null-_display crash
+    // class the action handlers (e.g. setFontSize) guard against. With a display, hop onto its (GUI)
+    // thread as before. With none, there is no render thread to marshal onto, and reloadConfigWithProfile
+    // is itself display-safe (activateProfile guards its one _display use), so run it directly rather than
+    // skip it — otherwise a background tab would keep serving the pre-reload config until it is
+    // reactivated.
+    if (_display != nullptr)
+        _display->post([this]() { reloadConfigWithProfile(_profileName); });
+    else
+        reloadConfigWithProfile(_profileName);
 
     // TODO: needed still?
     // if (setScreenDirty())

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -432,7 +432,6 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::NoSearchHighlight);
     bool operator()(actions::OpenCommandPalette);
     bool operator()(actions::OpenConfiguration);
-    bool operator()(actions::OpenSettings);
     bool operator()(actions::OpenFileManager);
     bool operator()(actions::OpenSelection);
     bool operator()(actions::PasteClipboard);

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -432,6 +432,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::NoSearchHighlight);
     bool operator()(actions::OpenCommandPalette);
     bool operator()(actions::OpenConfiguration);
+    bool operator()(actions::OpenSettings);
     bool operator()(actions::OpenFileManager);
     bool operator()(actions::OpenSelection);
     bool operator()(actions::PasteClipboard);

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -446,6 +446,25 @@ void TerminalSessionManager::openCommandPalette(TerminalSession* acting)
     controller->openCommandPalette();
 }
 
+void TerminalSessionManager::openSettings(TerminalSession* acting)
+{
+    auto* controller = controllerHostingSession(acting);
+    if (controller == nullptr)
+        return;
+
+    controller->openSettings();
+}
+
+void TerminalSessionManager::reloadAllSessions()
+{
+    // Refresh the master config first, so the app — and the settings page that reads it — see the new
+    // side files immediately. Then have each live session re-read and re-apply, updating the terminals.
+    config::loadConfigFromFile(_app.config(), _app.config().configFile);
+    for (auto& [id, session]: _sessionsById)
+        if (session != nullptr)
+            session->onConfigReload();
+}
+
 void TerminalSessionManager::openContextMenu(TerminalSession* acting)
 {
     // Announced before the routing, which no-ops when there is no window to show a menu in. That makes the

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -117,7 +117,8 @@ WindowController* TerminalSessionManager::controllerForDisplay(
     return _controllersByWindow.begin()->second;
 }
 
-TerminalSession* TerminalSessionManager::createSessionInBackground(vtmux::WindowId window)
+TerminalSession* TerminalSessionManager::createSessionInBackground(vtmux::WindowId window,
+                                                                   std::optional<std::string> profileName)
 {
     // TODO: Remove dependency on app-knowledge and pass shell / terminal-size instead.
     // The GuiApp *or* (Global)Config could be made a global to be accessible from within QML.
@@ -154,7 +155,7 @@ TerminalSession* TerminalSessionManager::createSessionInBackground(vtmux::Window
     // Pre-mint the session id so the model's allocator (see ctor) hands it back, keeping the model
     // tab/pane and the Qt session on one id.
     auto const sessionId = vtmux::SessionId { _nextSessionId++ };
-    auto* session = createBackingSession(sessionId, ptyPath, pageSize);
+    auto* session = createBackingSession(sessionId, ptyPath, pageSize, std::nullopt, profileName);
 
     // Mirror this new session into the vtmux model as a new single-pane tab.
     if (auto* tab = _model->createTab(window))
@@ -272,12 +273,13 @@ void TerminalSessionManager::syncFocusForWindow(WindowController* controller)
         setFocusedSession(controller->activeSession());
 }
 
-TerminalSession* TerminalSessionManager::createSession(vtmux::WindowId window)
+TerminalSession* TerminalSessionManager::createSession(vtmux::WindowId window,
+                                                       std::optional<std::string> profileName)
 {
     // Just create the backing session + its model tab. The model's activeTabChanged fires the owning
     // controller's proxy rebuild, and the pane tree's `session:` binding attaches the session to its
     // display — no legacy activateSession display-assignment.
-    return createSessionInBackground(window);
+    return createSessionInBackground(window, std::move(profileName));
 }
 
 void TerminalSessionManager::createNewTab(TerminalSession* acting)

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -3,6 +3,7 @@
 #include <contour/ContourGuiApp.h>
 #include <contour/LayoutBuilder.h>
 #include <contour/PaneProxy.h>
+#include <contour/SettingsController.h>
 #include <contour/TabLabel.h>
 #include <contour/TerminalSession.h>
 #include <contour/TerminalSessionManager.h>
@@ -465,6 +466,15 @@ void TerminalSessionManager::reloadAllSessions()
     for (auto& [id, session]: _sessionsById)
         if (session != nullptr)
             session->onConfigReload();
+
+    // The settings page reads through the app config just reloaded above, but each OS window owns its
+    // own SettingsController with model caches rebuilt only by refresh(). The controller that triggered
+    // the save refreshes itself; refresh every OTHER window's too, so a settings page open in a second
+    // window reflects the change immediately instead of serving stale caches until it is reopened.
+    for (auto& [windowId, controller]: _controllersByWindow)
+        if (controller != nullptr)
+            if (auto* settings = controller->settingsController(); settings != nullptr)
+                settings->refresh();
 }
 
 void TerminalSessionManager::openContextMenu(TerminalSession* acting)

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -142,8 +142,8 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     /// @param acting The session that triggered the action; its hosting window shows the palette.
     void openCommandPalette(TerminalSession* acting);
 
-    /// Shows the in-app settings page over the window hosting @p acting (the OpenSettings action).
-    /// No-ops if @p acting has no hosting window.
+    /// Shows the in-app settings page over the window hosting @p acting (the OpenConfiguration action's
+    /// default, and the tab-strip gear). No-ops if @p acting has no hosting window.
     /// @param acting The session that triggered the action; its hosting window shows the settings page.
     void openSettings(TerminalSession* acting);
 

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -92,13 +92,24 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     }
 
     /// Creates a backing session + its model tab in @p window (the calling controller's window).
-    contour::TerminalSession* createSessionInBackground(vtmux::WindowId window);
+    /// @param window      The target window.
+    /// @param profileName Profile to launch the session with, or std::nullopt for the app default.
+    contour::TerminalSession* createSessionInBackground(
+        vtmux::WindowId window, std::optional<std::string> profileName = std::nullopt);
 
     /// Creates a new tab in @p window (the GUI "+" button entry point, via WindowController).
-    contour::TerminalSession* createSession(vtmux::WindowId window);
+    /// @param window      The target window.
+    /// @param profileName Profile to launch the tab with, or std::nullopt for the app default.
+    contour::TerminalSession* createSession(vtmux::WindowId window,
+                                            std::optional<std::string> profileName = std::nullopt);
 
     /// Creates and activates a new tab in @p window.
-    void createNewTab(vtmux::WindowId window) { createSession(window); }
+    /// @param window      The target window.
+    /// @param profileName Profile to launch the tab with, or std::nullopt for the app default.
+    void createNewTab(vtmux::WindowId window, std::optional<std::string> profileName = std::nullopt)
+    {
+        createSession(window, std::move(profileName));
+    }
 
     /// Creates and activates a new tab in the window hosting @p acting (the CreateNewTab keybinding).
     void createNewTab(TerminalSession* acting);

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -142,6 +142,16 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     /// @param acting The session that triggered the action; its hosting window shows the palette.
     void openCommandPalette(TerminalSession* acting);
 
+    /// Shows the in-app settings page over the window hosting @p acting (the OpenSettings action).
+    /// No-ops if @p acting has no hosting window.
+    /// @param acting The session that triggered the action; its hosting window shows the settings page.
+    void openSettings(TerminalSession* acting);
+
+    /// Re-reads the master configuration from disk (picking up any GUI side-file changes) and pushes
+    /// it to every live session. The apply step the settings page runs after a Save/Delete so the
+    /// change takes effect immediately, without waiting for the optional live-reload file watcher.
+    void reloadAllSessions();
+
     /// Opens the terminal context menu over the pane of @p acting (the OpenContextMenu action).
     ///
     /// Makes that pane active first, so the menu is built from the state of the pane the user actually

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -94,6 +94,9 @@ void WindowController::setSettingsActive(bool active)
         return;
     _settingsActive = active;
     emit settingsActiveChanged();
+    // Toggling the settings view flips whether a terminal tab reads as active (see IsActiveRole), so
+    // repaint the strip: the active tab de-highlights on open and re-highlights on close.
+    refreshActiveTabHighlight();
 }
 
 void WindowController::openContextMenu()
@@ -241,7 +244,9 @@ QVariant WindowController::data(QModelIndex const& index, int role) const
             auto const color = tab != nullptr ? tab->color() : std::nullopt;
             return color.has_value() ? toQColor(*color) : QColor(Qt::transparent);
         }
-        case IsActiveRole: return row == activeTabIndex();
+        // No terminal tab reads as active while the settings "tab" is showing — the settings tab is the
+        // active view then, so the strip must not highlight two tabs at once.
+        case IsActiveRole: return !_settingsActive && row == activeTabIndex();
         case PaneCountRole: return tab != nullptr ? tab->paneCount() : 1;
         case ZoomedRole: return tab != nullptr && tab->isZoomed();
         default: return {};
@@ -296,11 +301,13 @@ QString WindowController::resolvedTabLabel(vtmux::Tab* tab, TerminalSession* ses
 // {{{ Tab-strip invokables — structural/session-lifetime ops delegate to the manager, tagged with
 // THIS window's id, so the same operation issued from any OS window targets that window's tabs.
 // Pure per-tab attributes (title, color) resolve the tab locally and write the model directly.
-void WindowController::createNewTab()
+void WindowController::createNewTab(QString const& profileName)
 {
     // A new terminal tab is a terminal view: leave the settings page so the content area shows it.
     setSettingsActive(false);
-    _manager.createNewTab(_windowId);
+    auto profile = profileName.isEmpty() ? std::optional<std::string> { std::nullopt }
+                                         : std::optional<std::string> { profileName.toStdString() };
+    _manager.createNewTab(_windowId, std::move(profile));
 }
 
 void WindowController::activateTab(int index)

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -3,7 +3,9 @@
 #include <contour/ContextMenu.h>
 #include <contour/ContextMenuModel.h>
 #include <contour/ContourGuiApp.h>
+#include <contour/GuiConfigStore.h>
 #include <contour/PaneProxy.h>
+#include <contour/SettingsController.h>
 #include <contour/Shortcut.h>
 #include <contour/TabColorScheme.h>
 #include <contour/TabLabel.h>
@@ -42,6 +44,15 @@ WindowController::WindowController(TerminalSessionManager& manager, vtmux::Windo
 {
     _commandPalette->setSources(
         { &_tabCommands, &_profileCommands, &_layoutCommands, &_boundCommands, &_actionCommands });
+
+    // The editable settings bridge. Its collaborators are injected so the whole workflow is testable:
+    // a config accessor into the app's live (reload-in-place) Config, a file-backed side-file store
+    // rooted at the config directory, and an apply step that reloads every session after a save.
+    _settingsController = std::make_unique<SettingsController>(
+        [this]() -> config::Config const& { return _manager.app().config(); },
+        std::make_shared<FileGuiConfigStore>(_manager.app().config().configFile.parent_path()),
+        [this]() { _manager.reloadAllSessions(); },
+        this);
 }
 
 WindowController::~WindowController() = default;
@@ -57,6 +68,32 @@ void WindowController::openCommandPalette()
     _commandPalette->refresh();
 
     emit commandPaletteRequested();
+}
+
+void WindowController::openSettings()
+{
+    // Rebuild the models against the current config on every open, so a config reload since the last
+    // visit is reflected — the same freshness discipline openCommandPalette() uses.
+    _settingsController->refresh();
+    setSettingsActive(true);
+}
+
+void WindowController::closeSettings()
+{
+    setSettingsActive(false);
+}
+
+void WindowController::toggleSettings()
+{
+    setSettingsActive(!_settingsActive);
+}
+
+void WindowController::setSettingsActive(bool active)
+{
+    if (_settingsActive == active)
+        return;
+    _settingsActive = active;
+    emit settingsActiveChanged();
 }
 
 void WindowController::openContextMenu()
@@ -261,11 +298,16 @@ QString WindowController::resolvedTabLabel(vtmux::Tab* tab, TerminalSession* ses
 // Pure per-tab attributes (title, color) resolve the tab locally and write the model directly.
 void WindowController::createNewTab()
 {
+    // A new terminal tab is a terminal view: leave the settings page so the content area shows it.
+    setSettingsActive(false);
     _manager.createNewTab(_windowId);
 }
 
 void WindowController::activateTab(int index)
 {
+    // Selecting a tab returns to the terminal content — the settings page and the tabs are mutually
+    // exclusive views of the same region, so activating any tab dismisses the settings page.
+    setSettingsActive(false);
     _manager.activateTab(_windowId, index);
 }
 

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -119,7 +119,10 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     [[nodiscard]] int activeTabIndex() const noexcept;
 
     // {{{ GUI tab-strip invokables (delegated to the manager, tagged with _windowId)
-    Q_INVOKABLE void createNewTab();
+    /// Opens a new tab. With an empty @p profileName the app-default profile is used; otherwise the
+    /// named profile is launched (the new-tab profile dropdown). The default argument keeps the bare
+    /// `createNewTab()` call site (the "+" button) working.
+    Q_INVOKABLE void createNewTab(QString const& profileName = {});
     Q_INVOKABLE void activateTab(int index);
     Q_INVOKABLE void moveTab(int fromIndex, int toIndex);
     /// The raw id of the window this controller adapts, so a QML drag payload can name its source
@@ -230,13 +233,13 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     }
 
     /// Shows the settings page over this window (the OpenConfiguration action's default, and the
-    /// tab-strip gear). Idempotent: showing it while already shown does nothing.
-    void openSettings();
+    /// new-tab dropdown's "Settings" entry). Idempotent: showing it while already shown does nothing.
+    Q_INVOKABLE void openSettings();
 
     /// Returns from the settings page to the active tab's terminal content. A no-op if not showing it.
     Q_INVOKABLE void closeSettings();
 
-    /// Toggles between the settings page and the terminal content — the tab-strip gear affordance.
+    /// Toggles between the settings page and the terminal content.
     Q_INVOKABLE void toggleSettings();
     // }}}
 

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -229,8 +229,8 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
         return _settingsController.get();
     }
 
-    /// Shows the settings page over this window (the OpenSettings action, and the tab-strip gear).
-    /// Idempotent: showing it while already shown does nothing.
+    /// Shows the settings page over this window (the OpenConfiguration action's default, and the
+    /// tab-strip gear). Idempotent: showing it while already shown does nothing.
     void openSettings();
 
     /// Returns from the settings page to the active tab's terminal content. A no-op if not showing it.

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -31,6 +31,7 @@ namespace contour
 class TerminalSessionManager;
 class TerminalSession;
 class PaneProxy;
+class SettingsController;
 
 /// Per-OS-window Qt/QML adapter over one vtmux::Window.
 ///
@@ -74,6 +75,8 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     Q_PROPERTY(int tabBarVisibility READ tabBarVisibility NOTIFY tabBarVisibilityChanged)
     Q_PROPERTY(bool tabBarShouldShow READ tabBarShouldShow NOTIFY tabBarShouldShowChanged)
     Q_PROPERTY(int chromeHeight READ chromeHeight WRITE setChromeHeight NOTIFY chromeHeightChanged)
+    Q_PROPERTY(bool settingsActive READ settingsActive NOTIFY settingsActiveChanged)
+    Q_PROPERTY(contour::SettingsController* settingsController READ settingsController CONSTANT)
     QML_ELEMENT
     QML_UNCREATABLE("Created by the session manager")
 
@@ -211,6 +214,30 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     /// used. Unknown ids are ignored (a row can go stale between a refresh and a click).
     /// @param id The command id (CommandPaletteModel's `commandId` role).
     Q_INVOKABLE void runCommand(QString const& id);
+    // }}}
+
+    // {{{ Settings page
+    /// Whether this window's content area currently shows the in-app settings page instead of the
+    /// active tab's terminal pane tree. The content Loader in main.qml switches on this, so the settings
+    /// page and the terminal are mutually-exclusive views of the same region (Windows-Terminal style).
+    [[nodiscard]] bool settingsActive() const noexcept { return _settingsActive; }
+
+    /// This window's editable settings bridge (never null; owned by this controller). The QML settings
+    /// page binds to it for the profile/color-scheme/default-profile models and the save/delete actions.
+    [[nodiscard]] SettingsController* settingsController() const noexcept
+    {
+        return _settingsController.get();
+    }
+
+    /// Shows the settings page over this window (the OpenSettings action, and the tab-strip gear).
+    /// Idempotent: showing it while already shown does nothing.
+    void openSettings();
+
+    /// Returns from the settings page to the active tab's terminal content. A no-op if not showing it.
+    Q_INVOKABLE void closeSettings();
+
+    /// Toggles between the settings page and the terminal content — the tab-strip gear affordance.
+    Q_INVOKABLE void toggleSettings();
     // }}}
 
     // {{{ Terminal context menu
@@ -470,8 +497,16 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     void tabBarShouldShowChanged();
     void activeSessionChanged();
     void chromeHeightChanged();
+    /// The content area switched between the settings page and the terminal (settingsActive changed).
+    void settingsActiveChanged();
 
   private:
+    /// Sets whether the settings page is shown, emitting settingsActiveChanged only on a real change.
+    /// Centralizes the notify so every entry point (openSettings/closeSettings/toggleSettings and the
+    /// tab-activation reset) stays consistent.
+    /// @param active The new settings-page visibility.
+    void setSettingsActive(bool active);
+
     /// The backing vtmux::Window, or nullptr if it has been removed.
     [[nodiscard]] vtmux::Window* window() const noexcept;
     /// The active tab of this window's vtmux::Window, or nullptr.
@@ -523,6 +558,13 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     BoundCommandSource _boundCommands;
     ActionCommandSource _actionCommands;
     std::unique_ptr<CommandPaletteModel> _commandPalette;
+    // }}}
+
+    // {{{ Settings page
+    /// Whether the content area currently shows the settings page instead of the terminal pane tree.
+    bool _settingsActive = false;
+    /// The editable settings bridge for this window (created in the constructor; never null).
+    std::unique_ptr<SettingsController> _settingsController;
     // }}}
 
     // {{{ Terminal context menu

--- a/src/contour/helper.cpp
+++ b/src/contour/helper.cpp
@@ -341,6 +341,38 @@ namespace
 
 } // namespace
 
+char32_t unshiftedCodepoint(char32_t ch) noexcept
+{
+    // The US-ASCII shifted -> base inverse of the shift level, kept consistent with the CharMappings
+    // table below (which reports the *shifted* symbol for a Shift+key chord). A row per shifted symbol,
+    // so extending it is data, not logic.
+    switch (ch)
+    {
+        case U')': return U'0';
+        case U'!': return U'1';
+        case U'@': return U'2';
+        case U'#': return U'3';
+        case U'$': return U'4';
+        case U'%': return U'5';
+        case U'^': return U'6';
+        case U'&': return U'7';
+        case U'*': return U'8';
+        case U'(': return U'9';
+        case U'<': return U',';
+        case U'>': return U'.';
+        case U'?': return U'/';
+        case U':': return U';';
+        case U'"': return U'\'';
+        case U'{': return U'[';
+        case U'}': return U']';
+        case U'|': return U'\\';
+        case U'~': return U'`';
+        case U'_': return U'-';
+        case U'+': return U'=';
+        default: return ch;
+    }
+}
+
 bool sendKeyEvent(QKeyEvent* event, vtbackend::KeyboardEventType eventType, TerminalSession& session)
 {
     using vtbackend::Key;

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -145,6 +145,18 @@ constexpr inline vtbackend::MouseButton makeMouseButton(Qt::MouseButton button)
     }
 }
 
+/// Maps a US-ASCII "shifted" character back to the base character its physical key produces without
+/// Shift (e.g. '<' -> ',', '?' -> '/', '_' -> '-', '@' -> '2'). Returns @p ch unchanged when it is not
+/// a shifted symbol.
+///
+/// Keyboard shortcuts are written with the base key label (e.g. `Ctrl+Shift+,`) and stored as the base
+/// character, but a Shift+punctuation chord is delivered by Qt as the *shifted* symbol (comma+Shift is
+/// reported as '<' on a US layout). Matching the delivered shifted codepoint against the base char a
+/// binding is stored under is what lets such shortcuts fire as the user intended.
+/// @param ch The (possibly shifted) input codepoint.
+/// @return The un-shifted base codepoint, or @p ch if it is not a recognized shifted symbol.
+[[nodiscard]] char32_t unshiftedCodepoint(char32_t ch) noexcept;
+
 class TerminalSession;
 bool sendKeyEvent(QKeyEvent* keyEvent, vtbackend::KeyboardEventType eventType, TerminalSession& session);
 void sendWheelEvent(QWheelEvent* event, TerminalSession& session);

--- a/src/contour/resources.qrc
+++ b/src/contour/resources.qrc
@@ -26,6 +26,8 @@
         <file>ui/SaveLayoutDialog.qml</file>
         <file>ui/SettingsPage.qml</file>
         <file>ui/SettingsNavItem.qml</file>
+        <file>ui/SettingsListItem.qml</file>
+        <file>ui/ConfirmDialog.qml</file>
         <file>ui/SettingRow.qml</file>
         <file>ui/ColorSchemeEditor.qml</file>
         <file>ui/main.qml</file>

--- a/src/contour/resources.qrc
+++ b/src/contour/resources.qrc
@@ -23,6 +23,9 @@
         <file>ui/TerminalContextMenu.qml</file>
         <file>ui/CommandPalette.qml</file>
         <file>ui/SaveLayoutDialog.qml</file>
+        <file>ui/SettingsPage.qml</file>
+        <file>ui/SettingRow.qml</file>
+        <file>ui/ColorSchemeEditor.qml</file>
         <file>ui/main.qml</file>
     </qresource>
 </RCC>

--- a/src/contour/resources.qrc
+++ b/src/contour/resources.qrc
@@ -13,6 +13,7 @@
         <file>ui/SessionChrome.qml</file>
         <file>ui/TitleBar.qml</file>
         <file>ui/TabStrip.qml</file>
+        <file>ui/NewTabMenu.qml</file>
         <file>ui/TabItem.qml</file>
         <file>ui/TabContextMenu.qml</file>
         <file>ui/TabColorFlyout.qml</file>

--- a/src/contour/resources.qrc
+++ b/src/contour/resources.qrc
@@ -24,6 +24,7 @@
         <file>ui/CommandPalette.qml</file>
         <file>ui/SaveLayoutDialog.qml</file>
         <file>ui/SettingsPage.qml</file>
+        <file>ui/SettingsNavItem.qml</file>
         <file>ui/SettingRow.qml</file>
         <file>ui/ColorSchemeEditor.qml</file>
         <file>ui/main.qml</file>

--- a/src/contour/test/CommandPaletteModel_test.cpp
+++ b/src/contour/test/CommandPaletteModel_test.cpp
@@ -265,6 +265,39 @@ TEST_CASE("The palette reports which title characters the filter matched", "[con
     }
 }
 
+TEST_CASE("Title-match highlight indices are UTF-16 code units, not UTF-8 byte offsets", "[contour][palette]")
+{
+    // Regression guard: the fuzzy filter reports matched positions as UTF-8 byte offsets, but the QML
+    // delegate indexes the title as a UTF-16 string. A tab title can carry any UTF-8 (a shell sets it), so
+    // a multibyte character before a match would otherwise shift — or drop — every highlight after it.
+    // U+2192 (→) is 3 UTF-8 bytes but a single UTF-16 code unit, so raw byte offsets run two ahead of the
+    // indices QML needs.
+    auto tabs = test::StubTabs { { "→zephyr" } }; // → then a run of letters unique to the title
+    auto const tabCommands = TabCommandSource { tabs };
+
+    auto history = CommandHistory { 3 };
+    auto model = CommandPaletteModel { history };
+    model.setSources({ &tabCommands });
+    model.refresh();
+
+    model.setFilter(QStringLiteral("zephyr"));
+    auto const row = rowOf(model, "SwitchToTab:1");
+    REQUIRE(row >= 0);
+    auto const title = QString::fromStdString(titleAt(model, row));
+    REQUIRE(title == QString::fromUtf8("Switch To Tab 1: →zephyr"));
+
+    // "zephyr" occurs exactly once, contiguously, right after the → at UTF-16 index 18. As raw byte
+    // offsets these would be 20..25 (two higher, and 25 is past the string's end).
+    auto const matches = titleMatchesAt(model, row);
+    CHECK(matches == std::vector<int> { 18, 19, 20, 21, 22, 23 });
+
+    // Each reported index must land on the matched character in the UTF-16 string — the property the QML
+    // highlighter relies on. Byte offsets would index the wrong characters (and run off the end) here.
+    auto const query = QStringLiteral("zephyr");
+    for (auto i = 0; i < static_cast<int>(matches.size()); ++i)
+        CHECK(title.at(matches[static_cast<std::size_t>(i)]) == query.at(i));
+}
+
 TEST_CASE("Recency breaks a tie between two equally good matches", "[contour][palette]")
 {
     // Two commands score the same against "toggle"; the one the user reached for last time should be

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -2043,7 +2043,7 @@ TEST_CASE("Config: GUI settings round-trip through emitGuiSettingsYaml / loadGui
     auto const path = std::filesystem::path(dir.path().toStdString()) / "settings.yml";
     {
         auto out = std::ofstream(path);
-        out << contour::config::emitGuiSettingsYaml({ .defaultProfile = "work" });
+        out << contour::config::emitGuiSettingsYaml({ .defaultProfile = "work", .globalOverrides = {} });
     }
 
     auto const loaded = contour::config::loadGuiSettingsFile(path);
@@ -2069,8 +2069,10 @@ TEST_CASE("Config: FileGuiConfigStore writes and removes side files the loader p
 
     auto store = contour::FileGuiConfigStore(configDir);
     REQUIRE(store.saveProfile("saved", profile).has_value());
-    REQUIRE(
-        store.saveGuiSettings(contour::config::GuiManagedSettings { .defaultProfile = "saved" }).has_value());
+    REQUIRE(store
+                .saveGuiSettings(
+                    contour::config::GuiManagedSettings { .defaultProfile = "saved", .globalOverrides = {} })
+                .has_value());
 
     auto const afterSave = loadFromYaml(dir, "default_profile: main\n");
     auto const* saved = afterSave.findProfile("saved");

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -1981,6 +1981,31 @@ profiles:
     CHECK(config.profileOrigins.at("work") == contour::config::SettingsOrigin::SideFile);
 }
 
+TEST_CASE("Config: a profiles/<name>.yml with CRLF line endings still loads", "[config][gui]")
+{
+    // Regression guard for a Windows-only defect: the side-file reader sizes its read by
+    // fs::file_size(), so it must open in binary. A text-mode read would collapse CRLF->LF, fall
+    // short of the byte count, and leave a trailing NUL that breaks the YAML parse. Editors on
+    // Windows routinely save CRLF, so this must round-trip. We write the bytes explicitly (binary)
+    // to exercise the CRLF path on every platform, not just Windows.
+    QTemporaryDir dir;
+    {
+        auto const path = std::filesystem::path(dir.path().toStdString()) / "profiles" / "crlf.yml";
+        std::filesystem::create_directories(path.parent_path());
+        auto out = std::ofstream(path, std::ios::binary);
+        // A bool and a string value, both terminated by CRLF. The string is the sharp test: a stray
+        // '\r' kept on the scalar would make wm_class compare unequal to "contour-crlf".
+        out << "show_title_bar: false\r\n"
+               "wm_class: contour-crlf\r\n";
+    }
+    auto const config = loadFromYaml(dir, "default_profile: main\n");
+
+    auto const* crlf = config.findProfile("crlf");
+    REQUIRE(crlf != nullptr);
+    CHECK(crlf->showTitleBar.value() == false);
+    CHECK(crlf->wmClass.value() == "contour-crlf");
+}
+
 TEST_CASE("Config: settings.yml default_profile overrides contour.yml's", "[config][gui]")
 {
     QTemporaryDir dir;

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -366,6 +366,27 @@ input_mapping:
     CHECK(hasLaunchLayoutBinding);
 }
 
+TEST_CASE("Config: OpenConfiguration in_editor parameter parses", "[config]")
+{
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+input_mapping:
+    - { mods: [Control], key: F1, action: OpenConfiguration }
+    - { mods: [Control], key: F2, action: OpenConfiguration, in_editor: true }
+)"sv);
+
+    // The defaults bind OpenConfiguration as CHAR mappings, so the two custom KEY mappings are ours.
+    auto flags = std::vector<bool> {};
+    for (auto const& mapping: config.inputMappings.value().keyMappings)
+        if (auto const* oc = std::get_if<contour::actions::OpenConfiguration>(&mapping.binding.at(0)))
+            flags.push_back(oc->inEditor);
+
+    REQUIRE(flags.size() == 2);
+    CHECK(std::ranges::count(flags, false) == 1); // default -> in-app settings dialog
+    CHECK(std::ranges::count(flags, true) == 1);  // in_editor: true -> external editor
+}
+
 TEST_CASE("Config: an out-of-range or non-numeric ratio is ignored", "[config][layout]")
 {
     QTemporaryDir dir;

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -8,7 +8,9 @@
 
 #include <contour/Actions.h>
 #include <contour/Config.h>
+#include <contour/GuiConfigStore.h>
 
+#include <vtbackend/Color.h>
 #include <vtbackend/primitives.h>
 
 #include <QtCore/QTemporaryDir>
@@ -46,6 +48,16 @@ namespace
     auto config = contour::config::Config {};
     contour::config::loadConfigFromFile(config, writeConfig(dir, yaml));
     return config;
+}
+
+/// Writes @p content to a GUI side file at @p relativePath under @p dir (the config directory),
+/// creating intermediate directories (e.g. `profiles/`, `colorschemes/`) as needed.
+void writeSideFile(QTemporaryDir& dir, std::filesystem::path const& relativePath, std::string_view content)
+{
+    auto const path = std::filesystem::path(dir.path().toStdString()) / relativePath;
+    std::filesystem::create_directories(path.parent_path());
+    auto out = std::ofstream(path);
+    out << content;
 }
 
 } // namespace
@@ -1913,3 +1925,163 @@ TEST_CASE("config.builtinFallbackMouseMappings", "[config]")
         CHECK_FALSE(bindsRight);
     }
 }
+
+// {{{ GUI-managed side files (profiles/*.yml, colorschemes/*.yml, settings.yml) and the lock key.
+
+TEST_CASE("Config: gui_config_locked loads and defaults to false", "[config][gui]")
+{
+    QTemporaryDir dir;
+    CHECK_FALSE(loadFromYaml(dir, "default_profile: main\n").guiConfigLocked.value());
+
+    QTemporaryDir dir2;
+    CHECK(loadFromYaml(dir2, "gui_config_locked: true\n").guiConfigLocked.value());
+}
+
+TEST_CASE("Config: a profiles/<name>.yml side file merges as an editable GUI profile", "[config][gui]")
+{
+    QTemporaryDir dir;
+    // The side file overrides only show_title_bar; every other field must inherit the default profile.
+    writeSideFile(dir, "profiles/work.yml", "show_title_bar: false\n");
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        show_title_bar: true
+        wm_class: inherited-value
+)");
+
+    auto const* work = config.findProfile("work");
+    REQUIRE(work != nullptr);
+    CHECK(work->showTitleBar.value() == false);        // overridden by the side file
+    CHECK(work->wmClass.value() == "inherited-value"); // inherited from the default profile
+
+    // Provenance gates GUI editability: inline entries are read-only, side-file entries are editable.
+    CHECK(config.profileOrigins.at("main") == contour::config::SettingsOrigin::MainConfig);
+    CHECK(config.profileOrigins.at("work") == contour::config::SettingsOrigin::SideFile);
+}
+
+TEST_CASE("Config: settings.yml default_profile overrides contour.yml's", "[config][gui]")
+{
+    QTemporaryDir dir;
+    writeSideFile(dir, "profiles/work.yml", "show_title_bar: false\n");
+    writeSideFile(dir, "settings.yml", "default_profile: work\n");
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        show_title_bar: true
+)");
+
+    CHECK(config.defaultProfileName.value() == "work");
+    REQUIRE(config.guiManagedSettings.defaultProfile.has_value());
+    CHECK(config.guiManagedSettings.defaultProfile.value() == "work");
+}
+
+TEST_CASE("Config: settings.yml default_profile naming a missing profile is ignored", "[config][gui]")
+{
+    QTemporaryDir dir;
+    writeSideFile(dir, "settings.yml", "default_profile: ghost\n");
+    auto const config = loadFromYaml(dir, "default_profile: main\n");
+    CHECK(config.defaultProfileName.value() == "main");
+}
+
+TEST_CASE("Config: a malformed profiles/<name>.yml is skipped, not fatal to the rest", "[config][gui]")
+{
+    QTemporaryDir dir;
+    writeSideFile(dir, "profiles/broken.yml", "colors: [1, 2\n"); // unterminated flow sequence
+    writeSideFile(dir, "profiles/ok.yml", "show_title_bar: false\n");
+    auto const config = loadFromYaml(dir, "default_profile: main\n");
+
+    CHECK(config.findProfile("ok") != nullptr);     // the valid side file still loaded
+    CHECK(config.findProfile("broken") == nullptr); // the broken one was skipped
+    CHECK(config.findProfile("main") != nullptr);   // the rest of the config is intact
+}
+
+TEST_CASE("Config: a profile round-trips through emitProfileYaml and the side-file loader", "[config][gui]")
+{
+    QTemporaryDir dir;
+    auto const source = loadFromYaml(dir, "default_profile: main\n");
+    auto profile = *source.findProfile("main");
+    profile.showTitleBar = false;
+    profile.dimUnfocused = true;
+
+    writeSideFile(dir, "profiles/roundtrip.yml", contour::config::emitProfileYaml(profile));
+
+    auto const reloaded = loadFromYaml(dir, "default_profile: main\n");
+    auto const* rt = reloaded.findProfile("roundtrip");
+    REQUIRE(rt != nullptr);
+    CHECK(rt->showTitleBar.value() == false);
+    CHECK(rt->dimUnfocused.value() == true);
+}
+
+TEST_CASE("Config: a colorschemes/<name>.yml written via emitColorSchemeYaml is resolved by a profile",
+          "[config][gui]")
+{
+    QTemporaryDir dir;
+    auto palette = vtbackend::ColorPalette {};
+    palette.defaultBackground = vtbackend::RGBColor { 0x12, 0x34, 0x56 };
+    writeSideFile(dir, "colorschemes/mono.yml", contour::config::emitColorSchemeYaml(palette));
+
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        colors: mono
+)");
+
+    auto const* main = config.findProfile("main");
+    REQUIRE(main != nullptr);
+    auto const* simple = std::get_if<contour::config::SimpleColorConfig>(&main->colors.value());
+    REQUIRE(simple != nullptr);
+    CHECK(simple->colors.defaultBackground == vtbackend::RGBColor { 0x12, 0x34, 0x56 });
+}
+
+TEST_CASE("Config: GUI settings round-trip through emitGuiSettingsYaml / loadGuiSettingsFile",
+          "[config][gui]")
+{
+    QTemporaryDir dir;
+    auto const path = std::filesystem::path(dir.path().toStdString()) / "settings.yml";
+    {
+        auto out = std::ofstream(path);
+        out << contour::config::emitGuiSettingsYaml({ .defaultProfile = "work" });
+    }
+
+    auto const loaded = contour::config::loadGuiSettingsFile(path);
+    REQUIRE(loaded.has_value());
+    REQUIRE(loaded->defaultProfile.has_value());
+    CHECK(loaded->defaultProfile.value() == "work");
+
+    // A missing file is default (all-unset), not an error.
+    auto const missing = contour::config::loadGuiSettingsFile(std::filesystem::path(dir.path().toStdString())
+                                                              / "does-not-exist.yml");
+    REQUIRE(missing.has_value());
+    CHECK_FALSE(missing->defaultProfile.has_value());
+}
+
+TEST_CASE("Config: FileGuiConfigStore writes and removes side files the loader picks up", "[config][gui]")
+{
+    QTemporaryDir dir;
+    auto const configDir = std::filesystem::path(dir.path().toStdString());
+
+    auto const base = loadFromYaml(dir, "default_profile: main\n");
+    auto profile = *base.findProfile("main");
+    profile.showTitleBar = false;
+
+    auto store = contour::FileGuiConfigStore(configDir);
+    REQUIRE(store.saveProfile("saved", profile).has_value());
+    REQUIRE(
+        store.saveGuiSettings(contour::config::GuiManagedSettings { .defaultProfile = "saved" }).has_value());
+
+    auto const afterSave = loadFromYaml(dir, "default_profile: main\n");
+    auto const* saved = afterSave.findProfile("saved");
+    REQUIRE(saved != nullptr);
+    CHECK(saved->showTitleBar.value() == false);
+    CHECK(afterSave.defaultProfileName.value() == "saved");
+    CHECK(afterSave.profileOrigins.at("saved") == contour::config::SettingsOrigin::SideFile);
+
+    REQUIRE(store.deleteProfile("saved").has_value());
+    auto const afterDelete = loadFromYaml(dir, "default_profile: main\n");
+    CHECK(afterDelete.findProfile("saved") == nullptr);
+}
+
+// }}}

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -2006,6 +2006,63 @@ TEST_CASE("Config: a profiles/<name>.yml with CRLF line endings still loads", "[
     CHECK(crlf->wmClass.value() == "contour-crlf");
 }
 
+TEST_CASE("Config: an in-place reload drops a removed side-file profile and its stale origin",
+          "[config][gui]")
+{
+    // Production reloads config in place (reloadAllSessions reuses the live Config object), unlike a fresh
+    // load. A profiles map that only ever accreted entries — and a provenance map that only ever emplaced
+    // — would keep a GUI profile alive after its side file was deleted, so the settings page would still
+    // offer it and a later Save would shadow contour.yml. The loader must reconcile both on every load.
+    QTemporaryDir dir;
+    writeSideFile(dir, "profiles/work.yml", "show_title_bar: false\n");
+    auto const configPath = writeConfig(dir, R"(
+default_profile: main
+profiles:
+    main:
+        show_title_bar: true
+)");
+
+    contour::config::Config config;
+    contour::config::loadConfigFromFile(config, configPath);
+    REQUIRE(config.findProfile("work") != nullptr);
+    REQUIRE(config.profileOrigins.at("work") == contour::config::SettingsOrigin::SideFile);
+
+    // Delete the side file and reload INTO THE SAME Config object.
+    std::filesystem::remove(std::filesystem::path(dir.path().toStdString()) / "profiles" / "work.yml");
+    contour::config::loadConfigFromFile(config, configPath);
+
+    CHECK(config.findProfile("work") == nullptr);    // no longer in the profiles map
+    CHECK(config.profileOrigins.count("work") == 0); // and no stale SideFile provenance left behind
+    REQUIRE(config.findProfile("main") != nullptr);  // the contour.yml profile is intact
+    CHECK(config.profileOrigins.at("main") == contour::config::SettingsOrigin::MainConfig);
+}
+
+TEST_CASE("Config: a settings.yml with CRLF line endings still applies", "[config][gui]")
+{
+    // settings.yml is read through the same CRLF-normalizing reader as the profile side files, so a file
+    // saved with Windows line endings must round-trip on every platform: a stray '\r' left on a scalar
+    // would make default_profile name an unknown "work\r" and fail the typed int global override. Written
+    // as explicit CRLF bytes in binary to exercise the path regardless of host line-ending conventions.
+    QTemporaryDir dir;
+    writeSideFile(dir, "profiles/work.yml", "show_title_bar: false\n");
+    {
+        auto const path = std::filesystem::path(dir.path().toStdString()) / "settings.yml";
+        auto out = std::ofstream(path, std::ios::binary);
+        out << "default_profile: work\r\n"
+               "read_buffer_size: 32768\r\n";
+    }
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+read_buffer_size: 16384
+profiles:
+    main:
+        show_title_bar: true
+)");
+
+    CHECK(config.defaultProfileName.value() == "work"); // CRLF did not corrupt the profile name
+    CHECK(config.ptyReadBufferSize.value() == 32768);   // the int global override applied through CRLF
+}
+
 TEST_CASE("Config: settings.yml default_profile overrides contour.yml's", "[config][gui]")
 {
     QTemporaryDir dir;

--- a/src/contour/test/Helper_test.cpp
+++ b/src/contour/test/Helper_test.cpp
@@ -54,6 +54,30 @@ TEST_CASE("makeModifiers maps Qt keyboard modifiers onto VT modifiers", "[helper
     CHECK(combined.locks.none());
 }
 
+TEST_CASE("unshiftedCodepoint inverts the US-ASCII shift level", "[helper][input]")
+{
+    using contour::unshiftedCodepoint;
+    // Punctuation and number-row shifted symbols map back to the base key label a binding is written
+    // with (this is what lets `Ctrl+Shift+,` fire when Qt delivers the shifted '<').
+    CHECK(unshiftedCodepoint(U'<') == U',');
+    CHECK(unshiftedCodepoint(U'>') == U'.');
+    CHECK(unshiftedCodepoint(U'?') == U'/');
+    CHECK(unshiftedCodepoint(U':') == U';');
+    CHECK(unshiftedCodepoint(U'"') == U'\'');
+    CHECK(unshiftedCodepoint(U'{') == U'[');
+    CHECK(unshiftedCodepoint(U'|') == U'\\');
+    CHECK(unshiftedCodepoint(U'_') == U'-');
+    CHECK(unshiftedCodepoint(U'+') == U'=');
+    CHECK(unshiftedCodepoint(U'!') == U'1');
+    CHECK(unshiftedCodepoint(U'@') == U'2');
+    CHECK(unshiftedCodepoint(U')') == U'0');
+    // Non-shifted symbols and letters (shift-invariant here) are returned unchanged.
+    CHECK(unshiftedCodepoint(U',') == U',');
+    CHECK(unshiftedCodepoint(U'P') == U'P');
+    CHECK(unshiftedCodepoint(U'a') == U'a');
+    CHECK(unshiftedCodepoint(U'5') == U'5');
+}
+
 #if !defined(_WIN32) && !defined(__APPLE__)
 TEST_CASE("makeModifiers derives CapsLock/NumLock from the X11 native modifier mask", "[helper][input]")
 {

--- a/src/contour/test/MultiWindow_test.cpp
+++ b/src/contour/test/MultiWindow_test.cpp
@@ -177,6 +177,39 @@ TEST_CASE("tab strip Always/Never gates ignore the tab count", "[contour][multiw
     }
 }
 
+TEST_CASE("settings tab: no terminal tab reads active while the settings page is open",
+          "[contour][multiwindow][settings]")
+{
+    // The settings page is shown as a pinned "tab" in the strip (TabStrip.qml); while it is the active
+    // view, IsActiveRole must report false for every terminal tab so the strip does not highlight two
+    // tabs at once. Closing settings re-highlights the previously active terminal tab.
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController window { manager };
+    REQUIRE(window.controller != nullptr);
+    createTabs(manager, *window, 2);
+    window->activateTab(1);
+
+    auto const isActive = [&](int row) {
+        return window->data(window->index(row), contour::WindowController::IsActiveRole).toBool();
+    };
+
+    // A terminal tab is active to begin with.
+    REQUIRE_FALSE(window->settingsActive());
+    CHECK(isActive(window->activeTabIndex()));
+
+    // Opening settings de-highlights every terminal tab.
+    window->openSettings();
+    CHECK(window->settingsActive());
+    CHECK_FALSE(isActive(0));
+    CHECK_FALSE(isActive(1));
+
+    // Closing settings restores the active terminal tab's highlight.
+    window->closeSettings();
+    CHECK_FALSE(window->settingsActive());
+    CHECK(isActive(window->activeTabIndex()));
+}
+
 TEST_CASE("REGRESSION: tab operations from a second window target that window, not the first",
           "[contour][multiwindow]")
 {

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -513,6 +513,9 @@ TEST_CASE("GUI QML tab components load without errors (offscreen)", "[contour][g
         QStringLiteral("qrc:/contour/ui/CommandPalette.qml"),
         QStringLiteral("qrc:/contour/ui/SaveLayoutDialog.qml"),
         QStringLiteral("qrc:/contour/ui/TerminalContextMenu.qml"),
+        QStringLiteral("qrc:/contour/ui/SettingRow.qml"),
+        QStringLiteral("qrc:/contour/ui/ColorSchemeEditor.qml"),
+        QStringLiteral("qrc:/contour/ui/SettingsPage.qml"),
     };
 
     for (auto const& url: components)

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -513,6 +513,7 @@ TEST_CASE("GUI QML tab components load without errors (offscreen)", "[contour][g
         QStringLiteral("qrc:/contour/ui/CommandPalette.qml"),
         QStringLiteral("qrc:/contour/ui/SaveLayoutDialog.qml"),
         QStringLiteral("qrc:/contour/ui/TerminalContextMenu.qml"),
+        QStringLiteral("qrc:/contour/ui/SettingsNavItem.qml"),
         QStringLiteral("qrc:/contour/ui/SettingRow.qml"),
         QStringLiteral("qrc:/contour/ui/ColorSchemeEditor.qml"),
         QStringLiteral("qrc:/contour/ui/SettingsPage.qml"),

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -515,6 +515,8 @@ TEST_CASE("GUI QML tab components load without errors (offscreen)", "[contour][g
         QStringLiteral("qrc:/contour/ui/SaveLayoutDialog.qml"),
         QStringLiteral("qrc:/contour/ui/TerminalContextMenu.qml"),
         QStringLiteral("qrc:/contour/ui/SettingsNavItem.qml"),
+        QStringLiteral("qrc:/contour/ui/SettingsListItem.qml"),
+        QStringLiteral("qrc:/contour/ui/ConfirmDialog.qml"),
         QStringLiteral("qrc:/contour/ui/SettingRow.qml"),
         QStringLiteral("qrc:/contour/ui/ColorSchemeEditor.qml"),
         QStringLiteral("qrc:/contour/ui/SettingsPage.qml"),

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -505,6 +505,7 @@ TEST_CASE("GUI QML tab components load without errors (offscreen)", "[contour][g
         QStringLiteral("qrc:/contour/ui/TabItem.qml"),
         QStringLiteral("qrc:/contour/ui/TabContextMenu.qml"),
         QStringLiteral("qrc:/contour/ui/TabColorFlyout.qml"),
+        QStringLiteral("qrc:/contour/ui/NewTabMenu.qml"),
         QStringLiteral("qrc:/contour/ui/TabStrip.qml"),
         QStringLiteral("qrc:/contour/ui/WindowControls.qml"),
         QStringLiteral("qrc:/contour/ui/ResizeBorder.qml"),

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -126,6 +126,24 @@ TEST_CASE("SettingsController: Save As refuses to shadow a contour.yml profile",
     CHECK(fx.controller->saveProfileAs("main") == false); // 'main' is defined in contour.yml
 }
 
+TEST_CASE("SettingsController: Save As refuses an existing GUI profile name and does not clobber it",
+          "[settings]")
+{
+    // 'work' is a GUI (side-file) profile, not a contour.yml one: Save As under that name must still be
+    // refused, otherwise the existing work.yml is silently overwritten with the current draft.
+    auto fx = Fixture(BasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work")); // creates work.yml (show_title_bar inherited: true)
+
+    fx.controller->newProfile("main");
+    fx.controller->setProfileField("show_title_bar", false);
+    CHECK(fx.controller->saveProfileAs("work") == false); // refused: 'work' already exists
+
+    auto const* work = fx.cfg.findProfile("work");
+    REQUIRE(work != nullptr);
+    CHECK(work->showTitleBar.value() == true); // the original side file was NOT clobbered
+}
+
 TEST_CASE("SettingsController: edit then Save updates a side-file profile in place", "[settings]")
 {
     auto fx = Fixture(BasicConfig);
@@ -220,6 +238,58 @@ TEST_CASE("SettingsController: rename moves a side-file color scheme with its dr
     CHECK(std::filesystem::exists(dir / "colorschemes" / "nightfall.yml"));
     CHECK_FALSE(std::filesystem::exists(dir / "colorschemes" / "midnight.yml"));
     CHECK(fx.controller->editingScheme() == "nightfall");
+}
+
+// A contour.yml with an inline color scheme; the settings page must treat that name as read-only, since
+// an inline scheme shadows a same-named side file at load time.
+constexpr auto InlineSchemeConfig = std::string_view { R"(
+default_profile: main
+color_schemes:
+    solarized:
+        default:
+            background: '#002b36'
+profiles:
+    main:
+        show_title_bar: true
+)" };
+
+TEST_CASE("SettingsController: saving a color scheme named like a contour.yml scheme is refused",
+          "[settings]")
+{
+    // An inline scheme shadows a side file at load, so a GUI save under that name would silently have no
+    // effect. Refuse it (and write nothing), mirroring Save As's contour.yml guard for profiles.
+    auto fx = Fixture(InlineSchemeConfig);
+    fx.controller->newColorScheme("");
+    fx.controller->setSchemeColor("background", "#111111");
+    CHECK(fx.controller->saveColorScheme("solarized") == false);
+    CHECK_FALSE(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "colorschemes"
+                                        / "solarized.yml"));
+}
+
+TEST_CASE("SettingsController: renaming a color scheme onto a contour.yml scheme name is refused",
+          "[settings]")
+{
+    auto fx = Fixture(InlineSchemeConfig);
+    fx.controller->newColorScheme("");
+    fx.controller->setSchemeColor("background", "#101010");
+    REQUIRE(fx.controller->saveColorScheme("midnight")); // a real GUI side-file scheme
+
+    // Renaming it onto the inline 'solarized' would write a dead colorschemes/solarized.yml the loader
+    // never resolves (the inline node wins); refuse it, and leave the source scheme untouched.
+    fx.controller->editColorScheme("midnight");
+    CHECK(fx.controller->renameColorScheme("midnight", "solarized") == false);
+    auto const dir = std::filesystem::path(fx.dir.path().toStdString());
+    CHECK_FALSE(std::filesystem::exists(dir / "colorschemes" / "solarized.yml"));
+    CHECK(std::filesystem::exists(dir / "colorschemes" / "midnight.yml"));
+}
+
+TEST_CASE("SettingsController: a non-side-file color scheme cannot be deleted", "[settings]")
+{
+    // deleteColorScheme must refuse a builtin/inline scheme (no side file): removeFile treats an absent
+    // file as success, so without the guard the controller would report a false 'deleted'.
+    auto fx = Fixture(InlineSchemeConfig);
+    CHECK(fx.controller->deleteColorScheme("default") == false);   // builtin
+    CHECK(fx.controller->deleteColorScheme("solarized") == false); // contour.yml inline
 }
 
 TEST_CASE("SettingsController: enum and integer profile fields round-trip", "[settings]")

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -70,7 +70,7 @@ struct Fixture
     return {};
 }
 
-constexpr auto kBasicConfig = std::string_view { R"(
+constexpr auto BasicConfig = std::string_view { R"(
 default_profile: main
 profiles:
     main:
@@ -81,7 +81,7 @@ profiles:
 
 TEST_CASE("SettingsController: lists profiles with provenance", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     auto const main = rowNamed(fx.controller->profiles(), "main");
     REQUIRE(!main.isEmpty());
     CHECK(main.value("origin").toString() == "main");
@@ -91,7 +91,7 @@ TEST_CASE("SettingsController: lists profiles with provenance", "[settings]")
 
 TEST_CASE("SettingsController: a contour.yml profile is read-only; Save is refused", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->editProfile("main");
     CHECK(fx.controller->editingReadOnly() == true);
     CHECK(fx.controller->saveProfile() == false); // refused: would shadow the hand-maintained file
@@ -99,7 +99,7 @@ TEST_CASE("SettingsController: a contour.yml profile is read-only; Save is refus
 
 TEST_CASE("SettingsController: new profile -> Save As creates an editable side-file profile", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     fx.controller->setProfileField("show_title_bar", false);
     fx.controller->setProfileField("dim_unfocused", 0.5);
@@ -121,14 +121,14 @@ TEST_CASE("SettingsController: new profile -> Save As creates an editable side-f
 
 TEST_CASE("SettingsController: Save As refuses to shadow a contour.yml profile", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     CHECK(fx.controller->saveProfileAs("main") == false); // 'main' is defined in contour.yml
 }
 
 TEST_CASE("SettingsController: edit then Save updates a side-file profile in place", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     REQUIRE(fx.controller->saveProfileAs("work"));
 
@@ -139,7 +139,7 @@ TEST_CASE("SettingsController: edit then Save updates a side-file profile in pla
 
 TEST_CASE("SettingsController: delete removes a side-file profile", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     REQUIRE(fx.controller->saveProfileAs("work"));
     REQUIRE(fx.cfg.findProfile("work") != nullptr);
@@ -153,13 +153,13 @@ TEST_CASE("SettingsController: delete removes a side-file profile", "[settings]"
 
 TEST_CASE("SettingsController: a contour.yml profile cannot be deleted", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     CHECK(fx.controller->deleteProfile("main") == false);
 }
 
 TEST_CASE("SettingsController: setDefaultProfile persists to settings.yml and overrides", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     REQUIRE(fx.controller->saveProfileAs("work"));
 
@@ -172,7 +172,7 @@ TEST_CASE("SettingsController: setDefaultProfile persists to settings.yml and ov
 TEST_CASE("SettingsController: rename moves a side-file profile and follows the default + draft",
           "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     REQUIRE(fx.controller->saveProfileAs("work"));
     REQUIRE(fx.controller->setDefaultProfile("work"));
@@ -195,7 +195,7 @@ TEST_CASE("SettingsController: rename moves a side-file profile and follows the 
 
 TEST_CASE("SettingsController: rename refuses contour.yml profiles and name collisions", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     REQUIRE(fx.controller->saveProfileAs("work"));
 
@@ -207,7 +207,7 @@ TEST_CASE("SettingsController: rename refuses contour.yml profiles and name coll
 
 TEST_CASE("SettingsController: rename moves a side-file color scheme with its draft", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newColorScheme("");
     fx.controller->setSchemeColor("background", "#101010");
     REQUIRE(fx.controller->saveColorScheme("midnight"));
@@ -224,7 +224,7 @@ TEST_CASE("SettingsController: rename moves a side-file color scheme with its dr
 
 TEST_CASE("SettingsController: enum and integer profile fields round-trip", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
     fx.controller->setProfileField("tab_bar_position", "Bottom");
     fx.controller->setProfileField("tab_bar_visibility", "Never");
@@ -242,7 +242,7 @@ TEST_CASE("SettingsController: enum and integer profile fields round-trip", "[se
 
 TEST_CASE("SettingsController: color-scheme selection supports a dark/light pair", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newProfile("main");
 
     fx.controller->setColorSchemeMode("dual");
@@ -258,7 +258,7 @@ TEST_CASE("SettingsController: color-scheme selection supports a dark/light pair
 
 TEST_CASE("SettingsController: create, edit and reload a color scheme", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     fx.controller->newColorScheme("");
     fx.controller->setSchemeColor("background", "#123456");
     REQUIRE(fx.controller->saveColorScheme("mono"));
@@ -307,7 +307,7 @@ TEST_CASE("SettingsController: global overrides write settings.yml, apply, and r
 
 TEST_CASE("SettingsController: exposes the configured keybindings read-only", "[settings]")
 {
-    auto fx = Fixture(kBasicConfig);
+    auto fx = Fixture(BasicConfig);
     auto const bindings = fx.controller->keybindings();
     REQUIRE(!bindings.isEmpty()); // the default config ships input mappings
     auto const first = bindings.first().toMap();

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the SettingsController — the editable bridge behind the GUI settings page. Each test
+// drives the real create/edit/save/save-as/delete workflow end to end: a real FileGuiConfigStore
+// writing side files into a temp config directory, and an apply callback that reloads the config from
+// disk exactly as the production apply does. So a test exercises the whole stack (controller → store →
+// loader), not a mock of it.
+
+#include <contour/Config.h>
+#include <contour/GuiConfigStore.h>
+#include <contour/SettingsController.h>
+
+#include <vtbackend/Color.h>
+
+#include <QtCore/QTemporaryDir>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string_view>
+
+using namespace contour;
+
+namespace
+{
+
+/// Writes @p yaml as the contour.yml inside @p dir and returns its path.
+[[nodiscard]] std::filesystem::path writeConfig(QTemporaryDir& dir, std::string_view yaml)
+{
+    auto const path = std::filesystem::path(dir.path().toStdString()) / "contour.yml";
+    auto out = std::ofstream(path);
+    out << yaml;
+    return path;
+}
+
+/// Owns a controller wired exactly like production: a live Config, a file-backed side-file store rooted
+/// at the config directory, and an apply callback that reloads the Config from disk. The whole
+/// create/edit/save/delete workflow runs against real files under a temp directory.
+struct Fixture
+{
+    QTemporaryDir dir;
+    config::Config cfg;
+    std::filesystem::path configPath;
+    std::shared_ptr<FileGuiConfigStore> store;
+    std::unique_ptr<SettingsController> controller;
+
+    explicit Fixture(std::string_view yaml)
+    {
+        configPath = writeConfig(dir, yaml);
+        config::loadConfigFromFile(cfg, configPath);
+        store = std::make_shared<FileGuiConfigStore>(std::filesystem::path(dir.path().toStdString()));
+        controller = std::make_unique<SettingsController>([this]() -> config::Config const& { return cfg; },
+                                                          store,
+                                                          [this]() {
+                                                              cfg = config::Config {};
+                                                              config::loadConfigFromFile(cfg, configPath);
+                                                          });
+    }
+};
+
+/// Finds the profile row named @p name in @p rows, or an empty map if absent.
+[[nodiscard]] QVariantMap rowNamed(QVariantList const& rows, QString const& name)
+{
+    for (auto const& row: rows)
+        if (row.toMap().value("name").toString() == name)
+            return row.toMap();
+    return {};
+}
+
+constexpr auto kBasicConfig = std::string_view { R"(
+default_profile: main
+profiles:
+    main:
+        show_title_bar: true
+)" };
+
+} // namespace
+
+TEST_CASE("SettingsController: lists profiles with provenance", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    auto const main = rowNamed(fx.controller->profiles(), "main");
+    REQUIRE(!main.isEmpty());
+    CHECK(main.value("origin").toString() == "main");
+    CHECK(main.value("editable").toBool() == false); // contour.yml profile: read-only in the GUI
+    CHECK(main.value("isDefault").toBool() == true);
+}
+
+TEST_CASE("SettingsController: a contour.yml profile is read-only; Save is refused", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->editProfile("main");
+    CHECK(fx.controller->editingReadOnly() == true);
+    CHECK(fx.controller->saveProfile() == false); // refused: would shadow the hand-maintained file
+}
+
+TEST_CASE("SettingsController: new profile -> Save As creates an editable side-file profile", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    fx.controller->setProfileField("show_title_bar", false);
+    fx.controller->setProfileField("dim_unfocused", 0.5);
+    REQUIRE(fx.controller->saveProfileAs("work"));
+
+    // The side file exists and the reloaded config now carries the new profile.
+    CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "profiles"
+                                  / "work.yml"));
+    auto const* work = fx.cfg.findProfile("work");
+    REQUIRE(work != nullptr);
+    CHECK(work->showTitleBar.value() == false);
+    CHECK(work->dimUnfocused.value() == Catch::Approx(0.5));
+
+    // It is now the editing target, editable (a side file), and listed as such.
+    CHECK(fx.controller->editingProfile() == "work");
+    CHECK(fx.controller->editingReadOnly() == false);
+    CHECK(rowNamed(fx.controller->profiles(), "work").value("editable").toBool() == true);
+}
+
+TEST_CASE("SettingsController: Save As refuses to shadow a contour.yml profile", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    CHECK(fx.controller->saveProfileAs("main") == false); // 'main' is defined in contour.yml
+}
+
+TEST_CASE("SettingsController: edit then Save updates a side-file profile in place", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work"));
+
+    fx.controller->setProfileField("dim_unfocused", 0.25);
+    REQUIRE(fx.controller->saveProfile());
+    CHECK(fx.cfg.findProfile("work")->dimUnfocused.value() == Catch::Approx(0.25));
+}
+
+TEST_CASE("SettingsController: delete removes a side-file profile", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work"));
+    REQUIRE(fx.cfg.findProfile("work") != nullptr);
+
+    REQUIRE(fx.controller->deleteProfile("work"));
+    CHECK(fx.cfg.findProfile("work") == nullptr);
+    CHECK(
+        std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "profiles" / "work.yml")
+        == false);
+}
+
+TEST_CASE("SettingsController: a contour.yml profile cannot be deleted", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    CHECK(fx.controller->deleteProfile("main") == false);
+}
+
+TEST_CASE("SettingsController: setDefaultProfile persists to settings.yml and overrides", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work"));
+
+    REQUIRE(fx.controller->setDefaultProfile("work"));
+    CHECK(fx.cfg.defaultProfileName.value() == "work");
+    CHECK(fx.controller->defaultProfile() == "work");
+    CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "settings.yml"));
+}
+
+TEST_CASE("SettingsController: color-scheme selection supports a dark/light pair", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+
+    fx.controller->setColorSchemeMode("dual");
+    CHECK(fx.controller->colorSchemeMode() == "dual");
+    fx.controller->setColorSchemeLight("default");
+    fx.controller->setColorSchemeDark("default");
+    REQUIRE(fx.controller->saveProfileAs("dually"));
+
+    auto const* profile = fx.cfg.findProfile("dually");
+    REQUIRE(profile != nullptr);
+    CHECK(std::holds_alternative<config::DualColorConfig>(profile->colors.value()));
+}
+
+TEST_CASE("SettingsController: create, edit and reload a color scheme", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newColorScheme("");
+    fx.controller->setSchemeColor("background", "#123456");
+    REQUIRE(fx.controller->saveColorScheme("mono"));
+
+    // The side file exists; re-opening it loads the color we set back.
+    CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "colorschemes"
+                                  / "mono.yml"));
+    fx.controller->editColorScheme("mono");
+    auto background = QString {};
+    for (auto const& row: fx.controller->schemeColors())
+        if (row.toMap().value("key").toString() == "background")
+            background = row.toMap().value("color").toString();
+    CHECK(background == "#123456");
+
+    REQUIRE(fx.controller->deleteColorScheme("mono"));
+    CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "colorschemes"
+                                  / "mono.yml")
+          == false);
+}
+
+TEST_CASE("SettingsController: gui_config_locked makes the page read-only", "[settings]")
+{
+    auto fx = Fixture("default_profile: main\ngui_config_locked: true\n");
+    CHECK(fx.controller->locked() == true);
+
+    fx.controller->newProfile("main");
+    CHECK(fx.controller->saveProfileAs("work") == false);
+    CHECK(fx.controller->setDefaultProfile("main") == false);
+}

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -169,6 +169,59 @@ TEST_CASE("SettingsController: setDefaultProfile persists to settings.yml and ov
     CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "settings.yml"));
 }
 
+TEST_CASE("SettingsController: rename moves a side-file profile and follows the default + draft",
+          "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work"));
+    REQUIRE(fx.controller->setDefaultProfile("work"));
+    fx.controller->editProfile("work"); // the profile we are about to rename is the open draft
+
+    auto const dir = std::filesystem::path(fx.dir.path().toStdString());
+    REQUIRE(fx.controller->renameProfile("work", "office"));
+
+    // The side file moved, and the reloaded config carries the new name only.
+    CHECK(std::filesystem::exists(dir / "profiles" / "office.yml"));
+    CHECK_FALSE(std::filesystem::exists(dir / "profiles" / "work.yml"));
+    CHECK(fx.cfg.findProfile("office") != nullptr);
+    CHECK(fx.cfg.findProfile("work") == nullptr);
+
+    // The default pointer and the open draft both followed the rename.
+    CHECK(fx.controller->defaultProfile() == "office");
+    CHECK(fx.cfg.defaultProfileName.value() == "office");
+    CHECK(fx.controller->editingProfile() == "office");
+}
+
+TEST_CASE("SettingsController: rename refuses contour.yml profiles and name collisions", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    REQUIRE(fx.controller->saveProfileAs("work"));
+
+    CHECK(fx.controller->renameProfile("main", "whatever") == false); // 'main' is from contour.yml
+    CHECK(fx.controller->renameProfile("work", "main") == false);     // collides with contour.yml 'main'
+    CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "profiles"
+                                  / "work.yml"));
+}
+
+TEST_CASE("SettingsController: rename moves a side-file color scheme with its draft", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newColorScheme("");
+    fx.controller->setSchemeColor("background", "#101010");
+    REQUIRE(fx.controller->saveColorScheme("midnight"));
+
+    auto const dir = std::filesystem::path(fx.dir.path().toStdString());
+    REQUIRE(std::filesystem::exists(dir / "colorschemes" / "midnight.yml"));
+
+    fx.controller->editColorScheme("midnight");
+    REQUIRE(fx.controller->renameColorScheme("midnight", "nightfall"));
+    CHECK(std::filesystem::exists(dir / "colorschemes" / "nightfall.yml"));
+    CHECK_FALSE(std::filesystem::exists(dir / "colorschemes" / "midnight.yml"));
+    CHECK(fx.controller->editingScheme() == "nightfall");
+}
+
 TEST_CASE("SettingsController: enum and integer profile fields round-trip", "[settings]")
 {
     auto fx = Fixture(kBasicConfig);

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -281,7 +281,8 @@ TEST_CASE("SettingsController: create, edit and reload a color scheme", "[settin
 
 TEST_CASE("SettingsController: global overrides write settings.yml, apply, and reset", "[settings]")
 {
-    auto fx = Fixture("default_profile: main\nreflow_on_resize: true\n");
+    auto fx = Fixture("default_profile: main\n"
+                      "reflow_on_resize: true\n");
     auto const configDir = std::filesystem::path(fx.dir.path().toStdString());
 
     REQUIRE(fx.controller->setGlobalField("reflow_on_resize", false));

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -169,6 +169,24 @@ TEST_CASE("SettingsController: setDefaultProfile persists to settings.yml and ov
     CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "settings.yml"));
 }
 
+TEST_CASE("SettingsController: enum and integer profile fields round-trip", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    fx.controller->newProfile("main");
+    fx.controller->setProfileField("tab_bar_position", "Bottom");
+    fx.controller->setProfileField("tab_bar_visibility", "Never");
+    fx.controller->setProfileField("slow_scrolling_time", 250);
+    fx.controller->setProfileField("maximized", true);
+    REQUIRE(fx.controller->saveProfileAs("work"));
+
+    auto const* work = fx.cfg.findProfile("work");
+    REQUIRE(work != nullptr);
+    CHECK(work->tabBarPosition.value() == config::TabBarPosition::Bottom);
+    CHECK(work->tabBarVisibility.value() == config::TabBarVisibility::Never);
+    CHECK(work->smoothLineScrolling.value() == std::chrono::milliseconds(250));
+    CHECK(work->maximized.value() == true);
+}
+
 TEST_CASE("SettingsController: color-scheme selection supports a dark/light pair", "[settings]")
 {
     auto fx = Fixture(kBasicConfig);
@@ -206,6 +224,41 @@ TEST_CASE("SettingsController: create, edit and reload a color scheme", "[settin
     CHECK(std::filesystem::exists(std::filesystem::path(fx.dir.path().toStdString()) / "colorschemes"
                                   / "mono.yml")
           == false);
+}
+
+TEST_CASE("SettingsController: global overrides write settings.yml, apply, and reset", "[settings]")
+{
+    auto fx = Fixture("default_profile: main\nreflow_on_resize: true\n");
+    auto const configDir = std::filesystem::path(fx.dir.path().toStdString());
+
+    REQUIRE(fx.controller->setGlobalField("reflow_on_resize", false));
+    CHECK(fx.cfg.reflowOnResize.value() == false);
+    REQUIRE(fx.controller->setGlobalField("read_buffer_size", 32768));
+    CHECK(fx.cfg.ptyReadBufferSize.value() == 32768);
+    REQUIRE(fx.controller->setGlobalField("word_delimiters", "abc"));
+    CHECK(fx.cfg.wordDelimiters.value() == "abc");
+    CHECK(std::filesystem::exists(configDir / "settings.yml"));
+
+    // The overridden field is flagged as such in the model.
+    auto overridden = false;
+    for (auto const& row: fx.controller->globalFields())
+        if (row.toMap().value("key").toString() == "reflow_on_resize")
+            overridden = row.toMap().value("overridden").toBool();
+    CHECK(overridden);
+
+    // Reset falls back to the contour.yml value.
+    REQUIRE(fx.controller->resetGlobalField("reflow_on_resize"));
+    CHECK(fx.cfg.reflowOnResize.value() == true);
+}
+
+TEST_CASE("SettingsController: exposes the configured keybindings read-only", "[settings]")
+{
+    auto fx = Fixture(kBasicConfig);
+    auto const bindings = fx.controller->keybindings();
+    REQUIRE(!bindings.isEmpty()); // the default config ships input mappings
+    auto const first = bindings.first().toMap();
+    CHECK(!first.value("trigger").toString().isEmpty());
+    CHECK(!first.value("action").toString().isEmpty());
 }
 
 TEST_CASE("SettingsController: gui_config_locked makes the page read-only", "[settings]")

--- a/src/contour/test/SettingsPageQml_test.cpp
+++ b/src/contour/test/SettingsPageQml_test.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end offscreen test of the settings page: it instantiates the real SettingsPage.qml against a
+// real SettingsController (backed by a file store in a temp directory) and drives it through the QML —
+// clicking "New profile", typing a name, clicking "Save As" — then asserts a side file appeared and the
+// config picked it up. This proves the QML actually wires its controls to the controller; the
+// controller's own logic is unit-tested separately in SettingsController_test.cpp.
+
+#include <contour/Config.h>
+#include <contour/GuiConfigStore.h>
+#include <contour/SettingsController.h>
+#include <contour/test/QmlMessageCapture.h>
+
+#include <QtCore/QTemporaryDir>
+#include <QtQml/QQmlComponent>
+#include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickItem>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+using namespace contour;
+
+namespace
+{
+
+/// Emits @p object's `clicked()` signal, running its QML onClicked handler regardless of the button's
+/// `enabled` binding (this drives the wiring directly rather than simulating a pointer event).
+void clickButton(QObject* object)
+{
+    REQUIRE(object != nullptr);
+    QMetaObject::invokeMethod(object, "clicked");
+}
+
+} // namespace
+
+TEST_CASE("SettingsPage creates a profile through the QML and it lands on disk (offscreen)",
+          "[contour][gui][qml][settings]")
+{
+    contour::test::QmlMessageCapture warnings;
+
+    QTemporaryDir dir;
+    auto const configDir = std::filesystem::path(dir.path().toStdString());
+    auto const configPath = configDir / "contour.yml";
+    {
+        auto out = std::ofstream(configPath);
+        out << "default_profile: main\nprofiles:\n    main:\n        show_title_bar: true\n";
+    }
+
+    config::Config cfg;
+    config::loadConfigFromFile(cfg, configPath);
+    auto store = std::make_shared<FileGuiConfigStore>(configDir);
+    auto controller = SettingsController([&]() -> config::Config const& { return cfg; },
+                                         store,
+                                         [&]() {
+                                             cfg = config::Config {};
+                                             config::loadConfigFromFile(cfg, configPath);
+                                         });
+
+    QQmlEngine engine;
+    QQmlComponent component(&engine, QUrl(QStringLiteral("qrc:/contour/ui/SettingsPage.qml")));
+    REQUIRE(component.isReady());
+
+    auto initial = QVariantMap {};
+    initial.insert("controller", QVariant::fromValue(&controller));
+    std::unique_ptr<QObject> page(component.createWithInitialProperties(initial));
+    REQUIRE(page != nullptr);
+    auto* item = qobject_cast<QQuickItem*>(page.get());
+    REQUIRE(item != nullptr);
+
+    // Start a new profile through the page's "New profile…" button.
+    clickButton(item->findChild<QObject*>("newProfileButton"));
+    CHECK(controller.editingProfile().isEmpty()); // an unsaved new draft
+    CHECK(!controller.profileFields().isEmpty()); // its fields are exposed for editing
+
+    // Type a name and Save As.
+    auto* saveAsField = item->findChild<QObject*>("saveAsField");
+    REQUIRE(saveAsField != nullptr);
+    saveAsField->setProperty("text", "work");
+    clickButton(item->findChild<QObject*>("saveProfileAsButton"));
+
+    // The side file exists, the reloaded config carries it, and the page now edits it.
+    CHECK(std::filesystem::exists(configDir / "profiles" / "work.yml"));
+    CHECK(cfg.findProfile("work") != nullptr);
+    CHECK(controller.editingProfile() == "work");
+
+    // No QML binding errors were raised while driving the page.
+    CHECK(warnings.count([](QString const& w) {
+        return w.contains("TypeError") || w.contains("ReferenceError");
+    }) == 0);
+}

--- a/src/contour/test/TerminalSessionManager_test.cpp
+++ b/src/contour/test/TerminalSessionManager_test.cpp
@@ -428,6 +428,30 @@ TEST_CASE("TerminalSessionManager: launchLayout births panes at the live window 
     CHECK(*factory->requestedPageSizes.back() == liveSize);
 }
 
+TEST_CASE("TerminalSessionManager: createSession launches under the named profile (new-tab dropdown)",
+          "[manager][profile]")
+{
+    // The new-tab profile dropdown threads a profile name through createNewTab -> createSession ->
+    // createSessionInBackground -> createBackingSession. Without a name the session follows the app
+    // default (no override); with one it records that profile as its explicit override.
+    auto factoryOwned = std::make_unique<contour::test::MockPtySessionFactory>();
+    contour::test::TestApp app { std::move(factoryOwned) };
+    contour::test::ScopedController win { app.manager() };
+
+    // A second profile to launch (cloned from the default so it resolves against the config).
+    auto& profiles = app.app().config().profiles.value();
+    profiles["work"] = profiles.at(app.app().profileName());
+
+    auto* def = app.manager().createSession(win.id);
+    REQUIRE(def != nullptr);
+    CHECK_FALSE(def->profileOverride().has_value()); // no argument -> follows the default profile
+
+    auto* work = app.manager().createSession(win.id, "work");
+    REQUIRE(work != nullptr);
+    REQUIRE(work->profileOverride().has_value());
+    CHECK(*work->profileOverride() == "work");
+}
+
 // ============================================================================================
 // Command palette: the full round trip a user actually performs — press Ctrl+Shift+P, pick a command,
 // see it run, and find it under "recently used" on the next start.

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -524,11 +524,16 @@ TEST_CASE("TerminalSession: opener, paste and reload actions run without a displ
                                                    + "/tmp");
 
     // The document/URL openers route through the injected ExternalLauncher (no desktop touched).
-    CHECK((*session)(actions::OpenConfiguration {}));
+    CHECK((*session)(actions::OpenConfiguration { .inEditor = true }));
     CHECK((*session)(actions::OpenFileManager {}));
     CHECK((*session)(actions::OpenSelection {}));
-    // OpenConfiguration opens the config file URL, OpenFileManager the local cwd, OpenSelection the
-    // (empty) selection.
+    // OpenConfiguration{in_editor} opens the config file URL, OpenFileManager the local cwd, and
+    // OpenSelection the (empty) selection.
+    CHECK(launcher.openedUrls.size() == 3);
+
+    // OpenConfiguration WITHOUT in_editor opens the in-app settings page instead — no URL is launched
+    // (headless, no hosting window, so it is a safe no-op that still returns true).
+    CHECK((*session)(actions::OpenConfiguration {}));
     CHECK(launcher.openedUrls.size() == 3);
 
     // FollowHyperlink with nothing hovered/selected returns false (no target).
@@ -1310,14 +1315,14 @@ TEST_CASE("TerminalSession: search-match focus actions move the vi cursor onto a
 TEST_CASE("TerminalSession: open and paste-shell actions run headlessly without a display",
           "[contour][session][actions]")
 {
-    // OpenConfiguration/OpenFileManager/OpenSelection route through QDesktopServices; under the
-    // offscreen platform these no-op (no handler) but must still run and return true. PasteSelection
+    // OpenConfiguration{in_editor}/OpenFileManager/OpenSelection route through QDesktopServices; under
+    // the offscreen platform these no-op (no handler) but must still run and return true. PasteSelection
     // with evaluate_in_shell sends the (empty) selection as raw input. None touch the display.
     contour::test::TestApp testApp;
     auto session = makeDisplaylessSession(testApp.app());
     namespace actions = contour::actions;
 
-    CHECK((*session)(actions::OpenConfiguration {}));
+    CHECK((*session)(actions::OpenConfiguration { .inEditor = true }));
     CHECK((*session)(actions::OpenFileManager {}));
     CHECK((*session)(actions::OpenSelection {}));
     CHECK((*session)(actions::PasteSelection { .evaluateInShell = true }));
@@ -1534,7 +1539,8 @@ TEST_CASE("TerminalSession: the opener actions log (do not crash) when the launc
     session->terminal().setCurrentWorkingDirectory("file://" + QHostInfo::localHostName().toStdString()
                                                    + "/tmp");
 
-    CHECK((*session)(actions::OpenConfiguration {}));
+    // in_editor so OpenConfiguration takes the openUrl() (file-open) path rather than the settings page.
+    CHECK((*session)(actions::OpenConfiguration { .inEditor = true }));
     CHECK((*session)(actions::OpenFileManager {}));
     CHECK((*session)(actions::OpenSelection {}));
     CHECK(testApp.launcher().openedUrls.size() == 3); // all attempted despite the failure

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -1637,6 +1637,26 @@ TEST_CASE("TerminalSession: Ctrl+Shift+P opens the palette instead of reaching t
     CHECK_FALSE(mockPtyOf(*session).stdinBuffer().empty());
 }
 
+TEST_CASE("TerminalSession: Ctrl+Shift+, fires despite Qt delivering the shifted '<'",
+          "[contour][session][input]")
+{
+    // The default binds Ctrl+Shift+',' to OpenConfiguration, but Qt reports a Shift+punctuation chord as
+    // the shifted keysym — comma+Shift arrives as '<' (Qt::Key_Less). Without base-char normalization the
+    // chord would miss its binding and fall through to the shell (a stray '<'). It must be CONSUMED.
+    TestApp testApp;
+    auto session = makeDisplaylessSession(testApp.app());
+    auto const now = std::chrono::steady_clock::now();
+    auto const ctrlShift = Modifiers { vtbackend::Modifier::Control, vtbackend::Modifier::Shift };
+
+    session->sendCharEvent(U'<', 0, ctrlShift, KeyboardEventType::Press, now);
+    CHECK(mockPtyOf(*session).stdinBuffer().empty()); // consumed by the ',' binding via its base char
+
+    // A shifted symbol whose base key has no binding still reaches the terminal (retry misses, falls
+    // through) — the normalization only rescues chords that are actually bound.
+    session->sendCharEvent(U'~', 0, ctrlShift, KeyboardEventType::Press, now); // base '`', unbound
+    CHECK_FALSE(mockPtyOf(*session).stdinBuffer().empty());
+}
+
 TEST_CASE("TerminalSession: executeAction runs a palette-picked command", "[contour][session][palette]")
 {
     // The palette does not synthesize key events — it hands the chosen action straight to the session

--- a/src/contour/ui/ColorSchemeEditor.qml
+++ b/src/contour/ui/ColorSchemeEditor.qml
@@ -127,8 +127,20 @@ Item {
                     objectName: "schemeNameField"
                     Layout.preferredWidth: 200
                     placeholderText: qsTr("Scheme name")
+                    // The initial value; a one-way binding to editingScheme would break the moment the user
+                    // types, and then selecting a different scheme would leave the stale typed name — so
+                    // Save would write the newly selected scheme's colors under the wrong name. Re-seed
+                    // imperatively, but only when the edited scheme's IDENTITY changes (editingSchemeChanged
+                    // fires for select/new/save/delete, NOT for color tweaks), so a name being typed for a
+                    // new or renamed scheme survives while its colors are edited.
                     text: root.controller ? root.controller.editingScheme : ""
                     selectByMouse: true
+                    Connections {
+                        target: root.controller
+                        function onEditingSchemeChanged() {
+                            schemeNameField.text = root.controller ? root.controller.editingScheme : ""
+                        }
+                    }
                 }
                 Button {
                     objectName: "saveSchemeButton"

--- a/src/contour/ui/ColorSchemeEditor.qml
+++ b/src/contour/ui/ColorSchemeEditor.qml
@@ -138,13 +138,8 @@ Item {
                     onClicked: root.controller.saveColorScheme(schemeNameField.text.trim())
                 }
                 Item { Layout.fillWidth: true }
-                Button {
-                    objectName: "deleteSchemeButton"
-                    text: qsTr("Delete scheme")
-                    enabled: root.controller && !root.controller.locked
-                             && root.controller.editingScheme.length > 0
-                    onClicked: root.controller.deleteColorScheme(root.controller.editingScheme)
-                }
+                // Delete lives on the color-scheme list row (hover trashcan / right-click), routed
+                // through the settings page's confirmation dialog.
             }
         }
     }

--- a/src/contour/ui/ColorSchemeEditor.qml
+++ b/src/contour/ui/ColorSchemeEditor.qml
@@ -1,0 +1,92 @@
+// vim:syntax=qml
+// The color-scheme editor: a grid of color slots (default fg/bg + the 8 normal and 8 bright ANSI
+// colors) bound to SettingsController.schemeColors ({ key, label, color }). Each slot shows a live
+// swatch and an editable "#rrggbb" field; committing writes the slot back through
+// SettingsController.setSchemeColor.
+//
+// A hex field is used deliberately instead of a native ColorDialog: QtQuick.Dialogs is not guaranteed
+// present on every target, and a hard import of it would break page loading where it is absent.
+//
+// Dark/light is handled at the PROFILE level (a profile references two schemes); a single scheme is one
+// palette, edited here, and either referenced directly or picked as the light or dark half of a profile.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    // The SettingsController (may be null during teardown; every access below is guarded).
+    property var controller: null
+
+    spacing: 12
+
+    Label {
+        text: (root.controller && root.controller.editingScheme.length > 0)
+              ? qsTr("Color scheme: %1").arg(root.controller.editingScheme)
+              : qsTr("New color scheme")
+        font.pointSize: 13
+        font.bold: true
+    }
+
+    GridLayout {
+        Layout.fillWidth: true
+        columns: 2
+        columnSpacing: 24
+        rowSpacing: 8
+
+        Repeater {
+            model: root.controller ? root.controller.schemeColors : []
+            delegate: RowLayout {
+                required property var modelData
+                spacing: 10
+                Rectangle {
+                    width: 26
+                    height: 26
+                    radius: 4
+                    color: modelData.color
+                    border.color: Qt.rgba(0, 0, 0, 0.35)
+                    border.width: 1
+                }
+                Label { text: modelData.label; Layout.preferredWidth: 130 }
+                TextField {
+                    Layout.preferredWidth: 110
+                    text: modelData.color
+                    enabled: root.controller && !root.controller.locked
+                    selectByMouse: true
+                    font.family: "monospace"
+                    inputMask: "\\#HHHHHH"
+                    onEditingFinished: if (root.controller) root.controller.setSchemeColor(modelData.key, text)
+                }
+            }
+        }
+    }
+
+    // Save / delete bar for the scheme.
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+        TextField {
+            id: schemeNameField
+            objectName: "schemeNameField"
+            Layout.preferredWidth: 200
+            placeholderText: qsTr("Scheme name")
+            text: root.controller ? root.controller.editingScheme : ""
+            selectByMouse: true
+        }
+        Button {
+            objectName: "saveSchemeButton"
+            text: qsTr("Save scheme")
+            enabled: root.controller && !root.controller.locked && schemeNameField.text.trim().length > 0
+            onClicked: root.controller.saveColorScheme(schemeNameField.text.trim())
+        }
+        Button {
+            objectName: "deleteSchemeButton"
+            text: qsTr("Delete scheme")
+            enabled: root.controller && !root.controller.locked
+                     && root.controller.editingScheme.length > 0
+            onClicked: root.controller.deleteColorScheme(root.controller.editingScheme)
+        }
+        Item { Layout.fillWidth: true }
+    }
+}

--- a/src/contour/ui/ColorSchemeEditor.qml
+++ b/src/contour/ui/ColorSchemeEditor.qml
@@ -1,8 +1,8 @@
 // vim:syntax=qml
-// The color-scheme editor: a grid of color slots (default fg/bg + the 8 normal and 8 bright ANSI
-// colors) bound to SettingsController.schemeColors ({ key, label, color }). Each slot shows a live
-// swatch and an editable "#rrggbb" field; committing writes the slot back through
-// SettingsController.setSchemeColor.
+// The color-scheme editor: a scrollable grid of swatch cards (default fg/bg + the 8 normal and 8
+// bright ANSI colors) bound to SettingsController.schemeColors ({ key, label, color }). Each card
+// shows a live swatch and an editable "#rrggbb" field; committing writes the slot back through
+// SettingsController.setSchemeColor. A pinned footer bar carries the scheme name + Save / Delete.
 //
 // A hex field is used deliberately instead of a native ColorDialog: QtQuick.Dialogs is not guaranteed
 // present on every target, and a hard import of it would break page loading where it is absent.
@@ -13,80 +13,139 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-ColumnLayout {
+Item {
     id: root
 
     // The SettingsController (may be null during teardown; every access below is guarded).
     property var controller: null
 
-    spacing: 12
-
-    Label {
-        text: (root.controller && root.controller.editingScheme.length > 0)
-              ? qsTr("Color scheme: %1").arg(root.controller.editingScheme)
-              : qsTr("New color scheme")
-        font.pointSize: 13
-        font.bold: true
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
     }
+    readonly property color subtleText: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.62)
+    readonly property color hairline: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.12)
 
-    GridLayout {
-        Layout.fillWidth: true
-        columns: 2
-        columnSpacing: 24
-        rowSpacing: 8
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 12
 
-        Repeater {
-            model: root.controller ? root.controller.schemeColors : []
-            delegate: RowLayout {
-                required property var modelData
-                spacing: 10
-                Rectangle {
-                    width: 26
-                    height: 26
-                    radius: 4
-                    color: modelData.color
-                    border.color: Qt.rgba(0, 0, 0, 0.35)
-                    border.width: 1
-                }
-                Label { text: modelData.label; Layout.preferredWidth: 130 }
-                TextField {
-                    Layout.preferredWidth: 110
-                    text: modelData.color
-                    enabled: root.controller && !root.controller.locked
-                    selectByMouse: true
-                    font.family: "monospace"
-                    inputMask: "\\#HHHHHH"
-                    onEditingFinished: if (root.controller) root.controller.setSchemeColor(modelData.key, text)
+        Label {
+            text: qsTr("Edit the palette below. A profile can reference this scheme directly, or pick it "
+                       + "as its light or dark half.")
+            color: root.subtleText
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+        }
+
+        ScrollView {
+            id: scroll
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentWidth: availableWidth
+            clip: true
+
+            GridLayout {
+                width: scroll.availableWidth
+                columns: 2
+                columnSpacing: 12
+                rowSpacing: 10
+
+                Repeater {
+                    model: root.controller ? root.controller.schemeColors : []
+                    delegate: Item {
+                        id: slot
+                        required property var modelData
+                        Layout.fillWidth: true
+                        implicitHeight: 56
+
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 8
+                            color: sys.base
+                            border.width: 1
+                            border.color: root.hairline
+                        }
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 12
+                            anchors.rightMargin: 12
+                            spacing: 12
+
+                            Rectangle {
+                                width: 32
+                                height: 32
+                                radius: 6
+                                color: slot.modelData.color
+                                border.color: root.hairline
+                                border.width: 1
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            Label {
+                                text: slot.modelData.label
+                                color: sys.windowText
+                                elide: Text.ElideRight
+                                Layout.fillWidth: true
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            TextField {
+                                Layout.preferredWidth: 110
+                                Layout.alignment: Qt.AlignVCenter
+                                text: slot.modelData.color
+                                enabled: root.controller && !root.controller.locked
+                                selectByMouse: true
+                                font.family: "monospace"
+                                inputMask: "\\#HHHHHH"
+                                onEditingFinished: if (root.controller)
+                                                       root.controller.setSchemeColor(slot.modelData.key, text)
+                            }
+                        }
+                    }
                 }
             }
         }
-    }
 
-    // Save / delete bar for the scheme.
-    RowLayout {
-        Layout.fillWidth: true
-        spacing: 8
-        TextField {
-            id: schemeNameField
-            objectName: "schemeNameField"
-            Layout.preferredWidth: 200
-            placeholderText: qsTr("Scheme name")
-            text: root.controller ? root.controller.editingScheme : ""
-            selectByMouse: true
+        // Save / delete bar for the scheme, pinned below the scrolling palette.
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: footerRow.implicitHeight + 20
+            radius: 8
+            color: sys.base
+            border.width: 1
+            border.color: root.hairline
+
+            RowLayout {
+                id: footerRow
+                anchors.fill: parent
+                anchors.leftMargin: 12
+                anchors.rightMargin: 12
+                spacing: 8
+
+                TextField {
+                    id: schemeNameField
+                    objectName: "schemeNameField"
+                    Layout.preferredWidth: 200
+                    placeholderText: qsTr("Scheme name")
+                    text: root.controller ? root.controller.editingScheme : ""
+                    selectByMouse: true
+                }
+                Button {
+                    objectName: "saveSchemeButton"
+                    text: qsTr("Save scheme")
+                    highlighted: true
+                    enabled: root.controller && !root.controller.locked && schemeNameField.text.trim().length > 0
+                    onClicked: root.controller.saveColorScheme(schemeNameField.text.trim())
+                }
+                Item { Layout.fillWidth: true }
+                Button {
+                    objectName: "deleteSchemeButton"
+                    text: qsTr("Delete scheme")
+                    enabled: root.controller && !root.controller.locked
+                             && root.controller.editingScheme.length > 0
+                    onClicked: root.controller.deleteColorScheme(root.controller.editingScheme)
+                }
+            }
         }
-        Button {
-            objectName: "saveSchemeButton"
-            text: qsTr("Save scheme")
-            enabled: root.controller && !root.controller.locked && schemeNameField.text.trim().length > 0
-            onClicked: root.controller.saveColorScheme(schemeNameField.text.trim())
-        }
-        Button {
-            objectName: "deleteSchemeButton"
-            text: qsTr("Delete scheme")
-            enabled: root.controller && !root.controller.locked
-                     && root.controller.editingScheme.length > 0
-            onClicked: root.controller.deleteColorScheme(root.controller.editingScheme)
-        }
-        Item { Layout.fillWidth: true }
     }
 }

--- a/src/contour/ui/CommandPalette.qml
+++ b/src/contour/ui/CommandPalette.qml
@@ -109,7 +109,8 @@ Popup {
     // because only QML knows the live OS accent and which row is current.
     //
     // The whole string is HTML-escaped (a live tab title can contain & < >), so it is always valid
-    // StyledText. Indices are byte offsets from the model, exact for the ASCII command titles shown.
+    // StyledText. `matches` are UTF-16 code-unit indices (the model converts them from the fuzzy filter's
+    // UTF-8 byte offsets), so they line up with charAt() even when a title contains multibyte characters.
     function highlightedTitle(text, matches, selected) {
         var open = selected ? "<b>" : "<b><font color=\"" + systemPalette.highlight.toString() + "\">";
         var close = selected ? "</b>" : "</font></b>";

--- a/src/contour/ui/ConfirmDialog.qml
+++ b/src/contour/ui/ConfirmDialog.qml
@@ -1,0 +1,96 @@
+// vim:syntax=qml
+// A small modal confirmation dialog (Cancel / destructive-confirm), theme-aware. Used before
+// irreversible actions such as deleting a profile or color scheme.
+//
+// Built on QtQuick.Controls' in-scene Dialog — NOT QtQuick.Dialogs, which is not present on every target
+// and whose hard import would break page loading where it is absent (same reason ColorSchemeEditor uses
+// a hex field rather than a native colour dialog).
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Dialog {
+    id: root
+
+    modal: true
+    anchors.centerIn: Overlay.overlay
+    focus: true
+    padding: 0
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    /// The bold heading line.
+    property string heading: qsTr("Confirm")
+    /// The explanatory body text.
+    property string message: ""
+    /// The label on the destructive (accept) button.
+    property string confirmText: qsTr("Delete")
+    /// Emitted when the user confirms; the dialog closes itself afterwards.
+    signal confirmed()
+
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
+    }
+
+    background: Rectangle {
+        color: sys.window
+        border.color: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.22)
+        border.width: 1
+        radius: 8
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 12
+
+        Label {
+            text: root.heading
+            font.pointSize: 14
+            font.weight: Font.DemiBold
+            color: sys.windowText
+            Layout.fillWidth: true
+            Layout.topMargin: 18
+            Layout.leftMargin: 18
+            Layout.rightMargin: 18
+        }
+        Label {
+            text: root.message
+            wrapMode: Text.WordWrap
+            color: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.78)
+            Layout.fillWidth: true
+            Layout.maximumWidth: 360
+            Layout.leftMargin: 18
+            Layout.rightMargin: 18
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.margins: 18
+            spacing: 8
+            Item { Layout.fillWidth: true }
+            Button {
+                objectName: "confirmCancelButton"
+                text: qsTr("Cancel")
+                onClicked: root.close()
+            }
+            Button {
+                objectName: "confirmAcceptButton"
+                text: root.confirmText
+                onClicked: {
+                    root.confirmed();
+                    root.close();
+                }
+                contentItem: Label {
+                    text: root.confirmText
+                    color: "#ffffff"
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+                background: Rectangle {
+                    radius: 4
+                    implicitWidth: 84
+                    implicitHeight: 30
+                    color: parent.down ? "#a01f1f" : (parent.hovered ? "#d23b3b" : "#c62828")
+                }
+            }
+        }
+    }
+}

--- a/src/contour/ui/NewTabMenu.qml
+++ b/src/contour/ui/NewTabMenu.qml
@@ -1,0 +1,89 @@
+// vim:syntax=qml
+// The new-tab dropdown (the "▾" beside "+"): one entry per configured profile — picking one opens a new
+// tab launched with that profile — then a separator and a "Settings" entry that opens the settings page.
+// Windows-Terminal style.
+//
+// The profile list is data from the SettingsController (reached via the WindowController), so the menu
+// never hard-codes it and stays in step with the config. The items are built at runtime the same way
+// TerminalContextMenu builds its rows (createObject under contentItem + addItem), for the same reason:
+// an Instantiator/Repeater cannot host a heterogeneous Menu, and a native OS menu cannot host runtime
+// items (it came up empty on Windows) — so this forces the in-scene popup and builds by hand.
+import QtQuick
+import QtQuick.Controls
+
+Menu {
+    id: root
+
+    // Force the in-scene (item) popup rather than a native OS menu (see TerminalContextMenu for the why).
+    popupType: Popup.Item
+
+    // The WindowController. Null-guarded throughout: it is torn down before this QML tree on window close.
+    required property var controller
+
+    // Objects this file created, destroyed on the next rebuild so nothing leaks.
+    property var _created: []
+
+    // Build the items when the component is complete (so they exist for offscreen tests, which cannot
+    // open a popup) and again just before each open (so a profile added by a live config reload shows up
+    // without reopening the window).
+    Component.onCompleted: root.rebuild()
+    onAboutToShow: root.rebuild()
+
+    Component {
+        id: profileEntry
+        MenuItem {
+            property string profileName: ""
+            onTriggered: if (root.controller) root.controller.createNewTab(profileName)
+        }
+    }
+    Component {
+        id: separatorEntry
+        MenuSeparator {}
+    }
+    Component {
+        id: settingsEntry
+        MenuItem {
+            text: qsTr("Settings")
+            onTriggered: if (root.controller) root.controller.openSettings()
+        }
+    }
+
+    // The configured profiles, or [] when unreachable (e.g. a lightweight mock controller in the tests,
+    // which has no settingsController). Reading a missing QObject property yields undefined, not an error.
+    function profileList() {
+        if (root.controller && root.controller.settingsController
+                && root.controller.settingsController.profiles)
+            return root.controller.settingsController.profiles
+        return []
+    }
+
+    function rebuild() {
+        // Tear down what we built last time (Qt owns nothing created here).
+        while (root.count > 0)
+            root.takeItem(0)
+        for (let i = 0; i < root._created.length; ++i)
+            root._created[i].destroy()
+        root._created = []
+
+        let created = []
+        const profiles = root.profileList()
+        for (let i = 0; i < profiles.length; ++i) {
+            const item = profileEntry.createObject(root.contentItem, {
+                "text": qsTr("New tab — %1").arg(profiles[i].name),
+                "profileName": profiles[i].name
+            })
+            root.addItem(item)
+            created.push(item)
+        }
+        if (profiles.length > 0) {
+            const sep = separatorEntry.createObject(root.contentItem)
+            root.addItem(sep)
+            created.push(sep)
+        }
+        const settings = settingsEntry.createObject(root.contentItem)
+        root.addItem(settings)
+        created.push(settings)
+
+        root._created = created
+    }
+}

--- a/src/contour/ui/SettingRow.qml
+++ b/src/contour/ui/SettingRow.qml
@@ -1,0 +1,92 @@
+// vim:syntax=qml
+// One editable setting: a label + help text on the left, and a type-driven editor on the right.
+//
+// It is the reusable building block of the settings page (mirroring Windows Terminal's SettingContainer):
+// a page is a column of these, each bound to one row of SettingsController.profileFields
+// ({ key, label, help, type, value }). The `type` string selects the editor widget, so a new field
+// type is a new case here — not a change to every page.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+RowLayout {
+    id: root
+
+    property string fieldKey: ""
+    property string label: ""
+    property string help: ""
+    property string type: "string"
+    property var value: null
+    property bool editable: true
+
+    // Emitted when the user commits a change; the page forwards it to SettingsController.setProfileField.
+    signal edited(string key, var value)
+
+    spacing: 16
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 2
+        Label { text: root.label; font.bold: true }
+        Label {
+            text: root.help
+            visible: root.help.length > 0
+            opacity: 0.7
+            font.pointSize: 9
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+        }
+    }
+
+    Loader {
+        id: editorLoader
+        Layout.preferredWidth: 240
+        sourceComponent: root.type === "bool" ? boolEditor
+                       : root.type === "double" ? doubleEditor
+                       : root.type === "int" ? intEditor
+                       : stringEditor
+    }
+
+    Component {
+        id: boolEditor
+        Switch {
+            checked: root.value === true
+            enabled: root.editable
+            onToggled: root.edited(root.fieldKey, checked)
+        }
+    }
+
+    Component {
+        id: doubleEditor
+        TextField {
+            Layout.fillWidth: true
+            text: root.value !== null && root.value !== undefined ? String(root.value) : ""
+            enabled: root.editable
+            selectByMouse: true
+            validator: DoubleValidator {}
+            onEditingFinished: root.edited(root.fieldKey, parseFloat(text))
+        }
+    }
+
+    Component {
+        id: intEditor
+        SpinBox {
+            enabled: root.editable
+            from: -1000000
+            to: 1000000
+            value: root.value !== null && root.value !== undefined ? root.value : 0
+            onValueModified: root.edited(root.fieldKey, value)
+        }
+    }
+
+    Component {
+        id: stringEditor
+        TextField {
+            Layout.fillWidth: true
+            text: root.value !== null && root.value !== undefined ? String(root.value) : ""
+            enabled: root.editable
+            selectByMouse: true
+            onEditingFinished: root.edited(root.fieldKey, text)
+        }
+    }
+}

--- a/src/contour/ui/SettingRow.qml
+++ b/src/contour/ui/SettingRow.qml
@@ -1,15 +1,17 @@
 // vim:syntax=qml
-// One editable setting: a label + help text on the left, and a type-driven editor on the right.
+// One editable setting, rendered as a Windows-Terminal-style "settings card": a rounded, subtly
+// elevated surface (SystemPalette.base over the page's window colour) with the label + help text on
+// the left and a type-driven editor on the right, plus a faint accent wash on hover.
 //
 // It is the reusable building block of the settings page (mirroring Windows Terminal's SettingContainer):
 // a page is a column of these, each bound to one row of SettingsController.profileFields
 // ({ key, label, help, type, value }). The `type` string selects the editor widget, so a new field
-// type is a new case here — not a change to every page.
+// type is a new case in the Loader below — not a change to every page.
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-RowLayout {
+Item {
     id: root
 
     property string fieldKey: ""
@@ -23,30 +25,69 @@ RowLayout {
     // Emitted when the user commits a change; the page forwards it to SettingsController.setProfileField.
     signal edited(string key, var value)
 
-    spacing: 16
+    implicitHeight: rowLayout.implicitHeight + 24
+    implicitWidth: rowLayout.implicitWidth + 32
 
-    ColumnLayout {
-        Layout.fillWidth: true
-        spacing: 2
-        Label { text: root.label; font.bold: true }
-        Label {
-            text: root.help
-            visible: root.help.length > 0
-            opacity: 0.7
-            font.pointSize: 9
-            wrapMode: Text.WordWrap
-            Layout.fillWidth: true
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
+    }
+    readonly property color subtleText: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.62)
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 8
+        color: sys.base
+        border.width: 1
+        border.color: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.12)
+        Rectangle {
+            anchors.fill: parent
+            radius: parent.radius
+            color: sys.highlight
+            opacity: cardHover.hovered ? 0.06 : 0.0
+            Behavior on opacity { NumberAnimation { duration: 90 } }
         }
+        HoverHandler { id: cardHover }
     }
 
-    Loader {
-        id: editorLoader
-        Layout.preferredWidth: 240
-        sourceComponent: root.type === "bool" ? boolEditor
-                       : root.type === "double" ? doubleEditor
-                       : root.type === "int" ? intEditor
-                       : root.type === "enum" ? enumEditor
-                       : stringEditor
+    RowLayout {
+        id: rowLayout
+        anchors.fill: parent
+        anchors.leftMargin: 16
+        anchors.rightMargin: 16
+        anchors.topMargin: 12
+        anchors.bottomMargin: 12
+        spacing: 16
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 2
+            Label {
+                text: root.label
+                font.weight: Font.DemiBold
+                color: sys.windowText
+            }
+            Label {
+                text: root.help
+                visible: root.help.length > 0
+                color: root.subtleText
+                font.pointSize: 9
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+        }
+
+        Loader {
+            id: editorLoader
+            // A bool is a compact Switch hugged to the right; every other editor claims a fixed column.
+            Layout.preferredWidth: root.type === "bool" ? -1 : 240
+            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+            sourceComponent: root.type === "bool" ? boolEditor
+                           : root.type === "double" ? doubleEditor
+                           : root.type === "int" ? intEditor
+                           : root.type === "enum" ? enumEditor
+                           : stringEditor
+        }
     }
 
     Component {

--- a/src/contour/ui/SettingRow.qml
+++ b/src/contour/ui/SettingRow.qml
@@ -17,6 +17,7 @@ RowLayout {
     property string help: ""
     property string type: "string"
     property var value: null
+    property var options: []
     property bool editable: true
 
     // Emitted when the user commits a change; the page forwards it to SettingsController.setProfileField.
@@ -44,7 +45,19 @@ RowLayout {
         sourceComponent: root.type === "bool" ? boolEditor
                        : root.type === "double" ? doubleEditor
                        : root.type === "int" ? intEditor
+                       : root.type === "enum" ? enumEditor
                        : stringEditor
+    }
+
+    Component {
+        id: enumEditor
+        ComboBox {
+            Layout.fillWidth: true
+            enabled: root.editable
+            model: root.options
+            currentIndex: Math.max(0, root.options.indexOf(root.value))
+            onActivated: root.edited(root.fieldKey, currentText)
+        }
     }
 
     Component {

--- a/src/contour/ui/SettingRow.qml
+++ b/src/contour/ui/SettingRow.qml
@@ -126,8 +126,11 @@ Item {
         id: intEditor
         SpinBox {
             enabled: root.editable
-            from: -1000000
-            to: 1000000
+            // Full 32-bit signed range: the config fields this drives are plain ints (e.g.
+            // read_buffer_size, which can legitimately exceed a megabyte), and a narrower cap would
+            // silently clamp such a value on display and then persist the clamped number on the next edit.
+            from: -2147483647
+            to: 2147483647
             value: root.value !== null && root.value !== undefined ? root.value : 0
             onValueModified: root.edited(root.fieldKey, value)
         }

--- a/src/contour/ui/SettingsListItem.qml
+++ b/src/contour/ui/SettingsListItem.qml
@@ -1,0 +1,194 @@
+// vim:syntax=qml
+// One row in the settings page's profile or color-scheme list. Beyond selecting the entry (a single
+// click opens it in the editor on the right), the row carries its per-entry actions inline, in the
+// Windows-Terminal idiom:
+//   - a home icon that marks and sets the DEFAULT profile (profiles only, gated by `showHome`); the
+//     default wears a filled home, the others reveal a faint one on hover — click it to move the default;
+//   - inline RENAME: double-click the name (or the context menu) to edit it in place, Enter commits and
+//     Escape/blur cancels — the same gesture the tab strip uses for tab titles;
+//   - a red TRASHCAN on hover to DELETE the entry (the page routes it through a confirmation dialog);
+//   - a right-click CONTEXT MENU gathering Set-as-default / Rename / Delete.
+// Rename and delete are offered only for `editable` (GUI-created side-file) entries; the default may
+// point at any profile. Colours follow the OS light/dark theme via SystemPalette.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    property string entryName: ""
+    property bool selected: false
+    property bool editable: true   ///< A GUI side-file entry (rename/delete allowed).
+    property bool isDefault: false ///< This profile is the current default (profiles only).
+    property bool showHome: false  ///< Show the default (home) affordance (profiles yes, schemes no).
+    property bool locked: false    ///< The whole settings page is read-only.
+
+    signal activated()                        ///< Open this entry in the editor.
+    signal setDefaultRequested()              ///< Make this profile the default.
+    signal renameRequested(string newName)    ///< Commit an inline rename.
+    signal deleteRequested()                  ///< Delete this entry (host shows the confirmation dialog).
+
+    implicitHeight: 38
+
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
+    }
+
+    HoverHandler { id: rowHover }
+
+    // Selected pill + accent wash on hover (mirrors SettingsNavItem).
+    Rectangle {
+        anchors.fill: parent
+        radius: 6
+        visible: root.selected
+        color: sys.base
+    }
+    Rectangle {
+        anchors.fill: parent
+        radius: 6
+        color: sys.highlight
+        opacity: root.selected ? 0.16 : (rowHover.hovered ? 0.08 : 0.0)
+        Behavior on opacity { NumberAnimation { duration: 90 } }
+    }
+    Rectangle {
+        visible: root.selected
+        width: 3
+        radius: 1.5
+        color: sys.highlight
+        anchors { left: parent.left; top: parent.top; bottom: parent.bottom; topMargin: 7; bottomMargin: 7 }
+    }
+
+    // Single click opens the entry; a double-click also starts an inline rename (editable only). Mirrors
+    // TabItem.qml's tap handling.
+    TapHandler {
+        acceptedButtons: Qt.LeftButton
+        onTapped: {
+            root.activated();
+            if (tapCount === 2 && root.editable && !root.locked)
+                root.startRename();
+        }
+    }
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: contextMenu.popup()
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 8
+        anchors.rightMargin: 6
+        spacing: 6
+
+        // Home / default affordance (profiles only): filled for the default, a faint outline on hover for
+        // the others — click to make that profile the default.
+        AbstractButton {
+            id: homeButton
+            objectName: "setDefaultButton"
+            visible: root.showHome
+            implicitWidth: 20
+            implicitHeight: 20
+            Layout.alignment: Qt.AlignVCenter
+            enabled: !root.locked && !root.isDefault
+            opacity: root.isDefault ? 1.0 : (rowHover.hovered ? 0.55 : 0.0)
+            Behavior on opacity { NumberAnimation { duration: 90 } }
+            ToolTip.visible: hovered
+            ToolTip.text: root.isDefault ? qsTr("Default profile") : qsTr("Set as default")
+            onClicked: if (!root.isDefault) root.setDefaultRequested()
+            contentItem: Label {
+                text: "⌂"
+                font.pointSize: 11
+                color: root.isDefault ? sys.highlight : sys.windowText
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            background: null
+        }
+
+        // The name, or an inline rename editor in its place.
+        Label {
+            id: nameLabel
+            visible: !renameField.visible
+            text: root.entryName
+            color: sys.windowText
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            font.weight: root.selected ? Font.DemiBold : Font.Normal
+        }
+        TextField {
+            id: renameField
+            objectName: "renameField"
+            visible: false
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            selectByMouse: true
+            onAccepted: root.commitRename()
+            onActiveFocusChanged: if (!activeFocus && visible) root.cancelRename()
+            Keys.onEscapePressed: root.cancelRename()
+        }
+
+        // Delete (trashcan) — editable rows only, revealed on hover / when selected.
+        AbstractButton {
+            id: trashButton
+            objectName: "deleteEntryButton"
+            visible: root.editable && !root.locked && (rowHover.hovered || root.selected)
+            implicitWidth: 22
+            implicitHeight: 22
+            Layout.alignment: Qt.AlignVCenter
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("Delete")
+            onClicked: root.deleteRequested()
+            contentItem: Label {
+                text: "🗑"
+                font.pointSize: 11
+                color: trashButton.hovered ? "#e53935" : "#c62828"
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            background: Rectangle {
+                radius: 4
+                color: trashButton.hovered ? Qt.rgba(0.9, 0.2, 0.2, 0.16) : "transparent"
+            }
+        }
+    }
+
+    Menu {
+        id: contextMenu
+        popupType: Popup.Item
+        MenuItem {
+            text: qsTr("Set as default")
+            height: visible ? implicitHeight : 0
+            visible: root.showHome
+            enabled: root.showHome && !root.isDefault && !root.locked
+            onTriggered: root.setDefaultRequested()
+        }
+        MenuItem {
+            text: qsTr("Rename")
+            enabled: root.editable && !root.locked
+            onTriggered: root.startRename()
+        }
+        MenuItem {
+            text: qsTr("Delete")
+            enabled: root.editable && !root.locked
+            onTriggered: root.deleteRequested()
+        }
+    }
+
+    function startRename() {
+        renameField.text = root.entryName;
+        renameField.visible = true;
+        renameField.forceActiveFocus();
+        renameField.selectAll();
+    }
+    function commitRename() {
+        var name = renameField.text.trim();
+        renameField.visible = false;
+        if (name.length > 0 && name !== root.entryName)
+            root.renameRequested(name);
+    }
+    function cancelRename() {
+        renameField.visible = false;
+    }
+}

--- a/src/contour/ui/SettingsNavItem.qml
+++ b/src/contour/ui/SettingsNavItem.qml
@@ -1,0 +1,96 @@
+// vim:syntax=qml
+// One row in the settings page's left navigation rail: a selectable "pill" with an optional leading
+// glyph or colour dot, a label, and an optional trailing badge (e.g. the default-profile star or a
+// read-only lock). Selection draws a Windows-Terminal-style accent bar on the left over a tinted
+// surface; hover shows a fainter tint. Colours follow the OS light/dark theme live via SystemPalette
+// (the same idiom as CommandPalette.qml / TabColorFlyout.qml), so the rail adapts in realtime.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ItemDelegate {
+    id: root
+
+    property string glyph: ""     ///< Optional leading emoji/glyph (mutually exclusive with the dot).
+    property bool showDot: false  ///< Draw a small colour dot instead of a glyph.
+    property color dotColor: "gray"
+    property string badge: ""     ///< Optional trailing marker (e.g. "★" default, "🔒" read-only).
+    property bool selected: false ///< Whether this item is the one currently shown in the content pane.
+    property bool accent: false   ///< Colour the label with the accent (used by the "New …" actions).
+
+    implicitHeight: 38
+    padding: 0
+
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
+    }
+    readonly property color subtleText: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.6)
+
+    background: Item {
+        // The selected item reads as a solid surface pill; hover is a fainter accent wash only.
+        Rectangle {
+            anchors.fill: parent
+            radius: 6
+            visible: root.selected
+            color: sys.base
+        }
+        Rectangle {
+            anchors.fill: parent
+            radius: 6
+            color: sys.highlight
+            opacity: root.selected ? 0.16 : (root.hovered ? 0.08 : 0.0)
+            Behavior on opacity { NumberAnimation { duration: 90 } }
+        }
+        Rectangle {
+            visible: root.selected
+            width: 3
+            radius: 1.5
+            color: sys.highlight
+            anchors {
+                left: parent.left
+                top: parent.top
+                bottom: parent.bottom
+                topMargin: 7
+                bottomMargin: 7
+            }
+        }
+    }
+
+    contentItem: RowLayout {
+        spacing: 8
+
+        Item { Layout.preferredWidth: 6 } // inset clear of the accent bar
+
+        Label {
+            visible: root.glyph.length > 0
+            text: root.glyph
+            font.pointSize: 11
+            Layout.alignment: Qt.AlignVCenter
+        }
+        Rectangle {
+            visible: root.showDot && root.glyph.length === 0
+            width: 8
+            height: 8
+            radius: 4
+            color: root.dotColor
+            Layout.alignment: Qt.AlignVCenter
+        }
+        Label {
+            text: root.text
+            Layout.fillWidth: true
+            elide: Text.ElideRight
+            color: root.accent ? sys.highlight : sys.windowText
+            font.weight: (root.selected || root.accent) ? Font.DemiBold : Font.Normal
+            Layout.alignment: Qt.AlignVCenter
+        }
+        Label {
+            visible: root.badge.length > 0
+            text: root.badge
+            color: root.subtleText
+            font.pointSize: 9
+            Layout.rightMargin: 8
+            Layout.alignment: Qt.AlignVCenter
+        }
+    }
+}

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -35,13 +35,6 @@ Rectangle {
 
     color: sys.window
 
-    readonly property var profileNameList: {
-        var out = []
-        if (controller)
-            for (var i = 0; i < controller.profiles.length; ++i)
-                out.push(controller.profiles[i].name)
-        return out
-    }
     readonly property var schemeNameList: {
         var out = []
         if (controller)
@@ -76,6 +69,32 @@ Rectangle {
         if (root.editorMode === "keybindings")
             return qsTr("Configured in contour.yml (read-only here).")
         return ""
+    }
+
+    // Delete is confirmed through a modal dialog; the row that asked stashes its target here first.
+    property string pendingDeleteKind: "" // "profile" | "scheme"
+    property string pendingDeleteName: ""
+
+    function requestDelete(kind, name) {
+        root.pendingDeleteKind = kind
+        root.pendingDeleteName = name
+        deleteDialog.open()
+    }
+
+    ConfirmDialog {
+        id: deleteDialog
+        heading: qsTr("Delete “%1”").arg(root.pendingDeleteName)
+        confirmText: qsTr("Delete")
+        message: root.pendingDeleteKind === "profile"
+                 ? qsTr("Delete the profile “%1”? This removes its GUI side file and cannot be undone.").arg(root.pendingDeleteName)
+                 : qsTr("Delete the color scheme “%1”? This removes its GUI side file and cannot be undone.").arg(root.pendingDeleteName)
+        onConfirmed: {
+            if (!root.controller) return
+            if (root.pendingDeleteKind === "profile")
+                root.controller.deleteProfile(root.pendingDeleteName)
+            else
+                root.controller.deleteColorScheme(root.pendingDeleteName)
+        }
     }
 
     ColumnLayout {
@@ -195,44 +214,28 @@ Rectangle {
                             Layout.leftMargin: 16
                             Layout.topMargin: 14
                         }
-                        RowLayout {
-                            Layout.fillWidth: true
-                            Layout.leftMargin: 16
-                            Layout.rightMargin: 16
-                            spacing: 8
-                            Label {
-                                text: qsTr("Default")
-                                color: root.subtleText
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                            ComboBox {
-                                id: defaultProfileCombo
-                                objectName: "defaultProfileCombo"
-                                Layout.fillWidth: true
-                                model: root.profileNameList
-                                enabled: root.controller && !root.controller.locked
-                                currentIndex: root.controller ? root.profileNameList.indexOf(root.controller.defaultProfile) : -1
-                                onActivated: if (root.controller) root.controller.setDefaultProfile(currentText)
-                            }
-                        }
                         Repeater {
                             model: root.controller ? root.controller.profiles : []
-                            delegate: SettingsNavItem {
+                            delegate: SettingsListItem {
                                 required property var modelData
                                 Layout.fillWidth: true
                                 Layout.leftMargin: 8
                                 Layout.rightMargin: 8
-                                text: modelData.name
-                                showDot: true
-                                dotColor: modelData.isDefault ? sys.highlight : root.subtleText
-                                badge: modelData.origin === "side" ? (modelData.isDefault ? "★" : "") : "🔒"
+                                entryName: modelData.name
+                                showHome: true
+                                isDefault: modelData.isDefault === true
+                                editable: modelData.editable === true
+                                locked: root.controller && root.controller.locked
                                 selected: root.editorMode === "profile" && root.controller
                                           && root.controller.editingProfile === modelData.name
-                                onClicked: {
+                                onActivated: {
                                     if (!root.controller) return
                                     root.controller.editProfile(modelData.name)
                                     root.editorMode = "profile"
                                 }
+                                onSetDefaultRequested: if (root.controller) root.controller.setDefaultProfile(modelData.name)
+                                onRenameRequested: (newName) => { if (root.controller) root.controller.renameProfile(modelData.name, newName) }
+                                onDeleteRequested: root.requestDelete("profile", modelData.name)
                             }
                         }
                         SettingsNavItem {
@@ -262,22 +265,24 @@ Rectangle {
                         }
                         Repeater {
                             model: root.controller ? root.controller.colorSchemes : []
-                            delegate: SettingsNavItem {
+                            delegate: SettingsListItem {
                                 required property var modelData
                                 Layout.fillWidth: true
                                 Layout.leftMargin: 8
                                 Layout.rightMargin: 8
-                                text: modelData.name
-                                showDot: true
-                                dotColor: root.subtleText
-                                badge: modelData.editable ? "" : "🔒"
+                                entryName: modelData.name
+                                showHome: false
+                                editable: modelData.editable === true
+                                locked: root.controller && root.controller.locked
                                 selected: root.editorMode === "scheme" && root.controller
                                           && root.controller.editingScheme === modelData.name
-                                onClicked: {
+                                onActivated: {
                                     if (!root.controller) return
                                     root.controller.editColorScheme(modelData.name)
                                     root.editorMode = "scheme"
                                 }
+                                onRenameRequested: (newName) => { if (root.controller) root.controller.renameColorScheme(modelData.name, newName) }
+                                onDeleteRequested: root.requestDelete("scheme", modelData.name)
                             }
                         }
                         SettingsNavItem {
@@ -518,14 +523,8 @@ Rectangle {
                                     }
                                 }
                                 Item { Layout.fillWidth: true }
-                                Button {
-                                    objectName: "deleteProfileButton"
-                                    text: qsTr("Delete")
-                                    enabled: root.controller && !root.controller.locked
-                                             && !root.controller.editingReadOnly
-                                             && root.controller.editingProfile.length > 0
-                                    onClicked: root.controller.deleteProfile(root.controller.editingProfile)
-                                }
+                                // Delete lives on the profile list row (hover trashcan / right-click),
+                                // routed through the page's confirmation dialog.
                             }
                         }
                     }

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -162,6 +162,21 @@ Rectangle {
                         root.editorMode = "scheme"
                     }
                 }
+
+                Button {
+                    objectName: "globalSettingsButton"
+                    Layout.fillWidth: true
+                    Layout.topMargin: 8
+                    text: qsTr("Global settings…")
+                    onClicked: root.editorMode = "globals"
+                }
+
+                Button {
+                    objectName: "keybindingsButton"
+                    Layout.fillWidth: true
+                    text: qsTr("Keybindings…")
+                    onClicked: root.editorMode = "keybindings"
+                }
             }
             // }}}
 
@@ -177,11 +192,15 @@ Rectangle {
                 Layout.fillHeight: true
                 clip: true
 
-                // Profile editor.
-                ColumnLayout {
-                    width: rightPane.width
+                // Profile editor (scrollable — the field list is long).
+                ScrollView {
+                    anchors.fill: parent
                     visible: root.editorMode === "profile"
-                    spacing: 12
+                    clip: true
+                    contentWidth: availableWidth
+                    ColumnLayout {
+                        width: rightPane.width - 24
+                        spacing: 12
 
                     Label {
                         text: (root.controller && root.controller.editingProfile.length > 0)
@@ -210,6 +229,7 @@ Rectangle {
                             help: modelData.help
                             type: modelData.type
                             value: modelData.value
+                            options: modelData.options
                             editable: root.controller && !root.controller.editingReadOnly
                             onEdited: (key, value) => root.controller.setProfileField(key, value)
                         }
@@ -311,13 +331,87 @@ Rectangle {
                             onClicked: root.controller.deleteProfile(root.controller.editingProfile)
                         }
                     }
-                }
+                    } // ColumnLayout (profile editor)
+                } // ScrollView
 
                 // Color-scheme editor.
                 ColorSchemeEditor {
                     width: parent.width
                     visible: root.editorMode === "scheme"
                     controller: root.controller
+                }
+
+                // Global (application-scope) settings, editable — written to settings.yml as overrides.
+                ScrollView {
+                    anchors.fill: parent
+                    visible: root.editorMode === "globals"
+                    clip: true
+                    contentWidth: availableWidth
+                    ColumnLayout {
+                        width: rightPane.width - 24
+                        spacing: 12
+                        Label { text: qsTr("Global settings"); font.pointSize: 14; font.bold: true }
+                        Label {
+                            text: qsTr("These override contour.yml application-wide, saved to settings.yml.")
+                            opacity: 0.7
+                        }
+                        Repeater {
+                            model: root.controller ? root.controller.globalFields : []
+                            delegate: RowLayout {
+                                required property var modelData
+                                Layout.fillWidth: true
+                                spacing: 8
+                                SettingRow {
+                                    Layout.fillWidth: true
+                                    fieldKey: modelData.key
+                                    label: modelData.label
+                                    help: modelData.help
+                                    type: modelData.type
+                                    value: modelData.value
+                                    editable: root.controller && !root.controller.locked
+                                    onEdited: (key, value) => root.controller.setGlobalField(key, value)
+                                }
+                                Button {
+                                    text: qsTr("Reset")
+                                    visible: modelData.overridden
+                                    enabled: root.controller && !root.controller.locked
+                                    onClicked: root.controller.resetGlobalField(modelData.key)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Keybindings (read-only viewer).
+                ColumnLayout {
+                    anchors.fill: parent
+                    visible: root.editorMode === "keybindings"
+                    spacing: 8
+                    Label { text: qsTr("Keybindings"); font.pointSize: 14; font.bold: true }
+                    Label {
+                        text: qsTr("Key bindings are configured in contour.yml (read-only here).")
+                        opacity: 0.7
+                    }
+                    ListView {
+                        objectName: "keybindingsList"
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        clip: true
+                        model: root.controller ? root.controller.keybindings : []
+                        delegate: RowLayout {
+                            required property var modelData
+                            width: ListView.view.width
+                            spacing: 12
+                            Label {
+                                text: modelData.trigger
+                                Layout.preferredWidth: 200
+                                font.family: "monospace"
+                                elide: Text.ElideRight
+                            }
+                            Label { text: modelData.action; Layout.fillWidth: true; elide: Text.ElideRight }
+                            Label { text: modelData.mode; opacity: 0.6; Layout.preferredWidth: 90 }
+                        }
+                    }
                 }
 
                 // Empty state.

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -77,6 +77,9 @@ Rectangle {
             // {{{ Left navigation
             ColumnLayout {
                 Layout.preferredWidth: 260
+                Layout.minimumWidth: 260
+                Layout.maximumWidth: 260
+                Layout.fillWidth: false
                 Layout.fillHeight: true
                 spacing: 8
 
@@ -165,14 +168,18 @@ Rectangle {
             ToolSeparator { Layout.fillHeight: true }
 
             // {{{ Right content pane
-            ScrollView {
+            // A plain Item (not a ScrollView): it hosts three mutually-exclusive, visible-toggled
+            // editors, and its Layout.fillWidth cleanly claims the row's remaining width. A ScrollView
+            // here would size itself to its (multiple) children and collapse the pane.
+            Item {
+                id: rightPane
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
 
                 // Profile editor.
                 ColumnLayout {
-                    width: parent.width
+                    width: rightPane.width
                     visible: root.editorMode === "profile"
                     spacing: 12
 

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -5,8 +5,10 @@
 // page). It never edits contour.yml: it creates/edits GUI-owned side files, and shows contour.yml /
 // builtin entities read-only.
 //
-// Layout (Windows-Terminal style): a left navigation column (default-profile selector, the profile
-// list, the color-scheme list) and a right content pane that edits the selected profile or scheme.
+// Layout (Windows-Terminal style): a title bar, a left navigation rail with accent "pill" selection
+// (grouped GENERAL / PROFILES / COLOR SCHEMES), and a right content pane with a page header band and
+// elevated "setting cards". All colours follow the OS light/dark theme live via SystemPalette, the same
+// idiom the command palette and tab flyouts use.
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -20,10 +22,18 @@ Rectangle {
     property var controller: null
     property var windowController: null
 
-    // Which editor the right pane shows: "profile", "scheme", or "" (nothing selected yet).
+    // Which editor the right pane shows: "profile", "scheme", "globals", "keybindings", or "" (nothing).
     property string editorMode: ""
 
-    color: palette.window
+    // Live OS palette handle, so the whole page follows dark/light in realtime (see CommandPalette.qml).
+    SystemPalette {
+        id: sys
+        colorGroup: SystemPalette.Active
+    }
+    readonly property color subtleText: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.6)
+    readonly property color hairline: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.12)
+
+    color: sys.window
 
     readonly property var profileNameList: {
         var out = []
@@ -40,31 +50,83 @@ Rectangle {
         return out
     }
 
+    // The page header, driven by which editor is open.
+    readonly property string headerTitle: {
+        if (root.editorMode === "profile")
+            return (root.controller && root.controller.editingProfile.length > 0)
+                   ? qsTr("Profile · %1").arg(root.controller.editingProfile)
+                   : qsTr("New profile")
+        if (root.editorMode === "scheme")
+            return (root.controller && root.controller.editingScheme.length > 0)
+                   ? qsTr("Color scheme · %1").arg(root.controller.editingScheme)
+                   : qsTr("New color scheme")
+        if (root.editorMode === "globals")
+            return qsTr("Global settings")
+        if (root.editorMode === "keybindings")
+            return qsTr("Keybindings")
+        return ""
+    }
+    readonly property string headerSubtitle: {
+        if (root.editorMode === "profile")
+            return qsTr("Appearance and behaviour for this profile — saved to profiles/<name>.yml.")
+        if (root.editorMode === "scheme")
+            return qsTr("A reusable palette — saved to colorschemes/<name>.yml.")
+        if (root.editorMode === "globals")
+            return qsTr("Application-wide overrides — saved to settings.yml.")
+        if (root.editorMode === "keybindings")
+            return qsTr("Configured in contour.yml (read-only here).")
+        return ""
+    }
+
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 16
-        spacing: 12
+        spacing: 0
 
-        // {{{ Header
-        RowLayout {
+        // {{{ Title bar
+        Rectangle {
             Layout.fillWidth: true
-            Label {
-                text: qsTr("Settings")
-                font.pointSize: 18
-                font.bold: true
-                Layout.fillWidth: true
+            Layout.preferredHeight: 56
+            color: "transparent"
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 20
+                anchors.rightMargin: 16
+                spacing: 12
+
+                Label {
+                    text: qsTr("Settings")
+                    font.pointSize: 18
+                    font.weight: Font.DemiBold
+                    color: sys.windowText
+                    Layout.fillWidth: true
+                }
+                Rectangle {
+                    objectName: "lockedBadge"
+                    visible: root.controller && root.controller.locked
+                    radius: 4
+                    color: Qt.rgba(sys.windowText.r, sys.windowText.g, sys.windowText.b, 0.08)
+                    Layout.preferredHeight: 24
+                    Layout.preferredWidth: lockedLabel.implicitWidth + 20
+                    Label {
+                        id: lockedLabel
+                        anchors.centerIn: parent
+                        text: qsTr("🔒 read-only (gui_config_locked)")
+                        color: root.subtleText
+                        font.pointSize: 9
+                    }
+                }
+                Button {
+                    objectName: "closeSettingsButton"
+                    text: qsTr("Close")
+                    onClicked: if (root.windowController) root.windowController.closeSettings()
+                }
             }
-            Label {
-                objectName: "lockedBadge"
-                visible: root.controller && root.controller.locked
-                text: qsTr("read-only (gui_config_locked)")
-                color: palette.mid
-                verticalAlignment: Text.AlignVCenter
-            }
-            Button {
-                objectName: "closeSettingsButton"
-                text: qsTr("Close")
-                onClicked: if (root.windowController) root.windowController.closeSettings()
+
+            Rectangle { // bottom hairline
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: 1
+                color: root.hairline
             }
         }
         // }}}
@@ -72,353 +134,524 @@ Rectangle {
         RowLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            spacing: 16
+            spacing: 0
 
-            // {{{ Left navigation
-            ColumnLayout {
-                Layout.preferredWidth: 260
-                Layout.minimumWidth: 260
-                Layout.maximumWidth: 260
-                Layout.fillWidth: false
+            // {{{ Left navigation rail
+            Rectangle {
+                Layout.preferredWidth: 280
+                Layout.minimumWidth: 280
+                Layout.maximumWidth: 280
                 Layout.fillHeight: true
-                spacing: 8
+                color: "transparent"
 
-                Label { text: qsTr("Default profile"); font.bold: true }
-                ComboBox {
-                    id: defaultProfileCombo
-                    objectName: "defaultProfileCombo"
-                    Layout.fillWidth: true
-                    model: root.profileNameList
-                    enabled: root.controller && !root.controller.locked
-                    currentIndex: root.controller ? root.profileNameList.indexOf(root.controller.defaultProfile) : -1
-                    onActivated: if (root.controller) root.controller.setDefaultProfile(currentText)
-                }
+                ScrollView {
+                    id: navScroll
+                    anchors.fill: parent
+                    contentWidth: availableWidth
+                    clip: true
 
-                Label { text: qsTr("Profiles"); font.bold: true; Layout.topMargin: 8 }
-                Frame {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    padding: 2
-                    ListView {
-                        id: profileList
-                        objectName: "profileList"
-                        anchors.fill: parent
-                        clip: true
-                        model: root.controller ? root.controller.profiles : []
-                        delegate: ItemDelegate {
-                            required property var modelData
-                            width: ListView.view.width
-                            text: modelData.name + (modelData.isDefault ? "  ★" : "")
-                                  + (modelData.origin === "side" ? "" : "  🔒")
+                    ColumnLayout {
+                        width: navScroll.availableWidth
+                        spacing: 4
+
+                        // General
+                        Label {
+                            text: qsTr("GENERAL")
+                            font.pointSize: 8
+                            font.bold: true
+                            font.letterSpacing: 1
+                            color: root.subtleText
+                            Layout.leftMargin: 16
+                            Layout.topMargin: 12
+                        }
+                        SettingsNavItem {
+                            objectName: "globalSettingsButton"
+                            Layout.fillWidth: true
+                            Layout.leftMargin: 8
+                            Layout.rightMargin: 8
+                            text: qsTr("Global settings")
+                            glyph: "⚙"
+                            selected: root.editorMode === "globals"
+                            onClicked: root.editorMode = "globals"
+                        }
+                        SettingsNavItem {
+                            objectName: "keybindingsButton"
+                            Layout.fillWidth: true
+                            Layout.leftMargin: 8
+                            Layout.rightMargin: 8
+                            text: qsTr("Keybindings")
+                            glyph: "⌨"
+                            selected: root.editorMode === "keybindings"
+                            onClicked: root.editorMode = "keybindings"
+                        }
+
+                        // Profiles
+                        Label {
+                            text: qsTr("PROFILES")
+                            font.pointSize: 8
+                            font.bold: true
+                            font.letterSpacing: 1
+                            color: root.subtleText
+                            Layout.leftMargin: 16
+                            Layout.topMargin: 14
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Layout.leftMargin: 16
+                            Layout.rightMargin: 16
+                            spacing: 8
+                            Label {
+                                text: qsTr("Default")
+                                color: root.subtleText
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            ComboBox {
+                                id: defaultProfileCombo
+                                objectName: "defaultProfileCombo"
+                                Layout.fillWidth: true
+                                model: root.profileNameList
+                                enabled: root.controller && !root.controller.locked
+                                currentIndex: root.controller ? root.profileNameList.indexOf(root.controller.defaultProfile) : -1
+                                onActivated: if (root.controller) root.controller.setDefaultProfile(currentText)
+                            }
+                        }
+                        Repeater {
+                            model: root.controller ? root.controller.profiles : []
+                            delegate: SettingsNavItem {
+                                required property var modelData
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 8
+                                Layout.rightMargin: 8
+                                text: modelData.name
+                                showDot: true
+                                dotColor: modelData.isDefault ? sys.highlight : root.subtleText
+                                badge: modelData.origin === "side" ? (modelData.isDefault ? "★" : "") : "🔒"
+                                selected: root.editorMode === "profile" && root.controller
+                                          && root.controller.editingProfile === modelData.name
+                                onClicked: {
+                                    if (!root.controller) return
+                                    root.controller.editProfile(modelData.name)
+                                    root.editorMode = "profile"
+                                }
+                            }
+                        }
+                        SettingsNavItem {
+                            objectName: "newProfileButton"
+                            Layout.fillWidth: true
+                            Layout.leftMargin: 8
+                            Layout.rightMargin: 8
+                            text: qsTr("New profile")
+                            glyph: "＋"
+                            accent: true
+                            enabled: root.controller && !root.controller.locked
                             onClicked: {
-                                if (!root.controller) return
-                                root.controller.editProfile(modelData.name)
+                                root.controller.newProfile(root.controller.defaultProfile)
                                 root.editorMode = "profile"
                             }
                         }
-                    }
-                }
-                Button {
-                    objectName: "newProfileButton"
-                    Layout.fillWidth: true
-                    text: qsTr("New profile…")
-                    enabled: root.controller && !root.controller.locked
-                    onClicked: {
-                        root.controller.newProfile(root.controller.defaultProfile)
-                        root.editorMode = "profile"
-                    }
-                }
 
-                Label { text: qsTr("Color schemes"); font.bold: true; Layout.topMargin: 8 }
-                Frame {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 120
-                    padding: 2
-                    ListView {
-                        id: schemeList
-                        objectName: "schemeList"
-                        anchors.fill: parent
-                        clip: true
-                        model: root.controller ? root.controller.colorSchemes : []
-                        delegate: ItemDelegate {
-                            required property var modelData
-                            width: ListView.view.width
-                            text: modelData.name + (modelData.editable ? "" : "  🔒")
+                        // Color schemes
+                        Label {
+                            text: qsTr("COLOR SCHEMES")
+                            font.pointSize: 8
+                            font.bold: true
+                            font.letterSpacing: 1
+                            color: root.subtleText
+                            Layout.leftMargin: 16
+                            Layout.topMargin: 14
+                        }
+                        Repeater {
+                            model: root.controller ? root.controller.colorSchemes : []
+                            delegate: SettingsNavItem {
+                                required property var modelData
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 8
+                                Layout.rightMargin: 8
+                                text: modelData.name
+                                showDot: true
+                                dotColor: root.subtleText
+                                badge: modelData.editable ? "" : "🔒"
+                                selected: root.editorMode === "scheme" && root.controller
+                                          && root.controller.editingScheme === modelData.name
+                                onClicked: {
+                                    if (!root.controller) return
+                                    root.controller.editColorScheme(modelData.name)
+                                    root.editorMode = "scheme"
+                                }
+                            }
+                        }
+                        SettingsNavItem {
+                            objectName: "newSchemeButton"
+                            Layout.fillWidth: true
+                            Layout.leftMargin: 8
+                            Layout.rightMargin: 8
+                            text: qsTr("New color scheme")
+                            glyph: "＋"
+                            accent: true
+                            enabled: root.controller && !root.controller.locked
                             onClicked: {
-                                if (!root.controller) return
-                                root.controller.editColorScheme(modelData.name)
+                                root.controller.newColorScheme("")
                                 root.editorMode = "scheme"
                             }
                         }
-                    }
-                }
-                Button {
-                    objectName: "newSchemeButton"
-                    Layout.fillWidth: true
-                    text: qsTr("New color scheme…")
-                    enabled: root.controller && !root.controller.locked
-                    onClicked: {
-                        root.controller.newColorScheme("")
-                        root.editorMode = "scheme"
-                    }
-                }
 
-                Button {
-                    objectName: "globalSettingsButton"
-                    Layout.fillWidth: true
-                    Layout.topMargin: 8
-                    text: qsTr("Global settings…")
-                    onClicked: root.editorMode = "globals"
-                }
-
-                Button {
-                    objectName: "keybindingsButton"
-                    Layout.fillWidth: true
-                    text: qsTr("Keybindings…")
-                    onClicked: root.editorMode = "keybindings"
+                        Item { Layout.fillHeight: true; Layout.preferredHeight: 12 }
+                    }
                 }
             }
             // }}}
 
-            ToolSeparator { Layout.fillHeight: true }
+            Rectangle { // vertical rail separator
+                Layout.preferredWidth: 1
+                Layout.fillHeight: true
+                color: root.hairline
+            }
 
             // {{{ Right content pane
-            // A plain Item (not a ScrollView): it hosts three mutually-exclusive, visible-toggled
-            // editors, and its Layout.fillWidth cleanly claims the row's remaining width. A ScrollView
-            // here would size itself to its (multiple) children and collapse the pane.
-            Item {
-                id: rightPane
+            ColumnLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                clip: true
+                Layout.margins: 20
+                spacing: 14
 
-                // Profile editor (scrollable — the field list is long).
-                ScrollView {
-                    anchors.fill: parent
-                    visible: root.editorMode === "profile"
-                    clip: true
-                    contentWidth: availableWidth
-                    ColumnLayout {
-                        width: rightPane.width - 24
-                        spacing: 12
-
+                // Page header band.
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    visible: root.editorMode !== ""
+                    spacing: 2
                     Label {
-                        text: (root.controller && root.controller.editingProfile.length > 0)
-                              ? qsTr("Profile: %1").arg(root.controller.editingProfile)
-                              : qsTr("New profile")
-                        font.pointSize: 14
-                        font.bold: true
+                        text: root.headerTitle
+                        font.pointSize: 16
+                        font.weight: Font.DemiBold
+                        color: sys.windowText
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
                     }
                     Label {
-                        objectName: "readOnlyBanner"
-                        visible: root.controller && root.controller.editingReadOnly
-                        text: qsTr("This profile is defined in contour.yml and is read-only here. "
-                                   + "Use \"Save As\" to create an editable copy.")
+                        text: root.headerSubtitle
+                        visible: text.length > 0
+                        color: root.subtleText
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
-                        color: palette.mid
                     }
-
-                    Repeater {
-                        model: root.controller ? root.controller.profileFields : []
-                        delegate: SettingRow {
-                            required property var modelData
-                            Layout.fillWidth: true
-                            fieldKey: modelData.key
-                            label: modelData.label
-                            help: modelData.help
-                            type: modelData.type
-                            value: modelData.value
-                            options: modelData.options
-                            editable: root.controller && !root.controller.editingReadOnly
-                            onEdited: (key, value) => root.controller.setProfileField(key, value)
-                        }
-                    }
-
-                    // Color-scheme selection (with dark/light distinction).
-                    Label { text: qsTr("Color scheme"); font.bold: true; Layout.topMargin: 8 }
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 8
-                        Label { text: qsTr("Mode") }
-                        ComboBox {
-                            id: schemeModeCombo
-                            objectName: "schemeModeCombo"
-                            enabled: root.controller && !root.controller.editingReadOnly
-                            model: [qsTr("Single"), qsTr("Light / Dark")]
-                            currentIndex: (root.controller && root.controller.colorSchemeMode === "dual") ? 1 : 0
-                            onActivated: if (root.controller)
-                                             root.controller.setColorSchemeMode(currentIndex === 1 ? "dual" : "simple")
-                        }
-                    }
-                    RowLayout {
-                        Layout.fillWidth: true
-                        visible: root.controller && root.controller.colorSchemeMode === "simple"
-                        spacing: 8
-                        Label { text: qsTr("Scheme") }
-                        ComboBox {
-                            objectName: "simpleSchemeCombo"
-                            Layout.preferredWidth: 220
-                            enabled: root.controller && !root.controller.editingReadOnly
-                            model: root.schemeNameList
-                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorScheme) : -1
-                            onActivated: if (root.controller) root.controller.setColorScheme(currentText)
-                        }
-                    }
-                    GridLayout {
-                        Layout.fillWidth: true
-                        visible: root.controller && root.controller.colorSchemeMode === "dual"
-                        columns: 2
-                        columnSpacing: 8
-                        rowSpacing: 6
-                        Label { text: qsTr("Light") }
-                        ComboBox {
-                            objectName: "lightSchemeCombo"
-                            Layout.preferredWidth: 220
-                            enabled: root.controller && !root.controller.editingReadOnly
-                            model: root.schemeNameList
-                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeLight) : -1
-                            onActivated: if (root.controller) root.controller.setColorSchemeLight(currentText)
-                        }
-                        Label { text: qsTr("Dark") }
-                        ComboBox {
-                            objectName: "darkSchemeCombo"
-                            Layout.preferredWidth: 220
-                            enabled: root.controller && !root.controller.editingReadOnly
-                            model: root.schemeNameList
-                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeDark) : -1
-                            onActivated: if (root.controller) root.controller.setColorSchemeDark(currentText)
-                        }
-                    }
-
-                    // Save bar.
-                    RowLayout {
-                        Layout.fillWidth: true
-                        Layout.topMargin: 12
-                        spacing: 8
-                        Button {
-                            objectName: "saveProfileButton"
-                            text: qsTr("Save")
-                            enabled: root.controller && !root.controller.locked
-                                     && !root.controller.editingReadOnly
-                                     && root.controller.editingProfile.length > 0
-                            onClicked: root.controller.saveProfile()
-                        }
-                        TextField {
-                            id: saveAsField
-                            objectName: "saveAsField"
-                            Layout.preferredWidth: 180
-                            placeholderText: qsTr("New profile name")
-                            selectByMouse: true
-                        }
-                        Button {
-                            objectName: "saveProfileAsButton"
-                            text: qsTr("Save As")
-                            enabled: root.controller && !root.controller.locked
-                                     && saveAsField.text.trim().length > 0
-                            onClicked: {
-                                if (root.controller.saveProfileAs(saveAsField.text.trim()))
-                                    saveAsField.clear()
-                            }
-                        }
-                        Item { Layout.fillWidth: true }
-                        Button {
-                            objectName: "deleteProfileButton"
-                            text: qsTr("Delete")
-                            enabled: root.controller && !root.controller.locked
-                                     && !root.controller.editingReadOnly
-                                     && root.controller.editingProfile.length > 0
-                            onClicked: root.controller.deleteProfile(root.controller.editingProfile)
-                        }
-                    }
-                    } // ColumnLayout (profile editor)
-                } // ScrollView
-
-                // Color-scheme editor.
-                ColorSchemeEditor {
-                    width: parent.width
-                    visible: root.editorMode === "scheme"
-                    controller: root.controller
                 }
 
-                // Global (application-scope) settings, editable — written to settings.yml as overrides.
-                ScrollView {
-                    anchors.fill: parent
-                    visible: root.editorMode === "globals"
+                // The editors: mutually exclusive, visible-toggled, each anchored to fill this pane.
+                Item {
+                    id: rightPane
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
                     clip: true
-                    contentWidth: availableWidth
+
+                    // {{{ Profile editor
                     ColumnLayout {
-                        width: rightPane.width - 24
+                        anchors.fill: parent
+                        visible: root.editorMode === "profile"
                         spacing: 12
-                        Label { text: qsTr("Global settings"); font.pointSize: 14; font.bold: true }
-                        Label {
-                            text: qsTr("These override contour.yml application-wide, saved to settings.yml.")
-                            opacity: 0.7
+
+                        Rectangle {
+                            objectName: "readOnlyBanner"
+                            visible: root.controller && root.controller.editingReadOnly
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: readOnlyLabel.implicitHeight + 20
+                            radius: 8
+                            color: Qt.rgba(sys.highlight.r, sys.highlight.g, sys.highlight.b, 0.10)
+                            border.width: 1
+                            border.color: Qt.rgba(sys.highlight.r, sys.highlight.g, sys.highlight.b, 0.35)
+                            Label {
+                                id: readOnlyLabel
+                                anchors.fill: parent
+                                anchors.margins: 10
+                                text: qsTr("🔒 This profile is defined in contour.yml and is read-only here. "
+                                           + "Use \"Save As\" to create an editable copy.")
+                                wrapMode: Text.WordWrap
+                                verticalAlignment: Text.AlignVCenter
+                                color: sys.windowText
+                            }
                         }
-                        Repeater {
-                            model: root.controller ? root.controller.globalFields : []
-                            delegate: RowLayout {
-                                required property var modelData
-                                Layout.fillWidth: true
-                                spacing: 8
-                                SettingRow {
+
+                        ScrollView {
+                            id: profileScroll
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            contentWidth: availableWidth
+                            clip: true
+
+                            ColumnLayout {
+                                width: profileScroll.availableWidth
+                                spacing: 10
+
+                                Repeater {
+                                    model: root.controller ? root.controller.profileFields : []
+                                    delegate: SettingRow {
+                                        required property var modelData
+                                        Layout.fillWidth: true
+                                        fieldKey: modelData.key
+                                        label: modelData.label
+                                        help: modelData.help
+                                        type: modelData.type
+                                        value: modelData.value
+                                        options: modelData.options
+                                        editable: root.controller && !root.controller.editingReadOnly
+                                        onEdited: (key, value) => root.controller.setProfileField(key, value)
+                                    }
+                                }
+
+                                // Color-scheme selection group (with dark/light distinction).
+                                Rectangle {
                                     Layout.fillWidth: true
-                                    fieldKey: modelData.key
-                                    label: modelData.label
-                                    help: modelData.help
-                                    type: modelData.type
-                                    value: modelData.value
-                                    editable: root.controller && !root.controller.locked
-                                    onEdited: (key, value) => root.controller.setGlobalField(key, value)
+                                    Layout.preferredHeight: schemeGroup.implicitHeight + 28
+                                    radius: 8
+                                    color: sys.base
+                                    border.width: 1
+                                    border.color: root.hairline
+
+                                    ColumnLayout {
+                                        id: schemeGroup
+                                        anchors.fill: parent
+                                        anchors.margins: 14
+                                        spacing: 8
+
+                                        Label {
+                                            text: qsTr("Color scheme")
+                                            font.weight: Font.DemiBold
+                                            color: sys.windowText
+                                        }
+                                        RowLayout {
+                                            Layout.fillWidth: true
+                                            spacing: 8
+                                            Label { text: qsTr("Mode"); color: root.subtleText }
+                                            ComboBox {
+                                                id: schemeModeCombo
+                                                objectName: "schemeModeCombo"
+                                                enabled: root.controller && !root.controller.editingReadOnly
+                                                model: [qsTr("Single"), qsTr("Light / Dark")]
+                                                currentIndex: (root.controller && root.controller.colorSchemeMode === "dual") ? 1 : 0
+                                                onActivated: if (root.controller)
+                                                                 root.controller.setColorSchemeMode(currentIndex === 1 ? "dual" : "simple")
+                                            }
+                                        }
+                                        RowLayout {
+                                            Layout.fillWidth: true
+                                            visible: root.controller && root.controller.colorSchemeMode === "simple"
+                                            spacing: 8
+                                            Label { text: qsTr("Scheme"); color: root.subtleText }
+                                            ComboBox {
+                                                objectName: "simpleSchemeCombo"
+                                                Layout.preferredWidth: 220
+                                                enabled: root.controller && !root.controller.editingReadOnly
+                                                model: root.schemeNameList
+                                                currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorScheme) : -1
+                                                onActivated: if (root.controller) root.controller.setColorScheme(currentText)
+                                            }
+                                        }
+                                        GridLayout {
+                                            Layout.fillWidth: true
+                                            visible: root.controller && root.controller.colorSchemeMode === "dual"
+                                            columns: 2
+                                            columnSpacing: 8
+                                            rowSpacing: 6
+                                            Label { text: qsTr("Light"); color: root.subtleText }
+                                            ComboBox {
+                                                objectName: "lightSchemeCombo"
+                                                Layout.preferredWidth: 220
+                                                enabled: root.controller && !root.controller.editingReadOnly
+                                                model: root.schemeNameList
+                                                currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeLight) : -1
+                                                onActivated: if (root.controller) root.controller.setColorSchemeLight(currentText)
+                                            }
+                                            Label { text: qsTr("Dark"); color: root.subtleText }
+                                            ComboBox {
+                                                objectName: "darkSchemeCombo"
+                                                Layout.preferredWidth: 220
+                                                enabled: root.controller && !root.controller.editingReadOnly
+                                                model: root.schemeNameList
+                                                currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeDark) : -1
+                                                onActivated: if (root.controller) root.controller.setColorSchemeDark(currentText)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Pinned action bar.
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: actionRow.implicitHeight + 20
+                            radius: 8
+                            color: sys.base
+                            border.width: 1
+                            border.color: root.hairline
+
+                            RowLayout {
+                                id: actionRow
+                                anchors.fill: parent
+                                anchors.leftMargin: 12
+                                anchors.rightMargin: 12
+                                spacing: 8
+                                Button {
+                                    objectName: "saveProfileButton"
+                                    text: qsTr("Save")
+                                    highlighted: true
+                                    enabled: root.controller && !root.controller.locked
+                                             && !root.controller.editingReadOnly
+                                             && root.controller.editingProfile.length > 0
+                                    onClicked: root.controller.saveProfile()
+                                }
+                                ToolSeparator {}
+                                TextField {
+                                    id: saveAsField
+                                    objectName: "saveAsField"
+                                    Layout.preferredWidth: 180
+                                    placeholderText: qsTr("New profile name")
+                                    selectByMouse: true
                                 }
                                 Button {
-                                    text: qsTr("Reset")
-                                    visible: modelData.overridden
+                                    objectName: "saveProfileAsButton"
+                                    text: qsTr("Save As")
                                     enabled: root.controller && !root.controller.locked
-                                    onClicked: root.controller.resetGlobalField(modelData.key)
+                                             && saveAsField.text.trim().length > 0
+                                    onClicked: {
+                                        if (root.controller.saveProfileAs(saveAsField.text.trim()))
+                                            saveAsField.clear()
+                                    }
+                                }
+                                Item { Layout.fillWidth: true }
+                                Button {
+                                    objectName: "deleteProfileButton"
+                                    text: qsTr("Delete")
+                                    enabled: root.controller && !root.controller.locked
+                                             && !root.controller.editingReadOnly
+                                             && root.controller.editingProfile.length > 0
+                                    onClicked: root.controller.deleteProfile(root.controller.editingProfile)
                                 }
                             }
                         }
                     }
-                }
+                    // }}}
 
-                // Keybindings (read-only viewer).
-                ColumnLayout {
-                    anchors.fill: parent
-                    visible: root.editorMode === "keybindings"
-                    spacing: 8
-                    Label { text: qsTr("Keybindings"); font.pointSize: 14; font.bold: true }
-                    Label {
-                        text: qsTr("Key bindings are configured in contour.yml (read-only here).")
-                        opacity: 0.7
+                    // Color-scheme editor.
+                    ColorSchemeEditor {
+                        anchors.fill: parent
+                        visible: root.editorMode === "scheme"
+                        controller: root.controller
                     }
-                    ListView {
-                        objectName: "keybindingsList"
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
+
+                    // {{{ Global settings
+                    ScrollView {
+                        id: globalsScroll
+                        anchors.fill: parent
+                        visible: root.editorMode === "globals"
+                        contentWidth: availableWidth
                         clip: true
-                        model: root.controller ? root.controller.keybindings : []
-                        delegate: RowLayout {
-                            required property var modelData
-                            width: ListView.view.width
-                            spacing: 12
-                            Label {
-                                text: modelData.trigger
-                                Layout.preferredWidth: 200
-                                font.family: "monospace"
-                                elide: Text.ElideRight
+
+                        ColumnLayout {
+                            width: globalsScroll.availableWidth
+                            spacing: 10
+                            Repeater {
+                                model: root.controller ? root.controller.globalFields : []
+                                delegate: RowLayout {
+                                    required property var modelData
+                                    Layout.fillWidth: true
+                                    spacing: 8
+                                    SettingRow {
+                                        Layout.fillWidth: true
+                                        fieldKey: modelData.key
+                                        label: modelData.label
+                                        help: modelData.help
+                                        type: modelData.type
+                                        value: modelData.value
+                                        editable: root.controller && !root.controller.locked
+                                        onEdited: (key, value) => root.controller.setGlobalField(key, value)
+                                    }
+                                    Button {
+                                        text: qsTr("Reset")
+                                        visible: modelData.overridden
+                                        enabled: root.controller && !root.controller.locked
+                                        onClicked: root.controller.resetGlobalField(modelData.key)
+                                    }
+                                }
                             }
-                            Label { text: modelData.action; Layout.fillWidth: true; elide: Text.ElideRight }
-                            Label { text: modelData.mode; opacity: 0.6; Layout.preferredWidth: 90 }
                         }
                     }
-                }
+                    // }}}
 
-                // Empty state.
-                Label {
-                    visible: root.editorMode === ""
-                    text: qsTr("Select a profile or color scheme on the left, or create a new one.")
-                    opacity: 0.7
+                    // {{{ Keybindings (read-only viewer)
+                    Rectangle {
+                        anchors.fill: parent
+                        visible: root.editorMode === "keybindings"
+                        radius: 8
+                        color: sys.base
+                        border.width: 1
+                        border.color: root.hairline
+                        clip: true
+
+                        ListView {
+                            objectName: "keybindingsList"
+                            anchors.fill: parent
+                            anchors.margins: 6
+                            clip: true
+                            model: root.controller ? root.controller.keybindings : []
+                            ScrollBar.vertical: ScrollBar {}
+                            delegate: Item {
+                                required property var modelData
+                                width: ListView.view.width
+                                height: 34
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: 10
+                                    anchors.rightMargin: 10
+                                    spacing: 12
+                                    Label {
+                                        text: modelData.trigger
+                                        Layout.preferredWidth: 200
+                                        font.family: "monospace"
+                                        color: sys.windowText
+                                        elide: Text.ElideRight
+                                    }
+                                    Label {
+                                        text: modelData.action
+                                        Layout.fillWidth: true
+                                        color: sys.windowText
+                                        elide: Text.ElideRight
+                                    }
+                                    Label {
+                                        text: modelData.mode
+                                        color: root.subtleText
+                                        Layout.preferredWidth: 90
+                                    }
+                                }
+                                Rectangle {
+                                    anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                                    height: 1
+                                    color: root.hairline
+                                    opacity: 0.5
+                                }
+                            }
+                        }
+                    }
+                    // }}}
+
+                    // {{{ Empty state
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        visible: root.editorMode === ""
+                        spacing: 10
+                        Label {
+                            text: "⚙"
+                            font.pointSize: 42
+                            opacity: 0.35
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                        Label {
+                            text: qsTr("Select a profile or color scheme on the left,\nor create a new one.")
+                            horizontalAlignment: Text.AlignHCenter
+                            color: root.subtleText
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                    }
+                    // }}}
                 }
             }
             // }}}

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -1,0 +1,326 @@
+// vim:syntax=qml
+// The in-app settings page, shown in the content area in place of the terminal when the
+// WindowController's settingsActive flag is set (see main.qml). It binds entirely to a
+// SettingsController (the editable bridge over the configuration) and a WindowController (to close the
+// page). It never edits contour.yml: it creates/edits GUI-owned side files, and shows contour.yml /
+// builtin entities read-only.
+//
+// Layout (Windows-Terminal style): a left navigation column (default-profile selector, the profile
+// list, the color-scheme list) and a right content pane that edits the selected profile or scheme.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+    id: root
+
+    // The SettingsController and the owning WindowController. Both null-guarded throughout: the
+    // controllers are torn down before the QML tree on window close, and bindings re-evaluate once
+    // against null during teardown (an unguarded access would raise a TypeError that fails the tests).
+    property var controller: null
+    property var windowController: null
+
+    // Which editor the right pane shows: "profile", "scheme", or "" (nothing selected yet).
+    property string editorMode: ""
+
+    color: palette.window
+
+    readonly property var profileNameList: {
+        var out = []
+        if (controller)
+            for (var i = 0; i < controller.profiles.length; ++i)
+                out.push(controller.profiles[i].name)
+        return out
+    }
+    readonly property var schemeNameList: {
+        var out = []
+        if (controller)
+            for (var i = 0; i < controller.colorSchemes.length; ++i)
+                out.push(controller.colorSchemes[i].name)
+        return out
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 12
+
+        // {{{ Header
+        RowLayout {
+            Layout.fillWidth: true
+            Label {
+                text: qsTr("Settings")
+                font.pointSize: 18
+                font.bold: true
+                Layout.fillWidth: true
+            }
+            Label {
+                objectName: "lockedBadge"
+                visible: root.controller && root.controller.locked
+                text: qsTr("read-only (gui_config_locked)")
+                color: palette.mid
+                verticalAlignment: Text.AlignVCenter
+            }
+            Button {
+                objectName: "closeSettingsButton"
+                text: qsTr("Close")
+                onClicked: if (root.windowController) root.windowController.closeSettings()
+            }
+        }
+        // }}}
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 16
+
+            // {{{ Left navigation
+            ColumnLayout {
+                Layout.preferredWidth: 260
+                Layout.fillHeight: true
+                spacing: 8
+
+                Label { text: qsTr("Default profile"); font.bold: true }
+                ComboBox {
+                    id: defaultProfileCombo
+                    objectName: "defaultProfileCombo"
+                    Layout.fillWidth: true
+                    model: root.profileNameList
+                    enabled: root.controller && !root.controller.locked
+                    currentIndex: root.controller ? root.profileNameList.indexOf(root.controller.defaultProfile) : -1
+                    onActivated: if (root.controller) root.controller.setDefaultProfile(currentText)
+                }
+
+                Label { text: qsTr("Profiles"); font.bold: true; Layout.topMargin: 8 }
+                Frame {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    padding: 2
+                    ListView {
+                        id: profileList
+                        objectName: "profileList"
+                        anchors.fill: parent
+                        clip: true
+                        model: root.controller ? root.controller.profiles : []
+                        delegate: ItemDelegate {
+                            required property var modelData
+                            width: ListView.view.width
+                            text: modelData.name + (modelData.isDefault ? "  ★" : "")
+                                  + (modelData.origin === "side" ? "" : "  🔒")
+                            onClicked: {
+                                if (!root.controller) return
+                                root.controller.editProfile(modelData.name)
+                                root.editorMode = "profile"
+                            }
+                        }
+                    }
+                }
+                Button {
+                    objectName: "newProfileButton"
+                    Layout.fillWidth: true
+                    text: qsTr("New profile…")
+                    enabled: root.controller && !root.controller.locked
+                    onClicked: {
+                        root.controller.newProfile(root.controller.defaultProfile)
+                        root.editorMode = "profile"
+                    }
+                }
+
+                Label { text: qsTr("Color schemes"); font.bold: true; Layout.topMargin: 8 }
+                Frame {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 120
+                    padding: 2
+                    ListView {
+                        id: schemeList
+                        objectName: "schemeList"
+                        anchors.fill: parent
+                        clip: true
+                        model: root.controller ? root.controller.colorSchemes : []
+                        delegate: ItemDelegate {
+                            required property var modelData
+                            width: ListView.view.width
+                            text: modelData.name + (modelData.editable ? "" : "  🔒")
+                            onClicked: {
+                                if (!root.controller) return
+                                root.controller.editColorScheme(modelData.name)
+                                root.editorMode = "scheme"
+                            }
+                        }
+                    }
+                }
+                Button {
+                    objectName: "newSchemeButton"
+                    Layout.fillWidth: true
+                    text: qsTr("New color scheme…")
+                    enabled: root.controller && !root.controller.locked
+                    onClicked: {
+                        root.controller.newColorScheme("")
+                        root.editorMode = "scheme"
+                    }
+                }
+            }
+            // }}}
+
+            ToolSeparator { Layout.fillHeight: true }
+
+            // {{{ Right content pane
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+
+                // Profile editor.
+                ColumnLayout {
+                    width: parent.width
+                    visible: root.editorMode === "profile"
+                    spacing: 12
+
+                    Label {
+                        text: (root.controller && root.controller.editingProfile.length > 0)
+                              ? qsTr("Profile: %1").arg(root.controller.editingProfile)
+                              : qsTr("New profile")
+                        font.pointSize: 14
+                        font.bold: true
+                    }
+                    Label {
+                        objectName: "readOnlyBanner"
+                        visible: root.controller && root.controller.editingReadOnly
+                        text: qsTr("This profile is defined in contour.yml and is read-only here. "
+                                   + "Use \"Save As\" to create an editable copy.")
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        color: palette.mid
+                    }
+
+                    Repeater {
+                        model: root.controller ? root.controller.profileFields : []
+                        delegate: SettingRow {
+                            required property var modelData
+                            Layout.fillWidth: true
+                            fieldKey: modelData.key
+                            label: modelData.label
+                            help: modelData.help
+                            type: modelData.type
+                            value: modelData.value
+                            editable: root.controller && !root.controller.editingReadOnly
+                            onEdited: (key, value) => root.controller.setProfileField(key, value)
+                        }
+                    }
+
+                    // Color-scheme selection (with dark/light distinction).
+                    Label { text: qsTr("Color scheme"); font.bold: true; Layout.topMargin: 8 }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        Label { text: qsTr("Mode") }
+                        ComboBox {
+                            id: schemeModeCombo
+                            objectName: "schemeModeCombo"
+                            enabled: root.controller && !root.controller.editingReadOnly
+                            model: [qsTr("Single"), qsTr("Light / Dark")]
+                            currentIndex: (root.controller && root.controller.colorSchemeMode === "dual") ? 1 : 0
+                            onActivated: if (root.controller)
+                                             root.controller.setColorSchemeMode(currentIndex === 1 ? "dual" : "simple")
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        visible: root.controller && root.controller.colorSchemeMode === "simple"
+                        spacing: 8
+                        Label { text: qsTr("Scheme") }
+                        ComboBox {
+                            objectName: "simpleSchemeCombo"
+                            Layout.preferredWidth: 220
+                            enabled: root.controller && !root.controller.editingReadOnly
+                            model: root.schemeNameList
+                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorScheme) : -1
+                            onActivated: if (root.controller) root.controller.setColorScheme(currentText)
+                        }
+                    }
+                    GridLayout {
+                        Layout.fillWidth: true
+                        visible: root.controller && root.controller.colorSchemeMode === "dual"
+                        columns: 2
+                        columnSpacing: 8
+                        rowSpacing: 6
+                        Label { text: qsTr("Light") }
+                        ComboBox {
+                            objectName: "lightSchemeCombo"
+                            Layout.preferredWidth: 220
+                            enabled: root.controller && !root.controller.editingReadOnly
+                            model: root.schemeNameList
+                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeLight) : -1
+                            onActivated: if (root.controller) root.controller.setColorSchemeLight(currentText)
+                        }
+                        Label { text: qsTr("Dark") }
+                        ComboBox {
+                            objectName: "darkSchemeCombo"
+                            Layout.preferredWidth: 220
+                            enabled: root.controller && !root.controller.editingReadOnly
+                            model: root.schemeNameList
+                            currentIndex: root.controller ? root.schemeNameList.indexOf(root.controller.colorSchemeDark) : -1
+                            onActivated: if (root.controller) root.controller.setColorSchemeDark(currentText)
+                        }
+                    }
+
+                    // Save bar.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 12
+                        spacing: 8
+                        Button {
+                            objectName: "saveProfileButton"
+                            text: qsTr("Save")
+                            enabled: root.controller && !root.controller.locked
+                                     && !root.controller.editingReadOnly
+                                     && root.controller.editingProfile.length > 0
+                            onClicked: root.controller.saveProfile()
+                        }
+                        TextField {
+                            id: saveAsField
+                            objectName: "saveAsField"
+                            Layout.preferredWidth: 180
+                            placeholderText: qsTr("New profile name")
+                            selectByMouse: true
+                        }
+                        Button {
+                            objectName: "saveProfileAsButton"
+                            text: qsTr("Save As")
+                            enabled: root.controller && !root.controller.locked
+                                     && saveAsField.text.trim().length > 0
+                            onClicked: {
+                                if (root.controller.saveProfileAs(saveAsField.text.trim()))
+                                    saveAsField.clear()
+                            }
+                        }
+                        Item { Layout.fillWidth: true }
+                        Button {
+                            objectName: "deleteProfileButton"
+                            text: qsTr("Delete")
+                            enabled: root.controller && !root.controller.locked
+                                     && !root.controller.editingReadOnly
+                                     && root.controller.editingProfile.length > 0
+                            onClicked: root.controller.deleteProfile(root.controller.editingProfile)
+                        }
+                    }
+                }
+
+                // Color-scheme editor.
+                ColorSchemeEditor {
+                    width: parent.width
+                    visible: root.editorMode === "scheme"
+                    controller: root.controller
+                }
+
+                // Empty state.
+                Label {
+                    visible: root.editorMode === ""
+                    text: qsTr("Select a profile or color scheme on the left, or create a new one.")
+                    opacity: 0.7
+                }
+            }
+            // }}}
+        }
+    }
+}

--- a/src/contour/ui/TabStrip.qml
+++ b/src/contour/ui/TabStrip.qml
@@ -1,8 +1,10 @@
 // vim:syntax=qml
-// The horizontal tab strip plus the new-tab ("+") button.
+// The horizontal tab strip plus the new-tab split button ("+" and a "▾" profile dropdown).
 //
-// The model is the TerminalSessionManager (exposed to QML as `terminalSessions`), whose rows are
-// the tabs and whose roles (title, accentColor, isActive, paneCount) drive each TabItem delegate.
+// The model is this window's WindowController (passed in as `controller`), whose rows are the tabs and
+// whose roles (title, accentColor, isActive, paneCount) drive each TabItem delegate. Alongside the tabs
+// the strip hosts a Qt-layer settings "tab" (shown while the settings page is open) and the new-tab
+// dropdown (NewTabMenu) — neither is a row of the tab model.
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -139,6 +141,67 @@ Row {
         }
     }
 
+    // The settings "tab": shown in the strip while the settings page is open (settingsActive), reading
+    // and behaving like a tab — highlighted as the active view, with a close button that leaves settings.
+    // It is a Qt-layer affordance (vtmux untouched), so it is a pinned item here rather than a model row.
+    Item {
+        id: settingsTab
+        objectName: "settingsTab"
+        height: root.height
+        // `=== true` coerces a missing/undefined property (a lightweight mock controller in the offscreen
+        // tests) to a real bool, so the binding never assigns undefined.
+        visible: root.controller !== null && root.controller.settingsActive === true
+        width: visible ? settingsTabRow.implicitWidth + 20 : 0
+
+        SystemPalette {
+            id: settingsTabPalette
+            colorGroup: SystemPalette.Active
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            // It exists only while active, so it always wears the active (OS highlight) fill.
+            color: settingsTabPalette.highlight
+        }
+
+        Row {
+            id: settingsTabRow
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 10
+            spacing: 6
+
+            Label {
+                text: qsTr("⚙ Settings")
+                color: settingsTabPalette.highlightedText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+            ToolButton {
+                id: settingsTabClose
+                objectName: "settingsTabClose"
+                width: 20
+                height: 20
+                anchors.verticalCenter: parent.verticalCenter
+                focusPolicy: Qt.NoFocus
+                onClicked: if (root.controller) root.controller.closeSettings()
+                contentItem: Label {
+                    text: "✕"
+                    color: settingsTabPalette.highlightedText
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+                background: Rectangle {
+                    radius: 3
+                    color: settingsTabClose.hovered
+                           ? Qt.rgba(settingsTabPalette.highlightedText.r,
+                                     settingsTabPalette.highlightedText.g,
+                                     settingsTabPalette.highlightedText.b, 0.25)
+                           : "transparent"
+                }
+            }
+        }
+    }
+
     ToolButton {
         id: newTabButton
         height: root.height
@@ -157,29 +220,29 @@ Row {
         }
     }
 
-    // The settings "tab": a pinned gear affordance that toggles the settings page in the content area.
-    // It reads as a tab (it sits in the strip) but is managed by the WindowController, not vtmux, so the
-    // Qt-free core stays untouched. Highlighted while the settings page is showing.
+    // The new-tab profile dropdown: the "▾" beside "+". Opens NewTabMenu — one entry per configured
+    // profile (open a new tab with it) plus a "Settings" entry — the Windows-Terminal split-button idiom.
     ToolButton {
-        id: settingsButton
-        objectName: "settingsButton"
+        id: newTabMenuButton
+        objectName: "newTabMenuButton"
         height: root.height
-        text: "⚙" // gear
-        font.pointSize: 12
+        text: "▾"
+        font.pointSize: 10
         focusPolicy: Qt.NoFocus
         ToolTip.visible: hovered
-        ToolTip.text: qsTr("Settings")
-        onClicked: if (root.controller) root.controller.toggleSettings()
+        ToolTip.text: qsTr("New tab with profile…")
+        onClicked: newTabMenu.popup(newTabMenuButton, 0, newTabMenuButton.height)
         background: Rectangle {
-            // `=== true` coerces a missing/undefined property (e.g. a lightweight mock controller in the
-            // offscreen tests) to a real bool, so the binding never assigns `undefined` to `active`.
-            readonly property bool active: root.controller !== null && root.controller.settingsActive === true
-            color: (settingsButton.hovered || active)
-                   ? Qt.rgba(settingsButton.palette.highlight.r,
-                             settingsButton.palette.highlight.g,
-                             settingsButton.palette.highlight.b,
-                             active ? 0.4 : 0.25)
-                   : "transparent"
+            color: newTabMenuButton.hovered ? Qt.rgba(newTabMenuButton.palette.highlight.r,
+                                                      newTabMenuButton.palette.highlight.g,
+                                                      newTabMenuButton.palette.highlight.b,
+                                                      0.25)
+                                            : "transparent"
+        }
+
+        NewTabMenu {
+            id: newTabMenu
+            controller: root.controller
         }
     }
 }

--- a/src/contour/ui/TabStrip.qml
+++ b/src/contour/ui/TabStrip.qml
@@ -156,4 +156,30 @@ Row {
                                         : "transparent"
         }
     }
+
+    // The settings "tab": a pinned gear affordance that toggles the settings page in the content area.
+    // It reads as a tab (it sits in the strip) but is managed by the WindowController, not vtmux, so the
+    // Qt-free core stays untouched. Highlighted while the settings page is showing.
+    ToolButton {
+        id: settingsButton
+        objectName: "settingsButton"
+        height: root.height
+        text: "⚙" // gear
+        font.pointSize: 12
+        focusPolicy: Qt.NoFocus
+        ToolTip.visible: hovered
+        ToolTip.text: qsTr("Settings")
+        onClicked: if (root.controller) root.controller.toggleSettings()
+        background: Rectangle {
+            // `=== true` coerces a missing/undefined property (e.g. a lightweight mock controller in the
+            // offscreen tests) to a real bool, so the binding never assigns `undefined` to `active`.
+            readonly property bool active: root.controller !== null && root.controller.settingsActive === true
+            color: (settingsButton.hovered || active)
+                   ? Qt.rgba(settingsButton.palette.highlight.r,
+                             settingsButton.palette.highlight.g,
+                             settingsButton.palette.highlight.b,
+                             active ? 0.4 : 0.25)
+                   : "transparent"
+        }
+    }
 }

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -141,12 +141,30 @@ ApplicationWindow
         anchors.left: parent.left
         anchors.right: parent.right
 
+        // The terminal content. Kept ACTIVE (so the pane tree and its PTYs keep running) even while the
+        // settings page is shown, just hidden — flipping back is instant and nothing is torn down.
         Loader {
             id: paneContentLoader
             anchors.fill: parent
             active: appWindow.win !== null && appWindow.win.activeTabRootPane !== null
+            // `=== true` coerces a missing/undefined property (lightweight mock `win` in tests) to a bool.
+            visible: !(appWindow.win !== null && appWindow.win.settingsActive === true)
             sourceComponent: PaneNode {
                 node: appWindow.win ? appWindow.win.activeTabRootPane : null
+            }
+        }
+
+        // The in-app settings page, shown in place of the terminal when the WindowController's
+        // settingsActive flag is set (the tab-strip gear, or the OpenSettings action). A peer of the
+        // pane-tree Loader, honoring the "single renderer" architecture — settings is not a pane.
+        Loader {
+            id: settingsPageLoader
+            anchors.fill: parent
+            active: appWindow.win !== null && appWindow.win.settingsActive === true
+            visible: active
+            sourceComponent: SettingsPage {
+                controller: appWindow.win ? appWindow.win.settingsController : null
+                windowController: appWindow.win
             }
         }
     }

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -155,7 +155,7 @@ ApplicationWindow
         }
 
         // The in-app settings page, shown in place of the terminal when the WindowController's
-        // settingsActive flag is set (the tab-strip gear, or the OpenSettings action). A peer of the
+        // settingsActive flag is set (the tab-strip gear, or the OpenConfiguration action). A peer of the
         // pane-tree Loader, honoring the "single renderer" architecture — settings is not a pane.
         Loader {
             id: settingsPageLoader


### PR DESCRIPTION
Today Contour is configured only by hand-editing `~/.config/contour/contour.yml`; the only in-app affordance shells out to an external editor. This branch adds a rich in-app settings experience, inspired by Windows Terminal, that never takes ownership of the user's hand-maintained `contour.yml` — the GUI writes only its own side files, merged back over `contour.yml` at load (the same pattern the existing `layouts.yml` merge already uses).

## Changes

- **In-app settings page**, shown as a tab in the content area: edit profiles, colour schemes (including a dark/light pair), global settings, and a read-only keybindings viewer. Edits happen on a clone with explicit Save / Save As, and take effect immediately via a live config reload.
- **Side-file ownership model.** The GUI writes `profiles/<name>.yml`, `colorschemes/<name>.yml` and a GUI-owned `settings.yml`; `contour.yml` and built-in entities are shown read-only, and a `gui_config_locked` key can make the whole page read-only. Serialization is single-sourced by reflecting over the same config members and doc templates the loader uses, so a new config field surfaces in the GUI and its writer automatically.
- **Windows-Terminal look**: a grouped left navigation rail with accent "pill" selection, elevated setting cards, a swatch-grid colour-scheme editor, and a page header band — all theme-aware (live light/dark).
- **Manage entries in the list**: the default profile is chosen with a home icon (click another row's home to move it); entries are renamed inline (double-click the name, or the right-click menu) and deleted via a red hover-trashcan behind a confirmation dialog.
- **Tab strip**: the settings page opens as a first-class tab, and the "+" new-tab button gains a "▾" dropdown listing every profile (open a new tab with it) plus a Settings entry — replacing the standalone gear button.
- **`OpenConfiguration` opens the GUI dialog by default**; an opt-in `in_editor: true` binding parameter restores the historical "open the config file in an external editor" behaviour.
- **Fix**: `Ctrl+Shift+<punctuation>` shortcuts (e.g. `Ctrl+Shift+,`) never fired, because Qt delivers a Shift+punctuation chord as the shifted keysym (`,` arrives as `<`); a char binding now retries under the un-shifted base codepoint so such shortcuts match as written.

All new I/O and the C++↔QML bridge land behind dependency-injection seams with unit tests; the QML surface is covered offscreen. `vtmux` and the render/pane path are untouched — the settings view is a peer of the pane-tree loader.