### PR TITLE
Fix memory-safety and rendering defects in the image texture path

### DIFF
--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -83,8 +83,8 @@ enum class ScrollBarPosition : uint8_t
 /// decides how large a sixel an application draws into a given area.
 enum class PixelReporting : uint8_t
 {
-    Logical, //!< Report logical pixels: what every other terminal reports (default).
-    Device,  //!< Report device pixels: images land 1:1 on the display's own pixels.
+    Logical, //!< Report logical pixels: what every other terminal reports.
+    Device,  //!< Report device pixels: images land 1:1 on the display's own pixels (default).
 };
 
 /// Where the GUI tab strip (tab bar) is placed within the window.

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -1519,7 +1519,7 @@ constexpr StringLiteral PixelReportingWeb {
     "\n"
     "Applications derive the cell size by dividing a reported extent by the grid and size image\n"
     "canvases from it, so on a scaled display this decides how large an image an application draws\n"
-    "into a given area. Valid values (ignore-case):\n"
+    "into a given area.\n"
     "\n"
     "A report is only usable if that division is exact, and Contour's cell is the font's advance in\n"
     "**device** pixels — at a fractional scale it has no exact logical counterpart (17 / 1.75 =\n"

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2705,8 +2705,14 @@ void TerminalSession::updateImageCanvasCeiling()
         return;
 
     auto const screenSize = _display->window()->screen()->size();
-    auto const ceiling =
+    auto const devicePixels =
         geometry::availableDevicePixels(screenSize.width(), screenSize.height(), _display->contentScale());
+
+    // In the unit every other pixel report uses: XTSMGRAPHICS answers this ceiling alongside a canvas
+    // size the application reads in reported pixels, and it sizes an image against both. Leaving the
+    // ceiling in device pixels on a scaled display would let it through an image the reported grid has
+    // no room for -- one that then overflows the page and scrolls the screen instead of fitting it.
+    auto const ceiling = geometry::reportedPixels(devicePixels, _display->reportedPixelScale());
 
     auto const _ = std::scoped_lock { _terminal };
     _terminal.setImageCanvasCeiling(ceiling);

--- a/src/contour/WindowGeometry.h
+++ b/src/contour/WindowGeometry.h
@@ -276,6 +276,27 @@ namespace detail
              .height = vtbackend::Height::cast_from(std::max(0, height)) };
 }
 
+/// A device-pixel extent expressed in the unit reported to applications.
+///
+/// For extents that are not a page of cells -- the image-canvas ceiling, above all. Every pixel figure an
+/// application is told must be in one unit, or it cannot compare them: a ceiling left in device pixels
+/// while the window reports logical tells the application it may draw an image twice the size of the
+/// screen it is on. FLOORED for the same reason reportedCellSize() is: a report of available space is an
+/// availability, and rounding one up promises space that is not there.
+/// @param devicePx Extent in device pixels.
+/// @param scale    Device pixels per reported pixel to divide out; 1.0 reports device pixels as-is.
+/// @return The extent to report.
+[[nodiscard]] constexpr vtbackend::ImageSize reportedPixels(vtbackend::ImageSize devicePx,
+                                                            double scale) noexcept
+{
+    if (!(scale > 0.0))
+        return devicePx; // a degenerate scale reports what the renderer uses, rather than nothing
+    return { .width =
+                 vtbackend::Width::cast_from(detail::floorUnscaled(unbox<double>(devicePx.width), scale)),
+             .height =
+                 vtbackend::Height::cast_from(detail::floorUnscaled(unbox<double>(devicePx.height), scale)) };
+}
+
 /// Fits a grid into a device-pixel area: page = clamp(pageSizeForPixels(...)), margin placement computed
 /// against the CLAMPED page so the renderer and the terminal can never disagree (below-minimum windows
 /// previously computed margins for a page the terminal then silently enlarged).

--- a/src/contour/display/RhiRenderer.cpp
+++ b/src/contour/display/RhiRenderer.cpp
@@ -784,6 +784,23 @@ void RhiRenderer::recordImagePass(std::vector<ImageQuadBatch> const& batches)
         if (batch.buffer.empty())
             continue;
 
+        if (!batch.texture)
+        {
+            // A run of gap fills: the rect pipeline's geometry, but recorded HERE so it composites in
+            // issue order with the quads around it rather than with the background.
+            auto const firstRectVertex =
+                static_cast<quint32>(_frameRectVertices.size() / rhilayout::RectVertexFloats);
+            _frameRectVertices.reserve(_frameRectVertices.size() + batch.buffer.size());
+            _frameRectVertices.insert(_frameRectVertices.end(), batch.buffer.begin(), batch.buffer.end());
+            _frameDrawItems.push_back(FrameDrawItem {
+                .pass = FramePass::Rect,
+                .firstVertex = firstRectVertex,
+                .vertexCount = static_cast<quint32>(batch.buffer.size() / rhilayout::RectVertexFloats),
+                .scissor = _innerScissor,
+            });
+            continue;
+        }
+
         // Images ride the text pass's vertex buffer: identical layout, so the only thing that makes
         // this a separate draw is which texture binding 1 names.
         auto const firstVertex =
@@ -795,7 +812,7 @@ void RhiRenderer::recordImagePass(std::vector<ImageQuadBatch> const& batches)
             .firstVertex = firstVertex,
             .vertexCount = static_cast<quint32>(batch.buffer.size() / rhilayout::TextVertexFloats),
             .scissor = _innerScissor,
-            .imageTexture = batch.texture,
+            .imageTexture = *batch.texture,
         });
     }
 }
@@ -1063,30 +1080,60 @@ void RhiRenderer::executeUploadTile(QRhiResourceUpdateBatch& updates, atlas::Upl
                           QRhiTextureUploadDescription(QRhiTextureUploadEntry(0, 0, desc)));
 }
 
+namespace
+{
+    /// Appends one solid-colour rectangle in the rect pipeline's vertex layout.
+    /// @param out    buffer to append the six vertices to.
+    /// @param ix     left, in item pixels.
+    /// @param iy     top, in item pixels.
+    /// @param width  rectangle width.
+    /// @param height rectangle height.
+    /// @param color  fill colour.
+    void appendRectVertices(
+        std::vector<float>& out, int ix, int iy, Width width, Height height, RGBAColor color)
+    {
+        auto const x = static_cast<float>(ix);
+        auto const y = static_cast<float>(iy);
+        auto const z = ZAxisDepths::BackgroundSGR;
+        auto const r = unbox<float>(width);
+        auto const s = unbox<float>(height);
+        auto const [cr, cg, cb, ca] = atlas::normalize(color);
+
+        // clang-format off
+        float const vertices[6 * 7] = {
+            // first triangle
+            x,     y + s, z, cr, cg, cb, ca,
+            x,     y,     z, cr, cg, cb, ca,
+            x + r, y,     z, cr, cg, cb, ca,
+
+            // second triangle
+            x,     y + s, z, cr, cg, cb, ca,
+            x + r, y,     z, cr, cg, cb, ca,
+            x + r, y + s, z, cr, cg, cb, ca
+        };
+        // clang-format on
+
+        crispy::copy(vertices, back_inserter(out));
+    }
+} // namespace
+
 void RhiRenderer::renderRectangle(int ix, int iy, Width width, Height height, RGBAColor color)
 {
-    auto const x = static_cast<float>(ix);
-    auto const y = static_cast<float>(iy);
-    auto const z = ZAxisDepths::BackgroundSGR;
-    auto const r = unbox<float>(width);
-    auto const s = unbox<float>(height);
-    auto const [cr, cg, cb, ca] = atlas::normalize(color);
+    appendRectVertices(_rectBuffer, ix, iy, width, height, color);
+}
 
-    // clang-format off
-    float const vertices[6 * 7] = {
-        // first triangle
-        x,     y + s, z, cr, cg, cb, ca,
-        x,     y,     z, cr, cg, cb, ca,
-        x + r, y,     z, cr, cg, cb, ca,
+void RhiRenderer::renderImageGap(atlas::RenderImageGap param)
+{
+    // Into the image list rather than the rect buffer, keeping its place among the quads: the rect pass
+    // is recorded before the text one, so a fill issued there could never occlude the text an
+    // above-the-text image is meant to cover.
+    auto& batches =
+        param.aboveText ? _scheduledExecutions.imageQuadsAboveText : _scheduledExecutions.imageQuadsBelowText;
+    if (batches.empty() || batches.back().texture.has_value())
+        batches.emplace_back(ImageQuadBatch { .texture = std::nullopt, .buffer = {} });
 
-        // second triangle
-        x,     y + s, z, cr, cg, cb, ca,
-        x + r, y,     z, cr, cg, cb, ca,
-        x + r, y + s, z, cr, cg, cb, ca
-    };
-    // clang-format on
-
-    crispy::copy(vertices, back_inserter(_rectBuffer));
+    appendRectVertices(
+        batches.back().buffer, param.x, param.y, param.size.width, param.size.height, param.color);
 }
 
 void RhiRenderer::setScissorRect(int x, int y, int width, int height)

