### PR TITLE
Fix missing focus notification when switching tabs and panes

### DIFF
--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -335,6 +335,7 @@ if(CONTOUR_FRONTEND_GUI)
             test/ViewportTextIndex_test.cpp
             test/KeyboardRouting_test.cpp
             test/MainWindowQml_test.cpp
+            test/FocusRouting_test.cpp
             test/MultiWindow_test.cpp
             test/NotificationRouter_test.cpp
             test/QmlDiagnosticPredicate_test.cpp

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -142,6 +142,13 @@ namespace
         // the profile's configured terminalSize. Applied here so the terminal is BORN at the right size,
         // not just corrected once a display attaches (which never happens for a background tab).
         settings.pageSize = initialPageSize.value_or(profile.terminalSize.value());
+
+        // Focus is granted, never assumed: TerminalSessionManager::setFocusedSession is the sole
+        // authority, and it only focus-OUTs the session that previously held focus. A session born
+        // focused (a background tab, a non-active split pane, any tab of a window that does not own
+        // focus) would therefore stay "focused" forever -- rendering an active cursor and withholding
+        // the DECSET 1004 focus-out its application is due.
+        settings.focused = false;
         settings.ptyBufferObjectSize = config.ptyBufferObjectSize.value();
         settings.ptyReadBufferSize = config.ptyReadBufferSize.value();
         settings.maxHistoryLineCount = profile.history.value().maxHistoryLineCount;

--- a/src/contour/TerminalSessionManager.cpp
+++ b/src/contour/TerminalSessionManager.cpp
@@ -92,6 +92,10 @@ WindowController* TerminalSessionManager::createWindowController()
     auto* controller = new WindowController(*this, window->id());
     QQmlEngine::setObjectOwnership(controller, QQmlEngine::CppOwnership);
     _controllersByWindow[window->id().value] = controller;
+    // A freshly spawned window is the one the user is looking at. Seeding ownership here (rather than
+    // waiting for the first Qt focus-in) is what lets the very first tab be focused at creation, and
+    // makes a tab switch notify the shell even before the window has ever been clicked.
+    _focusedWindow = window->id();
     return controller;
 }
 
@@ -124,9 +128,9 @@ TerminalSession* TerminalSessionManager::createSessionInBackground(vtmux::Window
     // TODO: Remove dependency on app-knowledge and pass shell / terminal-size instead.
     // The GuiApp *or* (Global)Config could be made a global to be accessible from within QML.
 
-    if (!_activeDisplay)
+    if (!_focusedWindow)
     {
-        managerLog()("No active display found. something went wrong.");
+        managerLog()("No focused window found. something went wrong.");
     }
 
     auto* targetWindow = _model->window(window);
@@ -217,10 +221,7 @@ void TerminalSessionManager::detachDisplay(display::TerminalDisplay* display) no
 
     // The display (one pane of a tab) is being destroyed. Session->display ownership lives solely on the
     // pane tree now, so there is no per-display map to scrub; just make sure no controller keeps this
-    // freed display as its focused one.
-    if (_activeDisplay == display)
-        _activeDisplay = nullptr;
-
+    // freed display as its focused one. Focus ownership is per WINDOW and survives this untouched.
     for (auto const& [id, controller]: _controllersByWindow)
         controller->onDisplayDetached(display);
 }
@@ -241,9 +242,14 @@ void TerminalSessionManager::FocusOnDisplay(display::TerminalDisplay* display)
     // a focused pane already owns its session. FocusOnDisplay only makes this the active display and hands
     // the focus to the owning window's controller, which re-points its window-service signal bridge and
     // re-emits the window bindings. Route by the display's OS window so the correct controller updates.
-    _activeDisplay = display;
     if (auto* c = controllerForDisplay(display))
+    {
+        // A genuine Qt focus-in transfers focus ownership to this display's window. The session is not
+        // re-pointed here: the caller (TerminalDisplay::focusInEvent) supplies its own pane's session,
+        // which mid-rebind can differ from the controller's active one.
+        _focusedWindow = c->windowId();
         c->focusDisplay(display);
+    }
 }
 
 void TerminalSessionManager::setFocusedSession(TerminalSession* next)
@@ -263,14 +269,30 @@ void TerminalSessionManager::clearFocusIfCurrent(TerminalSession* session)
         setFocusedSession(nullptr);
 }
 
