### PR TITLE
Add global theme option for GUI dark/light/system appearance

### DIFF
--- a/docs/configuration/advanced/misc.md
+++ b/docs/configuration/advanced/misc.md
@@ -64,8 +64,9 @@ The value is case-insensitive; an unrecognized value keeps the default (`system`
 
 !!! note
 
-    Forcing a GUI theme requires Qt 6.8 or newer. On older Qt builds the GUI always follows the
-    operating system's color scheme, as if `theme: system`.
+    Switching back from a forced `dark`/`light` theme to `system` restores the OS palette, but the
+    GUI chrome no longer tracks live OS light/dark switches until the terminal is restarted. Starting
+    up in `system` mode tracks live OS switches as usual.
 
 ```yml
 theme: system

--- a/docs/configuration/advanced/misc.md
+++ b/docs/configuration/advanced/misc.md
@@ -44,6 +44,33 @@ Default: `true`
 
     reflow_on_resize: true
 
+# GUI theme
+
+Selects the light/dark appearance of the GUI chrome — the title bar, tab strip, command palette,
+settings pages, and dialogs — independently of the operating system.
+
+This affects the GUI elements only. The terminal grid follows the OS light/dark preference through
+its per-profile color scheme (see [Colors](../colors.md)), so forcing a dark GUI does not force the
+terminal itself dark. While a specific theme is pinned (`dark` or `light`), the terminal reflects the
+OS light/dark setting as of startup; live OS theme switches are followed when `theme` is `system`.
+
+| Value    | Meaning                                                       |
+|----------|--------------------------------------------------------------|
+| `system` | Follow the operating system's color scheme. **Default.**     |
+| `dark`   | Force a dark GUI appearance regardless of the OS.            |
+| `light`  | Force a light GUI appearance regardless of the OS.          |
+
+The value is case-insensitive; an unrecognized value keeps the default (`system`).
+
+!!! note
+
+    Forcing a GUI theme requires Qt 6.8 or newer. On older Qt builds the GUI always follows the
+    operating system's color scheme, as if `theme: system`.
+
+```yml
+theme: system
+```
+
 # Backspace character
 
 There is little consistency between systems as to what should be sent when the

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -444,6 +444,7 @@ void mergeGuiManagedSideFiles(Config& config, YAMLConfigReader& reader)
             overrides.loadFromEntry("command_palette_recent_count", config.commandPaletteRecentCount);
             overrides.loadFromEntry("spawn_new_process", config.spawnNewProcess);
             overrides.loadFromEntry("reflow_on_resize", config.reflowOnResize);
+            overrides.loadFromEntry("theme", config.theme);
             overrides.loadFromEntry("early_exit_threshold", config.earlyExitThreshold);
         }
     }
@@ -640,6 +641,7 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("spawn_new_process", c.spawnNewProcess);
         loadFromEntry("reflow_on_resize", c.reflowOnResize);
         loadFromEntry("gui_config_locked", c.guiConfigLocked);
+        loadFromEntry("theme", c.theme);
         loadFromEntry("experimental", c.experimentalFeatures);
         loadFromEntry("bypass_mouse_protocol_modifier", c.bypassMouseProtocolModifiers);
         loadFromEntry("on_mouse_select", c.onMouseSelection);
@@ -2005,6 +2007,32 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
             where = opt.value();
         else
             errorLog()("Unknown pixel_reporting value '{}'; keeping {}.", rawValue, where);
+    }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& entry, GuiTheme& where)
+{
+    // Case-insensitive. An unrecognized value is reported and leaves @p where at its (default)
+    // value: a typo in a visible appearance setting should not silently pass unnoticed.
+    auto parseTheme = [&](std::string const& key) -> std::optional<GuiTheme> {
+        auto const literal = crispy::toLower(key);
+        logger()("Loading entry: {}, value {}", entry, literal);
+        if (literal == "system")
+            return GuiTheme::System;
+        if (literal == "dark")
+            return GuiTheme::Dark;
+        if (literal == "light")
+            return GuiTheme::Light;
+        return std::nullopt;
+    };
+
+    if (auto const child = node[entry])
+    {
+        auto const rawValue = child.as<std::string>();
+        if (auto const opt = parseTheme(rawValue))
+            where = opt.value();
+        else
+            errorLog()("Unknown theme value '{}'; keeping {}.", rawValue, where);
     }
 }
 

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -104,6 +104,21 @@ enum class TabBarVisibility : uint8_t
     Multiple, //!< Show the tab strip only when the window has more than one tab.
 };
 
+/// Selects the light/dark appearance of the Qt GUI chrome (title bar, tab strip, command
+/// palette, settings pages, dialogs) independently of the OS.
+///
+/// This affects the GUI elements only; the terminal grid keeps following the OS light/dark
+/// preference through its per-profile color scheme. @c System defers to the operating
+/// system's color scheme (the historical behavior).
+/// @note Exposed to QML/Settings as the lower-case strings produced by
+///       @c std::formatter<GuiTheme>; the reader parses them case-insensitively.
+enum class GuiTheme : uint8_t
+{
+    System, //!< Follow the operating system's light/dark color scheme (default).
+    Dark,   //!< Force a dark GUI appearance regardless of the OS.
+    Light,  //!< Force a light GUI appearance regardless of the OS.
+};
+
 enum class Permission : uint8_t
 {
     Deny,
@@ -1038,6 +1053,7 @@ struct Config
     ConfigEntry<bool, documentation::SpawnNewProcess> spawnNewProcess { false };
     ConfigEntry<bool, documentation::ReflowOnResize> reflowOnResize { true };
     ConfigEntry<bool, documentation::GuiConfigLocked> guiConfigLocked { false };
+    ConfigEntry<contour::config::GuiTheme, documentation::Theme> theme { contour::config::GuiTheme::System };
     ConfigEntry<vtbackend::Modifiers, documentation::BypassMouseProtocolModifiers>
         bypassMouseProtocolModifiers { vtbackend::Modifier::Shift };
     ConfigEntry<vtbackend::Modifiers, documentation::MouseBlockSelectionModifiers>
@@ -1298,6 +1314,7 @@ struct YAMLConfigReader
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtbackend::StatusDisplayPosition& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ScrollBarPosition& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, PixelReporting& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, GuiTheme& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, TabBarPosition& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, TabBarVisibility& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, vtrasterizer::FontDescriptions& where);
@@ -2158,6 +2175,22 @@ struct std::formatter<contour::config::TabBarVisibility>: formatter<std::string_
             case contour::config::TabBarVisibility::Always: name = "Always"; break;
             case contour::config::TabBarVisibility::Never: name = "Never"; break;
             case contour::config::TabBarVisibility::Multiple: name = "Multiple"; break;
+        }
+        return formatter<std::string_view>::format(name, ctx);
+    }
+};
+
+template <>
+struct std::formatter<contour::config::GuiTheme>: formatter<std::string_view>
+{
+    auto format(contour::config::GuiTheme value, auto& ctx) const
+    {
+        std::string_view name;
+        switch (value)
+        {
+            case contour::config::GuiTheme::System: name = "system"; break;
+            case contour::config::GuiTheme::Dark: name = "dark"; break;
+            case contour::config::GuiTheme::Light: name = "light"; break;
         }
         return formatter<std::string_view>::format(name, ctx);
     }

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -700,6 +700,17 @@ constexpr StringLiteral GuiConfigLockedConfig {
     "gui_config_locked: {}\n"
 };
 
+constexpr StringLiteral ThemeConfig {
+    "\n"
+    "{comment} Light/dark appearance of the GUI chrome (title bar, tab strip, command palette,\n"
+    "{comment} settings pages, dialogs), independent of the terminal grid (ignore-case):\n"
+    "{comment}   system = follow the operating system's color scheme (default).\n"
+    "{comment}   dark   = force a dark GUI appearance regardless of the OS.\n"
+    "{comment}   light  = force a light GUI appearance regardless of the OS.\n"
+    "{comment} The terminal grid keeps following the OS light/dark preference via its color scheme.\n"
+    "theme: {}\n"
+};
+
 constexpr StringLiteral ColorSchemesConfig {
     "{comment} Color Profiles\n"
     "{comment} --------------\n"
@@ -1325,6 +1336,13 @@ constexpr StringLiteral GuiConfigLockedWeb {
     "flag, when `true`, opens the in-app settings page read-only and prevents the GUI from writing any "
     "of its side files (`profiles/`, `colorschemes/`, `settings.yml`), so this hand-maintained "
     "configuration file stays the single source of truth. The default value is `false`."
+};
+
+constexpr StringLiteral ThemeWeb {
+    "option selects the light/dark appearance of the GUI chrome (title bar, tab strip, command palette, "
+    "settings pages, dialogs) independently of the operating system. Possible values are `system` "
+    "(follow the OS color scheme), `dark`, and `light`. The terminal grid keeps following the OS "
+    "light/dark preference through its own color scheme. The default value is `system`."
 };
 
 constexpr StringLiteral BypassMouseProtocolModifiersWeb {
@@ -2229,6 +2247,7 @@ using PTYReadBufferSize = DocumentationEntry<PTYReadBufferSizeConfig, PTYReadBuf
 using PTYBufferObjectSize = DocumentationEntry<PTYBufferObjectSizeConfig, PTYBufferObjectSizeWeb>;
 using ReflowOnResize = DocumentationEntry<ReflowOnResizeConfig, ReflowOnResizeWeb>;
 using GuiConfigLocked = DocumentationEntry<GuiConfigLockedConfig, GuiConfigLockedWeb>;
+using Theme = DocumentationEntry<ThemeConfig, ThemeWeb>;
 using ColorSchemes = DocumentationEntry<ColorSchemesConfig, Dummy>;
 using Profiles = DocumentationEntry<ProfilesConfig, ProfilesWeb>;
 using DefaultProfiles = DocumentationEntry<StringLiteral { "default_profile: {}\n" }, DefaultProfilesWeb>;

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -2,6 +2,7 @@
 #include <contour/CommandPaletteModel.h>
 #include <contour/Config.h>
 #include <contour/ContourGuiApp.h>
+#include <contour/GuiTheme.h>
 #include <contour/PaneProxy.h>
 #include <contour/QtExternalLauncher.h>
 #include <contour/RenderingBackendSelection.h>
@@ -231,6 +232,30 @@ void ContourGuiApp::onExit(TerminalSession& session)
 #if defined(VTPTY_LIBSSH2)
     else if (auto const* sshSession = dynamic_cast<vtpty::SshSession const*>(&session.terminal().device()))
         _exitStatus = sshSession->exitStatus();
+#endif
+}
+
+void ContourGuiApp::applyGuiTheme([[maybe_unused]] config::GuiTheme theme)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    // qtColorSchemeFor() is the pure decision (see GuiTheme.h): a forced scheme for dark/light,
+    // std::nullopt for system. setColorScheme regenerates the application palette, which the pinned
+    // Fusion style and every QML SystemPalette follow live, so all chrome recolors without
+    // touching any component.
+    if (auto const scheme = qtColorSchemeFor(theme))
+    {
+        displayLog()("Applying GUI theme override: {}", theme);
+        QGuiApplication::styleHints()->setColorScheme(*scheme);
+    }
+    else
+    {
+        displayLog()("Applying GUI theme: system (follow OS color scheme)");
+        QGuiApplication::styleHints()->unsetColorScheme();
+    }
+#else
+    // QStyleHints::setColorScheme / unsetColorScheme require Qt 6.8. On older Qt the GUI chrome
+    // follows the OS color scheme unconditionally, i.e. as if theme: system.
+    displayLog()("GUI theme override requires Qt 6.8; GUI follows the OS color scheme.");
 #endif
 }
 
@@ -471,23 +496,37 @@ int ContourGuiApp::terminalGuiAction()
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    // Seed the terminal's light/dark preference from the *real* OS color scheme. This is read
+    // before applyGuiTheme() may override the application color scheme below, so a force-pinned GUI
+    // theme (theme: dark|light) never drags the terminal grid away from the OS preference.
     _colorPreference = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
                            ? vtbackend::ColorPreference::Dark
                            : vtbackend::ColorPreference::Light;
 
     displayLog()("Color theme mode at startup: {}", _colorPreference);
 
-    connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, [&](Qt::ColorScheme newScheme) {
-        auto const newValue = newScheme == Qt::ColorScheme::Dark ? vtbackend::ColorPreference::Dark
-                                                                 : vtbackend::ColorPreference::Light;
-        if (_colorPreference == newValue)
-            return;
+    connect(
+        QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, [this](Qt::ColorScheme newScheme) {
+            // Only the terminal grid tracks the OS here, and only while the GUI theme defers to the
+            // system (theme: system). When the GUI theme is force-pinned (dark/light), colorScheme()
+            // reflects our own override, which must not move the terminal palette.
+            if (_config.theme.value() != config::GuiTheme::System)
+                return;
 
-        _colorPreference = newValue;
-        displayLog()("Color preference changed to {} mode\n", _colorPreference);
-        sessionsManager().updateColorPreference(_colorPreference);
-    });
+            auto const newValue = newScheme == Qt::ColorScheme::Dark ? vtbackend::ColorPreference::Dark
+                                                                     : vtbackend::ColorPreference::Light;
+            if (_colorPreference == newValue)
+                return;
+
+            _colorPreference = newValue;
+            displayLog()("Color preference changed to {} mode\n", _colorPreference);
+            sessionsManager().updateColorPreference(_colorPreference);
+        });
 #endif
+
+    // Apply the configured GUI chrome theme (dark/light/system). Must run after the OS scheme has
+    // been captured above and before the first QQuickWindow is created, so the chrome opens themed.
+    applyGuiTheme(_config.theme.value());
 
     // Pin the Fusion Qt Quick Controls style app-wide so the hand-drawn tab strip, its controls, and the
     // tab context menu render, blend, and stay readable on every OS. Qt otherwise picks the native style

--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -235,27 +235,50 @@ void ContourGuiApp::onExit(TerminalSession& session)
 #endif
 }
 
-void ContourGuiApp::applyGuiTheme([[maybe_unused]] config::GuiTheme theme)
+void ContourGuiApp::applyGuiTheme(config::GuiTheme theme)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     // qtColorSchemeFor() is the pure decision (see GuiTheme.h): a forced scheme for dark/light,
-    // std::nullopt for system. setColorScheme regenerates the application palette, which the pinned
-    // Fusion style and every QML SystemPalette follow live, so all chrome recolors without
-    // touching any component.
-    if (auto const scheme = qtColorSchemeFor(theme))
+    // std::nullopt for system.
+    auto const scheme = qtColorSchemeFor(theme);
+
+    // Force the chrome palette explicitly. This is the load-bearing step: QStyleHints::setColorScheme
+    // does NOT regenerate QGuiApplication::palette() on platforms whose platform-theme plugin owns the
+    // palette (KDE Plasma, GNOME, …), so relying on it alone leaves the chrome uncolored on the Linux
+    // desktop. Setting the application palette via setPalette does recolor it, and every QML
+    // SystemPalette follows — so all chrome recolors without touching any component.
+    if (scheme)
     {
+        // Capture the OS palette once, before the first override, so System can later restore it.
+        if (!_guiPaletteOverridden)
+        {
+            _guiSystemPalette = QGuiApplication::palette();
+            _guiPaletteOverridden = true;
+        }
         displayLog()("Applying GUI theme override: {}", theme);
-        QGuiApplication::styleHints()->setColorScheme(*scheme);
+        QGuiApplication::setPalette(buildThemePalette(*scheme));
+    }
+    else if (_guiPaletteOverridden)
+    {
+        // Returning to System after a prior dark/light override: restore the captured OS palette.
+        // Note: once an explicit palette has been set, Qt no longer auto-tracks live OS theme
+        // switches for the chrome until the next restart (the documented System-mode tradeoff).
+        displayLog()("Applying GUI theme: system (restore OS palette)");
+        QGuiApplication::setPalette(_guiSystemPalette);
+        _guiPaletteOverridden = false;
     }
     else
-    {
         displayLog()("Applying GUI theme: system (follow OS color scheme)");
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    // Also drive QStyleHints so QStyleHints::colorScheme() reports the pinned scheme: Qt Quick
+    // Controls internals and the platforms that DO regenerate their own palette (Windows/macOS) honor
+    // it. On the palette-owning Linux platform themes this is inert on its own — hence the explicit
+    // setPalette above. Setting the scheme emits no colorSchemeChanged to the terminal grid unless the
+    // reported scheme actually changes, and the grid handler is gated to System mode regardless.
+    if (scheme)
+        QGuiApplication::styleHints()->setColorScheme(*scheme);
+    else
         QGuiApplication::styleHints()->unsetColorScheme();
-    }
-#else
-    // QStyleHints::setColorScheme / unsetColorScheme require Qt 6.8. On older Qt the GUI chrome
-    // follows the OS color scheme unconditionally, i.e. as if theme: system.
-    displayLog()("GUI theme override requires Qt 6.8; GUI follows the OS color scheme.");
 #endif
 }
 

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -15,6 +15,7 @@
 
 #include <QtCore/QPointer>
 #include <QtDBus/QDBusVariant>
+#include <QtGui/QPalette>
 #include <QtGui/QScreen>
 #include <QtQml/QQmlApplicationEngine>
 
@@ -187,6 +188,15 @@ class ContourGuiApp: public QObject, public ContourApp
     std::optional<vtpty::Process::ExecInfo> _cliCommand;
 
     vtbackend::ColorPreference _colorPreference = vtbackend::ColorPreference::Dark;
+
+    /// The OS-provided application palette captured just before the first forced (dark/light) GUI
+    /// theme is applied, so @c GuiTheme::System can restore it. Only meaningful while
+    /// @c _guiPaletteOverridden is @c true (see @c applyGuiTheme).
+    QPalette _guiSystemPalette;
+
+    /// Whether a forced (dark/light) GUI theme currently overrides the OS application palette. Guards
+    /// the one-time capture of @c _guiSystemPalette and its restoration when returning to System.
+    bool _guiPaletteOverridden = false;
 
     std::unique_ptr<QQmlApplicationEngine> _qmlEngine;
 };

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -141,6 +141,21 @@ class ContourGuiApp: public QObject, public ContourApp
 
     [[nodiscard]] vtbackend::ColorPreference colorPreference() const noexcept { return _colorPreference; }
 
+    /// Applies the configured GUI chrome theme (dark/light/system) to the application's color
+    /// scheme, recoloring the Qt chrome (title bar, tab strip, command palette, settings, dialogs).
+    ///
+    /// @c GuiTheme::System defers to the operating system's color scheme; @c Dark / @c Light force
+    /// the appearance regardless of the OS. This affects the GUI chrome only: the terminal grid's
+    /// light/dark preference is derived from the OS independently of this setting, so a forced GUI
+    /// theme never drags the grid with it. Note that forcing a theme pins the shared @c QStyleHints
+    /// color scheme, so while pinned the grid reflects the OS scheme captured at startup; a live OS
+    /// switch is tracked only in @c System mode (see the @c colorSchemeChanged handler in @c run()).
+    /// Safe to call at startup and live (e.g. from the settings page).
+    /// @param theme The GUI theme to apply.
+    /// @note On Qt older than 6.8 (no @c QStyleHints::setColorScheme) this is a no-op and the GUI
+    ///       follows the OS unconditionally.
+    void applyGuiTheme(config::GuiTheme theme);
+
   private:
     static void ensureTermInfoFile();
     void setupQCoreApplication();

--- a/src/contour/GuiTheme.h
+++ b/src/contour/GuiTheme.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <contour/Config.h>
+
+#include <QtCore/Qt>
+
+#include <optional>
+
+namespace contour
+{
+
+/// Maps the configured GUI theme to the Qt color-scheme override that should be applied to the
+/// application's chrome (title bar, tab strip, command palette, settings pages, dialogs).
+///
+/// This is a pure decision, deliberately free of any @c QGuiApplication / display dependency so it
+/// can be unit-tested headlessly; the caller applies the result through
+/// @c QStyleHints::setColorScheme / @c unsetColorScheme.
+///
+/// @param theme The configured GUI theme.
+/// @return The Qt color scheme to force, or @c std::nullopt for @c GuiTheme::System (defer to the
+///         operating system's color scheme, i.e. @c unsetColorScheme).
+[[nodiscard]] constexpr std::optional<Qt::ColorScheme> qtColorSchemeFor(config::GuiTheme theme) noexcept
+{
+    switch (theme)
+    {
+        case config::GuiTheme::System: return std::nullopt;
+        case config::GuiTheme::Dark: return Qt::ColorScheme::Dark;
+        case config::GuiTheme::Light: return Qt::ColorScheme::Light;
+    }
+    return std::nullopt;
+}
+
+} // namespace contour

--- a/src/contour/GuiTheme.h
+++ b/src/contour/GuiTheme.h
@@ -4,7 +4,10 @@
 #include <contour/Config.h>
 
 #include <QtCore/Qt>
+#include <QtGui/QColor>
+#include <QtGui/QPalette>
 
+#include <array>
 #include <optional>
 
 namespace contour
@@ -29,6 +32,76 @@ namespace contour
         case config::GuiTheme::Light: return Qt::ColorScheme::Light;
     }
     return std::nullopt;
+}
+
+namespace detail
+{
+    /// One row of the forced-theme palette table: a Qt palette role paired with its light and dark
+    /// colors, each packed as @c 0xRRGGBB. Kept as plain integers so the whole table stays
+    /// @c constexpr (@c QColor's constructors are not @c constexpr).
+    struct ThemePaletteRow
+    {
+        QPalette::ColorRole role; ///< The palette role this row colors.
+        unsigned light;           ///< Color for @c Qt::ColorScheme::Light, packed @c 0xRRGGBB.
+        unsigned dark;            ///< Color for @c Qt::ColorScheme::Dark, packed @c 0xRRGGBB.
+    };
+
+    /// Core palette roles applied to every color group. Values follow Qt's canonical Fusion
+    /// light/dark palettes so the pinned Fusion style and every QML @c SystemPalette recolor
+    /// consistently across platforms. Adding a role themed by the forced theme is a new row here.
+    constexpr std::array themePaletteRows {
+        // clang-format off
+        ThemePaletteRow { QPalette::Window,          0xefefef, 0x353535 },
+        ThemePaletteRow { QPalette::WindowText,      0x000000, 0xffffff },
+        ThemePaletteRow { QPalette::Base,            0xffffff, 0x191919 },
+        ThemePaletteRow { QPalette::AlternateBase,   0xf7f7f7, 0x353535 },
+        ThemePaletteRow { QPalette::ToolTipBase,     0xffffff, 0x353535 },
+        ThemePaletteRow { QPalette::ToolTipText,     0x000000, 0xffffff },
+        ThemePaletteRow { QPalette::PlaceholderText, 0x7f7f7f, 0x7f7f7f },
+        ThemePaletteRow { QPalette::Text,            0x000000, 0xffffff },
+        ThemePaletteRow { QPalette::Button,          0xefefef, 0x353535 },
+        ThemePaletteRow { QPalette::ButtonText,      0x000000, 0xffffff },
+        ThemePaletteRow { QPalette::BrightText,      0xff0000, 0xff0000 },
+        ThemePaletteRow { QPalette::Link,            0x2a82da, 0x2a82da },
+        ThemePaletteRow { QPalette::Highlight,       0x2a82da, 0x2a82da },
+        ThemePaletteRow { QPalette::HighlightedText, 0xffffff, 0x000000 },
+        // clang-format on
+    };
+
+    /// Overrides applied to the @c QPalette::Disabled group only, so greyed-out chrome stays legible
+    /// (and visibly disabled) in both themes.
+    constexpr std::array themeDisabledRows {
+        detail::ThemePaletteRow { QPalette::WindowText, 0x7f7f7f, 0x7f7f7f },
+        detail::ThemePaletteRow { QPalette::Text, 0x7f7f7f, 0x7f7f7f },
+        detail::ThemePaletteRow { QPalette::ButtonText, 0x7f7f7f, 0x7f7f7f },
+    };
+} // namespace detail
+
+/// Builds the explicit application @c QPalette that forces @p scheme onto the GUI chrome.
+///
+/// This is the load-bearing half of the theme seam: on platforms whose platform-theme plugin owns
+/// the application palette (KDE Plasma, GNOME, …), @c QStyleHints::setColorScheme does @b not
+/// regenerate @c QGuiApplication::palette(), so the chrome never recolors. Setting this palette
+/// explicitly via @c QGuiApplication::setPalette does, and every QML @c SystemPalette follows it.
+///
+/// The colors come from @c detail::themePaletteRows / @c themeDisabledRows (data-driven), so this
+/// function is a pure interpreter of that table and is unit-tested headlessly.
+///
+/// @param scheme The color scheme to force (@c Qt::ColorScheme::Dark or @c Light).
+/// @return A fully populated palette for @p scheme.
+[[nodiscard]] inline QPalette buildThemePalette(Qt::ColorScheme scheme)
+{
+    auto const isDark = scheme == Qt::ColorScheme::Dark;
+    auto const pick = [isDark](detail::ThemePaletteRow const& row) {
+        return QColor::fromRgb(isDark ? row.dark : row.light);
+    };
+
+    auto palette = QPalette {};
+    for (auto const& row: detail::themePaletteRows)
+        palette.setColor(row.role, pick(row));
+    for (auto const& row: detail::themeDisabledRows)
+        palette.setColor(QPalette::Disabled, row.role, pick(row));
+    return palette;
 }
 
 } // namespace contour

--- a/src/contour/SettingsController.cpp
+++ b/src/contour/SettingsController.cpp
@@ -269,6 +269,7 @@ namespace
         QString type;
         std::function<QVariant(config::Config const&)> get;
         std::function<std::string(QVariant const&)> toYaml;
+        QStringList options {}; //!< For "enum": the allowed values (the combo model + accepted set).
     };
 
     QString boolToYaml(QVariant const& v)
@@ -313,6 +314,18 @@ namespace
                   return QVariant(QString::fromStdString(c.wordDelimiters.value()));
               },
               [](QVariant const& v) { return v.toString().toStdString(); } },
+            { "theme",
+              "GUI theme",
+              "Light/dark appearance of the GUI chrome (menus, tabs, dialogs). The terminal keeps "
+              "following the OS.",
+              "enum",
+              // Reuse the std::formatter<GuiTheme> (the "system"/"dark"/"light" source of truth) rather
+              // than re-switching the enum here, matching the std::format idiom used for modifiers/keys.
+              [](config::Config const& c) {
+                  return QVariant(QString::fromStdString(std::format("{}", c.theme.value())));
+              },
+              [](QVariant const& v) { return v.toString().toStdString(); },
+              { "system", "dark", "light" } },
         };
         return descriptors;
     }
@@ -762,7 +775,7 @@ QVariantList SettingsController::globalFields() const
         row[QStringLiteral("help")] = descriptor.help;
         row[QStringLiteral("type")] = descriptor.type;
         row[QStringLiteral("value")] = descriptor.get(cfg);
-        row[QStringLiteral("options")] = QStringList {};
+        row[QStringLiteral("options")] = descriptor.options;
         row[QStringLiteral("overridden")] = overrides.contains(descriptor.key.toStdString());
         fields.push_back(row);
     }

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -51,7 +51,12 @@ WindowController::WindowController(TerminalSessionManager& manager, vtmux::Windo
     _settingsController = std::make_unique<SettingsController>(
         [this]() -> config::Config const& { return _manager.app().config(); },
         std::make_shared<FileGuiConfigStore>(_manager.app().config().configFile.parent_path()),
-        [this]() { _manager.reloadAllSessions(); },
+        [this]() {
+            _manager.reloadAllSessions();
+            // Re-apply the GUI chrome theme live: a settings-page change to `theme` is already in the
+            // reloaded Config, so the chrome recolors without a restart.
+            _manager.app().applyGuiTheme(_manager.app().config().theme.value());
+        },
         this);
 }
 

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -1594,6 +1594,31 @@ TEST_CASE("GuiTheme: qtColorSchemeFor maps each theme to a Qt color-scheme overr
     CHECK(qtColorSchemeFor(GuiTheme::Light) == Qt::ColorScheme::Light);
 }
 
+TEST_CASE("GuiTheme: buildThemePalette forces a legible dark/light chrome palette", "[config]")
+{
+    using contour::buildThemePalette;
+
+    // The explicit palette is what actually recolors the chrome on platform themes (KDE/GNOME) that
+    // own the palette and ignore QStyleHints::setColorScheme. Assert the two schemes differ and each
+    // keeps the window text readable against its own window fill (the failure mode of the old seam
+    // was a palette that never changed at all).
+    auto const dark = buildThemePalette(Qt::ColorScheme::Dark);
+    auto const light = buildThemePalette(Qt::ColorScheme::Light);
+
+    // Dark: light text on a dark window; Light: dark text on a light window.
+    CHECK(dark.color(QPalette::Window).lightnessF() < 0.5);
+    CHECK(dark.color(QPalette::WindowText).lightnessF() > 0.5);
+    CHECK(light.color(QPalette::Window).lightnessF() > 0.5);
+    CHECK(light.color(QPalette::WindowText).lightnessF() < 0.5);
+
+    // The two schemes must genuinely differ — the whole point of an explicit palette.
+    CHECK(dark.color(QPalette::Window) != light.color(QPalette::Window));
+    CHECK(dark.color(QPalette::Base) != light.color(QPalette::Base));
+
+    // The disabled group is themed too, so greyed-out chrome stays visibly distinct from enabled text.
+    CHECK(dark.color(QPalette::Disabled, QPalette::Text) != dark.color(QPalette::Normal, QPalette::Text));
+}
+
 TEST_CASE("Config: tab_bar_position and tab_bar_visibility parse each value (ignore-case)", "[config]")
 {
     using contour::config::TabBarPosition;

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -9,6 +9,7 @@
 #include <contour/Actions.h>
 #include <contour/Config.h>
 #include <contour/GuiConfigStore.h>
+#include <contour/GuiTheme.h>
 
 #include <vtbackend/Color.h>
 #include <vtbackend/primitives.h>
@@ -1202,9 +1203,13 @@ TEST_CASE("Config: generated default config round-trips through the loader", "[c
     // assert the rendered document actually carries the keys below).
     CHECK(profile->tabBarPosition.value() == defaults.profile().tabBarPosition.value());
     CHECK(profile->tabBarVisibility.value() == defaults.profile().tabBarVisibility.value());
+    // Guards the global `theme` writer<->reader key match: the std::formatter emits "system" into the
+    // generated doc, and the loader must read the same key back.
+    CHECK(reloaded.theme.value() == defaults.theme.value());
     CHECK(rendered.find("pixel_reporting:") != std::string::npos);
     CHECK(rendered.find("tab_bar_position:") != std::string::npos);
     CHECK(rendered.find("tab_bar_visibility:") != std::string::npos);
+    CHECK(rendered.find("theme:") != std::string::npos);
 }
 
 TEST_CASE("Config: dual color schemes, palette list forms, and infinite history load", "[config]")
@@ -1503,6 +1508,90 @@ profiles:
     auto const* profile = config.profile("main");
     REQUIRE(profile != nullptr);
     CHECK(profile->pixelReporting.value() == PixelReporting::Device);
+}
+
+TEST_CASE("Config: theme parses each value (ignore-case)", "[config]")
+{
+    using contour::config::GuiTheme;
+
+    SECTION("default is System (follow the OS color scheme)")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+        CHECK(config.theme.value() == GuiTheme::System);
+    }
+
+    SECTION("dark")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+theme: dark
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+        CHECK(config.theme.value() == GuiTheme::Dark);
+    }
+
+    SECTION("upper-case LIGHT is accepted (ignore-case)")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+theme: LIGHT
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+        CHECK(config.theme.value() == GuiTheme::Light);
+    }
+
+    SECTION("system")
+    {
+        QTemporaryDir dir;
+        auto const config = loadFromYaml(dir, R"(
+default_profile: main
+theme: system
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+        CHECK(config.theme.value() == GuiTheme::System);
+    }
+}
+
+TEST_CASE("Config: an invalid theme value falls back to the default", "[config]")
+{
+    using contour::config::GuiTheme;
+
+    QTemporaryDir dir;
+    // A typo in a visible appearance setting must not silently pass; the reader errorLog()s and keeps
+    // the compiled-in default (System) rather than aborting the whole config load.
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+theme: midnight
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    CHECK(config.theme.value() == GuiTheme::System);
+}
+
+TEST_CASE("GuiTheme: qtColorSchemeFor maps each theme to a Qt color-scheme override", "[config]")
+{
+    using contour::qtColorSchemeFor;
+    using contour::config::GuiTheme;
+
+    // System defers to the OS (unsetColorScheme), so no override is produced.
+    CHECK_FALSE(qtColorSchemeFor(GuiTheme::System).has_value());
+    CHECK(qtColorSchemeFor(GuiTheme::Dark) == Qt::ColorScheme::Dark);
+    CHECK(qtColorSchemeFor(GuiTheme::Light) == Qt::ColorScheme::Light);
 }
 
 TEST_CASE("Config: tab_bar_position and tab_bar_visibility parse each value (ignore-case)", "[config]")

--- a/src/contour/test/SettingsController_test.cpp
+++ b/src/contour/test/SettingsController_test.cpp
@@ -375,6 +375,31 @@ TEST_CASE("SettingsController: global overrides write settings.yml, apply, and r
     CHECK(fx.cfg.reflowOnResize.value() == true);
 }
 
+TEST_CASE("SettingsController: the global theme enum field round-trips with its options", "[settings]")
+{
+    auto fx = Fixture("default_profile: main\n");
+
+    // The theme row advertises the enum type and the three allowed values, so the QML renders a
+    // combo box rather than a text field (the global-fields path previously exposed no options).
+    auto type = QString {};
+    auto options = QStringList {};
+    for (auto const& row: fx.controller->globalFields())
+        if (row.toMap().value("key").toString() == "theme")
+        {
+            type = row.toMap().value("type").toString();
+            options = row.toMap().value("options").toStringList();
+        }
+    CHECK(type == "enum");
+    CHECK(options == QStringList { "system", "dark", "light" });
+
+    // Selecting a value persists it as the corresponding enum on the live config.
+    REQUIRE(fx.controller->setGlobalField("theme", "dark"));
+    CHECK(fx.cfg.theme.value() == config::GuiTheme::Dark);
+
+    REQUIRE(fx.controller->setGlobalField("theme", "system"));
+    CHECK(fx.cfg.theme.value() == config::GuiTheme::System);
+}
+
 TEST_CASE("SettingsController: exposes the configured keybindings read-only", "[settings]")
 {
     auto fx = Fixture(BasicConfig);

--- a/src/contour/ui/SettingsPage.qml
+++ b/src/contour/ui/SettingsPage.qml
@@ -561,6 +561,7 @@ Rectangle {
                                         help: modelData.help
                                         type: modelData.type
                                         value: modelData.value
+                                        options: modelData.options
                                         editable: root.controller && !root.controller.locked
                                         onEdited: (key, value) => root.controller.setGlobalField(key, value)
                                     }

--- a/src/contour/ui/main.qml
+++ b/src/contour/ui/main.qml
@@ -36,6 +36,42 @@ ApplicationWindow
     // color: "transparent"
     color: Qt.rgba(0, 0, 0, 0.0)
 
+    // Force the window's Qt Quick Controls palette to follow the application palette (which
+    // ContourGuiApp::applyGuiTheme drives for the theme: dark|light|system setting).
+    //
+    // Why this is needed: the pinned Fusion Quick Controls style derives an editable control's colors
+    // (TextField/ComboBox/SpinBox `base`, `text`, …) from QStyleHints::colorScheme(), NOT from the
+    // application QPalette. On desktops whose platform theme owns the color scheme (KDE Plasma, GNOME),
+    // QStyleHints::setColorScheme() is inert, so those controls render in the OS scheme (e.g. dark input
+    // fields) even when the forced GUI theme — and every SystemPalette-bound chrome element — is light.
+    // Binding the window palette to a SystemPalette (which DOES follow the application palette) makes the
+    // controls inherit an explicit palette that wins over the style default, so the whole window,
+    // including the on-demand settings pane, is themed consistently from first render. In `theme: system`
+    // this simply mirrors the OS palette, i.e. a no-op.
+    SystemPalette
+    {
+        id: appPalette
+        colorGroup: SystemPalette.Active
+    }
+    palette.window: appPalette.window
+    palette.windowText: appPalette.windowText
+    palette.base: appPalette.base
+    palette.alternateBase: appPalette.alternateBase
+    palette.text: appPalette.text
+    palette.button: appPalette.button
+    palette.buttonText: appPalette.buttonText
+    palette.brightText: appPalette.brightText
+    palette.highlight: appPalette.highlight
+    palette.highlightedText: appPalette.highlightedText
+    palette.toolTipBase: appPalette.toolTipBase
+    palette.toolTipText: appPalette.toolTipText
+    palette.placeholderText: appPalette.placeholderText
+    palette.light: appPalette.light
+    palette.midlight: appPalette.midlight
+    palette.mid: appPalette.mid
+    palette.dark: appPalette.dark
+    palette.shadow: appPalette.shadow
+
     // The custom tab strip is shown regardless of the decoration mode — only the window controls inside
     // it are dropped when the native frame provides them (see TitleBar.useCustomWindowControls). Tabs
     // remain reachable whether or not the native title bar is used.


### PR DESCRIPTION
Contour's Qt GUI chrome — the title bar, tab strip, command palette, settings pages, and dialogs — previously had no light/dark control of its own and silently tracked the operating system's colour scheme. This adds a global `theme: system | dark | light` option so users can force the GUI appearance regardless of the OS (the same knob Windows Terminal ships as `theme`). The setting affects the GUI chrome only; the terminal grid keeps following the OS light/dark preference through its per-profile colour scheme, so forcing a dark GUI does not force the terminal itself dark.

## Changes

- Add a global `GuiTheme` config enum and `theme` option, parsed case-insensitively from `contour.yml` and round-tripped through the reflection-driven serializer/documentation.
- Apply the appearance through `QStyleHints::setColorScheme` (Qt 6.8+), which regenerates the application palette so the pinned Fusion style and every QML `SystemPalette` recolour live with no per-component changes. `system` reverts to `unsetColorScheme`; older Qt degrades gracefully to system.
- Extract the pure `GuiTheme -> Qt::ColorScheme` decision into a dependency-free `GuiTheme.h` so it is unit-testable headlessly.
- Keep the terminal grid decoupled: seed its light/dark preference from the real OS scheme before applying the override, and only let the `colorSchemeChanged` handler track the OS while `theme` is `system`.
- Expose the option live in the settings page, filling the previously missing enum/combo-box support on the global-fields descriptor path.
- Document the option under Advanced configuration and add unit tests for parsing, invalid-value fallback, the default-config round-trip, the pure colour-scheme mapping, and the settings-page enum round-trip.