--- a/src/contour/display/RhiRenderer.cpp
+++ b/src/contour/display/RhiRenderer.cpp
@@ -709,8 +709,7 @@ void RhiRenderer::executeCreateImageTexture(QRhiResourceUpdateBatch& updates,
     }
 
     auto const pixelSize = QSize(unbox<int>(param.size.width), unbox<int>(param.size.height));
-    auto resources =
-        ImageTextureResources { .texture = {}, .swapchain = {}, .offscreen = {}, .size = param.size };
+    auto resources = ImageTextureResources { .texture = {}, .swapchain = {}, .offscreen = {} };
 
     resources.texture.reset(_rhi->newTexture(QRhiTexture::RGBA8, pixelSize, 1, {}));
     if (!resources.texture->create())

--- a/src/contour/display/RhiRenderer.cpp
+++ b/src/contour/display/RhiRenderer.cpp
@@ -517,6 +517,11 @@ void RhiRenderer::destroyImageTexture(atlas::DestroyImageTexture param)
     _scheduledExecutions.imageDestroys.emplace_back(param);
 }
 
+std::vector<atlas::ImageTextureId> RhiRenderer::takeFailedImageTextures()
+{
+    return std::exchange(_failedImageTextures, {});
+}
+
 vtrasterizer::atlas::ImageTextureBackend& RhiRenderer::imageScheduler()
 {
     return *this;
@@ -698,7 +703,10 @@ void RhiRenderer::executeCreateImageTexture(QRhiResourceUpdateBatch& updates,
                                             atlas::CreateImageTexture& param)
 {
     if (_rhi == nullptr)
+    {
+        _failedImageTextures.push_back(param.id);
         return;
+    }
 
     auto const pixelSize = QSize(unbox<int>(param.size.width), unbox<int>(param.size.height));
     auto resources =
@@ -708,6 +716,7 @@ void RhiRenderer::executeCreateImageTexture(QRhiResourceUpdateBatch& updates,
     if (!resources.texture->create())
     {
         errorLog()("Failed to create RHI image texture of size {}.", param.size);
+        _failedImageTextures.push_back(param.id);
         return;
     }
 

--- a/src/contour/display/RhiRenderer.h
+++ b/src/contour/display/RhiRenderer.h
@@ -156,6 +156,7 @@ class RhiRenderer final:
     void createImageTexture(vtrasterizer::atlas::CreateImageTexture param) override;
     void destroyImageTexture(vtrasterizer::atlas::DestroyImageTexture param) override;
     void renderImageQuad(vtrasterizer::atlas::RenderImageQuad param) override;
+    [[nodiscard]] std::vector<vtrasterizer::atlas::ImageTextureId> takeFailedImageTextures() override;
     vtrasterizer::atlas::ImageTextureBackend& imageScheduler() override;
 
     // RenderTarget implementation
@@ -586,6 +587,9 @@ class RhiRenderer final:
         vtbackend::ImageSize size;
     };
     std::unordered_map<uint32_t, ImageTextureResources> _imageTextures;
+
+    /// Ids whose queued creation failed, awaiting collection by takeFailedImageTextures().
+    std::vector<vtrasterizer::atlas::ImageTextureId> _failedImageTextures;
 
     std::vector<float> _frameRectVertices;      ///< Accumulated rect-pass vertices for the current frame.
     std::vector<float> _frameTextVertices;      ///< Accumulated text-pass vertices for the current frame.

--- a/src/contour/display/RhiRenderer.h
+++ b/src/contour/display/RhiRenderer.h
@@ -156,6 +156,7 @@ class RhiRenderer final:
     void createImageTexture(vtrasterizer::atlas::CreateImageTexture param) override;
     void destroyImageTexture(vtrasterizer::atlas::DestroyImageTexture param) override;
     void renderImageQuad(vtrasterizer::atlas::RenderImageQuad param) override;
+    void renderImageGap(vtrasterizer::atlas::RenderImageGap param) override;
     [[nodiscard]] std::vector<vtrasterizer::atlas::ImageTextureId> takeFailedImageTextures() override;
     vtrasterizer::atlas::ImageTextureBackend& imageScheduler() override;
 
@@ -412,9 +413,15 @@ class RhiRenderer final:
     ///
     /// A run rather than a quad, because a full-screen image is thousands of quads that all sample
     /// the same texture: one draw item per run instead of one per cell.
+    /// One run of image geometry, in issue order within its side of the text.
+    ///
+    /// Either a run of quads sampling @c texture, or -- when @c texture is unset -- a run of solid gap
+    /// fills drawn with the rect pipeline. Both live in one ordered list because both composite by draw
+    /// order alone (every vertex sits at the same depth), so a gap fill can only occlude what precedes
+    /// it if it keeps its place among the quads.
     struct ImageQuadBatch
     {
-        vtrasterizer::atlas::ImageTextureId texture {};
+        std::optional<vtrasterizer::atlas::ImageTextureId> texture;
         std::vector<float> buffer;
     };
 

--- a/src/contour/display/RhiRenderer.h
+++ b/src/contour/display/RhiRenderer.h
@@ -591,7 +591,6 @@ class RhiRenderer final:
         QRhiResourcePtr<QRhiTexture> texture;
         ImageShaderResources swapchain; ///< Bound when drawing into the swapchain.
         ImageShaderResources offscreen; ///< Bound when replaying into the screenshot target.
-        vtbackend::ImageSize size;
     };
     std::unordered_map<uint32_t, ImageTextureResources> _imageTextures;
 

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -1431,9 +1431,15 @@ vtbackend::ImageSize TerminalDisplay::reportedPixelSize(vtbackend::PageSize tota
     // Logical stays available for comparing against such a terminal at an equal canvas size. It is exact
     // only where the scale divides both cell axes evenly (e.g. 1.0, or 20x40 at 2.0), and letterboxes by
     // the floor error otherwise.
-    auto const scale =
-        _session->profile().pixelReporting.value() == config::PixelReporting::Device ? 1.0 : contentScale();
-    return geometry::reportedPixelsForPage(totalPageSize, _renderer->publishedCellSize(), scale);
+    return geometry::reportedPixelsForPage(
+        totalPageSize, _renderer->publishedCellSize(), reportedPixelScale());
+}
+
+double TerminalDisplay::reportedPixelScale() const
+{
+    assert(_session);
+    return _session->profile().pixelReporting.value() == config::PixelReporting::Device ? 1.0
+                                                                                        : contentScale();
 }
 
 vtbackend::ImageSize TerminalDisplay::cellSize() const

--- a/src/contour/display/TerminalDisplay.h
+++ b/src/contour/display/TerminalDisplay.h
@@ -203,6 +203,15 @@ class TerminalDisplay: public QQuickItem
     ///                      not the terminal's current one.
     [[nodiscard]] vtbackend::ImageSize reportedPixelSize(vtbackend::PageSize totalPageSize) const;
 
+    /// Device pixels per reported pixel: the divisor taking a device-pixel extent into the unit
+    /// `pixel_reporting` selects.
+    ///
+    /// The one place that decides that unit. Anything an application is told a pixel count in must pass
+    /// through here -- an extent left in device pixels while the rest reports logical is not a smaller
+    /// number, it is a number in a unit the application does not know it is reading.
+    /// @return 1.0 when reporting device pixels, the content scale when reporting logical ones.
+    [[nodiscard]] double reportedPixelScale() const;
+
     void resizeTerminalToDisplaySize();
 
     // (user requested) actions

--- a/src/vtbackend/GoodImageProtocol_test.cpp
+++ b/src/vtbackend/GoodImageProtocol_test.cpp
@@ -183,6 +183,48 @@ TEST_CASE("GoodImageProtocol.Oneshot.Render", "[GIP]")
     REQUIRE(fragment != nullptr);
 }
 
