### PR TITLE
Fix segfault when closing the window with accessibility enabled

### DIFF
--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -378,6 +378,7 @@ if(CONTOUR_FRONTEND_GUI)
             test/ExitCode_test.cpp
             test/CaretGeometry_test.cpp
             test/CaretReportGate_test.cpp
+            test/TerminalAccessible_test.cpp
             test/Helper_test.cpp
             test/HyperlinkTooltip_test.cpp
             test/HorizontalWheelGesture_test.cpp

--- a/src/contour/display/TerminalAccessible.cpp
+++ b/src/contour/display/TerminalAccessible.cpp
@@ -65,11 +65,30 @@ namespace
 
 // {{{ TerminalAccessible
 
-TerminalAccessible::TerminalAccessible(TerminalDisplay* display): QAccessibleObject { display }
+TerminalAccessible::TerminalAccessible(TerminalDisplay* display):
+    QAccessibleObject { display }, _prompt { new PromptAccessible(this) }
 {
+    // Registered up front rather than on first use, so the two views of the prompt's ownership can
+    // never disagree: an interface reaches the cache the instant it becomes the subject of a
+    // QAccessibleEvent anyway, because that constructor calls QAccessible::uniqueId() on it.
+    // NB: PromptAccessible only stores the pointer, so passing a half-constructed `this` is safe.
+    QAccessible::registerAccessibleInterface(_prompt);
 }
 
-TerminalAccessible::~TerminalAccessible() = default;
+TerminalAccessible::~TerminalAccessible()
+{
+    // Hand the prompt back to Qt's accessibility cache, which is what deletes it -- ~QAccessibleInterface
+    // is protected precisely to say that the cache owns every interface it has handed an id to.
+    //
+    // It learns that one has gone away through QObject::destroyed alone, a hook QAccessibleCache::insert
+    // installs only for interfaces that HAVE an object. The prompt has none, so nothing would ever drop
+    // its entry: deleting it here instead left the cache holding a dangling pointer, which it then
+    // dereferenced and freed a second time from ~QAccessibleCache at application exit -- issue #2015.
+    //
+    // The id is looked up rather than remembered because the cache RECYCLES ids: a stored one could
+    // name someone else's interface by the time it is used.
+    QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(_prompt));
+}
 
 void TerminalAccessible::installFactory()
 {
@@ -159,11 +178,9 @@ QAccessibleInterface* TerminalAccessible::parent() const
     return QAccessible::queryAccessibleInterface(item->window());
 }
 
-PromptAccessible* TerminalAccessible::promptInterface() const
+PromptAccessible* TerminalAccessible::promptInterface() const noexcept
 {
-    if (!_prompt)
-        _prompt = std::make_unique<PromptAccessible>(const_cast<TerminalAccessible*>(this));
-    return _prompt.get();
+    return _prompt;
 }
 
 int TerminalAccessible::childCount() const
@@ -180,7 +197,7 @@ QAccessibleInterface* TerminalAccessible::child(int index) const
 
 int TerminalAccessible::indexOfChild(QAccessibleInterface const* child) const
 {
-    if (_promptShown && child == _prompt.get())
+    if (_promptShown && child == _prompt)
         return 0;
     return -1;
 }

--- a/src/contour/display/TerminalAccessible.h
+++ b/src/contour/display/TerminalAccessible.h
@@ -7,8 +7,6 @@
 #include <QtGui/QAccessibleInterface>
 #include <QtGui/QAccessibleObject>
 