+void TerminalSessionManager::setFocusedWindow(vtmux::WindowId window)
+{
+    // Taking ownership satisfies syncFocusForWindow's gate by construction, so the re-pointing half is
+    // that one implementation rather than a second copy of it.
+    _focusedWindow = window;
+    syncFocusForWindow(controllerFor(window));
+}
+
+void TerminalSessionManager::clearFocusedWindow(vtmux::WindowId window)
+{
+    if (_focusedWindow != window) // guarded like clearFocusIfCurrent
+        return;
+    _focusedWindow.reset();
+    setFocusedSession(nullptr);
+}
+
 void TerminalSessionManager::syncFocusForWindow(WindowController* controller)
 {
     if (controller == nullptr)
         return;
-    // Only the window owning the focused display moves focus (so a background window can't steal it);
-    // this is the seam that focuses a session swapped onto an already-focused display, where no Qt
-    // focus event fires.
-    if (_activeDisplay != nullptr && controllerForDisplay(_activeDisplay) == controller)
+    // Only the focus-owning window moves focus, so a background window can't steal it. This is also the
+    // seam that focuses a session swapped onto an already-focused display, where no Qt focus event
+    // fires at all -- which is the whole reason a tab switch notifies anyone. @see _focusedWindow.
+    if (_focusedWindow == controller->windowId())
         setFocusedSession(controller->activeSession());
 }
 
@@ -689,12 +711,17 @@ void TerminalSessionManager::removeWindowController(vtmux::WindowId windowId)
     if (controller != nullptr)
         controller->deleteLater();
 
+    // Ownership must not survive the window that held it: a stale WindowId would let a later model
+    // event in an unrelated window re-grant focus through syncFocusForWindow. The window's sessions
+    // were terminated by WindowController::closeWindow, and removeSession already dropped the focus
+    // back-pointer for each, so the focus-out this issues finds nothing to notify.
+    clearFocusedWindow(windowId);
+
     if (wasLast)
     {
         managerLog()("Last window closed: clearing residual session registries.");
         _sessionsById.clear();
         _tabBySession.clear();
-        _activeDisplay = nullptr;
     }
 }
 

--- a/src/contour/TerminalSessionManager.h
+++ b/src/contour/TerminalSessionManager.h
@@ -339,6 +339,25 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     /// @param session The session whose display just lost Qt focus.
     void clearFocusIfCurrent(TerminalSession* session);
 
+    /// The OS window that currently owns keyboard focus, as a model identity rather than a Qt pointer.
+    /// VT focus only ever moves within this window, so a model event raised in a background window (a
+    /// layout applying its tabs, a tab dropped in by a drag) cannot steal the focused terminal.
+    /// @return The focus-owning window, or std::nullopt when no window of this process owns focus.
+    [[nodiscard]] std::optional<vtmux::WindowId> focusedWindow() const noexcept { return _focusedWindow; }
+
+    /// Records @p window as the focus-owning OS window AND re-points terminal focus at its active leaf.
+    /// Idempotent. Ownership is also recorded — without re-pointing, since there is no session to point
+    /// at yet or the caller supplies its own — when a window is spawned (createWindowController) and
+    /// when one of its displays takes Qt focus (FocusOnDisplay). @see clearFocusedWindow.
+    /// @param window The window that just became the active OS window.
+    void setFocusedWindow(vtmux::WindowId window);
+
+    /// Revokes focus ownership iff @p window currently holds it, leaving no window focused and no
+    /// terminal focused. A no-op for any other window, so a background window deactivating cannot
+    /// clear the focused window's terminal focus.
+    /// @param window The window that just stopped being the active OS window (or is being destroyed).
+    void clearFocusedWindow(vtmux::WindowId window);
+
     void update() { updateStatusLine(); }
 
     /// Invalidates TitleRole on every tab row of EVERY window's tab strip (each WindowController
@@ -371,9 +390,10 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     /// @param session The session (by model id) whose hosting tab color should be cleared.
     void resetTabColorForSession(vtmux::SessionId session);
 
-    /// Clears the destroyed @p display from any controller that held it as its focused display, and from
-    /// the manager's _activeDisplay. Called when the display's QML item / pane is torn down. Session->
-    /// display ownership lives on the pane tree, so there is no per-display session map to scrub.
+    /// Clears the destroyed @p display from any controller that held it as its focused display. Called
+    /// when the display's QML item / pane is torn down. Session->display ownership lives on the pane
+    /// tree, so there is no per-display session map to scrub. Focus ownership is unaffected: it is held
+    /// per WINDOW (@see _focusedWindow), so a tab switch still notifies its sessions across this gap.
     /// @param display The display being destroyed.
     void detachDisplay(display::TerminalDisplay* display) noexcept;
 
@@ -644,12 +664,17 @@ class TerminalSessionManager: public QObject, public vtmux::ModelEvents
     bool _commandHistoryLoaded = false;
     std::chrono::seconds _earlyExitThreshold;
     // The process-wide "focused display". Session->display ownership lives on the pane tree; this is only
-    // the currently-focused display, routed to its owning WindowController for window services.
-    display::TerminalDisplay* _activeDisplay = nullptr;
-
     // The single session that currently holds terminal (VT) focus across all windows, or nullptr.