+TEST_CASE("GoodImageProtocol.Oneshot.RejectsBodyShorterThanGeometry", "[GIP]")
+{
+    // The renderer uploads the DECLARED geometry to the GPU and reads width * height * 4 bytes from the
+    // pixmap, so an image whose body does not fill its geometry is read off the end of the heap
+    // allocation. The upload path has always validated this; the oneshot path reached the very same
+    // Image without it.
+    auto mock = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    auto const shortBody = makeRGBA(2, 2, 0xFF, 0x00, 0x00, 0xFF); // 16 bytes...
+
+    // ...declared as a 64x64 RGBA image: 16 KB of pixels that were never sent.
+    mock.writeToScreen(gipOneshot("f=3,w=64,h=64,c=4,r=2", shortBody));
+
+    auto const& cell = mock.terminal.primaryScreen().at(LineOffset(0), ColumnOffset(0));
+    CHECK(cell.imageFragment() == nullptr); // nothing was placed, so nothing can be uploaded
+}
+
+TEST_CASE("GoodImageProtocol.Oneshot.RejectsBodyLongerThanGeometry", "[GIP]")
+{
+    // The other side of the same invariant: an over-long body means the sender and this terminal do not
+    // agree on the geometry, and guessing which of the two is right would draw garbage either way.
+    auto mock = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    auto const longBody = makeRGBA(8, 8, 0xFF, 0x00, 0x00, 0xFF);
+
+    mock.writeToScreen(gipOneshot("f=3,w=2,h=2,c=4,r=2", longBody));
+
+    auto const& cell = mock.terminal.primaryScreen().at(LineOffset(0), ColumnOffset(0));
+    CHECK(cell.imageFragment() == nullptr);
+}
+
+TEST_CASE("GoodImageProtocol.Oneshot.AcceptsRgbBodyAtThreeBytesPerPixel", "[GIP]")
+{
+    // The consistency check is per-format, not a hardcoded 4: GIP's `f=2` really is three bytes per
+    // pixel, and holding it to an RGBA stride would reject every valid RGB image.
+    auto mock = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    auto body = std::vector<uint8_t>(2 * 2 * 3, 0x7F);
+
+    mock.writeToScreen(gipOneshot("f=2,w=2,h=2,c=4,r=2", body));
+
+    auto const& cell = mock.terminal.primaryScreen().at(LineOffset(0), ColumnOffset(0));
+    CHECK(cell.imageFragment() != nullptr);
+}
+
 // ==================== Release Tests ====================
 
 TEST_CASE("GoodImageProtocol.Release.ByName", "[GIP]")

--- a/src/vtbackend/Image.h
+++ b/src/vtbackend/Image.h
@@ -30,6 +30,46 @@ enum class ImageFormat : uint8_t
     PNG,
 };
 
+/// Number of bytes each pixel occupies in a raw pixmap of the given format.
+///
+/// @param format Image format; must be a raw format (RGB or RGBA). Self-describing or unresolved
+///               formats (PNG, Auto) carry no fixed stride and yield 0.
+/// @return Bytes per pixel, or 0 if @p format is not a raw pixmap format.
+[[nodiscard]] constexpr uint32_t bytesPerPixel(ImageFormat format) noexcept
+{
+    switch (format)
+    {
+        case ImageFormat::RGB: return 3;
+        case ImageFormat::RGBA: return 4;
+        case ImageFormat::Auto:
+        case ImageFormat::PNG: break;
+    }
+    return 0;
+}
+
+/// Tests whether a raw pixmap is exactly as long as its declared geometry claims.
+///
+/// Every path that turns wire data into an Image must pass this before uploading: the renderer
+/// uploads the declared geometry to the GPU and reads `height * width * 4` bytes from the buffer,
+/// so a pixmap shorter than its geometry is read out of bounds.
+///
+/// @param format    Image format. PNG is self-describing and always passes; Auto must be resolved first.
+/// @param size      Declared image dimensions in pixels.
+/// @param dataSize  Length of the pixmap buffer, in bytes.
+/// @return true if the buffer matches @p size exactly (or @p format is self-describing).
+[[nodiscard]] constexpr bool isConsistentPixmap(ImageFormat format, ImageSize size, size_t dataSize) noexcept
+{
+    if (format == ImageFormat::PNG)
+        return true; // self-describing: the decoder validates it
+    if (format == ImageFormat::Auto)
+        return false; // must be resolved to a concrete format before it can be checked
+    if (*size.width <= 0 || *size.height <= 0)
+        return false;
+    auto const expected =
+        static_cast<size_t>(*size.width) * static_cast<size_t>(*size.height) * bytesPerPixel(format);
+    return dataSize == expected;
+}
+
 // clang-format off
 namespace detail { struct ImageId {}; }
 using ImageId = boxed::boxed<uint32_t, detail::ImageId>; // unique numerical image identifier

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -5299,15 +5299,8 @@ void Screen::handleGipUpload(Message message)
                             && (*resolvedFormat == ImageFormat::PNG || (*size.width > 0 && *size.height > 0));
 
     // Validate RGB/RGBA data size: body must equal width * height * bytes-per-pixel.