-#include <memory>
-
 namespace contour::display
 {
 
@@ -24,8 +22,11 @@ class TerminalAccessible;
 /// rectangle on the terminal itself would be read by nothing.
 ///
 /// Has no QObject behind it: it is a region of the terminal, not a widget. Qt 6 allows a QObject-less
-/// interface to be the subject of a QAccessibleEvent, which is all this needs. Owned by its parent
-/// @ref TerminalAccessible and destroyed with it.
+/// interface to be the subject of a QAccessibleEvent, which is all this needs.
+///
+/// Owned by Qt's accessibility cache, like every other QAccessibleInterface -- which is why
+/// ~QAccessibleInterface is protected. Its parent @ref TerminalAccessible registers it and hands it
+/// back on destruction; nobody else may delete it. @see TerminalAccessible::promptInterface.
 class PromptAccessible final: public QAccessibleInterface
 {
   public:
@@ -122,6 +123,10 @@ class TerminalAccessible final: public QAccessibleObject, public QAccessibleText
     /// The display this interface adapts, or nullptr once it has been destroyed.
     [[nodiscard]] TerminalDisplay* display() const;
 
+    /// The prompt child interface. Never null, and never to be deleted by a caller: it belongs to
+    /// Qt's accessibility cache, which this object hands it back to when it goes away.
+    [[nodiscard]] PromptAccessible* promptInterface() const noexcept;
+
     /// Recomputes the caret state and, if it changed in a way worth announcing, tells the OS.
     ///
     /// Runs on the GUI THREAD only. Reads the BLINK-FREE visibility predicate deliberately: the render
@@ -133,14 +138,11 @@ class TerminalAccessible final: public QAccessibleObject, public QAccessibleText
     void resetCaretGate();
 
   private:
-    /// The prompt child, created on demand while a live prompt exists.
-    [[nodiscard]] PromptAccessible* promptInterface() const;
-
     CaretReportGate _gate;
-    /// Mirrors whether a prompt child currently exists, so show/hide are announced once each.
+    /// Mirrors whether a prompt child is currently exposed, so show/hide are announced once each.
     bool _promptShown = false;
-    /// Created on first use, including from const query methods; owned here and destroyed with this.
-    mutable std::unique_ptr<PromptAccessible> _prompt;
+    /// Non-owning: Qt's accessibility cache owns it, and the destructor hands it back.
+    PromptAccessible* _prompt;
 };
 
 } // namespace contour::display

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -1054,6 +1054,43 @@ TEST_CASE("display: the accessibility interface reports the caret", "[display][a
     CHECK_NOTHROW(h.display->resetAccessibleCaret());
 }
 
