### PR TITLE
fix: guard IME cursor access against nullopt during blink-off phase

### DIFF
--- a/src/vtbackend/RenderBufferBuilder.cpp
+++ b/src/vtbackend/RenderBufferBuilder.cpp
@@ -139,8 +139,10 @@ RenderBufferBuilder::RenderBufferBuilder(Terminal const& terminal,
 
 optional<RenderCursor> RenderBufferBuilder::renderCursor() const
 {
-    if (!_cursorPosition || !_terminal->cursorCurrentlyVisible()
-        || !_terminal->viewport().isLineVisible(_cursorPosition->line))
+    // When IME composition is active, the cursor must be rendered regardless of blink phase:
+    // the IME preedit text is displayed AT the cursor position, so the cursor is its anchor.
+    auto const cursorVisible = _terminal->cursorCurrentlyVisible() || !_inputMethodData.preeditString.empty();
+    if (!_cursorPosition || !cursorVisible || !_terminal->viewport().isLineVisible(_cursorPosition->line))
         return nullopt;
 
     // TODO: check if CursorStyle has changed, and update render context accordingly.
@@ -662,7 +664,8 @@ bool RenderBufferBuilder::tryRenderInputMethodEditor(CellLocation screenPosition
             renderUtf8Text(screenPosition, textAttributes, _inputMethodData.preeditString, false);
         if (_inputMethodSkipColumns > ColumnCount(0))
         {
-            _output->cursor->position.column += ColumnOffset::cast_from(_inputMethodSkipColumns);
+            if (_output->cursor.has_value())
+                _output->cursor->position.column += ColumnOffset::cast_from(_inputMethodSkipColumns);
             _output->cells.at(_output->cells.size() - unbox<size_t>(_inputMethodSkipColumns)).groupStart =
                 true;
             _output->cells.back().groupEnd = true;

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -101,6 +101,45 @@ TEST_CASE("Terminal.BlinkingCursor", "[terminal]")
     }
 }
 
+// IME preedit text renders at the cursor position. While the IME is composing, the cursor must be
+// visible in the render buffer even when the blink phase is "off" -- without it, the IME path
+// dereferences a null optional and crashes. This test reproduces the crash reported via
+// SIGABRT on `std::optional<RenderCursor>::operator->()` in tryRenderInputMethodEditor().
+TEST_CASE("Terminal.IME.CursorVisibleDuringComposition", "[terminal]")
+{
+    auto mc = MockTerm { ColumnCount { 6 }, LineCount { 4 } };
+    auto& terminal = mc.terminal;
+    terminal.setCursorDisplay(vtbackend::CursorDisplay::Blink);
+    auto constexpr BlinkInterval = chrono::milliseconds(500);
+    terminal.setCursorBlinkingInterval(BlinkInterval);
+
+    auto const clockBase = chrono::steady_clock::time_point();
+
+    // Advance time past the first blink toggle so the cursor is in its "off" phase.
+    auto const clockBlinkOff = clockBase + BlinkInterval + chrono::milliseconds(1);
+    terminal.tick(clockBlinkOff);
+    terminal.ensureFreshRenderBuffer();
+    CHECK(!terminal.cursorCurrentlyVisible());
+
+    // Activate IME composition. Prior to the fix, the next line crashed inside
+    // tryRenderInputMethodEditor() because _output->cursor was nullopt while
+    // _cursorPosition was set.
+    terminal.updateInputMethodPreeditString("test");
+
+    // Advance the clock past the refresh interval so ensureFreshRenderBuffer
+    // actually rebuilds the buffer rather than skipping as a duplicate.
+    auto const clockAfterRefreshInterval = clockBlinkOff + chrono::milliseconds(100);
+    terminal.tick(clockAfterRefreshInterval);
+    terminal.ensureFreshRenderBuffer();
+
+    // Post-fix: the render buffer cursor must be present -- IME composition
+    // overrides the blink-off state so the cursor anchors the preedit text.
+    auto const renderBuffer = terminal.renderBuffer();
+    REQUIRE(renderBuffer.get().cursor.has_value());
+    CHECK(renderBuffer.get().cursor->position.column == ColumnOffset(0));
+    CHECK(renderBuffer.get().cursor->position.line == LineOffset(0));
+}
+
 TEST_CASE("Terminal.ModifierKeysDoNotScrollViewport", "[terminal]")
 {
     // Set up a terminal with history capacity to allow scrollback


### PR DESCRIPTION
This pull request addresses a crash that occurred when IME (Input Method Editor) composition was active and the cursor was not visible due to blinking. The main fix ensures the cursor is always rendered during IME composition, preventing dereferencing a null optional and improving stability. The changes also add a regression test to verify this behavior.

**IME Composition and Cursor Rendering:**

* Updated `RenderBufferBuilder::renderCursor()` to always render the cursor when IME composition is active, regardless of the cursor blink phase. This ensures the IME preedit text is anchored correctly and prevents crashes.
* In `RenderBufferBuilder::tryRenderInputMethodEditor()`, added a check to ensure the cursor is present before adjusting its position during IME composition.

**Testing and Validation:**

* Added a new test case `Terminal.IME.CursorVisibleDuringComposition` in `Terminal_test.cpp` to reproduce the prior crash and verify that the cursor is present during IME composition, even when the blink phase is "off".