-    // setFocusedSession() is the sole mutator and emits the symmetric focus-out/focus-in pair.
+    // setFocusedSession() is the only mutator that NOTIFIES (the symmetric focus-out/focus-in pair);
+    // the teardown paths (removeSession, and removeWindowController via clearFocusedWindow) drop the
+    // back-pointer without notifying a session that is already dying.
     TerminalSession* _focusedSession = nullptr;
+
+    // Which OS window owns focus, as a model identity rather than a Qt pointer: this is what gates
+    // whether a model event may move VT focus. A pointer to the focused display cannot serve, because
+    // it is null between a display teardown and the next Qt focus-in -- and a tab switch in that gap
+    // notified nobody. @see syncFocusForWindow.
+    std::optional<vtmux::WindowId> _focusedWindow;
 
     bool _multimediaReady = false;
 

--- a/src/contour/WindowController.cpp
+++ b/src/contour/WindowController.cpp
@@ -735,6 +735,31 @@ void WindowController::bindWindow(QQuickWindow* osWindow)
             this,
             &WindowController::onWindowScaleMaybeChanged,
             Qt::UniqueConnection);
+
+    // OS window activation (alt-tab, clicking another application) moves terminal focus, so a shell
+    // running under DECSET 1004 is told the window went away. Item-level Qt focus events usually cover
+    // this, but not for a window whose panes hold no focused display -- and the manager, not Qt, is the
+    // focus authority. A member slot, not a lambda: Qt::UniqueConnection only applies to member
+    // functions, and bindWindow may run more than once for the same window.
+    connect(osWindow,
+            &QWindow::activeChanged,
+            this,
+            &WindowController::onOSWindowActiveChanged,
+            Qt::UniqueConnection);
+}
+
+void WindowController::onOSWindowActiveChanged()
+{
+    // Read the window that RAISED the signal, not _osWindow: focusDisplay() re-points _osWindow for a
+    // display re-homed across windows, so the member and the event's subject can diverge.
+    auto const* osWindow = qobject_cast<QWindow*>(sender());
+    if (osWindow == nullptr)
+        return;
+
+    if (osWindow->isActive())
+        _manager.setFocusedWindow(_windowId);
+    else
+        _manager.clearFocusedWindow(_windowId);
 }
 
 void WindowController::showInitial()

--- a/src/contour/WindowController.h
+++ b/src/contour/WindowController.h
@@ -563,6 +563,11 @@ class WindowController: public QAbstractListModel, public TabTitleProvider
     /// fractional-scale arrival keep the grid, not the pixel size). Idempotent per scale value.
     void onWindowScaleMaybeChanged();
 