+TEST_CASE("display: the prompt interface leaves Qt's accessibility cache with its display", "[display][a11y]")
+{
+    // Issue #2015, end to end: a real session whose OSC 133 marks make the prompt genuinely appear, so
+    // the interface is registered by the production path rather than by the test. ~TerminalAccessible
+    // explains the ownership rule this asserts; TerminalAccessible_test.cpp gates it in CI.
+    //
+    // Asserting on the id rather than on the interface keeps the check itself safe: it compares
+    // pointers and never dereferences a freed one.
+    REQUIRE_DISPLAY_OR_SKIP();
+    auto harness = std::make_unique<DisplayHarness>();
+
+    contour::display::TerminalAccessible::installFactory();
+    harness->display->forceActiveFocus();
+
+    // OSC 133 A/B: the prompt-start / prompt-end pair that gives livePromptSpan() something to report,
+    // and thus the only thing that brings the prompt child interface into existence.
+    harness->feedAndSettle("\033]133;A\033\\$ \033]133;B\033\\"sv);
+
+    auto* accessible = dynamic_cast<contour::display::TerminalAccessible*>(
+        QAccessible::queryAccessibleInterface(harness->display));
+    REQUIRE(accessible != nullptr);
+
+    // Driven directly: reportAccessibleCaret() gates on an attached assistive client, and neither the
+    // test environment nor CI has one.
+    accessible->reportCaret();
+    REQUIRE(accessible->childCount() == 1); // the prompt branch really ran
+
+    auto* prompt = accessible->child(0);
+    REQUIRE(prompt != nullptr);
+    auto const promptId = QAccessible::uniqueId(prompt);
+    REQUIRE(QAccessible::accessibleInterface(promptId) == prompt);
+
+    harness.reset(); // deletes the display, and with it the terminal's accessible interface
+
+    CHECK(QAccessible::accessibleInterface(promptId) == nullptr);
+}
+
 TEST_CASE("display: mouse press/move drive selection and the cursor shape on the live display",
           "[display][mouse]")
 {

--- a/src/contour/test/TerminalAccessible_test.cpp
+++ b/src/contour/test/TerminalAccessible_test.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lifetime tests for the terminal's accessibility interfaces: nothing either of them registers with
+// Qt's accessibility cache may outlive the display. ~TerminalAccessible explains why that is not
+// automatic for the prompt, and what it cost when it was not enforced (issue #2015).
+//
+// Offscreen, so this gates in CI: an interface is created and cached independently of whether an
+// assistive client is attached. The end-to-end counterpart -- a live session whose OSC 133 marks make
+// the prompt genuinely appear -- is display-gated, in DisplayRendering_test.cpp.
+
+#include <contour/display/TerminalAccessible.h>
+#include <contour/display/TerminalDisplay.h>
+
+#include <QtGui/QAccessible>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+using contour::display::TerminalAccessible;
+using contour::display::TerminalDisplay;
+
+TEST_CASE("a11y: the terminal's interfaces leave Qt's accessibility cache with their display",
+          "[contour][a11y]")
+{
+    TerminalAccessible::installFactory();
+
+    auto display = std::make_unique<TerminalDisplay>();
+    auto* accessible =
+        dynamic_cast<TerminalAccessible*>(QAccessible::queryAccessibleInterface(display.get()));
+    REQUIRE(accessible != nullptr);
+
+    // uniqueId() registers on a miss, so both ids are live cache entries from here on. The terminal's
+    // own interface is the control: it HAS a QObject, so Qt has always cleaned it up correctly.
+    auto const terminalId = QAccessible::uniqueId(accessible);
+    auto const promptId = QAccessible::uniqueId(accessible->promptInterface());
+    REQUIRE(QAccessible::accessibleInterface(terminalId) == accessible);
+    REQUIRE(QAccessible::accessibleInterface(promptId) == accessible->promptInterface());
+
+    display.reset(); // QObject::destroyed -> the cache deletes the terminal's interface
+
+    CHECK(QAccessible::accessibleInterface(terminalId) == nullptr);
+    CHECK(QAccessible::accessibleInterface(promptId) == nullptr);
+}


### PR DESCRIPTION
Closing the Contour window segfaulted inside `QAccessibleCache::deleteInterface`, reached from `~QAccessibleCache` during `~QApplication`, sometimes preceded by a glibc double-free warning.

Qt's accessibility cache owns every `QAccessibleInterface` it has handed an id to — which is why `~QAccessibleInterface` is protected — and learns that one has gone away through `QObject::destroyed` alone, a hook `QAccessibleCache::insert` installs only for interfaces that have an object. `PromptAccessible` deliberately has none, so once `reportCaret()` made it the subject of a `QAccessibleEvent` (whose constructor registers it), nothing would ever drop its cache entry. Destroying the display then freed it through `TerminalAccessible`'s `unique_ptr` while the cache kept the pointer, and `~QAccessibleCache` dereferenced and freed it a second time at teardown. Every closed tab, split and window left one more dangling entry behind, so the odds grew with session churn.

The prompt is now created and registered in `TerminalAccessible`'s constructor and handed back with `QAccessible::deleteAccessibleInterface` in the destructor, so the two views of its ownership cannot disagree. The id is looked up rather than remembered, because the cache recycles ids. Constructing it up front also retires the `mutable` member and the `const_cast` that laziness required.

Two tests cover it, and both reproduce the crash without the fix: an offscreen one that gates in CI, and a display-gated end-to-end case driving a real OSC 133 prompt.

Reproducing the original report needs an active AT bridge, so it went unnoticed — but nothing about the defect is display-specific, which is what makes the CI-runnable test possible.

Fixes #2015