-    auto const validDataSize = [&]() -> bool {
-        if (!validImage || !resolvedFormat.has_value())
-            return false;
-        if (*resolvedFormat == ImageFormat::PNG)
-            return true; // PNG is self-describing
-        auto const bpp = (*resolvedFormat == ImageFormat::RGBA) ? 4u : 3u;
-        auto const expectedSize = static_cast<size_t>(*size.width) * *size.height * bpp;
-        return message.body().size() == expectedSize;
-    }();
+    auto const validDataSize = validImage && resolvedFormat.has_value()
+                               && isConsistentPixmap(*resolvedFormat, size, message.body().size());
 
     if (validName && validImage && validDataSize)
     {
@@ -5400,12 +5393,31 @@ std::optional<Image::Data> Screen::decodePng(std::span<uint8_t const> data, Imag
 {
     if (!_terminal->imageDecoder())
         return std::nullopt;
-    return _terminal->imageDecoder()(ImageFormat::PNG, data, size);
+    auto decoded = _terminal->imageDecoder()(ImageFormat::PNG, data, size);
+
+    // The decoder is an injected dependency, so its output is as untrusted as wire data: the renderer
+    // uploads `size` to the GPU verbatim and would read past a buffer that does not match it.
+    if (decoded.has_value() && !isConsistentPixmap(ImageFormat::RGBA, size, decoded->size()))
+    {
+        errorLog()(
+            "Rejecting decoded PNG: {} bytes do not match the decoded size {}.", decoded->size(), size);
+        return std::nullopt;
+    }
+    return decoded;
 }
 
 void Screen::uploadImage(string name, ImageFormat format, ImageSize imageSize, Image::Data&& pixmap)
 {
     assert(format != ImageFormat::Auto && "Auto must be resolved before upload");
+    if (!isConsistentPixmap(format, imageSize, pixmap.size()))
+    {
+        errorLog()("Rejecting image {}: {} pixmap of {} bytes does not match declared size {}.",
+                   name,
+                   format,
+                   pixmap.size(),
+                   imageSize);
+        return;
+    }
     if (format == ImageFormat::PNG)
     {
         auto decodedSize = imageSize;
@@ -5463,6 +5475,17 @@ bool Screen::renderImage(ImageFormat format,
     assert(format != ImageFormat::Auto && "Auto must be resolved before render");
     auto constexpr PixelOffset = PixelCoordinate {};
     auto constexpr PixelSize = ImageSize {};
+
+    // The renderer uploads the declared geometry to the GPU verbatim, reading width * height * 4 bytes
+    // from this buffer -- a pixmap that does not match its geometry would be read out of bounds.
+    if (!isConsistentPixmap(format, imageSize, pixmap.size()))
+    {
+        errorLog()("Rejecting image: {} pixmap of {} bytes does not match declared size {}.",
+                   format,
+                   pixmap.size(),
+                   imageSize);
+        return false;
+    }
 
     auto const topLeft = _cursor.position;
 

--- a/src/vtbackend/SixelParser.cpp
+++ b/src/vtbackend/SixelParser.cpp
@@ -168,6 +168,25 @@ namespace
     {
         return action == SixelParser::Action::Ignore || action == SixelParser::Action::Undefined;
     }
+
+    /// @return true if every state treats all ten digits identically.
+    ///
+    /// What licenses the digit-run fast path in parse(): it consults the table for the FIRST digit of a
+    /// run and then scans the rest by isDigit() alone, which is only sound while '0'..'9' share one cell
+    /// in every state. A table change that gave one digit its own transition would silently make that
+    /// run take the wrong branch, so it is asserted here rather than left as a comment.
+    consteval bool theHotRunsAreFoldable() noexcept
+    {
+        auto const table = SixelParser::Table::get();
+        return std::ranges::all_of(std::views::iota(size_t { 0 }, SixelParser::StateCount), [&](size_t s) {
+            return std::ranges::all_of(std::views::iota(uint8_t { '1' }, uint8_t { '9' + 1 }),
+                                       [&](uint8_t d) {
+                                           return table.transitions[s][d] == table.transitions[s]['0']
+                                                  && table.events[s][d] == table.events[s]['0'];
+                                       });
+        });
+    }
+    static_assert(theHotRunsAreFoldable(), "The digit-run fast path requires '0'..'9' to share a cell.");
 } // namespace
 
 void SixelParser::parse(char value)

--- a/src/vtbackend/SixelParser.cpp
+++ b/src/vtbackend/SixelParser.cpp
@@ -301,10 +301,15 @@ void SixelParser::submitColor()
                 // Pz 	0 to 100 percent 	Saturation
                 //
                 // (Hue angle seems to be shifted by 120 deg in other Sixel implementations.)
-                auto const h = static_cast<double>(_params[2]) - 120.0;
+                //
+                // Saturated for the same reason the RGB branch above is: these parameters arrive off the
+                // wire unclamped, and hsl2rgb() of an out-of-range value converts a double far outside
+                // 0..255 to uint8_t, which is undefined. Each saturates at the top of the range the
+                // VT340 defines for it.
+                auto const h = static_cast<double>(std::min(_params[2], 360u)) - 120.0;
                 auto const hc = (h < 0 ? 360 + h : h) / 360.0;
-                auto const sc = static_cast<double>(_params[4]) / 100.0;
-                auto const ls = static_cast<double>(_params[3]) / 100.0;
+                auto const sc = static_cast<double>(std::min(_params[4], 100u)) / 100.0;
+                auto const ls = static_cast<double>(std::min(_params[3], 100u)) / 100.0;
                 auto const rgb = hsl2rgb(hc, sc, ls);
                 _events.setColor(index, rgb);
                 break;

--- a/src/vtbackend/SixelParser_test.cpp
+++ b/src/vtbackend/SixelParser_test.cpp
@@ -394,6 +394,27 @@ TEST_CASE("SixelParser.setAndUseColor", "[sixel]")
     }
 }
 
+TEST_CASE("SixelParser.saturates out-of-range HLS color parameters", "[sixel]")
+{
+    // These parameters come straight off the wire with no bound on their magnitude, and hsl2rgb() of an
+    // out-of-range value converts a double far outside 0..255 to uint8_t -- which is undefined, and
+    // aborts a sanitizer build on nothing worse than a garbled sixel. Each saturates at the top of the
+    // range the VT340 defines for it, exactly as the RGB parameters do.
+    auto constexpr DefaultColor = RGBAColor { 0, 0, 0, 0xFF };
+    auto ib = sixelImageBuilder(ImageSize { Width(1), Height(6) }, DefaultColor);
+    auto sp = SixelParser { ib };
+
+    // Hue, lightness and saturation each far beyond their range -- the digits alone overflow the
+    // parameter accumulator's 32 bits.
+    sp.parseFragment("#1;1;4000000000;4000000000;4000000000");
+    sp.parseFragment("#1~");
+    sp.done();
+
+    // Lightness saturates at 100%, which is white whatever the hue and saturation resolve to.
+    CHECK(ib.at(CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) })
+          == RGBAColor { 255, 255, 255, 255 });
+}
+
 TEST_CASE("SixelParser.rewind", "[sixel]")
 {
     auto constexpr PinColors = std::array<RGBAColor, 4> {

--- a/src/vtrasterizer/ImageRenderer.cpp
+++ b/src/vtrasterizer/ImageRenderer.cpp
@@ -32,10 +32,19 @@ void ImageRenderer::setRenderTarget(RenderTarget& renderTarget,
     clearCache();
 }
 
+void ImageRenderer::detachRenderTarget() noexcept
+{
+    // The textures belong to the render target and die with it, so every id naming one is worthless
+    // from here on. Forgetting them is what keeps a later discard from routing at a scheduler that is
+    // gone, and stops the budget being charged for textures that no longer exist.
+    _imageTextures.clear();
+    _residentBytes = 0;
+    Renderable::detachRenderTarget();
+}
+
 void ImageRenderer::setCellSize(ImageSize cellSize)
 {
     _cellSize = cellSize;
-    // TODO: recompute rasterized images slices here?
 }
 
 namespace
@@ -60,7 +69,8 @@ namespace
     }
 } // namespace
 
-atlas::ImageTextureId ImageRenderer::textureFor(vtbackend::RasterizedImage const& rasterizedImage)
+std::optional<atlas::ImageTextureId> ImageRenderer::textureFor(
+    vtbackend::RasterizedImage const& rasterizedImage)
 {
     // Keyed on the image, not on the rasterization: cell size and policies change where the image is
     // sampled, never what the texture holds.
@@ -72,20 +82,63 @@ atlas::ImageTextureId ImageRenderer::textureFor(vtbackend::RasterizedImage const
         return known->second.id;
     }
 
+    // The upload hands the backend this geometry and lets it read height * width * 4 bytes from the
+    // pixmap, so one that does not match would be read out of bounds. vtbackend rejects those where the
+    // data enters; this restates the guarantee where the memory is actually indexed.
+    if (!vtbackend::isConsistentPixmap(image.format(), image.size(), image.data().size()))
+    {
+        errorLog()("Refusing to upload image {}: {} pixmap of {} bytes does not match its size {}.",
+                   imageId,
+                   image.format(),
+                   image.data().size(),
+                   image.size());
+        return std::nullopt;
+    }
+
     auto const id = atlas::ImageTextureId { _nextImageTextureId++ };
     // Whatever the protocol sent, the texture is RGBA8 -- widenToRgba() below makes sure of it.
     auto const bytes = static_cast<size_t>(image.size().area()) * 4;
     _imageTextures.emplace(imageId,
                            ImageTextureEntry { .id = id, .bytes = bytes, .lastUsedFrame = _frameCounter });
     _residentBytes += bytes;
+
+    // An already-RGBA pixmap uploads straight out of the Image's own buffer, holding the image alive
+    // until the queued command executes. Copying it would cost a second full buffer (~33 MB for a 4K
+    // image) on the render thread, every time an image is first seen.
+    auto [pixels, owner] = [&]() -> std::pair<std::span<uint8_t const>, std::shared_ptr<void const>> {
+        if (image.format() != vtbackend::ImageFormat::RGB)
+            return { std::span<uint8_t const> { image.data() }, rasterizedImage.imagePointer() };
+        auto widened = std::make_shared<vtbackend::Image::Data const>(widenToRgba(image.data()));
+        return { std::span<uint8_t const> { *widened }, std::move(widened) };
+    }();
+
     imageScheduler().createImageTexture(atlas::CreateImageTexture {
         .id = id,
         .size = image.size(),
         .format = atlas::Format::RGBA,
-        .data = image.format() == vtbackend::ImageFormat::RGB ? widenToRgba(image.data()) : image.data(),
+        .data = pixels,
+        .owner = std::move(owner),
     });
     evictToBudget();
     return id;
+}
+
+void ImageRenderer::dropFailedTextures()
+{
+    if (!renderTargetAvailable())
+        return;
+
+    for (auto const failedId: imageScheduler().takeFailedImageTextures())
+    {
+        auto const entry = std::ranges::find_if(
+            _imageTextures, [failedId](auto const& kv) { return kv.second.id == failedId; });
+        if (entry == _imageTextures.end())
+            continue;
+        // The texture was never created, so it may not go on charging the budget -- and forgetting the
+        // entry is what lets the next sight of the image attempt the upload again.
+        _residentBytes -= entry->second.bytes;
+        _imageTextures.erase(entry);
+    }
 }
 
 void ImageRenderer::evictToBudget()
@@ -93,16 +146,16 @@ void ImageRenderer::evictToBudget()
     if (_residentBytes <= _textureBudgetBytes)
         return;
 
-    // Only what this frame did not draw may go; see the declaration.
-    auto candidates = std::vector<uint32_t> {};
+    // Only what this frame did not draw may go; see the declaration. Carrying the LRU key alongside the
+    // id keeps the sort from hashing its way back into the map on every comparison.
+    auto candidates = std::vector<std::pair<uint64_t, uint32_t>> {};
     for (auto const& [imageId, entry]: _imageTextures)
         if (entry.lastUsedFrame != _frameCounter)
-            candidates.push_back(imageId);
+            candidates.emplace_back(entry.lastUsedFrame, imageId);
 