+    /// OS window activation handler (QWindow::activeChanged): grants focus ownership to this window
+    /// when it becomes the active OS window and revokes it when it stops being active, so alt-tabbing
+    /// away from Contour notifies the shell (DECSET 1004) even when no display holds Qt item focus.
+    void onOSWindowActiveChanged();
+
     /// Watches the bound window for QEvent::DevicePixelRatioChange (no QWindow signal exists for it).
     bool eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -1091,15 +1091,52 @@ TEST_CASE("display: focus in/out toggle the terminal's focus state on the live d
 {
     REQUIRE_DISPLAY_OR_SKIP();
     DisplayHarness h;
+    auto& controller = h.bindController();
+    auto& manager = h.testApp.app().sessionsManager();
+
+    // A session is born unfocused (Settings::focused is false for every contour session) — focus is
+    // granted by the manager, never assumed. @see TerminalSession's createSettingsFromConfig.
+    REQUIRE_FALSE(h.session->terminal().focused());
 
     QFocusEvent focusIn(QEvent::FocusIn);
     QCoreApplication::sendEvent(h.display, &focusIn);
     h.pump();
+    // A Qt focus-in on a display routes through the manager, which is the single VT-focus authority:
+    // it focuses this session AND records the display's window as the focus owner.
+    CHECK(h.session->terminal().focused());
+    CHECK(manager.focusedWindow() == controller.windowId());
+
     QFocusEvent focusOut(QEvent::FocusOut);
     QCoreApplication::sendEvent(h.display, &focusOut);
     h.pump();
+    CHECK_FALSE(h.session->terminal().focused());
+
     // Focus events must not desync the session — it stays alive and renders.
     CHECK(h.session->terminal().pageSize().lines.value > 0);
+}
+
+TEST_CASE("display: revoking the window's focus ownership leaves its live session unfocused",
+          "[display][focus][window]")
+{
+    // Alt-tabbing away from Contour revokes the window's focus ownership, which must unfocus the live
+    // session so a DECSET 1004 application is told. (That the QWindow::activeChanged signal is wired to
+    // this revoke is pinned headlessly in FocusRouting_test; here it runs against a real display.)
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    auto& controller = h.bindController();
+    auto& manager = h.testApp.app().sessionsManager();
+
+    // Focus the session the way production does, through a Qt focus-in on its display.
+    QFocusEvent focusIn(QEvent::FocusIn);
+    QCoreApplication::sendEvent(h.display, &focusIn);
+    h.pump();
+    REQUIRE(h.session->terminal().focused());
+    REQUIRE(manager.focusedWindow() == controller.windowId());
+
+    manager.clearFocusedWindow(controller.windowId());
+    h.pump();
+    CHECK_FALSE(manager.focusedWindow().has_value());
+    CHECK_FALSE(h.session->terminal().focused());
 }
 
 TEST_CASE("display: blur-behind and programmatic resize route through the live display", "[display][window]")

--- a/src/contour/test/FocusRouting_test.cpp
+++ b/src/contour/test/FocusRouting_test.cpp
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end coverage of terminal (VT) focus routing: a tab or pane switch must send a focus-OUT to
+// the session that had focus and a focus-IN to the one that gains it, so a shell running under
+// DECSET 1004 (FocusTracking) receives CSI O / CSI I.
+//
+// Why this needs its own file. Qt fires NO focus event on a tab switch: PaneNode.qml's leaf Loader
+// stays active, so the same TerminalDisplay item is reused and only its `session:` property rebinds.
+// TerminalSessionManager::syncFocusForWindow is the compensating seam, and it is reached from the
+// model's activeTabChanged / activePaneChanged. TerminalSession_test covers the setFocusedSession
+// PRIMITIVE; these cases cover the CHAIN, down to the bytes in the PTY.
+//
+// These are also the regression pins for the focus-ownership refactor. syncFocusForWindow used to
+// gate on `_activeDisplay != nullptr` — a raw Qt pointer that is null between a display teardown and
+// the next Qt focus-in, and null in every headless test. A tab switch in that gap notified nobody,
+// and the path was untestable. Ownership is now a modelled vtmux::WindowId, so the production path
+// is the tested path. All cases here run headless: no [display] tag, nothing skips offscreen.
+
+#include <contour/ContourGuiApp.h>
+#include <contour/TerminalSession.h>
+#include <contour/TerminalSessionManager.h>
+#include <contour/WindowController.h>
+#include <contour/test/GuiTestFixtures.h>
+
+#include <vtbackend/primitives.h>
+
+#include <vtpty/MockPty.h>
+
+#include <crispy/escape.h>
+
+#include <QtGui/QWindow>
+#include <QtQuick/QQuickWindow>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <string>
+
+#include <vtmux/Pane.h>
+#include <vtmux/SessionModel.h>
+#include <vtmux/Tab.h>
+
+namespace
+{
+
+using contour::test::mockPtyOf;
+using contour::test::MockPtySessionFactory;
+using contour::test::ScopedController;
+using contour::test::TestApp;
+
+/// Turns on focus reporting (DECSET 1004) for @p session, as an application like vim would.
+void enableFocusTracking(contour::TerminalSession& session)
+{
+    session.terminal().setMode(vtbackend::DECMode::FocusTracking, true);
+}
+
+/// Drops whatever the session has written so far, so a following assertion sees only the bytes the
+/// operation under test produced.
+void clearPtyInput(contour::TerminalSession& session)
+{
+    mockPtyOf(session).stdinBuffer().clear();
+}
+
+/// Escaped view of everything @p session wrote towards the shell (readable Catch2 diffs).
+[[nodiscard]] std::string writtenBy(contour::TerminalSession& session)
+{
+    return crispy::escape(mockPtyOf(session).stdinBuffer());
+}
+
+/// The session backing the active pane of tab @p index in @p window.
+[[nodiscard]] contour::TerminalSession* sessionOfTabAt(contour::TerminalSessionManager& manager,
+                                                       vtmux::WindowId window,
+                                                       int index)
+{
+    auto* modelWindow = manager.model().window(window);
+    REQUIRE(modelWindow != nullptr);
+    auto* tab = modelWindow->tabAt(index);
+    REQUIRE(tab != nullptr);
+    REQUIRE(tab->activePane() != nullptr);
+    return manager.sessionForId(tab->activePane()->session());
+}
+
+/// Closes every tab of @p controller, mirroring how the multi-window tests wind sessions down.
+void closeAllTabs(contour::WindowController& controller)
+{
+    for (int row = controller.count() - 1; row >= 0; --row)
+        controller.closeTabAtIndex(row);
+}
+
+} // namespace
+
+TEST_CASE("focus: switching tabs focuses out the old tab and focuses in the new one", "[contour][focus][tab]")
+{
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    // A freshly spawned window owns focus, so a tab switch moves VT focus even before the window has
+    // ever been clicked (no Qt focus event has been delivered in this headless run).
+    REQUIRE(manager.focusedWindow() == window.id);
+
+    window->createNewTab();
+    window->createNewTab();
+    REQUIRE(window->count() == 2);
+    REQUIRE(window->activeTabIndex() == 1);
+
+    auto* a = sessionOfTabAt(manager, window.id, 0);
+    auto* b = sessionOfTabAt(manager, window.id, 1);
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    REQUIRE(a != b);
+
+    // Creating the second tab already moved focus off the first: exactly one session is ever focused.
+    CHECK(b->terminal().focused());
+    CHECK_FALSE(a->terminal().focused());
+
+    window->activateTab(0);
+    CHECK(a->terminal().focused());
+    CHECK_FALSE(b->terminal().focused());
+
+    window->activateTab(1);
+    CHECK(b->terminal().focused());
+    CHECK_FALSE(a->terminal().focused());
+
+    closeAllTabs(*window);
+}
+
+TEST_CASE("focus: a tab switch writes CSI O and CSI I to the two tabs' PTYs under DECMode 1004",
+          "[contour][focus][tab][modes]")
+{
+    // The point of the whole chain: the bytes must actually reach the shell, not merely flip an
+    // internal flag. Terminal::flushInput() is what writes them into the PTY.
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    window->createNewTab();
+    window->createNewTab();
+    REQUIRE(window->count() == 2);
+
+    auto* a = sessionOfTabAt(manager, window.id, 0);
+    auto* b = sessionOfTabAt(manager, window.id, 1);
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+
+    SECTION("with focus reporting enabled both ends of the switch are reported")
+    {
+        enableFocusTracking(*a);
+        enableFocusTracking(*b);
+        clearPtyInput(*a);
+        clearPtyInput(*b);
+
+        // Tab 1 (b) is active; switching to tab 0 must tell b it lost focus and a that it gained it.
+        window->activateTab(0);
+        CHECK(writtenBy(*b) == crispy::escape("\033[O"));
+        CHECK(writtenBy(*a) == crispy::escape("\033[I"));
+
+        clearPtyInput(*a);
+        clearPtyInput(*b);
+
+        // ...and symmetrically on the way back.
+        window->activateTab(1);
+        CHECK(writtenBy(*a) == crispy::escape("\033[O"));
+        CHECK(writtenBy(*b) == crispy::escape("\033[I"));
+    }
+
+    SECTION("with focus reporting disabled nothing reaches either PTY")
+    {
+        // Focus still moves internally (the renderer needs it); only the notification is gated.
+        clearPtyInput(*a);
+        clearPtyInput(*b);
+
+        window->activateTab(0);
+        CHECK(mockPtyOf(*a).stdinBuffer().empty());
+        CHECK(mockPtyOf(*b).stdinBuffer().empty());
+        CHECK(a->terminal().focused());
+        CHECK_FALSE(b->terminal().focused());
+    }
+
+    closeAllTabs(*window);
+}
+
+TEST_CASE("focus: switching panes within a tab moves focus between the panes' sessions",
+          "[contour][focus][pane]")
+{
+    // The same seam, reached through activePaneChanged instead of activeTabChanged.
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    window->createNewTab();
+    REQUIRE(window->count() == 1);
+
+    auto* modelWindow = manager.model().window(window.id);
+    REQUIRE(modelWindow != nullptr);
+    auto* tab = modelWindow->tabAt(0);
+    REQUIRE(tab != nullptr);
+
+    auto const firstPaneId = tab->activePane()->id();
+    auto* first = window->activeSession();
+    REQUIRE(first != nullptr);
+
+    manager.splitActivePane(/*vertical*/ true, window->activeSession());
+    auto const secondPaneId = tab->activePane()->id();
+    REQUIRE(firstPaneId != secondPaneId);
+
+    auto* second = window->activeSession();
+    REQUIRE(second != nullptr);
+    REQUIRE(first != second);
+
+    // A split makes the new pane active from birth, so focus has already moved onto it.
+    CHECK(second->terminal().focused());
+    CHECK_FALSE(first->terminal().focused());
+
+    enableFocusTracking(*first);
+    enableFocusTracking(*second);
+    clearPtyInput(*first);
+    clearPtyInput(*second);
+
+    // Move focus back to the original pane by id (orientation-independent, unlike a direction move).
+    manager.activatePane(tab->id(), firstPaneId);
+    CHECK(first->terminal().focused());
+    CHECK_FALSE(second->terminal().focused());
+    CHECK(writtenBy(*second) == crispy::escape("\033[O"));
+    CHECK(writtenBy(*first) == crispy::escape("\033[I"));
+
+    closeAllTabs(*window);
+}
+
+TEST_CASE("focus: moving a tab to another window does not carry VT focus into the unfocused window",
+          "[contour][focus][multiwindow]")
+{
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+    ScopedController windowA { manager };
+    ScopedController windowB { manager };
+
+    windowA->createNewTab();
+    windowA->createNewTab();
+    windowB->createNewTab();
+    REQUIRE(windowA->count() == 2);
+    REQUIRE(windowB->count() == 1);
+
+    // Spawning B took ownership; state the intent explicitly so the test does not lean on creation order.
+    manager.setFocusedWindow(windowA.id);
+    REQUIRE(manager.focusedWindow() == windowA.id);
+
+    auto* moved = sessionOfTabAt(manager, windowA.id, 0);
+    auto* stayed = sessionOfTabAt(manager, windowA.id, 1);
+    REQUIRE(moved != nullptr);
+    REQUIRE(stayed != nullptr);
+
+    // The transplant routes through activeTabChanged on the DESTINATION window, which does not own
+    // focus — so the moved tab must not steal it.
+    windowB->moveTabIntoThisWindow(windowA.id.value, 0, 0);
+    CHECK_FALSE(moved->terminal().focused());
+    CHECK(stayed->terminal().focused());
+
+    // Handing ownership to B focuses its active leaf and releases A's.
+    manager.setFocusedWindow(windowB.id);
+    CHECK(moved->terminal().focused());
+    CHECK_FALSE(stayed->terminal().focused());
+
+    closeAllTabs(*windowA);
+    closeAllTabs(*windowB);
+}
+
+TEST_CASE("focus: bindWindow wires OS window activation to focus ownership", "[contour][focus][window]")
+{
+    // Alt-tabbing away from Contour must notify a DECSET 1004 application even when no display holds Qt
+    // item focus, so bindWindow connects QWindow::activeChanged to the manager's grant/revoke. The
+    // connection is the whole mechanism: without it the feature is silently absent, and no assertion
+    // about focus behaviour would notice. Asserted via disconnect(), which reports whether a matching
+    // connection existed -- deterministic, and independent of whether a window manager will activate a
+    // test window.
+    TestApp app;
+    auto& manager = app.manager();
+    ScopedController window { manager };
+
+    auto osWindow = std::make_unique<QQuickWindow>();
+    window->bindWindow(osWindow.get());
+
+    // NB: this consumes the connection it verifies; nothing below depends on it.
+    CHECK(QObject::disconnect(osWindow.get(), &QWindow::activeChanged, window.controller, nullptr));
+
+    // And the two ends of what that signal drives: a grant focuses the window's active leaf, a revoke
+    // leaves nothing focused.
+    manager.clearFocusedWindow(window.id);
+    CHECK_FALSE(manager.focusedWindow().has_value());
+    manager.setFocusedWindow(window.id);
+    CHECK(manager.focusedWindow() == window.id);
+}
+
+TEST_CASE("focus: closing the focused window drops focus ownership and leaves no terminal focused",
+          "[contour][focus][multiwindow]")
+{
+    // Ownership must not outlive its window: a stale WindowId would let a later model event in an
+    // unrelated window re-grant focus through syncFocusForWindow.
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+
+    ScopedController window { manager };
+    window->createNewTab();
+    REQUIRE(manager.focusedWindow() == window.id);
+
+    closeAllTabs(*window);
+    manager.removeWindowController(window.id);
+
+    CHECK_FALSE(manager.focusedWindow().has_value());
+}
+
+TEST_CASE("focus: a background window's tab activation cannot steal focus", "[contour][focus][multiwindow]")
+{
+    // The anti-steal property the ownership gate exists for: only the focus-owning window may move VT
+    // focus, so a background window applying a layout or activating a tab leaves the user's terminal
+    // focused.
+    TestApp app { std::make_unique<MockPtySessionFactory>() };
+    auto& manager = app.manager();
+    ScopedController windowA { manager };
+    ScopedController windowB { manager };
+
+    windowA->createNewTab();
+    windowB->createNewTab();
+    windowB->createNewTab();
+
+    manager.setFocusedWindow(windowA.id);
+    REQUIRE(manager.focusedWindow() == windowA.id);
+
+    auto* foreground = windowA->activeSession();
+    REQUIRE(foreground != nullptr);
+    auto* background = sessionOfTabAt(manager, windowB.id, 0);
+    REQUIRE(background != nullptr);
+    REQUIRE(foreground != background);
+
+    enableFocusTracking(*foreground);
+    clearPtyInput(*foreground);
+
+    windowB->activateTab(0);
+
+    CHECK(manager.focusedWindow() == windowA.id);
+    CHECK(foreground->terminal().focused());
+    CHECK_FALSE(background->terminal().focused());
+    // The foreground shell was not told anything happened.
+    CHECK(mockPtyOf(*foreground).stdinBuffer().empty());
+
+    closeAllTabs(*windowA);
+    closeAllTabs(*windowB);
+}

--- a/src/contour/test/GuiTestFixtures.h
+++ b/src/contour/test/GuiTestFixtures.h
@@ -80,6 +80,15 @@ class MockPtySessionFactory final: public contour::SessionFactory
     std::vector<vtpty::MockPty*> createdPtys;
 };
 
+/// The MockPty backing @p session, for seeding output and inspecting the bytes the terminal wrote
+/// towards the shell (key/mouse encodings, replies, focus events).
+/// @param session A session created over a MockPty (via MockPtySessionFactory or directly).
+/// @return The session's PTY, downcast. Throws std::bad_cast if it is not a MockPty.
+[[nodiscard]] inline vtpty::MockPty& mockPtyOf(contour::TerminalSession& session)
+{
+    return dynamic_cast<vtpty::MockPty&>(session.terminal().device());
+}
+
 /// Loads @p yaml through the PRODUCTION config file loader (writing it to a throwaway temp file
 /// first), so a test asserts what a real user's configuration would parse to — including the
 /// sibling-layouts merge and every fallback loadConfigFromFile applies.

--- a/src/contour/test/Helper_test.cpp
+++ b/src/contour/test/Helper_test.cpp
@@ -116,10 +116,7 @@ namespace
     return std::make_unique<contour::TerminalSession>(&app.sessionsManager(), std::move(pty), app);
 }
 
-[[nodiscard]] vtpty::MockPty& mockPtyOf(contour::TerminalSession& s)
-{
-    return dynamic_cast<vtpty::MockPty&>(s.terminal().device());
-}
+using contour::test::mockPtyOf;
 } // namespace
 
 TEST_CASE("sendKeyEvent maps Qt key events onto the terminal's PTY encoding", "[helper][input]")

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -153,11 +153,7 @@ namespace
 using vtbackend::KeyboardEventType;
 using vtbackend::Modifiers;
 