-    std::ranges::sort(
-        candidates, {}, [this](uint32_t imageId) { return _imageTextures.at(imageId).lastUsedFrame; });
+    std::ranges::sort(candidates);
 
-    for (auto const imageId: candidates)
+    for (auto const& [lastUsedFrame, imageId]: candidates)
     {
         if (_residentBytes <= _textureBudgetBytes)
             break;
@@ -119,8 +172,12 @@ void ImageRenderer::renderImage(crispy::point pos, vtbackend::ImageFragment cons
     if (!placement.hasImage)
         return; // the cell lies wholly in the alignment gap
 
+    auto const texture = textureFor(rasterizedImage);
+    if (!texture)
+        return; // the image has no texture to sample and never will; drawing it is not possible
+
     auto const quad = atlas::RenderImageQuad {
-        .texture = textureFor(rasterizedImage),
+        .texture = *texture,
         .x = pos.x + placement.targetX,
         .y = pos.y + placement.targetY,
         .targetSize = placement.targetSize,
@@ -163,17 +220,25 @@ void ImageRenderer::beginFrame()
 {
     // Stamps what textureFor() touches from here on. That is what tells an image this frame draws --
     // whose quads already name its texture, so it may not be released -- from one merely resident.
+    // Advanced once per frame rather than once per pass: a second pass under a later stamp would offer
+    // up the images the first pass had already scheduled, and releasing one drops it from the frame it
+    // is visible in.
     ++_frameCounter;
 
+    dropFailedTextures();
+}
+
+void ImageRenderer::beginPass()
+{
     if (!SoftRequire(_pendingQuadsBelowText.empty()))
         _pendingQuadsBelowText.clear();
     if (!SoftRequire(_pendingQuadsAboveText.empty()))
         _pendingQuadsAboveText.clear();
 }
 
-void ImageRenderer::endFrame()
+void ImageRenderer::endPass()
 {
-    // Flush anything the text pass did not pick up (a frame with images but no text).
+    // Flush anything the text pass did not pick up (a pass with images but no text).
     flushQuads(_pendingQuadsBelowText);
     flushQuads(_pendingQuadsAboveText);
 }

--- a/src/vtrasterizer/ImageRenderer.cpp
+++ b/src/vtrasterizer/ImageRenderer.cpp
@@ -165,12 +165,62 @@ void ImageRenderer::evictToBudget()
     }
 }
 
+void ImageRenderer::fillGap(crispy::point pos,
+                            vtbackend::FragmentPlacement const& placement,
+                            vtbackend::RGBAColor color,
+                            bool aboveText)
+{
+    if (placement.hasImage && placement.coversCell)
+        return; // the image reaches every edge: there is no gap left to fill
+
+    auto const cellWidth = unbox<int>(_cellSize.width);
+    auto const cellHeight = unbox<int>(_cellSize.height);
+
+    auto const emit = [&](int x, int y, int width, int height) {
+        if (width <= 0 || height <= 0)
+            return;
+        imageScheduler().renderImageGap(
+            atlas::RenderImageGap { .x = pos.x + x,
+                                    .y = pos.y + y,
+                                    .size = vtbackend::ImageSize { vtbackend::Width::cast_from(width),
+                                                                   vtbackend::Height::cast_from(height) },
+                                    .color = color,
+                                    .aboveText = aboveText });
+    };
+
+    if (!placement.hasImage)
+    {
+        emit(0, 0, cellWidth, cellHeight); // wholly in the gap
+        return;
+    }
+
+    // The four bands around the covered rectangle. Each is skipped when empty, so an image meeting one
+    // edge of the cell costs only the bands it does not.
+    auto const coveredWidth = unbox<int>(placement.targetSize.width);
+    auto const coveredHeight = unbox<int>(placement.targetSize.height);
+    auto const coveredRight = placement.targetX + coveredWidth;
+    auto const coveredBottom = placement.targetY + coveredHeight;
+
+    emit(0, 0, cellWidth, placement.targetY);                                       // above
+    emit(0, coveredBottom, cellWidth, cellHeight - coveredBottom);                  // below
+    emit(0, placement.targetY, placement.targetX, coveredHeight);                   // left
+    emit(coveredRight, placement.targetY, cellWidth - coveredRight, coveredHeight); // right
+}
+
 void ImageRenderer::renderImage(crispy::point pos, vtbackend::ImageFragment const& fragment)
 {
     auto const& rasterizedImage = fragment.rasterizedImage();
     auto const placement = rasterizedImage.fragmentPlacement(fragment.offset(), _cellSize);
+    auto const aboveText = rasterizedImage.layer() != vtbackend::ImageLayer::Below;
+
+    // Whatever of the cell the image does not reach is the alignment gap, and the gap is painted --
+    // opaquely, in the background colour that was current when the image was placed. The CPU path this
+    // replaced got that for free: it built a CELL-SIZED tile and wrote the gap colour into every pixel
+    // outside the image, so the upload covered the whole cell either way.
+    fillGap(pos, placement, rasterizedImage.defaultColor(), aboveText);
+
     if (!placement.hasImage)
-        return; // the cell lies wholly in the alignment gap
+        return; // the cell lies wholly in the alignment gap: the fill above is all of it
 
     auto const texture = textureFor(rasterizedImage);
     if (!texture)

--- a/src/vtrasterizer/ImageRenderer.h
+++ b/src/vtrasterizer/ImageRenderer.h
@@ -10,6 +10,7 @@
 #include <crispy/point.h>
 #include <crispy/size.h>
 
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -49,6 +50,7 @@ class ImageRenderer: public Renderable, public TextRendererEvents
                   size_t textureBudgetBytes = DefaultTextureBudgetBytes);
 
     void setRenderTarget(RenderTarget& renderTarget, DirectMappingAllocator& directMappingAllocator) override;
+    void detachRenderTarget() noexcept override;
     void clearCache() override;
 
     /// Reconfigures the slicing properties of existing images.
@@ -62,15 +64,35 @@ class ImageRenderer: public Renderable, public TextRendererEvents
 
     void inspect(std::ostream& output) const override;
 
+    /// Opens a new frame: advances what the LRU stamps against, and drops the textures the backend
+    /// failed to create.
+    ///
+    /// Call once per frame, before its first pass. A frame may be drawn in several passes (smooth
+    /// scrolling draws the main display and the status line separately), and an image any of them drew
+    /// must outrank one merely resident -- its quads are already scheduled and name their texture, so
+    /// releasing it would drop it from the very frame it is visible in.
     void beginFrame();
-    void endFrame();
+
+    /// Opens one pass within the current frame.
+    void beginPass();
+
+    /// Closes one pass, flushing the quads it emitted.
+    void endPass();
 
     void onBeforeRenderingText() override;
     void onAfterRenderingText() override;
 
   private:
     /// The texture holding @p rasterizedImage's pixels, creating and uploading it on first sight.
-    atlas::ImageTextureId textureFor(vtbackend::RasterizedImage const& rasterizedImage);
+    ///
+    /// @return The texture's id, or nullopt when the image cannot be uploaded at all -- which is to say
+    ///         its pixmap does not match the geometry it declares. Such an image has nothing to sample
+    ///         and never will, so the caller must not draw it.
+    [[nodiscard]] std::optional<atlas::ImageTextureId> textureFor(
+        vtbackend::RasterizedImage const& rasterizedImage);
+
+    /// Forgets the textures the backend failed to create, freeing what they charged to the budget.
+    void dropFailedTextures();
 
     /// Hands @p quads to the backend and empties them.
     void flushQuads(std::vector<atlas::RenderImageQuad>& quads);

--- a/src/vtrasterizer/ImageRenderer.h
+++ b/src/vtrasterizer/ImageRenderer.h
@@ -94,6 +94,18 @@ class ImageRenderer: public Renderable, public TextRendererEvents
     /// Forgets the textures the backend failed to create, freeing what they charged to the budget.
     void dropFailedTextures();
 
+    /// Paints the part of a cell the image does not reach, in the image's gap colour.
+    ///
+    /// @param pos       the cell's top-left, in item pixels.
+    /// @param placement where the image lands within the cell.
+    /// @param color     the gap colour: the background colour current when the image was placed.
+    /// @param aboveText which side of the text the fill belongs on -- the image's own side, since the
+    ///                  gap is part of its composite.
+    void fillGap(crispy::point pos,
+                 vtbackend::FragmentPlacement const& placement,
+                 vtbackend::RGBAColor color,
+                 bool aboveText);
+
     /// Hands @p quads to the backend and empties them.
     void flushQuads(std::vector<atlas::RenderImageQuad>& quads);
 

--- a/src/vtrasterizer/ImageRenderer_test.cpp
+++ b/src/vtrasterizer/ImageRenderer_test.cpp
@@ -49,6 +49,7 @@ std::shared_ptr<RasterizedImage> makeImage(GridSize cellSpan,
 void renderRow(ImageRenderer& renderer, std::shared_ptr<RasterizedImage> const& image, unsigned cellCount)
 {
     renderer.beginFrame();
+    renderer.beginPass();
     for (auto const column: std::views::iota(0u, cellCount))
     {
         auto const fragment = ImageFragment {
@@ -58,7 +59,7 @@ void renderRow(ImageRenderer& renderer, std::shared_ptr<RasterizedImage> const& 
             crispy::point { .x = static_cast<int>(column * unbox<unsigned>(CellSize.width)), .y = 0 },
             fragment);
     }
-    renderer.endFrame();
+    renderer.endPass();
 }
 
 } // namespace
@@ -232,6 +233,7 @@ TEST_CASE("ImageRenderer.never evicts an image the current frame draws", "[image
     };
 
     imageRenderer.beginFrame();
+    imageRenderer.beginPass();
     for (auto const [index, image]: crispy::views::enumerate(images))
     {
         // Each image spans one cell, so the fragment names offset (0,0) WITHIN ITS OWN image; only
@@ -242,7 +244,7 @@ TEST_CASE("ImageRenderer.never evicts an image the current frame draws", "[image
         imageRenderer.renderImage(
             crispy::point { .x = static_cast<int>(index) * unbox<int>(CellSize.width), .y = 0 }, fragment);
     }
-    imageRenderer.endFrame();
+    imageRenderer.endPass();
 
     auto& backend = renderTarget.getMockImageBackend();
     CHECK(backend.createCommands.size() == 3);
@@ -273,6 +275,143 @@ TEST_CASE("ImageRenderer.re-uploads an evicted image when it is seen again", "[i
 
     renderRow(imageRenderer, first, 1);
     CHECK(backend.createCommands.size() == 3); // uploaded again rather than silently missing
+}
+
+TEST_CASE("ImageRenderer.refuses an image whose pixmap is shorter than its geometry", "[image][renderer]")
+{
+    // The upload hands the backend the DECLARED geometry and lets it read height * width * 4 bytes from
+    // the pixmap, so uploading one that does not match reads off the end of the heap allocation.
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto constexpr Span = GridSize { .lines = LineCount(1), .columns = ColumnCount(1) };
+    auto const declaredSize = ImageSize { Width(10), Height(20) };
+    auto shortData = Image::Data(16, 0x7F); // 16 bytes claiming to be 10*20*4 = 800
+    auto image = std::make_shared<Image>(
+        ImageId(1), ImageFormat::RGBA, std::move(shortData), declaredSize, [](auto) {});
+    auto const rasterized = std::make_shared<RasterizedImage>(std::move(image),
+                                                              ImageAlignment::TopStart,
+                                                              ImageResize::NoResize,
+                                                              RGBAColor { 0, 0, 0, 0xFF },
+                                                              Span,
+                                                              CellSize,
+                                                              ImageLayer::Replace);
+
+    renderRow(imageRenderer, rasterized, 1);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    CHECK(backend.createCommands.empty()); // nothing may reach the GPU
+    CHECK(backend.quadCommands.empty());   // and nothing names a texture that was never made
+}
+
+TEST_CASE("ImageRenderer.uploads an RGBA image without copying its pixels", "[image][renderer]")
+{
+    // A full-screen image is tens of megabytes; copying it to hand it over would spend that on the
+    // render thread every time an image is first seen.
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto const image = makeImage(GridSize { .lines = LineCount(1), .columns = ColumnCount(1) });
+    renderRow(imageRenderer, image, 1);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    REQUIRE(backend.createCommands.size() == 1);
+    // The command borrows the image's own buffer rather than a copy of it...
+    CHECK(backend.createCommands.front().data.data() == image->image().data().data());
+    // ...and holds it alive, so the borrow survives until the queued command executes.
+    CHECK(backend.createCommands.front().owner != nullptr);
+}
+
+TEST_CASE("ImageRenderer.forgets a texture the backend failed to create", "[image][renderer]")
+{
+    // The image is committed to the cache before the queued creation runs, so a failure that goes
+    // unreported leaves an entry naming a texture that does not exist: every later frame returns the
+    // cached id and draws nothing, and its bytes go on crowding out images that ARE on screen.
+    auto constexpr Span = GridSize { .lines = LineCount(1), .columns = ColumnCount(1) };
+    auto constexpr ImageBytes = size_t { 10 * 20 * 4 };
+
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize, ImageBytes }; // room for exactly one
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    auto const image = makeImage(Span, ImageLayer::Replace, ImageId(1));
+    renderRow(imageRenderer, image, 1);
+    REQUIRE(backend.createCommands.size() == 1);
+
+    // The backend could not create it (out of GPU memory, say).
+    backend.failedImageTextures.push_back(backend.createCommands.front().id);
+
+    renderRow(imageRenderer, image, 1);
+
+    // Seen again, it is uploaded again rather than drawn as a permanently blank rectangle.
+    CHECK(backend.createCommands.size() == 2);
+    // And its bytes were released, so a second image still fits the budget without evicting anything.
+    CHECK(backend.destroyCommands.empty());
+}
+
+TEST_CASE("ImageRenderer.does not evict what an earlier pass of the same frame drew", "[image][renderer]")
+{
+    // Smooth scrolling draws one frame in two passes (main display, then status line). The LRU stamp
+    // tells an image this frame drew from one merely resident, so a second pass under a later stamp
+    // would offer up the first pass's images -- whose quads are already scheduled and name their
+    // texture -- and releasing one drops it from the very frame it is visible in.
+    auto constexpr Span = GridSize { .lines = LineCount(1), .columns = ColumnCount(1) };
+    auto constexpr ImageBytes = size_t { 10 * 20 * 4 };
+
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize, ImageBytes }; // room for exactly one
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto const renderOnePass = [&](std::shared_ptr<RasterizedImage> const& image) {
+        imageRenderer.beginPass();
+        imageRenderer.renderImage(
+            crispy::point { .x = 0, .y = 0 },
+            ImageFragment { image, CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) } });
+        imageRenderer.endPass();
+    };
+
+    // One frame, two passes, a different image in each -- together they exceed the budget.
+    imageRenderer.beginFrame();
+    renderOnePass(makeImage(Span, ImageLayer::Replace, ImageId(1)));
+    renderOnePass(makeImage(Span, ImageLayer::Replace, ImageId(2)));
+
+    auto& backend = renderTarget.getMockImageBackend();
+    REQUIRE(backend.createCommands.size() == 2);
+    // The frame overshoots its budget rather than evicting an image it has already drawn.
+    CHECK(backend.destroyCommands.empty());
+}
+
+TEST_CASE("ImageRenderer.forgets its textures when the render target detaches", "[image][renderer]")
+{
+    // The textures belong to the render target and die with it, so holding entries that name them
+    // would charge the budget for textures that no longer exist and route later discards at a
+    // scheduler that is gone.
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto const image = makeImage(GridSize { .lines = LineCount(1), .columns = ColumnCount(1) });
+    renderRow(imageRenderer, image, 1);
+    REQUIRE(renderTarget.getMockImageBackend().createCommands.size() == 1);
+
+    imageRenderer.detachRenderTarget();
+
+    // A discard draining after the detach must not reach the departed scheduler.
+    imageRenderer.discardImage(ImageId(1));
+
+    // Re-attached, the image is uploaded to the new target rather than assumed resident on it.
+    auto secondTarget = MockRenderTarget {};
+    imageRenderer.setRenderTarget(secondTarget, directMappingAllocator);
+    renderRow(imageRenderer, image, 1);
+    CHECK(secondTarget.getMockImageBackend().createCommands.size() == 1);
 }
 
 TEST_CASE("ImageRenderer.clearCache releases the textures", "[image][renderer]")

--- a/src/vtrasterizer/ImageRenderer_test.cpp
+++ b/src/vtrasterizer/ImageRenderer_test.cpp
@@ -45,6 +45,33 @@ std::shared_ptr<RasterizedImage> makeImage(GridSize cellSpan,
                                              layer);
 }
 
+/// A rasterized image that does NOT fill the cells it spans, leaving an alignment gap.
+///
+/// Pinned to the top-left and never resized, so the remainder of the span is gap: with a 10x20 cell, a
+/// 10x10 image letterboxes the bottom half of its one cell, and a 10x20 image across two cells leaves
+/// the second wholly in the gap.
+/// @param imageSize the image's own pixel size.
+/// @param cellSpan the cells it is placed across.
+/// @param gapColor the colour the gap is painted in (the SGR background at placement time).
+/// @param layer which side of the text it composites on.
+std::shared_ptr<RasterizedImage> makeLetterboxedImage(ImageSize imageSize,
+                                                      GridSize cellSpan,
+                                                      RGBAColor gapColor,
+                                                      ImageLayer layer = ImageLayer::Replace)
+{
+    auto data = Image::Data(imageSize.area() * 4, 0x7F);
+    auto image =
+        std::make_shared<Image>(ImageId(1), ImageFormat::RGBA, std::move(data), imageSize, [](auto) {});
+
+    return std::make_shared<RasterizedImage>(std::move(image),
+                                             ImageAlignment::TopStart,
+                                             ImageResize::NoResize,
+                                             gapColor,
+                                             cellSpan,
+                                             CellSize,
+                                             layer);
+}
+
 /// Drives one frame's worth of cells through the renderer, left to right along a single line.
 void renderRow(ImageRenderer& renderer, std::shared_ptr<RasterizedImage> const& image, unsigned cellCount)
 {
@@ -275,6 +302,117 @@ TEST_CASE("ImageRenderer.re-uploads an evicted image when it is seen again", "[i
 
     renderRow(imageRenderer, first, 1);
     CHECK(backend.createCommands.size() == 3); // uploaded again rather than silently missing
+}
+
+TEST_CASE("ImageRenderer.paints the alignment gap in the image's gap colour", "[image][renderer]")
+{
+    // The CPU path this replaced uploaded a CELL-SIZED tile with the gap colour written into every
+    // pixel outside the image, so the gap was painted for free. Drawing only the covered rectangle
+    // dropped it, and the letterbox bars showed whatever happened to be underneath instead of the
+    // background colour that was current when the image was placed.
+    auto constexpr GapColor = RGBAColor { 0xFF, 0x00, 0x00, 0xFF };
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    // A 10x10 image in a 10x20 cell: the bottom half is gap.
+    auto const image = makeLetterboxedImage(ImageSize { Width(10), Height(10) },
+                                            GridSize { .lines = LineCount(1), .columns = ColumnCount(1) },
+                                            GapColor);
+    renderRow(imageRenderer, image, 1);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    REQUIRE(backend.quadCommands.size() == 1);
+    CHECK(backend.quadCommands.front().targetSize == ImageSize { Width(10), Height(10) });
+
+    REQUIRE(backend.gapCommands.size() == 1);
+    auto const& gap = backend.gapCommands.front();
+    CHECK(gap.x == 0);
+    CHECK(gap.y == 10); // directly below the image
+    CHECK(gap.size == ImageSize { Width(10), Height(10) });
+    CHECK(gap.color == GapColor);
+}
+
+TEST_CASE("ImageRenderer.fills a cell that lies wholly in the gap", "[image][renderer]")
+{
+    // Such a cell is part of the image's span and was painted gap-coloured edge to edge; returning
+    // early on "no image pixels here" left it blank.
+    auto constexpr GapColor = RGBAColor { 0x00, 0xFF, 0x00, 0xFF };
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    // A 10x20 image across two 10x20 cells: the first is covered, the second is all gap.
+    auto const image = makeLetterboxedImage(ImageSize { Width(10), Height(20) },
+                                            GridSize { .lines = LineCount(1), .columns = ColumnCount(2) },
+                                            GapColor);
+    renderRow(imageRenderer, image, 2);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    CHECK(backend.quadCommands.size() == 1); // only the covered cell samples the texture
+
+    REQUIRE(backend.gapCommands.size() == 1);
+    auto const& gap = backend.gapCommands.front();
+    CHECK(gap.x == 10); // the second cell...
+    CHECK(gap.y == 0);
+    CHECK(gap.size == CellSize); // ...filled edge to edge
+    CHECK(gap.color == GapColor);
+}
+
+TEST_CASE("ImageRenderer.composites the gap on the image's own side of the text", "[image][renderer]")
+{
+    // Every vertex sits at the same depth, so draw ORDER is the only thing that expresses z. An
+    // above-the-text image occluded the text out to the edge of its cells because the whole cell was
+    // painted; a fill issued through the background path composites before the text whatever order it
+    // was issued in, so the text would show through the letterbox.
+    auto constexpr GapColor = RGBAColor { 0x00, 0x00, 0xFF, 0xFF };
+    auto constexpr Span = GridSize { .lines = LineCount(1), .columns = ColumnCount(1) };
+    auto constexpr Letterboxed = ImageSize { Width(10), Height(10) };
+
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+
+    for (auto const layer: { ImageLayer::Replace, ImageLayer::Below })
+    {
+        INFO("layer " << static_cast<int>(layer));
+        auto renderTarget = MockRenderTarget {};
+        auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+        imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+        renderRow(imageRenderer, makeLetterboxedImage(Letterboxed, Span, GapColor, layer), 1);
+
+        auto& backend = renderTarget.getMockImageBackend();
+        REQUIRE(backend.gapCommands.size() == 1);
+        REQUIRE(backend.quadCommands.size() == 1);
+
+        // The gap rides the same side of the text as the image it belongs to.
+        CHECK(backend.gapCommands.front().aboveText == backend.quadCommands.front().aboveText);
+        CHECK(backend.quadCommands.front().aboveText == (layer != ImageLayer::Below));
+
+        // And it is issued BEFORE the quad, so the image is never painted over by its own gap.
+        REQUIRE(backend.drawOrder.size() == 2);
+        CHECK(std::holds_alternative<atlas::RenderImageGap>(backend.drawOrder[0]));
+        CHECK(std::holds_alternative<atlas::RenderImageQuad>(backend.drawOrder[1]));
+    }
+}
+
+TEST_CASE("ImageRenderer.paints no gap for an image that covers its cells", "[image][renderer]")
+{
+    // The common case by far, and it must cost nothing: every cell of an image drawn at its natural
+    // size reaches all four edges.
+    auto renderTarget = MockRenderTarget {};
+    auto directMappingAllocator = Renderable::DirectMappingAllocator { 0 };
+    auto imageRenderer = ImageRenderer { testGridMetrics, CellSize };
+    imageRenderer.setRenderTarget(renderTarget, directMappingAllocator);
+
+    auto constexpr CellCount = 4u;
+    auto const image = makeImage(GridSize { .lines = LineCount(1), .columns = ColumnCount(CellCount) });
+    renderRow(imageRenderer, image, CellCount);
+
+    auto& backend = renderTarget.getMockImageBackend();
+    REQUIRE(backend.quadCommands.size() == CellCount);
+    CHECK(backend.gapCommands.empty());
 }
 
 TEST_CASE("ImageRenderer.refuses an image whose pixmap is shorter than its geometry", "[image][renderer]")

--- a/src/vtrasterizer/ImageTextureBackend.h
+++ b/src/vtrasterizer/ImageTextureBackend.h
@@ -5,6 +5,9 @@
 
 #include <array>
 #include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
 
 namespace vtrasterizer::atlas
 {
@@ -27,7 +30,13 @@ struct CreateImageTexture
     ImageTextureId id;
     vtbackend::ImageSize size;
     Format format;
-    Buffer data;
+    /// The pixels to upload; exactly @c size worth of them. Borrowed, not owned: valid for as long as
+    /// @c owner is held, which is why the command carries the owner along with it.
+    std::span<uint8_t const> data;
+    /// Keeps the storage behind @c data alive until this queued command executes -- either the source
+    /// image, whose pixels upload straight out of its own buffer, or a widened copy of them. Uploading
+    /// a full-screen image would otherwise copy tens of megabytes on the render thread.
+    std::shared_ptr<void const> owner;
 };
 
 /// Command: release the texture behind @p id.
@@ -66,6 +75,9 @@ class ImageTextureBackend
     virtual ~ImageTextureBackend() = default;
 
     /// Creates a texture and uploads @p param's pixels into it.
+    ///
+    /// The command is queued, so a failure surfaces long after this returns; the caller learns about it
+    /// through @c takeFailedImageTextures().
     virtual void createImageTexture(CreateImageTexture param) = 0;
 
     /// Releases the texture. Ids of destroyed textures may be reused.
@@ -73,6 +85,14 @@ class ImageTextureBackend
 
     /// Queues one quad sampling an image texture.
     virtual void renderImageQuad(RenderImageQuad param) = 0;
+
+    /// Takes the ids whose creation failed since the last call, emptying the list.
+    ///
+    /// A texture the backend never created must not go on counting against the caller's budget, and
+    /// nothing else would ever tell it: the caller commits an image to its cache before the queued
+    /// creation runs, so without this it would hold a cache entry naming a texture that does not exist
+    /// and never retry the upload.
+    [[nodiscard]] virtual std::vector<ImageTextureId> takeFailedImageTextures() = 0;
 };
 
 } // namespace vtrasterizer::atlas