-/// The MockPty backing @p session, for seeding output and inspecting written input bytes.
-[[nodiscard]] vtpty::MockPty& mockPtyOf(contour::TerminalSession& session)
-{
-    return dynamic_cast<vtpty::MockPty&>(session.terminal().device());
-}
+using contour::test::mockPtyOf;
 
 /// Registers a copy of the "main" profile under @p name in @p app's config, letting @p mutate it, so
 /// a session constructed under that name exercises config-driven behaviour (hint patterns, bell

--- a/src/vtbackend/InputGenerator.cpp
+++ b/src/vtbackend/InputGenerator.cpp
@@ -1160,7 +1160,7 @@ bool InputGenerator::generateFocusOutEvent()
         inputLog()("Sending focus-out event.");
         return true;
     }
-    return true;
+    return false;
 }
 
 bool InputGenerator::generateRaw(std::string_view const& raw)

--- a/src/vtbackend/InputGenerator_test.cpp
+++ b/src/vtbackend/InputGenerator_test.cpp
@@ -1796,4 +1796,46 @@ TEST_CASE("InputGenerator.Wheel.ScrollMultiplier.repeats_cursor_keys", "[termina
 
 // }}}
 
+// {{{ focus events (DECSET 1004)
+
+// NB: bracket-per-tag. Catch2 reads "[terminal,input]" (used widely above) as ONE tag literally named
+// `terminal,input`, so such cases are unreachable via a `[focus]` filter.
+TEST_CASE("InputGenerator.focusEvents", "[terminal][input][focus]")
+{
+    // DECMode::FocusTracking (1004) gates focus notification. The return value is load-bearing:
+    // Terminal::sendFocus{In,Out}Event keys its flushInput() on it, so "nothing was generated" must
+    // read as false. generateFocusOutEvent used to return true on both branches, claiming an event
+    // had been sent with the mode off.
+
+    SECTION("mode off: nothing is generated and neither event claims to have been sent")
+    {
+        auto input = InputGenerator {};
+        REQUIRE_FALSE(input.generateFocusEvents());
+
+        CHECK_FALSE(input.generateFocusInEvent());
+        CHECK_FALSE(input.generateFocusOutEvent());
+        CHECK(input.peek().empty());
+    }
+
+    SECTION("mode on: focus-in emits CSI I")
+    {
+        auto input = InputGenerator {};
+        input.setGenerateFocusEvents(true);
+
+        CHECK(input.generateFocusInEvent());
+        CHECK(escape(input.peek()) == "\\e[I");
+    }
+
+    SECTION("mode on: focus-out emits CSI O")
+    {
+        auto input = InputGenerator {};
+        input.setGenerateFocusEvents(true);
+
+        CHECK(input.generateFocusOutEvent());
+        CHECK(escape(input.peek()) == "\\e[O");
+    }
+}
+
+// }}}
+
 // }}}

--- a/src/vtbackend/Settings.h
+++ b/src/vtbackend/Settings.h
@@ -117,6 +117,16 @@ struct Settings
     /// User-initiated transitions (e.g. leaving Vi mode) are not affected.
     bool autoScrollOnUpdate = true;
 
+    /// Whether the terminal considers itself focused at birth. Birth state, not a runtime knob: it is
+    /// read once by the constructor and thereafter only sendFocus{In,Out}Event writes the flag.
+    ///
+    /// A host that multiplexes several terminals and routes focus between them sets this false, so
+    /// focus is granted rather than assumed — a terminal born focused but never told otherwise would
+    /// render an active cursor and an active indicator status line forever, and would never send its
+    /// application the DECSET 1004 focus-out it is due. A host with a single terminal that never moves
+    /// focus leaves it true.
+    bool focused = true;
+
     // Size in bytes per PTY Buffer Object.
     //
     // Defaults to 1 MB, that's roughly 10k lines when column count is 100.

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -194,6 +194,7 @@ Terminal::Terminal(Events& eventListener,
     _cellPixelSize {},
     _defaultColorPalette { _settings.colorPalette },
     _colorPalette { _settings.colorPalette },
+    _focused { _settings.focused },
     _pageMargins {},
     _hostWritableScreenMargin { .vertical = Margin::Vertical { .from = {}, .to = LineOffset(0) },
                                 .horizontal =

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -2215,7 +2215,9 @@ class Terminal
     std::vector<ColorPalette> _savedColorPalettes;
     size_t _lastSavedColorPalette = 0;
 
-    bool _focused = true;
+    /// Whether this terminal currently has focus. Seeded from Settings::focused (NOT defaulted here, so
+    /// there is one source of truth) and thereafter written only by sendFocus{In,Out}Event.
+    bool _focused;
 
     VTType _terminalId = VTType::VT525;
     VTType _operatingLevel = VTType::VT525;

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -4353,3 +4353,40 @@ TEST_CASE("TraceHandler.an_APC_body_waits_its_turn_like_every_other_sequence", "
     // runs it until the user steps the trace forward.
     CHECK(mock.terminal.primaryScreen().at(LineOffset(0), ColumnOffset(0)).imageFragment() == nullptr);
 }
+
+TEST_CASE("Terminal.focus.events_reach_the_pty_only_under_DECMode_1004", "[terminal][focus]")
+{
+    // Focus state is tracked unconditionally (the renderer needs it for the inactive cursor shape and
+    // the inactive indicator status line), but the CSI I / CSI O notification is gated on DECMode 1004.
+    // The return value reports whether bytes were actually produced.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(10) } };
+
+    SECTION("mode off: focus is tracked, nothing reaches the PTY")
+    {
+        mock.discardPendingReplies();
+
+        CHECK_FALSE(mock.terminal.sendFocusOutEvent());
+        CHECK_FALSE(mock.terminal.focused());
+        CHECK(mock.replyData().empty());
+
+        CHECK_FALSE(mock.terminal.sendFocusInEvent());
+        CHECK(mock.terminal.focused());
+        CHECK(mock.replyData().empty());
+    }
+
+    SECTION("mode on: CSI O on focus loss, CSI I on focus gain")
+    {
+        mock.writeToScreen("\033[?1004h");
+        mock.discardPendingReplies();
+
+        CHECK(mock.terminal.sendFocusOutEvent());
+        CHECK_FALSE(mock.terminal.focused());
+        CHECK(e(mock.replyData()) == e("\033[O"s));
+
+        mock.resetReplyData();
+
+        CHECK(mock.terminal.sendFocusInEvent());
+        CHECK(mock.terminal.focused());
+        CHECK(e(mock.replyData()) == e("\033[I"s));
+    }
+}


### PR DESCRIPTION
An application that enables focus reporting (`DECSET 1004`) expects `CSI I` when it gains focus and `CSI O` when it loses it. Contour did send both on a tab or pane switch, but only conditionally, and nothing tested it.

`syncFocusForWindow` exists because a tab switch fires no Qt focus event at all — `PaneNode.qml`'s leaf `Loader` stays active, so the same `TerminalDisplay` is reused and only its `session:` property rebinds. That seam was gated on `_activeDisplay`, a raw Qt pointer that is null between a display teardown and the next Qt focus-in. Switching tabs after collapsing a split therefore notified nobody, and the same null made the path unreachable from a headless test — which is why no test covered it.

## Changes

- Focus ownership is a modelled `vtmux::WindowId` rather than a display pointer. It moves on a window spawn, a genuine Qt focus-in, and OS window activation; a model event never moves it, so a background window applying a layout or receiving a dropped tab still cannot steal focus.
- `QWindow::activeChanged` is wired to that grant/revoke, so alt-tabbing away notifies the shell even for a window whose panes hold no focused display.
- Sessions are born unfocused. `setFocusedSession` only focus-OUTs the session that previously held focus, so a session born in a background tab, a non-active split pane, or a window that does not own focus stayed "focused" forever — an active cursor shape, an active indicator status line, and no focus-out for its application.
- `InputGenerator::generateFocusOutEvent` returned `true` on both branches, claiming an event had been sent with focus reporting off; its focus-in counterpart already returned `false`. `Terminal::sendFocusOutEvent` keys its `flushInput()` on that value.
- The manager's `_activeDisplay` had no remaining reader once the gate moved, and is gone.

New coverage asserts the actual bytes arriving in the PTY — not just the internal flag — for tab switch, pane switch, cross-window tab move, window close, and the background-window anti-steal property.