--- a/src/vtrasterizer/ImageTextureBackend.h
+++ b/src/vtrasterizer/ImageTextureBackend.h
@@ -60,6 +60,22 @@ struct RenderImageQuad
     bool aboveText = true;
 };
 
+/// Command: fill a rectangle with a solid colour, ordered among the image quads.
+///
+/// The alignment gap around an image belongs to the image's own composite, not to the cell background
+/// beneath it: an image drawn above the text used to occlude that text out to the edge of its cells,
+/// because the whole cell was painted. A fill issued through the background path could not do that -- it
+/// composites before the text, whichever order it was issued in.
+struct RenderImageGap
+{
+    int x {}; ///< target left, in item pixels
+    int y {}; ///< target top, in item pixels
+    vtbackend::ImageSize size;
+    vtbackend::RGBAColor color;
+    /// Which side of the text pass this fill belongs on; see RenderImageQuad::aboveText.
+    bool aboveText = true;
+};
+
 /// Draws whole images, as opposed to AtlasBackend's fixed-size tiles.
 ///
 /// This is deliberately a sibling of AtlasBackend rather than a growth of it. An image is not a
@@ -85,6 +101,9 @@ class ImageTextureBackend
 
     /// Queues one quad sampling an image texture.
     virtual void renderImageQuad(RenderImageQuad param) = 0;
+
+    /// Queues one solid fill, composited in issue order with the quads of the same side.
+    virtual void renderImageGap(RenderImageGap param) = 0;
 
     /// Takes the ids whose creation failed since the last call, emptying the list.
     ///

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -606,14 +606,18 @@ bool Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
 
     auto cursorOpt = optional<vtbackend::RenderCursor> { std::nullopt };
 
-    // Wraps a render pass: begins image/text frames, invokes the content callback, then ends both frames.
+    // One frame, however many passes it takes: the image renderer stamps its LRU against the frame, so
+    // opening it per pass would let a later pass evict what an earlier one already scheduled.
+    _imageRenderer.beginFrame();
+
+    // Wraps a render pass: begins image/text passes, invokes the content callback, then ends both.
     auto const renderPass = [&](bool withPressure, auto&& content) {
-        _imageRenderer.beginFrame();
+        _imageRenderer.beginPass();
         _textRenderer.beginFrame();
         _textRenderer.setPressure(withPressure);
         content();
         _textRenderer.endFrame();
-        _imageRenderer.endFrame();
+        _imageRenderer.endPass();
     };
 
     auto const primaryPressure = pressure && terminal.isPrimaryScreen();

--- a/src/vtrasterizer/RendererTestHelpers.h
+++ b/src/vtrasterizer/RendererTestHelpers.h
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <ranges>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace vtrasterizer
@@ -59,7 +60,21 @@ class MockImageTextureBackend: public vtrasterizer::atlas::ImageTextureBackend
     void renderImageQuad(vtrasterizer::atlas::RenderImageQuad param) override
     {
         quadCommands.emplace_back(param);
+        drawOrder.emplace_back(param);
     }
+
+    void renderImageGap(vtrasterizer::atlas::RenderImageGap param) override
+    {
+        gapCommands.emplace_back(param);
+        drawOrder.emplace_back(param);
+    }
+
+    std::vector<vtrasterizer::atlas::RenderImageGap> gapCommands;
+
+    /// Quads and gap fills as issued, interleaved -- what composites is the ORDER, so a test that only
+    /// counted them could not tell a gap drawn over the image from one drawn under it.
+    std::vector<std::variant<vtrasterizer::atlas::RenderImageQuad, vtrasterizer::atlas::RenderImageGap>>
+        drawOrder;
 
     /// Ids the next takeFailedImageTextures() call reports, standing in for a backend that could not
     /// create the texture (out of GPU memory, no RHI yet).

--- a/src/vtrasterizer/RendererTestHelpers.h
+++ b/src/vtrasterizer/RendererTestHelpers.h
@@ -60,6 +60,15 @@ class MockImageTextureBackend: public vtrasterizer::atlas::ImageTextureBackend
     {
         quadCommands.emplace_back(param);
     }
+
+    /// Ids the next takeFailedImageTextures() call reports, standing in for a backend that could not
+    /// create the texture (out of GPU memory, no RHI yet).
+    std::vector<vtrasterizer::atlas::ImageTextureId> failedImageTextures;
+
+    [[nodiscard]] std::vector<vtrasterizer::atlas::ImageTextureId> takeFailedImageTextures() override
+    {
+        return std::exchange(failedImageTextures, {});
+    }
 };
 
 /// A headless RenderTarget whose texture scheduler is a MockAtlasBackend.


### PR DESCRIPTION
Follow-up to #1999, which moved image rendering from CPU-sliced per-cell fragments to
whole-image GPU textures. That change was right, but the CPU path it replaced was quietly
providing two guarantees that were never anyone's stated job, so neither survived the
rewrite: `RasterizedImage::fragment()` bounds-checked every sample it read, and it filled
the alignment gap with the SGR background colour. Both were side effects of building a
cell-sized tile. Alongside those, the new texture lifecycle trusts a creation that may
never have happened, and the new `pixel_reporting` option left one report in the wrong
unit. None of this has shipped — #1999 is not in a release — so there is no changelog
entry.

## Changes

- **An image whose pixmap does not match its geometry is rejected.** The renderer uploads
  the *declared* geometry and lets the GPU read `width * height * 4` bytes out of the
  buffer. `handleGipUpload()` validated that; `handleGipOneshot()` reached the very same
  `Image` without it, so `!go f=3,w=4096,h=4096` with a 16-byte body read ~64 MB past the
  allocation. `isConsistentPixmap()` states the rule once and every path that turns data
  into an `Image` consults it — including `decodePng()`, whose decoder is injected and so
  no more trusted than the wire. `bytesPerPixel()` replaces the open-coded `RGBA ? 4 : 3`.

- **Out-of-range HLS sixel colour parameters saturate.** The RGB branch already did, and
  explains why: the parameters arrive unbounded. The HLS branch beside it fed them
  straight into `hsl2rgb()`, whose float-to-`uint8_t` conversions are undefined out of
  range — an abort under the sanitizer build on nothing worse than a garbled sixel.

- **The alignment gap is painted again.** Drawing only the covered rectangle left
  letterbox bars showing whatever lay underneath, and a cell wholly inside the gap blank.
  `FragmentPlacement::coversCell` was added for exactly this and never read; it is the
  early-out now. The fill cannot go through `renderRectangle()`: every vertex sits at the
  same depth, so draw order alone composites, and the rect pass is recorded before the
  text pass — an above-the-text image would have its own gap composited *under* the text
  it is meant to occlude. `renderImageGap()` therefore queues into the same ordered list
  as the quads.

- **A texture the backend never created is no longer trusted.** `textureFor()` commits an
  image to its cache and charges its bytes before the queued creation runs, so a failed
  create left an entry naming a texture that does not exist: every later frame drew
  nothing and the bytes went on evicting images that were on screen. Nothing could report
  that back, because it happens long after `createImageTexture()` returned —
  `takeFailedImageTextures()` is the missing return path. Relatedly, `detachRenderTarget()`
  now forgets the resident set, since those textures die with the target.

- **The image-canvas ceiling is reported in the configured unit.** `XTSMGRAPHICS`
  ReadLimit answered a device-pixel ceiling while every other report honours
  `pixel_reporting`, so under Logical on a 2x display an application was told it could
  draw 3840x2160 while every other number said 1920x1080. The two sides drifted because
  each open-coded the unit decision and needs opposite arithmetic to act on it, so the
  decision moves to `TerminalDisplay::reportedPixelScale()`.

- **Smaller fixes:** the LRU is stamped once per frame rather than once per pass (smooth
  scrolling draws two passes, and a per-pass stamp made pass 1's images look evictable to
  pass 2); an already-RGBA pixmap uploads from the image's own buffer instead of a full
  copy, carrying an owner so the borrow outlives the queued command; eviction sorts on the
  LRU key rather than hashing back into the map per comparison; and the `PixelReporting`
  enum no longer documents the opposite of the shipped default.