### PR TITLE
Match hint-mode patterns across wrapped lines, add a scrollback scope

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -3,7 +3,9 @@ aaaaaaaaaa
 aaaabbbbcccc
 aabbcc
 ababab
+abcdefghi
 abcdefghijklmnopqrstuvwxy
+abcdefghijklmnopqrstuvwxyz
 ABCDEFGHIX
 ABCDEFGHXJKLMNOPQRST
 ABCXDEFGHI
@@ -238,6 +240,7 @@ istreambuf
 journalctl
 keychain
 keysym
+labelable
 letterbox
 letterboxes
 libcuda

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -3,9 +3,7 @@ aaaaaaaaaa
 aaaabbbbcccc
 aabbcc
 ababab
-abcdefghi
 abcdefghijklmnopqrstuvwxy
-abcdefghijklmnopqrstuvwxyz
 ABCDEFGHIX
 ABCDEFGHXJKLMNOPQRST
 ABCXDEFGHI

--- a/docs/demo/hint-mode.md
+++ b/docs/demo/hint-mode.md
@@ -113,6 +113,51 @@ The `patterns` parameter accepts:
 - Multiple pattern names separated by `|`: `filepath|githash`
 - `all` or empty: scan for all builtin patterns at once
 
+### Scope: Reaching Into Scrollback
+
+By default hint mode scans only what is on screen. The `scope` parameter widens
+that to the scrollback history:
+
+```yaml
+input_mapping:
+    # Scan the visible page (the default — may be omitted)
+    - { mods: [Control, Shift], key: U, action: HintMode, patterns: url, hint_action: Open, scope: Visible }
+
+    # Scan the visible page *and* scrollback history
+    - { mods: [Control, Shift], key: Y, action: HintMode, patterns: url, hint_action: Open, scope: Scrollback }
+```
+
+Under `scope: Scrollback`, labels are assigned once when hint mode is activated and
+then **stay put**: scrolling reveals the labels on other rows rather than renaming
+the ones you have already read. So the workflow is: activate, scroll to the output
+you want, then type its label. A label acts on its match even while it is off screen.
+
+`scope: Visible` behaves the other way round, because its scan region *is* the
+viewport: scrolling re-scans and re-labels.
+
+How much history a `Scrollback` activation reads is capped per profile, so a very
+large scrollback does not turn one keystroke into a long scan:
+
+```yaml
+profiles:
+  main:
+    # Maximum scrollback rows a `scope: Scrollback` activation scans (default: 1000).
+    hint_scrollback_lines: 1000
+```
+
+### Wrapped Lines
+
+A pattern is matched against the *logical* line, so a URL that the terminal broke
+across two or more rows because the window was too narrow is still found as a
+single hint, and selecting it yields the whole URL rather than the fragment on one
+row. The label sits at the start of the match, and the highlight follows the match
+across the line break.
+
+A hint is only offered where its label can be drawn. A match that begins above the
+scanned region — so that its label would be invisible — is not offered, since a
+label you cannot see is a label you cannot type. A match that begins inside the
+region and runs past its end *is* offered, and still yields its complete text.
+
 ### Colors
 
 Hint mode label and match colors are configured in the color scheme section of

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -226,6 +226,8 @@
           <li>Fixes profile settings that only took effect after a restart: changing background_image, its blur or opacity, the background color, or the scrollbar position now applies as soon as the config is reloaded or the profile is switched</li>
           <li>Fixes searching for text outside Latin-1: a needle such as "Привет" or an emoji drove the case handling through functions that are undefined for those codepoints, which could silently mismatch or abort the terminal. Case is now folded per the Unicode character database, so "smart case" and case-insensitive search work for non-Latin scripts as well</li>
           <li>Fixes passive mouse tracking (DEC mode 2029) surviving a terminal reset: after RIS the mode read as off while mouse reports still carried its extra parameter, which applications cannot parse, and wheel scrolling on the alternate screen emitted nothing</li>
+          <li>Fixes hint mode missing any URL or path that the terminal broke across two rows because the window was too narrow: patterns are now matched against the whole logical line, so such a match is one hint whose highlight follows it across the line break and which yields the complete text rather than the fragment on one row</li>
+          <li>Adds a scope parameter to the HintMode action: scope: Scrollback scans the scrollback history as well as the visible page, capped by the new hint_scrollback_lines profile option (default 1000). Its labels are assigned once and stay put, so you can activate hint mode, scroll to older output, and then type the label you see; scope: Visible remains the default</li>
         </ul>
       </description>
     </release>

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -63,7 +63,7 @@ struct DecreaseOpacity{};
 struct FocusNextSearchMatch{};
 struct FocusPreviousSearchMatch{};
 struct FollowHyperlink{ std::string uri; }; // empty uri => whatever lies under the mouse cursor right now
-struct HintMode{ std::string patterns; vtbackend::HintAction hintAction = vtbackend::HintAction::Copy; };
+struct HintMode{ std::string patterns; vtbackend::HintAction hintAction = vtbackend::HintAction::Copy; vtbackend::HintScope scope = vtbackend::HintScope::Visible; };
 struct IncreaseFontSize{};
 struct IncreaseOpacity{};
 struct NewTerminal{ std::optional<std::string> profileName; };
@@ -385,10 +385,13 @@ namespace documentation
         "Follows the hyperlink that is exposed via OSC 8 under the current cursor position."
     };
     constexpr inline std::string_view HintMode {
-        "Activates hint mode: scans the visible terminal for regex-matched patterns (URLs, file paths, "
+        "Activates hint mode: scans the terminal for regex-matched patterns (URLs, file paths, "
         "git hashes, etc.), renders short alphabetic labels on each match, and lets the user type a label "
         "to act on that match (copy, open, paste). Parameter `patterns` selects which pattern set to use, "
-        "and `hint_action` specifies the action (Copy, Open, Paste, CopyAndPaste, Select)."
+        "`hint_action` specifies the action (Copy, Open, Paste, CopyAndPaste, Select), and `scope` selects "
+        "how much to scan: Visible (the default, the current viewport) or Scrollback (the viewport plus up "
+        "to `hint_scrollback_lines` rows of history, whose labels stay put while you scroll to reach them). "
+        "A pattern that wraps across a line break is matched as one hint."
     };
     constexpr inline std::string_view IncreaseFontSize { "Increases the font size by 1 pixel." };
     constexpr inline std::string_view IncreaseOpacity { "Increases the default-background opacity by 5%." };
@@ -919,6 +922,21 @@ struct std::formatter<vtbackend::HintAction>: std::formatter<std::string_view>
             case vtbackend::HintAction::Paste: output = "Paste"; break;
             case vtbackend::HintAction::CopyAndPaste: output = "CopyAndPaste"; break;
             case vtbackend::HintAction::Select: output = "Select"; break;
+        }
+        return formatter<string_view>::format(output, ctx);
+    }
+};
+
+template <>
+struct std::formatter<vtbackend::HintScope>: std::formatter<std::string_view>
+{
+    auto format(vtbackend::HintScope value, auto& ctx) const
+    {
+        string_view output;
+        switch (value)
+        {
+            case vtbackend::HintScope::Visible: output = "Visible"; break;
+            case vtbackend::HintScope::Scrollback: output = "Scrollback"; break;
         }
         return formatter<string_view>::format(output, ctx);
     }

--- a/src/contour/Command.cpp
+++ b/src/contour/Command.cpp
@@ -73,8 +73,9 @@ CommandArguments commandArguments(actions::Action const& action)
                 return { .id = a.delimiters, .title = std::format(": {}", a.delimiters) };
             },
             [](HintMode const& a) -> CommandArguments {
-                return { .id = std::format("{}:{}", a.patterns, a.hintAction),
-                         .title = std::format(": {} ({})", a.patterns, a.hintAction) };
+                // The scope belongs in the id: two mappings that differ only by it are two commands.
+                return { .id = std::format("{}:{}:{}", a.patterns, a.hintAction, a.scope),
+                         .title = std::format(": {} ({}, {})", a.patterns, a.hintAction, a.scope) };
             },
             [](SendChars const& a) -> CommandArguments {
                 return { .id = a.chars, .title = std::format(": {}", crispy::escape(a.chars)) };

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -932,6 +932,7 @@ void YAMLConfigReader::loadProfileBody(YAML::Node const& child, TerminalProfile&
 
         loadFromEntry(child, "hyperlink_decoration", where.hyperlinkDecoration);
         loadFromEntry(child, "hint_patterns", where.hintPatterns);
+        loadFromEntry(child, "hint_scrollback_lines", where.hintScrollbackLines);
     }
 }
 
@@ -3081,11 +3082,35 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
                 }
             }
 
+            auto scope = vtbackend::HintScope::Visible;
+            if (auto nodeScope = node["scope"]; nodeScope && nodeScope.IsScalar())
+            {
+                auto const scopeStr = crispy::toUpper(nodeScope.as<std::string>());
+                static auto constexpr HintScopeMappings =
+                    std::array<std::pair<std::string_view, vtbackend::HintScope>, 2> { {
+                        { "VISIBLE", vtbackend::HintScope::Visible },
+                        { "SCROLLBACK", vtbackend::HintScope::Scrollback },
+                    } };
+                if (auto const p = std::ranges::find_if(HintScopeMappings,
+                                                        [&](auto const& t) { return t.first == scopeStr; });
+                    p != HintScopeMappings.end())
+                {
+                    scope = p->second;
+                }
+                else
+                {
+                    logger()("Invalid scope '{}' in HintMode action. Defaulting to 'Visible'.",
+                             nodeScope.as<std::string>());
+                }
+            }
+
             auto patterns = std::string {};
             if (auto nodePatterns = node["patterns"]; nodePatterns && nodePatterns.IsScalar())
                 patterns = nodePatterns.as<std::string>();
 
-            return actions::HintMode { .patterns = std::move(patterns), .hintAction = hintAction };
+            return actions::HintMode { .patterns = std::move(patterns),
+                                       .hintAction = hintAction,
+                                       .scope = scope };
         }
 
         return action;

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -700,6 +700,9 @@ struct TerminalProfile
     ConfigEntry<ColorConfig, documentation::Colors> colors { SimpleColorConfig {} };
     ConfigEntry<HyperlinkDecorationConfig, documentation::HyperlinkDecoration> hyperlinkDecoration {};
     ConfigEntry<std::vector<HintPatternConfig>, documentation::HintPatterns> hintPatterns {};
+    ConfigEntry<vtbackend::LineCount, documentation::HintScrollbackLines> hintScrollbackLines {
+        vtbackend::LineCount { 1000 }
+    };
 
     ConfigEntry<std::string, documentation::WMClass> wmClass { CONTOUR_APP_ID };
     ConfigEntry<std::string, documentation::TabLabel> tabLabel { "{WindowTitle}" };

--- a/src/contour/ConfigDocumentation.h
+++ b/src/contour/ConfigDocumentation.h
@@ -1233,6 +1233,13 @@ constexpr StringLiteral HintPatternsConfig {
     "'\\b[0-9a-fA-F]{{8}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{12}}\\b'\n"
 };
 
+constexpr StringLiteral HintScrollbackLinesConfig {
+    "\n"
+    "{comment} How many scrollback rows a HintMode action with `scope: Scrollback` scans at most.\n"
+    "{comment} Only that scope reads this; `scope: Visible` (the default) never leaves the viewport.\n"
+    "hint_scrollback_lines: {}\n"
+};
+
 constexpr StringLiteral IndicatorStatusLineConfig {
     "\n"
     "{comment} Defines the colors to be used for the Indicator status line.\n"
@@ -2380,6 +2387,7 @@ using WordHighlight = DocumentationEntry<WordHighlightConfig, Dummy>;
 using HintLabel = DocumentationEntry<HintLabelConfig, Dummy>;
 using HintMatch = DocumentationEntry<HintMatchConfig, Dummy>;
 using HintPatterns = DocumentationEntry<HintPatternsConfig, Dummy>;
+using HintScrollbackLines = DocumentationEntry<HintScrollbackLinesConfig, Dummy>;
 using IndicatorStatusLine = DocumentationEntry<IndicatorStatusLineConfig, Dummy>;
 using InputMethodEditor = DocumentationEntry<InputMethodEditorConfig, Dummy>;
 using InputMethodEditorSupport = DocumentationEntry<InputMethodEditorSupportConfig, Dummy>;

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -1998,7 +1998,10 @@ bool TerminalSession::operator()(actions::FollowHyperlink const& action)
 
 bool TerminalSession::operator()(actions::HintMode const& action)
 {
-    sessionLog()("Activating hint mode with patterns: '{}', action: {}", action.patterns, action.hintAction);
+    sessionLog()("Activating hint mode with patterns: '{}', action: {}, scope: {}",
+                 action.patterns,
+                 action.hintAction,
+                 action.scope);
 
     // Start with builtin patterns.
     auto patterns = vtbackend::HintModeHandler::builtinPatterns();
@@ -2050,8 +2053,13 @@ bool TerminalSession::operator()(actions::HintMode const& action)
         }
     }
 
-    auto const hintAction = action.hintAction;
-    crispy::locked(terminal(), [&]() { terminal().activateHintMode(patterns, hintAction); });
+    auto request = vtbackend::HintModeRequest {
+        .patterns = std::move(patterns),
+        .action = action.hintAction,
+        .scope = action.scope,
+        .scrollbackLimit = profile().hintScrollbackLines.value(),
+    };
+    crispy::locked(terminal(), [&]() { terminal().activateHintMode(std::move(request)); });
     return true;
 }
 

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -1934,7 +1934,7 @@ input_mapping:
 }
 
 // No comma in the name: Catch2 splits its command-line test filter on commas, so a comma here
-// would make the case unrunnable on its own.
+// would leave no way to run the case on its own.
 TEST_CASE("Config: HintMode parses its scope and rejects an unknown one", "[config][input-mapping]")
 {
     QTemporaryDir dir;

--- a/src/contour/test/Config_test.cpp
+++ b/src/contour/test/Config_test.cpp
@@ -1204,6 +1204,7 @@ profiles:
         hint_patterns:
             - { name: 'url', regex: 'https?://\S+' }
             - { name: '', regex: 'incomplete' }
+        hint_scrollback_lines: 250
         mouse:
             hide_while_typing: false
 )"sv);
@@ -1221,6 +1222,7 @@ profiles:
     // Hint patterns: the complete entry loads, the nameless one is skipped with a warning.
     REQUIRE(profile->hintPatterns.value().size() == 1);
     CHECK(profile->hintPatterns.value().at(0).name == "url");
+    CHECK(profile->hintScrollbackLines.value() == vtbackend::LineCount(250));
 
     CHECK(profile->mouse.value().hideWhileTyping == false);
 }
@@ -1929,6 +1931,38 @@ input_mapping:
     CHECK(resizes[0].percent == 8);
     CHECK(resizes[1].direction == contour::actions::Direction::Right);
     CHECK(resizes[1].percent == 5); // default when omitted
+}
+
+// No comma in the name: Catch2 splits its command-line test filter on commas, so a comma here
+// would make the case unrunnable on its own.
+TEST_CASE("Config: HintMode parses its scope and rejects an unknown one", "[config][input-mapping]")
+{
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+input_mapping:
+    - { mods: [Control], key: 'h', action: HintMode, patterns: url, scope: Scrollback }
+    - { mods: [Control], key: 'j', action: HintMode, patterns: url, scope: visible }
+    - { mods: [Control], key: 'k', action: HintMode, patterns: url, scope: sideways }
+    - { mods: [Control], key: 'l', action: HintMode, patterns: url }
+)"sv);
+
+    // A binding on a literal character lands in charMappings, not keyMappings — the latter holds
+    // only the named keys (LeftArrow, Insert, F6, …).
+    std::vector<contour::actions::HintMode> hints;
+    for (auto const& cm: config.inputMappings.value().charMappings)
+        for (auto const& action: cm.binding)
+            if (auto const* h = std::get_if<contour::actions::HintMode>(&action))
+                hints.push_back(*h);
+
+    REQUIRE(hints.size() == 4);
+    CHECK(hints[0].scope == vtbackend::HintScope::Scrollback);
+    CHECK(hints[1].scope == vtbackend::HintScope::Visible); // case-insensitive
+    CHECK(hints[2].scope == vtbackend::HintScope::Visible); // unknown value falls back
+    CHECK(hints[3].scope == vtbackend::HintScope::Visible); // omitted: the default
 }
 
 TEST_CASE("Config: color scheme with 0x colors and sequence color maps parses", "[config]")

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -1339,6 +1339,9 @@ TEST_CASE("TerminalSession: HintMode merges user patterns, skips invalid regex, 
     CHECK((*session)(actions::HintMode { .patterns = "ticket|url" }));
     CHECK((*session)(actions::HintMode { .patterns = "no-such-pattern" }));
     CHECK((*session)(actions::HintMode { .patterns = "" }));
+
+    // The scrollback scope reads the profile's hint_scrollback_lines and scans history as well.
+    CHECK((*session)(actions::HintMode { .patterns = "all", .scope = vtbackend::HintScope::Scrollback }));
 }
 
 TEST_CASE("TerminalSession: search-match focus actions move the vi cursor onto a found match",

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -180,12 +180,10 @@ void HintModeHandler::rescanLines(HintScanArea const& area)
     _filteredMatches = _allMatches;
 }
 
-void HintModeHandler::activate(HintScanArea const& area,
-                               vector<HintPattern> const& patterns,
-                               HintAction action)
+void HintModeHandler::activate(HintScanArea const& area, vector<HintPattern> patterns, HintAction action)
 {
     _action = action;
-    _patterns = patterns;
+    _patterns = std::move(patterns);
     rescanLines(area);
 
     _active = true;
@@ -196,6 +194,37 @@ void HintModeHandler::activate(HintScanArea const& area,
 void HintModeHandler::refresh(HintScanArea const& area)
 {
     rescanLines(area);
+    _executor.requestRedraw();
+}
+
+void HintModeHandler::applyScroll(LineOffset lines, LineCount historyLineCount)
+{
+    if (!_active)
+        return;
+
+    // The oldest row still in the buffer; anything above it has scrolled out for good.
+    auto const top = -historyLineCount.as<LineOffset>();
+
+    // Scrolling changes only positions, never labels, so the label-prefix filter membership is
+    // unchanged: shift both lists in place rather than re-filtering _allMatches into _filteredMatches
+    // (which would deep-copy every surviving match's strings on each scrolled line).
+    auto const shiftAndPrune = [top, lines](std::vector<HintMatch>& matches) {
+        for (auto& match: matches)
+        {
+            match.start.line -= lines;
+            match.end.line -= lines;
+        }
+        std::erase_if(matches, [top](auto const& match) { return match.start.line < top; });
+    };
+    shiftAndPrune(_allMatches);
+    shiftAndPrune(_filteredMatches);
+
+    if (_allMatches.empty())
+    {
+        deactivate();
+        return;
+    }
+
     _executor.requestRedraw();
 }
 

--- a/src/vtbackend/HintModeHandler.cpp
+++ b/src/vtbackend/HintModeHandler.cpp
@@ -10,41 +10,123 @@ using namespace std;
 namespace vtbackend
 {
 
+namespace
+{
+    /// The characters labels are built from — the same set @ref HintModeHandler::processInput accepts.
+    constexpr auto Alphabet = string_view { "abcdefghijklmnopqrstuvwxyz" };
+} // namespace
+
+auto Utf8CodepointCursor::codepointIndexAt(size_t byteOffset) noexcept -> size_t
+{
+    auto const limit = min(byteOffset, _text.size());
+    // Count bytes that are NOT continuation bytes (10xxxxxx), resuming where the last call stopped.
+    for (; _byteOffset < limit; ++_byteOffset)
+        if ((static_cast<char8_t>(_text[_byteOffset]) & 0xC0) != 0x80)
+            ++_codepointIndex;
+    return _codepointIndex;
+}
+
 auto utf8ByteOffsetToCodepointIndex(string_view text, size_t byteOffset) noexcept -> size_t
 {
-    auto const limit = min(byteOffset, text.size());
-    // Count bytes that are NOT continuation bytes (10xxxxxx).
-    return static_cast<size_t>(ranges::count_if(views::iota(size_t { 0 }, limit), [&](auto i) {
-        return (static_cast<char8_t>(text[i]) & 0xC0) != 0x80;
-    }));
+    return Utf8CodepointCursor { text }.codepointIndexAt(byteOffset);
+}
+
+auto buildLogicalLines(vector<HintScanRow> const& rows) -> vector<HintLogicalLine>
+{
+    auto result = vector<HintLogicalLine>();
+
+    for (auto const& row: rows)
+    {
+        auto const codepoints = utf8ByteOffsetToCodepointIndex(row.text, row.text.size());
+
+        // A continuation row extends the logical line above it. Two cases start a new one anyway:
+        // there is no row above (the head scrolled out of the scanned range, so this row is all we
+        // can see of its logical line), and a gap in the row offsets (which would break the
+        // firstLine + rowIndex arithmetic gridPositionOf() relies on).
+        auto const continuesPrevious =
+            row.continuation == LineContinuation::Yes && !result.empty()
+            && row.line
+                   == result.back().firstLine + LineOffset::cast_from(result.back().rowCodepointEnds.size());
+
+        if (continuesPrevious)
+        {
+            auto& logical = result.back();
+            logical.text += row.text;
+            logical.rowCodepointEnds.push_back(logical.rowCodepointEnds.back() + codepoints);
+            continue;
+        }
+
+        result.push_back(HintLogicalLine {
+            .text = row.text,
+            .firstLine = row.line,
+            .rowCodepointEnds = { codepoints },
+        });
+    }
+
+    return result;
+}
+
+auto gridPositionOf(HintLogicalLine const& logical, size_t codepointIndex) noexcept -> CellLocation
+{
+    auto const& ends = logical.rowCodepointEnds;
+
+    // The first row whose exclusive end is past the index is the row the index falls on.
+    auto const it = ranges::upper_bound(ends, codepointIndex);
+    if (it != ends.end())
+    {
+        auto const rowIndex = static_cast<size_t>(std::distance(ends.begin(), it));
+        auto const rowStart = rowIndex == 0 ? size_t { 0 } : ends[rowIndex - 1];
+        return CellLocation { .line = logical.firstLine + LineOffset::cast_from(rowIndex),
+                              .column = ColumnOffset::cast_from(codepointIndex - rowStart) };
+    }
+
+    // Past the end: clamp to the last cell that exists. Asking for the final codepoint takes the
+    // branch above, so this recurses exactly once.
+    if (ends.empty() || ends.back() == 0)
+        return CellLocation { .line = logical.firstLine, .column = ColumnOffset(0) };
+    return gridPositionOf(logical, ends.back() - 1);
 }
 
 HintModeHandler::HintModeHandler(Executor& executor): _executor { executor }
 {
 }
 
-void HintModeHandler::rescanLines(vector<string> const& visibleLines, PageSize pageSize)
+void HintModeHandler::rescanLines(HintScanArea const& area)
 {
     _filter.clear();
     _allMatches.clear();
     _filteredMatches.clear();
 
-    // Scan each visible line for regex matches.
-    auto const lineCount = std::min(visibleLines.size(), static_cast<size_t>(unbox<int>(pageSize.lines)));
-    for (auto const lineIdx: std::views::iota(size_t { 0 }, lineCount))
+    // Match against logical lines, not physical rows: a URL broken across a wrap is one match.
+    //
+    // A row that wrapped mid-wide-character left a pad space in its last cell, and joining the rows
+    // therefore inserts that space inside such a match. Every terminal that pads this way has the
+    // same limitation; the alternative is to guess which trailing blanks are padding.
+    for (auto const& logical: buildLogicalLines(area.rows))
     {
-        auto const& lineText = visibleLines[lineIdx];
-        auto const lineOffset = LineOffset(static_cast<int>(lineIdx));
-
         for (auto const& pattern: _patterns)
         {
-            auto matchIter = sregex_iterator(lineText.begin(), lineText.end(), pattern.regex);
+            auto matchIter = sregex_iterator(logical.text.begin(), logical.text.end(), pattern.regex);
             auto const matchEnd = sregex_iterator();
+
+            // One forward pass per pattern: sregex_iterator yields non-overlapping matches in
+            // increasing position order, so every offset this converts is non-decreasing.
+            auto codepointIndexOf = Utf8CodepointCursor { logical.text };
 
             for (; matchIter != matchEnd; ++matchIter)
             {
                 auto const& match = *matchIter;
                 if (match.empty())
+                    continue;
+
+                auto const startIndex =
+                    codepointIndexOf.codepointIndexAt(static_cast<size_t>(match.position()));
+                auto const start = gridPositionOf(logical, startIndex);
+
+                // The label is drawn at the match start, so a match starting on a row that cannot
+                // carry one could never be selected: do not offer it. Tested before the validator,
+                // which may go to the filesystem.
+                if (!area.labelableRows.contains(start.line))
                     continue;
 
                 auto const matchStr = match.str();
@@ -53,31 +135,25 @@ void HintModeHandler::rescanLines(vector<string> const& visibleLines, PageSize p
                 if (pattern.validator && !pattern.validator(matchStr))
                     continue;
 
-                auto const startCol =
-                    ColumnOffset::cast_from(utf8ByteOffsetToCodepointIndex(lineText, match.position()));
-                auto const endCodepointIndex =
-                    utf8ByteOffsetToCodepointIndex(lineText, match.position() + match.length());
-                auto const endCol = ColumnOffset::cast_from(endCodepointIndex - 1);
-
-                auto const actionText = pattern.transformer ? pattern.transformer(matchStr) : matchStr;
+                auto const endIndex =
+                    codepointIndexOf.codepointIndexAt(static_cast<size_t>(match.position() + match.length()));
 
                 _allMatches.push_back(HintMatch {
                     .label = {},
-                    .matchedText = actionText,
-                    .start = CellLocation { .line = lineOffset, .column = startCol },
-                    .end = CellLocation { .line = lineOffset, .column = endCol },
+                    .matchedText = pattern.transformer ? pattern.transformer(matchStr) : matchStr,
+                    .start = start,
+                    .end = gridPositionOf(logical, endIndex - 1),
                 });
             }
         }
     }
 
-    // Sort matches top-to-bottom, left-to-right, longer matches first at same start.
+    // Sort matches in reading order, longer matches first at the same start. CellLocation's
+    // defaulted operator<=> compares line before column, so it already is reading order.
     ranges::sort(_allMatches, [](auto const& a, auto const& b) {
-        if (a.start.line != b.start.line)
-            return a.start.line < b.start.line;
-        if (a.start.column != b.start.column)
-            return a.start.column < b.start.column;
-        return a.end.column > b.end.column; // Longer match first at same start position.
+        if (a.start != b.start)
+            return a.start < b.start;
+        return b.end < a.end; // Longer match first at the same start position.
     });
 
     // Remove duplicate matches (same text at same position).
@@ -85,14 +161,15 @@ void HintModeHandler::rescanLines(vector<string> const& visibleLines, PageSize p
         _allMatches, [](auto const& a, auto const& b) { return a.start == b.start && a.end == b.end; });
     _allMatches.erase(eraseBegin, eraseEnd);
 
-    // Remove overlapping matches — keep the longer (earlier) match at each position.
+    // Remove overlapping matches — keep the longer (earlier) match at each position. The list is
+    // sorted, so only the last kept match can overlap, and comparing whole positions rather than
+    // columns makes this hold across a wrap boundary too.
     {
         auto kept = vector<HintMatch>();
         kept.reserve(_allMatches.size());
         for (auto& match: _allMatches)
         {
-            if (!kept.empty() && kept.back().start.line == match.start.line
-                && match.start.column <= kept.back().end.column)
+            if (!kept.empty() && match.start <= kept.back().end)
                 continue; // Overlap detected — skip the shorter/later match.
             kept.push_back(std::move(match));
         }
@@ -103,23 +180,22 @@ void HintModeHandler::rescanLines(vector<string> const& visibleLines, PageSize p
     _filteredMatches = _allMatches;
 }
 
-void HintModeHandler::activate(vector<string> const& visibleLines,
-                               PageSize pageSize,
+void HintModeHandler::activate(HintScanArea const& area,
                                vector<HintPattern> const& patterns,
                                HintAction action)
 {
     _action = action;
     _patterns = patterns;
-    rescanLines(visibleLines, pageSize);
+    rescanLines(area);
 
     _active = true;
     _executor.onHintModeEntered();
     _executor.requestRedraw();
 }
 
-void HintModeHandler::refresh(vector<string> const& visibleLines, PageSize pageSize)
+void HintModeHandler::refresh(HintScanArea const& area)
 {
-    rescanLines(visibleLines, pageSize);
+    rescanLines(area);
     _executor.requestRedraw();
 }
 
@@ -197,20 +273,25 @@ void HintModeHandler::assignLabels()
     if (matchCount == 0)
         return;
 
-    auto const useTwoChar = matchCount > 26;
+    auto const radix = Alphabet.size();
+
+    // The narrowest width that can name every match, 26 labels per character. Every label gets the
+    // same width so none is a prefix of another, which is what lets progressive filtering
+    // auto-select the moment the typed prefix is unique.
+    auto labelWidth = size_t { 1 };
+    for (auto capacity = radix; capacity < matchCount; capacity *= radix)
+        ++labelWidth;
 
     for (auto const i: std::views::iota(size_t { 0 }, matchCount))
     {
-        if (useTwoChar)
+        auto label = string(labelWidth, Alphabet.front());
+        auto rest = i;
+        for (auto digit = labelWidth; digit > 0; --digit)
         {
-            auto const first = static_cast<char>('a' + static_cast<int>(i / 26));
-            auto const second = static_cast<char>('a' + static_cast<int>(i % 26));
-            _allMatches[i].label = string { first, second };
+            label[digit - 1] = Alphabet[rest % radix];
+            rest /= radix;
         }
-        else
-        {
-            _allMatches[i].label = string { static_cast<char>('a' + static_cast<int>(i)) };
-        }
+        _allMatches[i].label = std::move(label);
     }
 }
 

--- a/src/vtbackend/HintModeHandler.h
+++ b/src/vtbackend/HintModeHandler.h
@@ -23,6 +23,59 @@ enum class HintAction : uint8_t
     Select,       ///< Pre-select the match range in visual mode.
 };
 
+/// How much of the terminal a hint activation scans.
+enum class HintScope : uint8_t
+{
+    Visible = 0,    ///< The visible page only.
+    Scrollback = 1, ///< The visible page plus scrollback history, up to a configured limit.
+};
+
+/// Whether a physical row continues the logical line begun on the row above.
+///
+/// A logical line is what was actually written; the rows below its head exist only because the
+/// window happened to be too narrow. Hint patterns are matched against the logical line, so a URL
+/// broken across two rows is still one match.
+enum class LineContinuation : uint8_t
+{
+    No = 0,  ///< This row starts a new logical line.
+    Yes = 1, ///< This row is a wrapped continuation of the row above.
+};
+
+/// One physical terminal row handed to the hint scanner.
+struct HintScanRow
+{
+    /// The row's full, untrimmed text: exactly one codepoint per grid cell, so a codepoint index
+    /// into it is a column offset (wide-character continuation cells emit a space).
+    std::string text;
+    /// Grid line offset of this row. Zero is the top of the page; negative reaches into history.
+    LineOffset line;
+    LineContinuation continuation = LineContinuation::No;
+};
+
+/// An inclusive range of grid rows.
+struct HintRowRange
+{
+    LineOffset first; ///< Topmost row (inclusive).
+    LineOffset last;  ///< Bottommost row (inclusive).
+
+    [[nodiscard]] constexpr bool contains(LineOffset line) const noexcept
+    {
+        return first <= line && line <= last;
+    }
+};
+
+/// The terminal region one hint activation scans.
+struct HintScanArea
+{
+    /// The rows to scan, in ascending, consecutive grid-line order.
+    std::vector<HintScanRow> rows;
+
+    /// The rows whose matches may be labelled. A match starting outside it is discarded — its label
+    /// could not be drawn, so it would be unreachable. Rows outside it still contribute their text,
+    /// so a match running past the range still yields its complete text.
+    HintRowRange labelableRows;
+};
+
 /// A named regex pattern used for hint scanning.
 struct HintPattern
 {
@@ -37,13 +90,47 @@ struct HintPattern
     std::function<std::string(std::string const&)> transformer;
 };
 
+/// What one hint-mode activation should scan and do.
+struct HintModeRequest
+{
+    /// The regex patterns to scan for.
+    std::vector<HintPattern> patterns;
+
+    /// What to do with the match the user selects.
+    HintAction action = HintAction::Copy;
+
+    /// How much of the terminal to scan.
+    HintScope scope = HintScope::Visible;
+
+    /// How many scrollback rows to scan at most under HintScope::Scrollback; ignored otherwise.
+    /// Zero — the default, matching the default scope — scans no history at all.
+    LineCount scrollbackLimit { 0 };
+};
+
 /// A single match found during hint scanning, with its label and grid positions.
+///
+/// Positions are grid-absolute (zero is the top of the page, negative reaches into history), so
+/// they survive scrolling. @ref start and @ref end may sit on different rows when the match spans
+/// a wrapped logical line; the region they name is a run of text, not a rectangle.
 struct HintMatch
 {
     std::string label;       ///< The label shown on the overlay (e.g. "a", "bc").
     std::string matchedText; ///< The actual matched text.
     CellLocation start;      ///< Start position in the grid.
     CellLocation end;        ///< End position in the grid (inclusive).
+};
+
+/// A run of consecutive physical rows forming one logical line, plus what is needed to map a
+/// codepoint index within @ref text back to the grid cell it came from.
+struct HintLogicalLine
+{
+    std::string text;     ///< Concatenated row texts, in row order.
+    LineOffset firstLine; ///< Grid offset of the first row.
+
+    /// Where each row ends within @ref text, as an exclusive codepoint index, in row order. Stored
+    /// cumulatively rather than as per-row lengths so @ref gridPositionOf can binary-search it: a
+    /// linear walk is O(rows) per call, and one wrapped line can be a thousand rows long.
+    std::vector<size_t> rowCodepointEnds;
 };
 
 /// Handles hint mode logic: scanning visible text for regex matches,
@@ -61,10 +148,10 @@ class HintModeHandler
         ///
         /// @param matchedText The text that was matched by the hint pattern.
         /// @param action      The action to perform on the match.
-        /// @param start       The start position of the match, relative to the visible viewport
-        ///                    area (line 0 = first visible line).
-        /// @param end         The end position of the match (inclusive), relative to the visible
-        ///                    viewport area.
+        /// @param start       The grid-absolute start position of the match (line 0 = top of the
+        ///                    page, negative = history).
+        /// @param end         The grid-absolute end position of the match (inclusive). It may lie
+        ///                    on a later row than @p start when the match spans a wrapped line.
         virtual void onHintSelected(std::string const& matchedText,
                                     HintAction action,
                                     CellLocation start,
@@ -82,20 +169,19 @@ class HintModeHandler
 
     explicit HintModeHandler(Executor& executor);
 
-    /// Activates hint mode by scanning visible lines for matches.
+    /// Activates hint mode by scanning @p area for matches.
     ///
-    /// @param visibleLines   Text of each visible line, indexed by line offset.
-    /// @param pageSize       The terminal page size.
-    /// @param patterns       The regex patterns to scan for.
-    /// @param action         The action to perform on selection.
-    void activate(std::vector<std::string> const& visibleLines,
-                  PageSize pageSize,
-                  std::vector<HintPattern> const& patterns,
-                  HintAction action);
+    /// Rows flagged as wrapped continuations are joined with the row above before matching, so one
+    /// pattern may span several rows.
+    ///
+    /// @param area     The rows to scan and which of them may carry a label.
+    /// @param patterns The regex patterns to scan for.
+    /// @param action   The action to perform on selection.
+    void activate(HintScanArea const& area, std::vector<HintPattern> const& patterns, HintAction action);
 
-    /// Re-scans visible lines using previously stored patterns and action.
-    /// Called on viewport scroll to update hints without re-entering hint mode.
-    void refresh(std::vector<std::string> const& visibleLines, PageSize pageSize);
+    /// Re-scans @p area using the patterns and action stored by @ref activate.
+    /// Called on viewport scroll to update visible-scope hints without re-entering hint mode.
+    void refresh(HintScanArea const& area);
 
     /// Deactivates hint mode.
     void deactivate();
@@ -121,8 +207,8 @@ class HintModeHandler
 
   private:
     /// Core scanning logic shared by activate() and refresh().
-    /// Clears existing matches, scans visible lines, sorts, deduplicates, and assigns labels.
-    void rescanLines(std::vector<std::string> const& visibleLines, PageSize pageSize);
+    /// Clears existing matches, scans the rows, sorts, deduplicates, and assigns labels.
+    void rescanLines(HintScanArea const& area);
 
     /// Assigns labels to all matches.
     void assignLabels();
@@ -168,5 +254,42 @@ class HintModeHandler
 /// index equals the column index for these strings.
 [[nodiscard]] auto utf8ByteOffsetToCodepointIndex(std::string_view text, size_t byteOffset) noexcept
     -> size_t;
+
+/// Converts a monotonically non-decreasing sequence of UTF-8 byte offsets within one string to
+/// codepoint indices in a single forward pass over that string.
+///
+/// @ref utf8ByteOffsetToCodepointIndex counts from the start of the string on every call, which is
+/// quadratic across the many matches of one long logical line — and a wrapped logical line can be a
+/// thousand rows of text. Regex matches arrive in increasing, non-overlapping position order, so
+/// this remembers where the previous conversion ended and counts only the delta.
+class Utf8CodepointCursor
+{
+  public:
+    explicit Utf8CodepointCursor(std::string_view text) noexcept: _text { text } {}
+
+    /// @param byteOffset Must be at least the offset given to the previous call.
+    /// @return The codepoint index @p byteOffset falls on.
+    [[nodiscard]] auto codepointIndexAt(size_t byteOffset) noexcept -> size_t;
+
+  private:
+    std::string_view _text;
+    size_t _byteOffset = 0;
+    size_t _codepointIndex = 0;
+};
+
+/// Groups @p rows into logical lines, joining each run of wrapped continuations onto the row that
+/// heads it. A leading continuation row (its head scrolled out of the scanned range) heads its own
+/// logical line rather than being dropped.
+///
+/// @param rows Rows in ascending, consecutive grid-line order.
+/// @return One entry per logical line, in the same order.
+[[nodiscard]] auto buildLogicalLines(std::vector<HintScanRow> const& rows) -> std::vector<HintLogicalLine>;
+
+/// Maps a codepoint index within @p logical back to the grid cell it came from.
+///
+/// An index at or past the end of the logical line clamps to its last cell, so a caller need not
+/// special-case a zero-length tail.
+[[nodiscard]] auto gridPositionOf(HintLogicalLine const& logical, size_t codepointIndex) noexcept
+    -> CellLocation;
 
 } // namespace vtbackend

--- a/src/vtbackend/HintModeHandler.h
+++ b/src/vtbackend/HintModeHandler.h
@@ -175,13 +175,23 @@ class HintModeHandler
     /// pattern may span several rows.
     ///
     /// @param area     The rows to scan and which of them may carry a label.
-    /// @param patterns The regex patterns to scan for.
+    /// @param patterns The regex patterns to scan for; taken by value and moved into the handler,
+    ///                 so a caller with a throwaway vector should std::move it in.
     /// @param action   The action to perform on selection.
-    void activate(HintScanArea const& area, std::vector<HintPattern> const& patterns, HintAction action);
+    void activate(HintScanArea const& area, std::vector<HintPattern> patterns, HintAction action);
 
     /// Re-scans @p area using the patterns and action stored by @ref activate.
     /// Called on viewport scroll to update visible-scope hints without re-entering hint mode.
     void refresh(HintScanArea const& area);
+
+    /// Tracks grid content scrolling into history while a hint session is open, so a label keeps
+    /// pointing at the same text instead of at whatever text scrolled into its old grid-absolute
+    /// position. Every match moves up by @p lines; a match whose start has scrolled out of the
+    /// @p historyLineCount-deep buffer is dropped, and the session deactivates if none remain.
+    ///
+    /// @param lines            Rows scrolled into history (positive), as reported by the buffer.
+    /// @param historyLineCount The scrollback depth after the scroll.
+    void applyScroll(LineOffset lines, LineCount historyLineCount);
 
     /// Deactivates hint mode.
     void deactivate();
@@ -249,9 +259,9 @@ class HintModeHandler
 
 /// Converts a UTF-8 byte offset within @p text to the corresponding codepoint index.
 ///
-/// In the UTF-8 strings produced by Line::toUtf8(), each grid cell emits exactly one
-/// codepoint (wide-character continuation cells emit a space). Therefore the codepoint
-/// index equals the column index for these strings.
+/// In the column-aligned UTF-8 strings the hint scanner uses (see @ref Line::toUtf8ColumnAligned),
+/// each grid cell emits exactly one codepoint (a wide character's continuation cell emits a space).
+/// Therefore the codepoint index equals the column index for these strings.
 [[nodiscard]] auto utf8ByteOffsetToCodepointIndex(std::string_view text, size_t byteOffset) noexcept
     -> size_t;
 

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -1248,6 +1248,56 @@ TEST_CASE("HintModeHandler.HistoryRowOffsetsRoundTrip", "[hintmode]")
 
 // }}}
 
+// {{{ Content-scroll tracking
+
+TEST_CASE("HintModeHandler.ApplyScrollTracksContentScroll", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> {
+        "https://alpha.com",
+        "https://beta.com",
+    };
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 2);
+    auto const before = handler.matches();
+
+    // Two rows of new output scroll the grid up by two: every match keeps its label and text but
+    // moves up two rows so a label the user has already read stays on the same text.
+    handler.applyScroll(LineOffset(2), LineCount(100));
+
+    auto const& after = handler.matches();
+    REQUIRE(after.size() == 2);
+    for (auto const i: std::views::iota(size_t { 0 }, after.size()))
+    {
+        CHECK(after[i].label == before[i].label);
+        CHECK(after[i].matchedText == before[i].matchedText);
+        CHECK(after[i].start.line == before[i].start.line - LineOffset(2));
+        CHECK(after[i].end.line == before[i].end.line - LineOffset(2));
+    }
+}
+
+TEST_CASE("HintModeHandler.ApplyScrollDropsMatchesScrolledOutOfHistory", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto lines = std::vector<std::string> { "https://gone.example" };
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 1);
+
+    // Scrolling far past a shallow history buffer carries the only match out of the buffer, so the
+    // session has nothing left to offer and ends.
+    handler.applyScroll(LineOffset(5), LineCount(2));
+
+    CHECK(handler.matches().empty());
+    CHECK(!handler.isActive());
+    CHECK(executor.hintExitedCount == 1);
+}
+
+// }}}
+
 // {{{ Label widths
 
 namespace

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -4,8 +4,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <ranges>
+#include <set>
 
 using namespace vtbackend;
 
@@ -79,6 +81,39 @@ auto filepathOnlyPatterns() -> std::vector<HintPattern>
     return result;
 }
 
+/// @p lines as unwrapped rows starting at grid line 0, every one of them labelable.
+auto scanArea(std::vector<std::string> const& lines) -> HintScanArea
+{
+    auto area = HintScanArea {
+        .rows = {},
+        .labelableRows = HintRowRange { .first = LineOffset(0),
+                                        .last = LineOffset::cast_from(lines.size()) - LineOffset(1) },
+    };
+    for (auto const i: std::views::iota(size_t { 0 }, lines.size()))
+        area.rows.push_back(HintScanRow {
+            .text = lines[i], .line = LineOffset::cast_from(i), .continuation = LineContinuation::No });
+    return area;
+}
+
+/// @p lines as one wrapped logical line: the first row heads it, every later row continues it.
+/// Starts at grid line @p firstLine, and every row is labelable.
+auto wrappedScanArea(std::vector<std::string> const& lines, LineOffset firstLine = LineOffset(0))
+    -> HintScanArea
+{
+    auto area = HintScanArea {
+        .rows = {},
+        .labelableRows =
+            HintRowRange { .first = firstLine,
+                           .last = firstLine + LineOffset::cast_from(lines.size()) - LineOffset(1) },
+    };
+    for (auto const i: std::views::iota(size_t { 0 }, lines.size()))
+        area.rows.push_back(
+            HintScanRow { .text = lines[i],
+                          .line = firstLine + LineOffset::cast_from(i),
+                          .continuation = i == 0 ? LineContinuation::No : LineContinuation::Yes });
+    return area;
+}
+
 } // namespace
 
 TEST_CASE("HintModeHandler.LabelAssignment.SingleChar", "[hintmode]")
@@ -91,7 +126,7 @@ TEST_CASE("HintModeHandler.LabelAssignment.SingleChar", "[hintmode]")
         "also https://test.org and https://other.net",
     };
 
-    handler.activate(lines, PageSize { LineCount(2), ColumnCount(50) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     auto const& matches = handler.matches();
@@ -132,10 +167,7 @@ TEST_CASE("HintModeHandler.LabelAssignment.TwoChar", "[hintmode]")
     if (!line.empty())
         lines.push_back(line);
 
-    handler.activate(lines,
-                     PageSize { LineCount(static_cast<int>(lines.size())), ColumnCount(200) },
-                     urlOnlyPatterns(),
-                     HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 27);
@@ -156,7 +188,7 @@ TEST_CASE("HintModeHandler.ProgressiveFiltering", "[hintmode]")
         "https://alpha.com https://beta.com https://gamma.com",
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.matches().size() == 3);
     CHECK(handler.matches()[0].label == "a");
@@ -183,7 +215,7 @@ TEST_CASE("HintModeHandler.EscapeCancels", "[hintmode]")
 
     auto lines = std::vector<std::string> { "https://example.com" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
 
@@ -201,7 +233,7 @@ TEST_CASE("HintModeHandler.NoMatches", "[hintmode]")
 
     auto lines = std::vector<std::string> { "no urls or hashes here" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     CHECK(handler.matches().empty());
@@ -214,7 +246,7 @@ TEST_CASE("HintModeHandler.FilePathPattern", "[hintmode]")
 
     auto lines = std::vector<std::string> { "edit /home/user/file.txt and ./local/path" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, allPatterns(), HintAction::Open);
+    handler.activate(scanArea(lines), allPatterns(), HintAction::Open);
 
     REQUIRE(handler.isActive());
     // Should find file paths.
@@ -238,7 +270,7 @@ TEST_CASE("HintModeHandler.GitHashPattern", "[hintmode]")
 
     auto lines = std::vector<std::string> { "commit a1b2c3d some message" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, allPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), allPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     auto foundHash = false;
@@ -261,7 +293,7 @@ TEST_CASE("HintModeHandler.BackspaceRemovesFilter", "[hintmode]")
 
     auto const patterns = urlOnlyPatterns();
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+    handler.activate(scanArea(lines), patterns, HintAction::Copy);
 
     REQUIRE(handler.matches().size() == 3);
 
@@ -270,7 +302,7 @@ TEST_CASE("HintModeHandler.BackspaceRemovesFilter", "[hintmode]")
     CHECK(!handler.isActive()); // 'a' is unique label -> auto-selected.
 
     // Reactivate for backspace test.
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+    handler.activate(scanArea(lines), patterns, HintAction::Copy);
 
     // Test backspace on empty filter is a no-op.
     handler.processInput(U'\x08'); // Backspace on empty filter.
@@ -285,7 +317,7 @@ TEST_CASE("HintModeHandler.CaseInsensitive", "[hintmode]")
 
     auto lines = std::vector<std::string> { "https://example.com" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.matches().size() == 1);
     CHECK(handler.matches()[0].label == "a");
@@ -303,7 +335,7 @@ TEST_CASE("HintModeHandler.ActionDispatch", "[hintmode]")
 
     auto lines = std::vector<std::string> { "https://example.com" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Open);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Open);
 
     handler.processInput(U'a');
 
@@ -320,7 +352,7 @@ TEST_CASE("HintModeHandler.OverlappingPatterns", "[hintmode]")
     // The overlap removal should keep only the longer URL match.
     auto lines = std::vector<std::string> { "visit https://example.com/path for info" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, allPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), allPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
 
@@ -355,8 +387,7 @@ TEST_CASE("HintModeHandler.BareRelativeFilePath", "[hintmode]")
         "error in lib/utils/helpers.h:42",
     };
 
-    handler.activate(
-        lines, PageSize { LineCount(2), ColumnCount(50) }, filepathOnlyPatterns(), HintAction::Open);
+    handler.activate(scanArea(lines), filepathOnlyPatterns(), HintAction::Open);
 
     REQUIRE(handler.isActive());
 
@@ -381,8 +412,7 @@ TEST_CASE("HintModeHandler.BareRelativeDoesNotMatchPlainWords", "[hintmode]")
     // Plain words without slashes must NOT match the filepath pattern.
     auto lines = std::vector<std::string> { "hello world foo bar" };
 
-    handler.activate(
-        lines, PageSize { LineCount(1), ColumnCount(30) }, filepathOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), filepathOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     CHECK(handler.matches().empty());
@@ -404,7 +434,7 @@ TEST_CASE("HintModeHandler.ValidatorFiltersMatches", "[hintmode]")
         };
     }
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, patterns, HintAction::Open);
+    handler.activate(scanArea(lines), patterns, HintAction::Open);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -419,8 +449,7 @@ TEST_CASE("HintModeHandler.NoValidatorPassesAll", "[hintmode]")
     auto lines = std::vector<std::string> { "see /foo/bar and /baz/qux" };
 
     // No validator set — both paths should pass through.
-    handler.activate(
-        lines, PageSize { LineCount(1), ColumnCount(40) }, filepathOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), filepathOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
 
@@ -461,7 +490,7 @@ TEST_CASE("HintModeHandler.BareFilenameWithValidatedPattern", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Open);
+    handler.activate(scanArea(lines), patterns, HintAction::Open);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 4);
@@ -493,7 +522,7 @@ TEST_CASE("HintModeHandler.BareFilenameFilteredByValidator", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Copy);
+    handler.activate(scanArea(lines), patterns, HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -518,7 +547,7 @@ TEST_CASE("HintModeHandler.SingleCharTokensNotMatched", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, patterns, HintAction::Copy);
+    handler.activate(scanArea(lines), patterns, HintAction::Copy);
 
     REQUIRE(handler.isActive());
     CHECK(handler.matches().empty());
@@ -533,8 +562,7 @@ TEST_CASE("HintModeHandler.BuiltinRegexDoesNotMatchBareFilenames", "[hintmode]")
     // bare filenames must NOT be matched — they need a path separator.
     auto lines = std::vector<std::string> { "edit main.cpp and README.md" };
 
-    handler.activate(
-        lines, PageSize { LineCount(1), ColumnCount(40) }, filepathOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), filepathOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     // No filepath matches because there are no slashes.
@@ -658,7 +686,7 @@ TEST_CASE("HintModeHandler.CwdRelativeFilesystemValidation", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(100) }, patterns, HintAction::Open);
+    handler.activate(scanArea(lines), patterns, HintAction::Open);
 
     REQUIRE(handler.isActive());
 
@@ -706,7 +734,7 @@ TEST_CASE("HintModeHandler.HiddenFilesWithValidatedPattern", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, patterns, HintAction::Open);
+    handler.activate(scanArea(lines), patterns, HintAction::Open);
 
     REQUIRE(handler.isActive());
 
@@ -741,7 +769,7 @@ TEST_CASE("HintModeHandler.DotPrefixedRelativePath", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, patterns, HintAction::Open);
+    handler.activate(scanArea(lines), patterns, HintAction::Open);
 
     REQUIRE(handler.isActive());
 
@@ -769,7 +797,7 @@ TEST_CASE("HintModeHandler.TransformerRewritesMatchedText", "[hintmode]")
         },
     };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, patterns, HintAction::Copy);
+    handler.activate(scanArea(lines), patterns, HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -790,7 +818,7 @@ TEST_CASE("HintModeHandler.IPv6FullAddress", "[hintmode]")
 
     auto lines = std::vector<std::string> { "address 2001:0db8:85a3:0000:0000:8a2e:0370:7334 here" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -804,7 +832,7 @@ TEST_CASE("HintModeHandler.IPv6CompressedMiddle", "[hintmode]")
 
     auto lines = std::vector<std::string> { "link-local fe80::4117:f059:6f05:b06 on eth0" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(60) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -818,7 +846,7 @@ TEST_CASE("HintModeHandler.IPv6CompressedStart", "[hintmode]")
 
     auto lines = std::vector<std::string> { "loopback ::1 and ::ffff:abcd more" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 2);
@@ -833,7 +861,7 @@ TEST_CASE("HintModeHandler.IPv6CompressedEnd", "[hintmode]")
 
     auto lines = std::vector<std::string> { "prefix fe80:: in use" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -847,7 +875,7 @@ TEST_CASE("HintModeHandler.IPv6ShortCompressed", "[hintmode]")
 
     auto lines = std::vector<std::string> { "dns 2001:db8::1 server" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -861,7 +889,7 @@ TEST_CASE("HintModeHandler.IPv6DoesNotMatchCppScope", "[hintmode]")
 
     auto lines = std::vector<std::string> { "std::vector and boost::asio and Foo::Bar" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     CHECK(handler.matches().empty());
@@ -874,7 +902,7 @@ TEST_CASE("HintModeHandler.IPv6DoesNotMatchPlainHex", "[hintmode]")
 
     auto lines = std::vector<std::string> { "hash abcdef0123 and word deadbeef" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, ipv6OnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), ipv6OnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     CHECK(handler.matches().empty());
@@ -893,7 +921,7 @@ TEST_CASE("HintModeHandler.UnicodeOffsetInPrompt", "[hintmode]")
     // Without the fix, startCol would incorrectly be 4 instead of 2.
     auto lines = std::vector<std::string> { "\xe2\x9d\xaf https://example.com" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -910,7 +938,7 @@ TEST_CASE("HintModeHandler.AsciiPositionsUnchanged", "[hintmode]")
     // Pure ASCII: byte offset == column offset. Regression guard.
     auto lines = std::vector<std::string> { "visit https://example.com for more" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -932,7 +960,7 @@ TEST_CASE("HintModeHandler.WideCharacterOffset", "[hintmode]")
     //   col 4: ' ' (separator), col 5..20: URL.
     auto lines = std::vector<std::string> { "\xe4\xb8\xad \xe4\xb8\xad  https://test.org" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(40) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -952,7 +980,7 @@ TEST_CASE("HintModeHandler.MultipleUnicodeSegments", "[hintmode]")
     //          ' ' = 15, ★ = 16, ' ' = 17, URL2 starts at 18 (len 14, ends at 30)
     auto lines = std::vector<std::string> { "\xe2\x86\x92 https://a.com \xe2\x98\x85 https://b.com" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(50) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 2);
@@ -973,7 +1001,7 @@ TEST_CASE("HintModeHandler.MatchAtLineStartWithUnicode", "[hintmode]")
     // "https://start.org ❯" — URL at columns 0..17, then space at 18, ❯ at 19.
     auto lines = std::vector<std::string> { "https://start.org \xe2\x9d\xaf" };
 
-    handler.activate(lines, PageSize { LineCount(1), ColumnCount(30) }, urlOnlyPatterns(), HintAction::Copy);
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
 
     REQUIRE(handler.isActive());
     REQUIRE(handler.matches().size() == 1);
@@ -981,3 +1009,419 @@ TEST_CASE("HintModeHandler.MatchAtLineStartWithUnicode", "[hintmode]")
     CHECK(handler.matches()[0].start.column == ColumnOffset(0));
     CHECK(handler.matches()[0].end.column == ColumnOffset(16));
 }
+
+// {{{ Logical-line grouping and offset mapping
+
+TEST_CASE("buildLogicalLines.UnwrappedRowsStayApart", "[hintmode]")
+{
+    auto const rows = std::vector<HintScanRow> {
+        HintScanRow { .text = "one", .line = LineOffset(0), .continuation = LineContinuation::No },
+        HintScanRow { .text = "two", .line = LineOffset(1), .continuation = LineContinuation::No },
+    };
+
+    auto const logical = buildLogicalLines(rows);
+
+    REQUIRE(logical.size() == 2);
+    CHECK(logical[0].text == "one");
+    CHECK(logical[0].firstLine == LineOffset(0));
+    CHECK(logical[1].text == "two");
+    CHECK(logical[1].firstLine == LineOffset(1));
+}
+
+TEST_CASE("buildLogicalLines.ContinuationsJoinTheHead", "[hintmode]")
+{
+    auto const rows = std::vector<HintScanRow> {
+        HintScanRow { .text = "head", .line = LineOffset(3), .continuation = LineContinuation::No },
+        HintScanRow { .text = "-mid", .line = LineOffset(4), .continuation = LineContinuation::Yes },
+        HintScanRow { .text = "-end", .line = LineOffset(5), .continuation = LineContinuation::Yes },
+        HintScanRow { .text = "next", .line = LineOffset(6), .continuation = LineContinuation::No },
+    };
+
+    auto const logical = buildLogicalLines(rows);
+
+    REQUIRE(logical.size() == 2);
+    CHECK(logical[0].text == "head-mid-end");
+    CHECK(logical[0].firstLine == LineOffset(3));
+    CHECK(logical[0].rowCodepointEnds == std::vector<size_t> { 4, 8, 12 });
+    CHECK(logical[1].text == "next");
+    CHECK(logical[1].firstLine == LineOffset(6));
+}
+
+TEST_CASE("buildLogicalLines.LeadingContinuationHeadsItsOwnLine", "[hintmode]")
+{
+    // The head scrolled out of the scanned range: the continuation is all we can see of it, and
+    // must not be dropped.
+    auto const rows = std::vector<HintScanRow> {
+        HintScanRow { .text = "tail", .line = LineOffset(0), .continuation = LineContinuation::Yes },
+        HintScanRow { .text = "-end", .line = LineOffset(1), .continuation = LineContinuation::Yes },
+    };
+
+    auto const logical = buildLogicalLines(rows);
+
+    REQUIRE(logical.size() == 1);
+    CHECK(logical[0].text == "tail-end");
+    CHECK(logical[0].firstLine == LineOffset(0));
+}
+
+TEST_CASE("buildLogicalLines.NonConsecutiveRowsBreakTheRun", "[hintmode]")
+{
+    // A gap in the offsets would break gridPositionOf()'s firstLine + rowIndex arithmetic.
+    auto const rows = std::vector<HintScanRow> {
+        HintScanRow { .text = "aaa", .line = LineOffset(0), .continuation = LineContinuation::No },
+        HintScanRow { .text = "bbb", .line = LineOffset(7), .continuation = LineContinuation::Yes },
+    };
+
+    auto const logical = buildLogicalLines(rows);
+
+    REQUIRE(logical.size() == 2);
+    CHECK(logical[1].firstLine == LineOffset(7));
+}
+
+TEST_CASE("gridPositionOf.MapsAcrossRowBoundaries", "[hintmode]")
+{
+    auto const logical = HintLogicalLine {
+        .text = "abcdefghi",
+        .firstLine = LineOffset(-2),
+        .rowCodepointEnds = { 3, 6, 9 },
+    };
+
+    // First row.
+    CHECK(gridPositionOf(logical, 0) == CellLocation { .line = LineOffset(-2), .column = ColumnOffset(0) });
+    CHECK(gridPositionOf(logical, 2) == CellLocation { .line = LineOffset(-2), .column = ColumnOffset(2) });
+    // Second row starts exactly at the boundary.
+    CHECK(gridPositionOf(logical, 3) == CellLocation { .line = LineOffset(-1), .column = ColumnOffset(0) });
+    CHECK(gridPositionOf(logical, 5) == CellLocation { .line = LineOffset(-1), .column = ColumnOffset(2) });
+    // Third row.
+    CHECK(gridPositionOf(logical, 6) == CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    CHECK(gridPositionOf(logical, 8) == CellLocation { .line = LineOffset(0), .column = ColumnOffset(2) });
+    // Past the end clamps to the last existing cell.
+    CHECK(gridPositionOf(logical, 9) == CellLocation { .line = LineOffset(0), .column = ColumnOffset(2) });
+    CHECK(gridPositionOf(logical, 99) == CellLocation { .line = LineOffset(0), .column = ColumnOffset(2) });
+}
+
+TEST_CASE("gridPositionOf.EmptyLogicalLineClampsToItsFirstCell", "[hintmode]")
+{
+    auto const logical =
+        HintLogicalLine { .text = "", .firstLine = LineOffset(4), .rowCodepointEnds = { 0 } };
+
+    CHECK(gridPositionOf(logical, 0) == CellLocation { .line = LineOffset(4), .column = ColumnOffset(0) });
+}
+
+// }}}
+
+// {{{ Wrapped-line matching
+
+TEST_CASE("HintModeHandler.UrlWrappedAcrossTwoRows", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // "https://example.com/some/very/long/path" broken after column 20.
+    auto const lines = std::vector<std::string> { "https://example.com/", "some/very/long/path" };
+
+    handler.activate(wrappedScanArea(lines), urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    auto const& match = handler.matches()[0];
+    CHECK(match.matchedText == "https://example.com/some/very/long/path");
+    CHECK(match.start == CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    CHECK(match.end == CellLocation { .line = LineOffset(1), .column = ColumnOffset(18) });
+}
+
+TEST_CASE("HintModeHandler.UrlWrappedAcrossThreeRows", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto const lines = std::vector<std::string> { "https://example.com/a/", "middle/part/", "tail" };
+
+    handler.activate(wrappedScanArea(lines), urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    auto const& match = handler.matches()[0];
+    CHECK(match.matchedText == "https://example.com/a/middle/part/tail");
+    CHECK(match.start == CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    CHECK(match.end == CellLocation { .line = LineOffset(2), .column = ColumnOffset(3) });
+}
+
+TEST_CASE("HintModeHandler.UnwrappedRowsDoNotBleedIntoEachOther", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Same text as the two-row wrap case, but the rows are separate logical lines: the second row
+    // is not a URL at all, so only the first must match.
+    auto const lines = std::vector<std::string> { "https://example.com/", "some/very/long/path" };
+
+    handler.activate(scanArea(lines), urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "https://example.com/");
+    CHECK(handler.matches()[0].end.line == LineOffset(0));
+}
+
+TEST_CASE("HintModeHandler.SelectionForwardsAWrappedRange", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    auto const lines = std::vector<std::string> { "https://example.com/", "wrapped" };
+
+    handler.activate(wrappedScanArea(lines), urlOnlyPatterns(), HintAction::Select);
+    REQUIRE(handler.matches().size() == 1);
+
+    handler.processInput(U'a');
+
+    CHECK(executor.hintSelectedCount == 1);
+    CHECK(executor.lastAction == HintAction::Select);
+    CHECK(executor.lastSelectedText == "https://example.com/wrapped");
+    CHECK(executor.lastStart == CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    CHECK(executor.lastEnd == CellLocation { .line = LineOffset(1), .column = ColumnOffset(6) });
+}
+
+TEST_CASE("HintModeHandler.OverlapIsRejectedAcrossARowBoundary", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // The URL wraps, and its tail rows also look like file paths. Only the longest match at each
+    // position survives, and the nested path matches inside the URL must not reappear as hints.
+    auto const lines = std::vector<std::string> { "https://example.com/", "src/vtbackend/x.h" };
+
+    handler.activate(wrappedScanArea(lines), allPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "https://example.com/src/vtbackend/x.h");
+}
+
+// }}}
+
+// {{{ Labelable range
+
+TEST_CASE("HintModeHandler.MatchStartingOutsideTheLabelableRangeIsNotOffered", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Row 0 is scanned for its text but cannot carry a label, so the URL that starts there — and
+    // wraps into the labelable row 1 — is not offered at all.
+    auto area = wrappedScanArea(std::vector<std::string> { "https://example.com/", "wrapped" });
+    area.labelableRows = HintRowRange { .first = LineOffset(1), .last = LineOffset(1) };
+
+    handler.activate(area, urlOnlyPatterns(), HintAction::Copy);
+
+    CHECK(handler.matches().empty());
+}
+
+TEST_CASE("HintModeHandler.MatchEndingOutsideTheLabelableRangeIsOfferedInFull", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // The mirror case: the label lands on the visible row 0, and row 1 is scanned only to complete
+    // the text. The hint is offered, and the text it yields is whole.
+    auto area = wrappedScanArea(std::vector<std::string> { "https://example.com/", "wrapped" });
+    area.labelableRows = HintRowRange { .first = LineOffset(0), .last = LineOffset(0) };
+
+    handler.activate(area, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "https://example.com/wrapped");
+    CHECK(handler.matches()[0].end.line == LineOffset(1));
+}
+
+TEST_CASE("HintModeHandler.HistoryRowOffsetsRoundTrip", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Grid rows above the page carry negative offsets; they must survive scanning unchanged.
+    auto const area =
+        wrappedScanArea(std::vector<std::string> { "see https://example.com/", "tail" }, LineOffset(-4));
+
+    handler.activate(area, urlOnlyPatterns(), HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].start == CellLocation { .line = LineOffset(-4), .column = ColumnOffset(4) });
+    CHECK(handler.matches()[0].end == CellLocation { .line = LineOffset(-3), .column = ColumnOffset(3) });
+}
+
+// }}}
+
+// {{{ Label widths
+
+namespace
+{
+/// One URL per match, spread over @p count single-row logical lines.
+auto linesWithUrls(size_t count) -> std::vector<std::string>
+{
+    auto lines = std::vector<std::string>();
+    lines.reserve(count);
+    for (auto const i: std::views::iota(size_t { 0 }, count))
+        lines.push_back(std::format("https://site{}.example", i));
+    return lines;
+}
+} // namespace
+
+TEST_CASE("HintModeHandler.LabelWidthGrowsWithTheMatchCount", "[hintmode]")
+{
+    struct TestCase
+    {
+        size_t matchCount;
+        size_t expectedWidth;
+    };
+
+    // 26 labels per character: 26 fit in one, 676 in two, and beyond that three are needed. Before
+    // the base-26 generalization, index 676 produced 'a' + 26 == '{' — a label no keystroke could
+    // ever select.
+    auto const cases = std::vector<TestCase> {
+        TestCase { .matchCount = 1, .expectedWidth = 1 },
+        TestCase { .matchCount = 26, .expectedWidth = 1 },
+        TestCase { .matchCount = 27, .expectedWidth = 2 },
+        TestCase { .matchCount = 676, .expectedWidth = 2 },
+        TestCase { .matchCount = 677, .expectedWidth = 3 },
+    };
+
+    for (auto const& testCase: cases)
+    {
+        INFO(std::format("{} matches", testCase.matchCount));
+        auto executor = MockExecutor {};
+        auto handler = HintModeHandler { executor };
+
+        handler.activate(scanArea(linesWithUrls(testCase.matchCount)), urlOnlyPatterns(), HintAction::Copy);
+
+        auto const& matches = handler.matches();
+        REQUIRE(matches.size() == testCase.matchCount);
+
+        auto seen = std::set<std::string> {};
+        for (auto const& match: matches)
+        {
+            CHECK(match.label.size() == testCase.expectedWidth);
+            // Every character must be one hint mode accepts, and every label must be unique.
+            for (auto const ch: match.label)
+                CHECK((ch >= 'a' && ch <= 'z'));
+            CHECK(seen.insert(match.label).second);
+        }
+    }
+}
+
+TEST_CASE("HintModeHandler.ThreeCharLabelIsSelectable", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    handler.activate(scanArea(linesWithUrls(677)), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 677);
+
+    // The last match gets the highest label; typing it must select that match and nothing else.
+    auto const label = handler.matches().back().label;
+    auto const expectedText = handler.matches().back().matchedText;
+    REQUIRE(label.size() == 3);
+
+    for (auto const ch: label)
+        handler.processInput(static_cast<char32_t>(ch));
+
+    CHECK(executor.hintSelectedCount == 1);
+    CHECK(executor.lastSelectedText == expectedText);
+    CHECK(!handler.isActive());
+}
+
+// }}}
+
+// {{{ Input handling paths a single-character label set cannot reach
+
+TEST_CASE("HintModeHandler.BackspaceRemovesATypedCharacter", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // More than 26 matches, so labels are two characters and one keystroke cannot auto-select --
+    // which is the only way a non-empty filter can still be there when Backspace arrives.
+    handler.activate(scanArea(linesWithUrls(30)), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 30);
+
+    handler.processInput(U'a');
+    REQUIRE(handler.isActive());
+    REQUIRE(handler.currentFilter() == "a");
+    auto const narrowed = handler.matches().size();
+    CHECK(narrowed < 30); // 'a' filtered to the "a?" labels only.
+
+    handler.processInput(U'\x08');
+
+    CHECK(handler.isActive());
+    CHECK(handler.currentFilter().empty());
+    CHECK(handler.matches().size() == 30); // every candidate is back
+}
+
+TEST_CASE("HintModeHandler.NonAlphabeticInputIsIgnored", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    handler.activate(scanArea(linesWithUrls(3)), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 3);
+
+    // Consumed so it cannot leak to the running application, but it changes nothing.
+    CHECK(handler.processInput(U'1'));
+    CHECK(handler.processInput(U'-'));
+
+    CHECK(handler.isActive());
+    CHECK(handler.currentFilter().empty());
+    CHECK(executor.hintSelectedCount == 0);
+}
+
+TEST_CASE("HintModeHandler.AKeyMatchingNoLabelExitsHintMode", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    handler.activate(scanArea(linesWithUrls(3)), urlOnlyPatterns(), HintAction::Copy);
+    REQUIRE(handler.matches().size() == 3); // labels a, b, c
+
+    handler.processInput(U'z');
+
+    CHECK(!handler.isActive());
+    CHECK(executor.hintSelectedCount == 0);
+    CHECK(executor.hintExitedCount == 1);
+}
+
+TEST_CASE("HintModeHandler.InputAndDeactivationAreNoOpsWhenInactive", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Never activated: input is not consumed, so the caller passes it on.
+    CHECK_FALSE(handler.processInput(U'a'));
+
+    handler.activate(scanArea(linesWithUrls(1)), urlOnlyPatterns(), HintAction::Copy);
+    handler.deactivate();
+    REQUIRE(executor.hintExitedCount == 1);
+
+    // Deactivating twice must not fire the exit callback again -- the Escape key and an
+    // auto-selection can both arrive at deactivate().
+    handler.deactivate();
+    CHECK(executor.hintExitedCount == 1);
+}
+
+TEST_CASE("HintModeHandler.LongestMatchWinsAtTheSameStart", "[hintmode]")
+{
+    auto executor = MockExecutor {};
+    auto handler = HintModeHandler { executor };
+
+    // Two patterns that match at the very same position with different lengths. The sort's
+    // tie-break puts the longer one first, and the overlap pass then drops the shorter -- the rule
+    // the wrapped-line overlap comparison relies on.
+    auto patterns = std::vector<HintPattern> {
+        HintPattern {
+            .name = "short", .regex = std::regex(R"([0-9a-f]{7})"), .validator = {}, .transformer = {} },
+        HintPattern {
+            .name = "long", .regex = std::regex(R"([0-9a-f]{10})"), .validator = {}, .transformer = {} },
+    };
+
+    handler.activate(scanArea(std::vector<std::string> { "abcdef0123" }), patterns, HintAction::Copy);
+
+    REQUIRE(handler.matches().size() == 1);
+    CHECK(handler.matches()[0].matchedText == "abcdef0123");
+}
+
+// }}}

--- a/src/vtbackend/HintModeHandler_test.cpp
+++ b/src/vtbackend/HintModeHandler_test.cpp
@@ -1160,7 +1160,7 @@ TEST_CASE("HintModeHandler.UnwrappedRowsDoNotBleedIntoEachOther", "[hintmode]")
     CHECK(handler.matches()[0].end.line == LineOffset(0));
 }
 
-TEST_CASE("HintModeHandler.SelectionForwardsAWrappedRange", "[hintmode]")
+TEST_CASE("HintModeHandler.SelectionForwardsWrappedRange", "[hintmode]")
 {
     auto executor = MockExecutor {};
     auto handler = HintModeHandler { executor };
@@ -1330,7 +1330,7 @@ TEST_CASE("HintModeHandler.ThreeCharLabelIsSelectable", "[hintmode]")
 
 // {{{ Input handling paths a single-character label set cannot reach
 
-TEST_CASE("HintModeHandler.BackspaceRemovesATypedCharacter", "[hintmode]")
+TEST_CASE("HintModeHandler.BackspaceRemovesOneTypedCharacter", "[hintmode]")
 {
     auto executor = MockExecutor {};
     auto handler = HintModeHandler { executor };

--- a/src/vtbackend/Line.cpp
+++ b/src/vtbackend/Line.cpp
@@ -72,7 +72,12 @@ std::string Line::toUtf8() const
     return toUtf8(ColumnOffset(0), ColumnOffset::cast_from(_columns));
 }
 
-std::string Line::toUtf8(ColumnOffset begin, ColumnOffset end) const
+std::string Line::toUtf8ColumnAligned() const
+{
+    return toUtf8(ColumnOffset(0), ColumnOffset::cast_from(_columns), ContinuationCell::Pad);
+}
+
+std::string Line::toUtf8(ColumnOffset begin, ColumnOffset end, ContinuationCell continuation) const
 {
     auto const cols = unbox<size_t>(_columns);
     auto const first = std::min(static_cast<size_t>(std::max(*begin, 0)), cols);
@@ -97,6 +102,10 @@ std::string Line::toUtf8(ColumnOffset begin, ColumnOffset end) const
         if (skipCount > 0)
         {
             --skipCount;
+            // A wide character's continuation cell: emit a padding space when the caller wants one
+            // codepoint per grid column, otherwise let the leading cell stand for the whole glyph.
+            if (continuation == ContinuationCell::Pad)
+                str += ' ';
             continue;
         }
         if (_storage.clusterSize[i] == 0)

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -25,6 +25,18 @@
 namespace vtbackend
 {
 
+/// How @ref Line::toUtf8 renders the continuation cell(s) of a wide (double-width) character.
+enum class ContinuationCell : uint8_t
+{
+    /// Emit nothing: a wide character contributes a single codepoint, so the result is the text as
+    /// written. This is what copy/yank and selection want.
+    Collapse = 0,
+    /// Emit one space per continuation cell, so every grid cell contributes exactly one codepoint and
+    /// a codepoint index into the result equals a column offset. This is what the hint scanner needs
+    /// to map a regex match position back to a grid column.
+    Pad = 1,
+};
+
 // clang-format off
 template <typename, bool> struct OptionalProperty;
 template <typename T> struct OptionalProperty<T, false> {};
@@ -315,7 +327,16 @@ class Line
     /// The text of the columns [@p begin, @p end) of this line, blank cells rendered as spaces.
     /// @param begin First column to render; clamped to the line.
     /// @param end One past the last column to render; clamped to the line.
-    [[nodiscard]] std::string toUtf8(ColumnOffset begin, ColumnOffset end) const;
+    /// @param continuation Whether a wide character's continuation cell(s) collapse away or emit a
+    ///                     padding space; see @ref ContinuationCell.
+    [[nodiscard]] std::string toUtf8(ColumnOffset begin,
+                                     ColumnOffset end,
+                                     ContinuationCell continuation = ContinuationCell::Collapse) const;
+
+    /// The full text of this line with exactly one codepoint per grid column: a wide character's
+    /// continuation cell becomes a space, so a codepoint index into the result equals a column
+    /// offset. Used by the hint scanner, which maps regex match positions back to grid columns.
+    [[nodiscard]] std::string toUtf8ColumnAligned() const;
 
     [[nodiscard]] std::string toUtf8Trimmed() const;
     [[nodiscard]] std::string toUtf8Trimmed(bool stripLeadingSpaces, bool stripTrailingSpaces) const;

--- a/src/vtbackend/Line_test.cpp
+++ b/src/vtbackend/Line_test.cpp
@@ -123,6 +123,29 @@ TEST_CASE("Line.toUtf8", "[Line]")
     CHECK(trimmed == "Hi");
 }
 
+TEST_CASE("Line.toUtf8ColumnAligned", "[Line]")
+{
+    auto constexpr DisplayWidth = ColumnCount(5);
+
+    auto line = Line(DisplayWidth, LineFlag::None, GraphicsAttributes {});
+
+    // A double-width character (CJK U+4E2D) in columns 0-1, then an ASCII 'X' in column 2.
+    line.useCellAt(ColumnOffset(0)).write(GraphicsAttributes {}, U'\x4e2d', 2);
+    line.useCellAt(ColumnOffset(2)).write(GraphicsAttributes {}, U'X', 1);
+
+    // toUtf8 collapses the wide character to its single codepoint (what copy/yank and selection
+    // want): the continuation cell contributes nothing.
+    CHECK(line.toUtf8()
+          == "\xe4\xb8\xad"
+             "X  ");
+
+    // toUtf8ColumnAligned emits exactly one codepoint per grid column: the continuation cell becomes
+    // a space, so 'X' sits at codepoint index 2 (its column) rather than index 1.
+    CHECK(line.toUtf8ColumnAligned()
+          == "\xe4\xb8\xad"
+             " X  ");
+}
+
 // ---------------------------------------------------------------------------
 // Lazy-blank Line behavior
 // ---------------------------------------------------------------------------

--- a/src/vtbackend/MockTerm.h
+++ b/src/vtbackend/MockTerm.h
@@ -170,6 +170,7 @@ class MockTerm: public Terminal::NullEvents
     Terminal terminal;
 
     std::string clipboardData;
+    std::string openedDocument;
 
     /// The most recent window-frame (tab) color assigned via DECAC item 2, or std::nullopt if the
     /// frame color was reset (or never set). @see setWindowFrameColor, resetWindowFrameColor.
@@ -194,6 +195,10 @@ class MockTerm: public Terminal::NullEvents
     void copyToClipboard(std::string_view data) override { clipboardData = data; }
 
     std::string getClipboard() override { return clipboardData; }
+
+    /// Records what the terminal asked the desktop to open, so a test can assert on it instead of
+    /// only on the absence of a crash.
+    void openDocument(std::string_view fileOrUrl) override { openedDocument = fileOrUrl; }
 
     void setWindowFrameColor(RGBColor color) override
     {

--- a/src/vtbackend/Screen.h
+++ b/src/vtbackend/Screen.h
@@ -818,6 +818,14 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
         return _grid.lineAt(line).toUtf8Trimmed(stripLeadingSpaces, stripTrailingSpaces);
     }
 
+    /// The full text of @p line with exactly one codepoint per grid column — a wide character's
+    /// continuation cell becomes a space — so a codepoint index into the result is a column offset.
+    /// Used by the hint scanner; see @ref Line::toUtf8ColumnAligned.
+    [[nodiscard]] std::string lineTextColumnAlignedAt(LineOffset line) const noexcept
+    {
+        return _grid.lineAt(line).toUtf8ColumnAligned();
+    }
+
     [[nodiscard]] bool isLineEmpty(LineOffset line) const noexcept { return _grid.lineAt(line).empty(); }
 
     [[nodiscard]] uint8_t cellWidthAt(CellLocation position) const noexcept

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2551,29 +2551,61 @@ std::optional<std::string> Terminal::localPathAtMousePosition() const
 
 // {{{ Hint mode
 
-void Terminal::refreshHints()
+HintScanArea Terminal::collectHintScanArea(HintScope scope, LineCount scrollbackLimit) const
 {
-    auto const lines = unbox<int>(pageSize().lines);
-    auto const scrollOff = unbox<int>(_viewport.scrollOffset());
-    auto visibleLines = std::vector<std::string>();
-    visibleLines.reserve(static_cast<size_t>(lines));
-    for (auto const i: std::views::iota(0, lines))
-        visibleLines.push_back(currentScreen().lineTextAt(LineOffset(i - scrollOff), false, false));
+    auto const& screen = currentScreen();
+    auto const gridBottom = pageSize().lines.as<LineOffset>() - LineOffset(1);
+    auto const historyTop = -screen.historyLineCount().as<LineOffset>();
 
-    _hintModeHandler.refresh(visibleLines, pageSize());
+    // A label can only be typed once it has been drawn. Under Visible that is the viewport; under
+    // Scrollback the labels are fixed for the session, so every scanned row can carry one and the
+    // user scrolls to reach it.
+    auto const labelableRows = [&] {
+        if (scope == HintScope::Scrollback)
+            return HintRowRange { .first = std::max(historyTop, -scrollbackLimit.as<LineOffset>()),
+                                  .last = gridBottom };
+        auto const viewportTop = -_viewport.scrollOffset().as<LineOffset>();
+        return HintRowRange { .first = viewportTop, .last = viewportTop + gridBottom };
+    }();
+
+    // Extend the scan to whole logical lines: a pattern that wraps across the boundary is then
+    // matched in full, and only its tail goes unrendered.
+    auto first = labelableRows.first;
+    while (first > historyTop && screen.isLineWrapped(first))
+        --first;
+    auto last = labelableRows.last;
+    while (last < gridBottom && screen.isLineWrapped(last + LineOffset(1)))
+        ++last;
+
+    auto area = HintScanArea { .rows = {}, .labelableRows = labelableRows };
+    area.rows.reserve(static_cast<size_t>(unbox(last - first) + 1));
+    for (auto line = first; line <= last; ++line)
+        area.rows.push_back(HintScanRow {
+            // Untrimmed on purpose: one codepoint per cell is what makes a codepoint index a column.
+            .text = screen.lineTextAt(line, false, false),
+            .line = line,
+            .continuation = screen.isLineWrapped(line) ? LineContinuation::Yes : LineContinuation::No,
+        });
+    return area;
 }
 
-void Terminal::activateHintMode(std::vector<HintPattern> const& patterns, HintAction action)
+void Terminal::refreshHints()
 {
-    auto const lines = unbox<int>(pageSize().lines);
-    auto const scrollOff = unbox<int>(_viewport.scrollOffset());
-    auto visibleLines = std::vector<std::string>();
-    visibleLines.reserve(static_cast<size_t>(lines));
-    for (auto const i: std::views::iota(0, lines))
-        visibleLines.push_back(currentScreen().lineTextAt(LineOffset(i - scrollOff), false, false));
+    // Scrollback-scope labels are assigned once and must not move: scrolling reveals other rows'
+    // labels rather than renaming them, so a label the user already read stays valid. Only the
+    // visible scope, whose scan region *is* the viewport, re-scans.
+    if (_hintScope == HintScope::Scrollback)
+        return;
 
-    // Make a mutable copy so we can attach validators.
-    auto mutablePatterns = patterns;
+    _hintModeHandler.refresh(collectHintScanArea(HintScope::Visible, LineCount(0)));
+}
+
+void Terminal::activateHintMode(HintModeRequest request)
+{
+    _hintScope = request.scope;
+    auto const area = collectHintScanArea(request.scope, request.scrollbackLimit);
+
+    auto mutablePatterns = std::move(request.patterns);
 
     // When CWD is available, attach a filesystem-existence validator to filepath patterns.
     auto const cwdUrl = currentWorkingDirectory();
@@ -2606,12 +2638,21 @@ void Terminal::activateHintMode(std::vector<HintPattern> const& patterns, HintAc
                 return resolved;
             };
 
-            pattern.validator = [resolvePath, home](std::string const& matchStr) -> bool {
+            // Memoized per activation: the broadened regex matches every bare word, and a
+            // scrollback-scope scan of a thousand rows would otherwise stat() each repeated one
+            // again — brutal on a network filesystem. Repetition is the norm in terminal output
+            // (a file named once per compiler diagnostic), so the cache earns its keep.
+            pattern.validator = [resolvePath, home, cache = std::make_shared<std::map<std::string, bool>>()](
+                                    std::string const& matchStr) -> bool {
                 // Cannot resolve ~/ paths when HOME is unset — let them through unvalidated.
                 if (matchStr.starts_with("~/") && home.empty())
                     return true;
+                if (auto const cached = cache->find(matchStr); cached != cache->end())
+                    return cached->second;
                 auto ec = std::error_code {};
-                return std::filesystem::exists(resolvePath(matchStr), ec);
+                auto const exists = std::filesystem::exists(resolvePath(matchStr), ec);
+                cache->emplace(matchStr, exists);
+                return exists;
             };
 
             // Transform matched text to absolute path so Copy/Open actions work correctly.
@@ -2619,7 +2660,7 @@ void Terminal::activateHintMode(std::vector<HintPattern> const& patterns, HintAc
         }
     }
 
-    _hintModeHandler.activate(visibleLines, pageSize(), mutablePatterns, action);
+    _hintModeHandler.activate(area, mutablePatterns, request.action);
     _inputHandler.setMode(ViMode::Hint);
 }
 
@@ -2629,6 +2670,9 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
         return;
 
     auto const& matches = _hintModeHandler.matches();
+    if (matches.empty())
+        return;
+
     auto const& filter = _hintModeHandler.currentFilter();
 
     // Resolve palette colors for hint rendering.
@@ -2652,75 +2696,85 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
     auto const matchBg = resolveColor(hintMatch.background);
     auto const matchBgAlpha = hintMatch.backgroundAlpha;
 
+    // A match projected from scroll-invariant grid rows into render-buffer rows.
+    struct ProjectedMatch
+    {
+        CellLocationRange body;  ///< The whole match: a run of text that may cross rows.
+        CellLocation labelStart; ///< Where the label's first character is drawn.
+        std::string_view label;
+    };
+
+    // Bucket the matches by the main-screen row they touch, so the sweep below consults only the
+    // matches on the row it is on rather than all of them. A wrapped match lands in every row it
+    // covers. Under HintScope::Scrollback the match count is unbounded by the page size, which is
+    // what makes this necessary rather than merely tidy.
+    auto const scrollOffset = _viewport.scrollOffset().as<LineOffset>();
+    auto const pageLines = pageSize().lines.as<LineOffset>();
+    auto rowBuckets = std::vector<std::vector<ProjectedMatch>>(unbox<size_t>(pageLines));
+
     for (auto const& match: matches)
     {
-        auto const labelLen = static_cast<int>(match.label.size());
-        auto const matchLine = baseLine + match.start.line;
+        auto const first = match.start + scrollOffset;
+        auto const last = match.end + scrollOffset;
+        auto const projected = ProjectedMatch {
+            .body = CellLocationRange { .first = first + baseLine, .second = last + baseLine },
+            .labelStart = first + baseLine,
+            .label = match.label,
+        };
+        auto const from = std::max(first.line, LineOffset(0));
+        auto const to = std::min(last.line, pageLines - LineOffset(1));
+        for (auto row = from; row <= to; ++row)
+            rowBuckets[unbox<size_t>(row)].push_back(projected);
+    }
 
-        // Apply overlay for each cell in the RenderBuffer.
-        for (auto& cell: output.cells)
+    for (auto& cell: output.cells)
+    {
+        // Rows outside the main screen — the status line — carry no hints, so they only ever dim,
+        // exactly as before.
+        auto const row = cell.position.line - baseLine;
+        auto const bucket = row >= LineOffset(0) && row < pageLines
+                                ? std::span<ProjectedMatch const> { rowBuckets[unbox<size_t>(row)] }
+                                : std::span<ProjectedMatch const> {};
+
+        auto onMatch = false;
+        for (auto const& match: bucket)
         {
-            auto const line = cell.position.line;
-            auto const col = cell.position.column;
-
-            // Check if this cell is in the label region.
-            if (line == matchLine && col >= match.start.column
-                && col < match.start.column + ColumnOffset(labelLen))
+            // The label is drawn over the first label.size() cells of the match's first row even
+            // where it overruns a match shorter than its own label: a half-drawn label cannot be
+            // typed.
+            auto const labelEnd = match.labelStart.column + ColumnOffset::cast_from(match.label.size());
+            if (cell.position.line == match.labelStart.line && cell.position.column >= match.labelStart.column
+                && cell.position.column < labelEnd)
             {
-                auto const labelIdx = static_cast<size_t>(unbox(col) - unbox(match.start.column));
-                if (labelIdx < match.label.size())
-                {
-                    // Replace codepoints with label character.
-                    cell.codepoints = std::u32string(1, static_cast<char32_t>(match.label[labelIdx]));
-                    cell.width = 1;
+                auto const labelIdx = unbox<size_t>(cell.position.column - match.labelStart.column);
 
-                    // Distinguish typed-so-far from remaining label characters.
-                    if (labelIdx < filter.size())
-                    {
-                        // Already-typed portion: dimmed label styling.
-                        cell.attributes.foregroundColor = typedLabelFg;
-                        cell.attributes.backgroundColor = typedLabelBg;
-                    }
-                    else
-                    {
-                        // Remaining label: bright label styling from palette.
-                        cell.attributes.foregroundColor = labelFg;
-                        cell.attributes.backgroundColor = labelBg;
-                    }
-                    cell.attributes.flags |= CellFlag::Bold;
-                }
+                // Replace codepoints with label character.
+                cell.codepoints = std::u32string(1, static_cast<char32_t>(match.label[labelIdx]));
+                cell.width = 1;
+
+                // Distinguish the already-typed prefix from the characters still to type.
+                auto const typed = labelIdx < filter.size();
+                cell.attributes.foregroundColor = typed ? typedLabelFg : labelFg;
+                cell.attributes.backgroundColor = typed ? typedLabelBg : labelBg;
+                cell.attributes.flags |= CellFlag::Bold;
+
+                onMatch = true;
+                break;
             }
-            // Check if this cell is in the match body region (after the label).
-            else if (line == matchLine && col > match.start.column + ColumnOffset(labelLen - 1)
-                     && col <= match.end.column)
+
+            if (match.body.contains(cell.position))
             {
                 // Highlight match body with palette-configured background blend.
                 cell.attributes.backgroundColor =
                     mixColor(cell.attributes.backgroundColor, matchBg, matchBgAlpha);
+                onMatch = true;
+                break;
             }
         }
-    }
 
-    // Dim all cells that don't belong to any match when hints are active.
-    // This helps the labels stand out.
-    if (!matches.empty())
-    {
-        for (auto& cell: output.cells)
-        {
-            auto const line = cell.position.line;
-            auto const col = cell.position.column;
-
-            auto const belongsToMatch = std::ranges::any_of(matches, [&](auto const& m) {
-                auto const mLine = baseLine + m.start.line;
-                return line == mLine && col >= m.start.column && col <= m.end.column;
-            });
-
-            if (!belongsToMatch)
-            {
-                // Fade non-match cells toward the terminal's default background.
-                blendAttributesTo(cell.attributes, _colorPalette.defaultBackground, 0.5f);
-            }
-        }
+        // Fade cells that belong to no match toward the default background, so labels stand out.
+        if (!onMatch)
+            blendAttributesTo(cell.attributes, _colorPalette.defaultBackground, 0.5f);
     }
 }
 
@@ -2739,19 +2793,15 @@ void Terminal::HintModeExecutor::onHintSelected(std::string const& matchedText,
             terminal.sendRawInput(matchedText);
             break;
         case HintAction::Select: {
-            // Convert viewport-relative coordinates to grid-relative coordinates.
-            auto const scrollOff = LineOffset::cast_from(terminal._viewport.scrollOffset());
-            auto const gridStart = CellLocation { .line = start.line - scrollOff, .column = start.column };
-            auto const gridEnd = CellLocation { .line = end.line - scrollOff, .column = end.column };
-
             // Clear any existing selection so that entering Visual mode uses our
             // cursor position as the anchor, not a stale selection start.
             terminal.clearSelection();
 
-            // Enter vi visual mode with the match range pre-selected.
-            terminal._viCommands.cursorPosition = gridStart;
+            // Enter vi visual mode with the match range pre-selected. The positions are already
+            // grid-absolute, which is what the Vi cursor speaks.
+            terminal._viCommands.cursorPosition = start;
             terminal._inputHandler.setMode(ViMode::Visual);
-            terminal._viCommands.moveCursorTo(gridEnd);
+            terminal._viCommands.moveCursorTo(end);
             break;
         }
     }

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -2578,7 +2578,7 @@ HintScanArea Terminal::collectHintScanArea(HintScope scope, LineCount scrollback
         ++last;
 
     auto area = HintScanArea { .rows = {}, .labelableRows = labelableRows };
-    area.rows.reserve(static_cast<size_t>(unbox(last - first) + 1));
+    area.rows.reserve(unbox<size_t>(last - first) + 1);
     for (auto line = first; line <= last; ++line)
         area.rows.push_back(HintScanRow {
             // Untrimmed on purpose: one codepoint per cell is what makes a codepoint index a column.

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -580,8 +580,16 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
 
     auto const hoveringHyperlinkGuard = ScopedHyperlinkHover { *this, *_currentScreen };
     auto const mainDisplayReverseVideo = isModeEnabled(vtbackend::DECMode::ReverseVideo);
-    auto const highlightSearchMatches =
-        _search.pattern.empty() ? HighlightSearchMatches::No : HighlightSearchMatches::Yes;
+
+    // A non-empty search pattern forces every visible line onto the per-cell render path (the
+    // uniform-line fast path emits one RenderLine and no per-cell data). Hint mode needs the same:
+    // its overlay dims unmatched cells and stamps label glyphs by rewriting per-cell data, so while
+    // a hint session is active every line must take the per-cell path, or a label on a plain line —
+    // the common case — would never be drawn. Grid::render reuses its search-highlight flag as that
+    // per-cell switch.
+    auto const renderLinesPerCell = (!_search.pattern.empty() || isHintModeActive())
+                                        ? HighlightSearchMatches::Yes
+                                        : HighlightSearchMatches::No;
 
     auto const theCursorPosition = [&]() -> std::optional<CellLocation> {
         if (inputHandler().mode() == ViMode::Insert)
@@ -615,7 +623,7 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
                                                                             effectiveCursorPosition,
                                                                             includeSelection },
                                                       _viewport.scrollOffset(),
-                                                      highlightSearchMatches,
+                                                      renderLinesPerCell,
                                                       smoothScrollExtra);
     else
         _lastRenderPassHints = displayedScreen.render(RenderBufferBuilder { *this,
@@ -629,7 +637,7 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
                                                                             effectiveCursorPosition,
                                                                             includeSelection },
                                                       _viewport.scrollOffset(),
-                                                      highlightSearchMatches);
+                                                      renderLinesPerCell);
 
     // Save the baseLine used for the main screen before the bottom status line shifts it.
     auto const mainScreenLine = baseLine;
@@ -2557,6 +2565,10 @@ HintScanArea Terminal::collectHintScanArea(HintScope scope, LineCount scrollback
     auto const gridBottom = pageSize().lines.as<LineOffset>() - LineOffset(1);
     auto const historyTop = -screen.historyLineCount().as<LineOffset>();
 
+    // A scrollback limit is a row count; a negative value (an out-of-range config) would push
+    // labelableRows.first past last and underflow the reserve() below, so clamp it to zero.
+    scrollbackLimit = std::max(scrollbackLimit, LineCount(0));
+
     // A label can only be typed once it has been drawn. Under Visible that is the viewport; under
     // Scrollback the labels are fixed for the session, so every scanned row can carry one and the
     // user scrolls to reach it.
@@ -2581,8 +2593,9 @@ HintScanArea Terminal::collectHintScanArea(HintScope scope, LineCount scrollback
     area.rows.reserve(unbox<size_t>(last - first) + 1);
     for (auto line = first; line <= last; ++line)
         area.rows.push_back(HintScanRow {
-            // Untrimmed on purpose: one codepoint per cell is what makes a codepoint index a column.
-            .text = screen.lineTextAt(line, false, false),
+            // Column-aligned on purpose: one codepoint per grid cell (a wide character's
+            // continuation cell becomes a space) is what makes a codepoint index a column.
+            .text = screen.lineTextColumnAlignedAt(line),
             .line = line,
             .continuation = screen.isLineWrapped(line) ? LineContinuation::Yes : LineContinuation::No,
         });
@@ -2660,7 +2673,7 @@ void Terminal::activateHintMode(HintModeRequest request)
         }
     }
 
-    _hintModeHandler.activate(area, mutablePatterns, request.action);
+    _hintModeHandler.activate(area, std::move(mutablePatterns), request.action);
     _inputHandler.setMode(ViMode::Hint);
 }
 
@@ -2710,6 +2723,7 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
     // what makes this necessary rather than merely tidy.
     auto const scrollOffset = _viewport.scrollOffset().as<LineOffset>();
     auto const pageLines = pageSize().lines.as<LineOffset>();
+    auto const pageColumns = unbox<int>(pageSize().columns);
     auto rowBuckets = std::vector<std::vector<ProjectedMatch>>(unbox<size_t>(pageLines));
 
     for (auto const& match: matches)
@@ -2721,11 +2735,29 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
             .labelStart = first + baseLine,
             .label = match.label,
         };
+        // The label may overrun the row's right edge and wrap onto the next row(s), so it can touch
+        // a row the body does not; bucket every row either of them covers.
+        auto const labelEndColumn = unbox<int>(first.column) + static_cast<int>(match.label.size()) - 1;
+        auto const labelEndLine = first.line + LineOffset(labelEndColumn / pageColumns);
         auto const from = std::max(first.line, LineOffset(0));
-        auto const to = std::min(last.line, pageLines - LineOffset(1));
+        auto const to = std::min(std::max(last.line, labelEndLine), pageLines - LineOffset(1));
         for (auto row = from; row <= to; ++row)
             rowBuckets[unbox<size_t>(row)].push_back(projected);
     }
+
+    // The label occupies label.size() consecutive grid cells starting at labelStart, flowing left to
+    // right and wrapping onto the next row at the page's right edge (exactly as the wrapped match's
+    // body does). Returns which label character, if any, falls on @p pos.
+    auto const labelIndexAt = [&](CellLocation pos, ProjectedMatch const& match) -> std::optional<size_t> {
+        auto const rowDelta = unbox<int>(pos.line - match.labelStart.line);
+        if (rowDelta < 0)
+            return std::nullopt;
+        auto const index =
+            (rowDelta * pageColumns) + unbox<int>(pos.column) - unbox<int>(match.labelStart.column);
+        if (index < 0 || static_cast<size_t>(index) >= match.label.size())
+            return std::nullopt;
+        return static_cast<size_t>(index);
+    };
 
     for (auto& cell: output.cells)
     {
@@ -2739,21 +2771,17 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
         auto onMatch = false;
         for (auto const& match: bucket)
         {
-            // The label is drawn over the first label.size() cells of the match's first row even
-            // where it overruns a match shorter than its own label: a half-drawn label cannot be
-            // typed.
-            auto const labelEnd = match.labelStart.column + ColumnOffset::cast_from(match.label.size());
-            if (cell.position.line == match.labelStart.line && cell.position.column >= match.labelStart.column
-                && cell.position.column < labelEnd)
+            // The label is drawn over the match's first label.size() cells — wrapping onto the next
+            // row rather than being clipped at the right edge, and drawn in full even where it
+            // overruns a match shorter than its own label: a half-drawn label cannot be typed.
+            if (auto const labelIdx = labelIndexAt(cell.position, match))
             {
-                auto const labelIdx = unbox<size_t>(cell.position.column - match.labelStart.column);
-
                 // Replace codepoints with label character.
-                cell.codepoints = std::u32string(1, static_cast<char32_t>(match.label[labelIdx]));
+                cell.codepoints = std::u32string(1, static_cast<char32_t>(match.label[*labelIdx]));
                 cell.width = 1;
 
                 // Distinguish the already-typed prefix from the characters still to type.
-                auto const typed = labelIdx < filter.size();
+                auto const typed = *labelIdx < filter.size();
                 cell.attributes.foregroundColor = typed ? typedLabelFg : labelFg;
                 cell.attributes.backgroundColor = typed ? typedLabelBg : labelBg;
                 cell.attributes.flags |= CellFlag::Bold;
@@ -3884,8 +3912,23 @@ void Terminal::onBufferScrolled(LineCount n) noexcept
     _viCommands.cursorPosition.line -= n;
 
     // Adjust viewport accordingly to make it fixed at the scroll-offset as if nothing has happened.
+    // A viewport that actually moved has already run onViewportChanged() (and, in hint mode, the
+    // refreshHints() there); remember that so the visible-scope branch below does not re-scan twice.
+    auto viewportFollowedContent = false;
     if (viewport().scrolled() || _viewport.pixelOffset() > 0.0f || _inputHandler.mode() == ViMode::Normal)
-        viewport().scrollUp(n);
+        viewportFollowedContent = viewport().scrollUp(n);
+
+    // Keep an open hint session consistent with content that just scrolled. Scrollback labels are
+    // fixed for the session, so shift each match up to stay on its own text. The visible scope
+    // re-scans its (now-changed) viewport instead — but only when the viewport did not already move,
+    // since onViewportChanged() re-scans for us when it does.
+    if (_hintModeHandler.isActive())
+    {
+        if (_hintScope == HintScope::Scrollback)
+            _hintModeHandler.applyScroll(boxed_cast<LineOffset>(n), primaryScreen().historyLineCount());
+        else if (!viewportFollowedContent)
+            refreshHints();
+    }
 
     if (!_selection)
         return;

--- a/src/vtbackend/Terminal.h
+++ b/src/vtbackend/Terminal.h
@@ -1573,8 +1573,8 @@ class Terminal
     [[nodiscard]] Search const& search() const noexcept { return _search; }
 
     // {{{ hint mode
-    /// Activates hint mode by scanning visible lines for regex matches.
-    void activateHintMode(std::vector<HintPattern> const& patterns, HintAction action);
+    /// Activates hint mode, scanning the region @p request asks for.
+    void activateHintMode(HintModeRequest request);
 
     /// Returns true if hint mode is currently active.
     [[nodiscard]] bool isHintModeActive() const noexcept { return _hintModeHandler.isActive(); }
@@ -1596,6 +1596,7 @@ class Terminal
     [[nodiscard]] HintModeHandler& hintModeHandler() noexcept { return _hintModeHandler; }
 
     /// Re-scans hints for the current viewport (called on scroll while hint mode is active).
+    /// A no-op under HintScope::Scrollback, whose labels are assigned once and must not move.
     void refreshHints();
     // }}} hint mode
 
@@ -2384,6 +2385,13 @@ class Terminal
     };
     HintModeExecutor _hintModeExecutor { *this };
     HintModeHandler _hintModeHandler { _hintModeExecutor };
+
+    /// The scope the active hint session was activated with; decides whether a scroll re-scans.
+    HintScope _hintScope = HintScope::Visible;
+
+    /// Gathers the rows hint mode scans under @p scope, extended past the labelable range to whole
+    /// logical lines so a pattern wrapped across the boundary is still matched in full.
+    [[nodiscard]] HintScanArea collectHintScanArea(HintScope scope, LineCount scrollbackLimit) const;
 
     std::unique_ptr<ShellIntegration> _shellIntegration;
     SemanticBlockTracker _semanticBlockTracker;

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -4625,8 +4625,9 @@ TEST_CASE("Terminal.hint_mode_scrollback_scope_finds_history", "[terminal][hintm
 TEST_CASE("Terminal.hint_mode_scrollback_labels_survive_scrolling", "[terminal][hintmode]")
 {
     auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
-    // The escape and the URL are written separately: check-spelling splits identifiers on case
-    // boundaries, so "\r\nhttps" would arrive as the nonsense token `nhttps`.
+    // The two URLs go in separate calls so that each line-break escape ends a literal rather than
+    // sitting in front of a word: check-spelling splits identifiers on case boundaries, so an escape
+    // glued ahead of a word forms a nonsense token and fails the spell gate.
     mock.writeToScreen("https://one.example\r\n");
     mock.writeToScreen("https://two.example\r\n\r\n\r\n\r\n\r\n");
     mock.terminal.flushInput();
@@ -4654,7 +4655,7 @@ TEST_CASE("Terminal.hint_mode_scrollback_labels_survive_scrolling", "[terminal][
     }
 }
 
-TEST_CASE("Terminal.hint_mode_visible_scope_rescans_on_scroll", "[terminal][hintmode]")
+TEST_CASE("Terminal.hint_mode_visible_scope_scans_again_on_scroll", "[terminal][hintmode]")
 {
     auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
     mock.writeToScreen("https://scrolled-away.example\r\n\r\n\r\n\r\n\r\n");

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -4913,3 +4913,124 @@ TEST_CASE("Terminal.hint_mode_extends_the_scan_past_the_viewport_to_finish_a_wra
         CHECK(mock.terminal.hintMatches().empty());
     }
 }
+
+TEST_CASE("Terminal.hint_mode_maps_columns_past_a_wide_character", "[terminal][hintmode]")
+{
+    // A double-width glyph before the URL must not shift the label/highlight left: the scan text is
+    // column-aligned (the wide character's continuation cell becomes a space), so the URL's grid
+    // column accounts for the two cells the glyph occupies.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(10) };
+    mock.writeToScreen("\xe4\xb8\xad https://example.com"); // 中 (2 columns) + space + URL
+    mock.terminal.flushInput();
+
+    // 中 really is double-width here, otherwise the column arithmetic below would not be exercised.
+    REQUIRE(mock.terminal.currentScreen().cellWidthAt(
+                CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) })
+            == 2);
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    CHECK(match.matchedText == "https://example.com");
+    // 中 occupies columns 0-1 and the space column 2, so the URL starts at column 3 — not column 2,
+    // which is where a codepoint-counted (wide-character-collapsing) mapping would wrongly place it.
+    CHECK(match.start == CellLocation { .line = LineOffset(0), .column = ColumnOffset(3) });
+}
+
+TEST_CASE("Terminal.hint_mode_survives_a_negative_scrollback_limit", "[terminal][hintmode]")
+{
+    // A negative hint_scrollback_lines (an out-of-range config value) must not push the labelable
+    // range past the grid and underflow the row reservation, which would terminate the terminal.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
+    mock.writeToScreen("https://one.example\r\n\r\n\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Scrollback,
+                                     .scrollbackLimit = vtbackend::LineCount(-100) });
+
+    // It did not crash; the negative limit clamped to "no history", so the scrolled-away URL is out
+    // of range and nothing is offered.
+    CHECK(mock.terminal.isHintModeActive());
+    CHECK(mock.terminal.hintMatches().empty());
+}
+
+TEST_CASE("Terminal.hint_mode_matches_track_content_scrolling", "[terminal][hintmode]")
+{
+    // A hint session's positions are grid-absolute. When new output scrolls the grid while the
+    // session is open, each match must move up with its own text rather than staying at a now-stale
+    // row that other text has scrolled into.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(50) };
+    mock.writeToScreen("https://tracked.example\r\n");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Scrollback,
+                                     .scrollbackLimit = vtbackend::LineCount(1000) });
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const before = mock.terminal.hintMatches().at(0);
+
+    // Three more lines scroll the grid up by two; the match keeps its label and text but moves up.
+    // Each line goes in its own write so a line-break escape ends its literal rather than gluing to
+    // the next word (which check-spelling would read as a nonsense token).
+    mock.writeToScreen("more\r\n");
+    mock.writeToScreen("lines\r\n");
+    mock.writeToScreen("here\r\n");
+    mock.terminal.flushInput();
+
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const after = mock.terminal.hintMatches().at(0);
+    CHECK(after.matchedText == before.matchedText);
+    CHECK(after.label == before.label);
+    CHECK(after.start.line < before.start.line); // followed its text up into history
+}
+
+TEST_CASE("Terminal.hint_mode_overlay_wraps_a_label_past_the_row_edge", "[terminal][hintmode]")
+{
+    // 27 matches force two-character labels. One URL starts at the very last column, so its label
+    // cannot fit on that row: the second character must appear on the wrapped continuation row
+    // rather than being silently dropped.
+    auto urlPatterns = std::vector<vtbackend::HintPattern>();
+    for (auto& pattern: vtbackend::HintModeHandler::builtinPatterns())
+        if (pattern.name == "url")
+            urlPatterns.push_back(std::move(pattern));
+
+    auto mock = MockTerm { PageSize { LineCount(30), ColumnCount(20) }, LineCount(50) };
+    for (auto const i: std::views::iota(0, 26))
+        mock.writeToScreen(std::format("https://s{}.io\r\n", i));
+    // 19 blank filler columns then the URL, so its match starts at column 19 (the last column).
+    mock.writeToScreen(std::string(19, ' ') + "https://edge.example");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest { .patterns = std::move(urlPatterns),
+                                                                .action = vtbackend::HintAction::Copy });
+
+    auto const& matches = mock.terminal.hintMatches();
+    REQUIRE(matches.size() == 27);
+    auto const edge =
+        std::ranges::find_if(matches, [](auto const& m) { return m.matchedText == "https://edge.example"; });
+    REQUIRE(edge != matches.end());
+    REQUIRE(edge->label.size() == 2);
+    REQUIRE(edge->start.column == ColumnOffset(19)); // the last column of a 20-wide page
+
+    mock.terminal.refreshRenderBuffer();
+    auto const buf = mock.terminal.renderBuffer();
+    auto const codepointsAt = [&](CellLocation pos) -> std::optional<std::u32string> {
+        auto const it =
+            std::ranges::find_if(buf.get().cells, [&](auto const& cell) { return cell.position == pos; });
+        if (it == buf.get().cells.end())
+            return std::nullopt;
+        return it->codepoints;
+    };
+
+    // First label character on the start cell, second wrapped onto the next row's first column.
+    auto const wrapped = CellLocation { .line = edge->start.line + LineOffset(1), .column = ColumnOffset(0) };
+    CHECK(codepointsAt(edge->start) == std::u32string(1, static_cast<char32_t>(edge->label[0])));
+    CHECK(codepointsAt(wrapped) == std::u32string(1, static_cast<char32_t>(edge->label[1])));
+}

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -4035,8 +4035,9 @@ TEST_CASE("Terminal.hint_mode_accepts_labels_while_lock_keys_are_latched", "[ter
         auto mock = MockTerm { PageSize { LineCount(5), ColumnCount(40) } };
         mock.writeToScreen("visit https://example.com now");
 
-        mock.terminal.activateHintMode(vtbackend::HintModeHandler::builtinPatterns(),
-                                       vtbackend::HintAction::Copy);
+        mock.terminal.activateHintMode(
+            vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                         .action = vtbackend::HintAction::Copy });
         REQUIRE(mock.terminal.isHintModeActive());
         REQUIRE(mock.terminal.hintMatches().size() == 1);
 
@@ -4561,4 +4562,353 @@ TEST_CASE("Terminal.IME queries answered under the state lock survive concurrent
     REQUIRE(addressable(cursor));
     CHECK(terminal.currentScreen().cellWidthAt(cursor) <= 2);
     CHECK(terminal.currentScreen().lineTextAt(cursor.line).size() <= 4uz * 80);
+}
+
+// {{{ #1864: hint mode across wrapped lines, and the scrollback scope
+
+TEST_CASE("Terminal.hint_mode_matches_a_url_wrapped_across_rows", "[terminal][hintmode]")
+{
+    // 20 columns forces "https://example.com/wrapped" to wrap after column 20. Scanning per
+    // physical row would find at most the truncated head; the logical line yields the whole URL.
+    auto mock = MockTerm { PageSize { LineCount(5), ColumnCount(20) }, LineCount(10) };
+    mock.writeToScreen("https://example.com/wrapped");
+    mock.terminal.flushInput();
+
+    REQUIRE(mock.terminal.currentScreen().isLineWrapped(LineOffset(1)));
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    CHECK(match.matchedText == "https://example.com/wrapped");
+    CHECK(match.start == CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) });
+    CHECK(match.end == CellLocation { .line = LineOffset(1), .column = ColumnOffset(6) });
+}
+
+TEST_CASE("Terminal.hint_mode_visible_scope_ignores_scrollback", "[terminal][hintmode]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
+    mock.writeToScreen("https://scrolled-away.example\r\n\r\n\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    // The URL is now above the page: it must not be offered under the default scope.
+    REQUIRE(mock.terminal.currentScreen().historyLineCount() > LineCount(0));
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Visible });
+
+    CHECK(mock.terminal.hintMatches().empty());
+}
+
+TEST_CASE("Terminal.hint_mode_scrollback_scope_finds_history", "[terminal][hintmode]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
+    mock.writeToScreen("https://scrolled-away.example\r\n\r\n\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Scrollback,
+                                     .scrollbackLimit = LineCount(1000) });
+
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    CHECK(match.matchedText == "https://scrolled-away.example");
+    // A history row: a negative, scroll-invariant line offset.
+    CHECK(match.start.line < LineOffset(0));
+}
+
+TEST_CASE("Terminal.hint_mode_scrollback_labels_survive_scrolling", "[terminal][hintmode]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
+    // The escape and the URL are written separately: check-spelling splits identifiers on case
+    // boundaries, so "\r\nhttps" would arrive as the nonsense token `nhttps`.
+    mock.writeToScreen("https://one.example\r\n");
+    mock.writeToScreen("https://two.example\r\n\r\n\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Scrollback,
+                                     .scrollbackLimit = LineCount(1000) });
+
+    auto const before = mock.terminal.hintMatches();
+    REQUIRE(before.size() == 2);
+
+    // Scrolling reveals other rows' labels; it must not rename the ones already on screen, or a
+    // label the user has read becomes wrong under their fingers.
+    mock.terminal.viewport().scrollUp(LineCount(2));
+
+    auto const after = mock.terminal.hintMatches();
+    REQUIRE(after.size() == before.size());
+    for (auto const i: std::views::iota(size_t { 0 }, after.size()))
+    {
+        CHECK(after[i].label == before[i].label);
+        CHECK(after[i].start == before[i].start);
+        CHECK(after[i].matchedText == before[i].matchedText);
+    }
+}
+
+TEST_CASE("Terminal.hint_mode_visible_scope_rescans_on_scroll", "[terminal][hintmode]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(20) };
+    mock.writeToScreen("https://scrolled-away.example\r\n\r\n\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(
+        vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                     .action = vtbackend::HintAction::Copy,
+                                     .scope = vtbackend::HintScope::Visible });
+    REQUIRE(mock.terminal.hintMatches().empty());
+
+    // The visible scope's scan region *is* the viewport, so scrolling the URL back into view must
+    // surface it. Scroll to the very top rather than by a hardcoded count: the URL is on the oldest
+    // history row, wherever the scroll accounting puts it.
+    REQUIRE(mock.terminal.viewport().scrollToTop());
+
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    CHECK(mock.terminal.hintMatches().at(0).matchedText == "https://scrolled-away.example");
+}
+
+// }}}
+
+TEST_CASE("Terminal.hint_mode_overlay_draws_labels_into_the_render_buffer", "[terminal][hintmode]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(10) };
+    mock.writeToScreen("visit https://example.com now");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    REQUIRE(match.label == "a");
+
+    mock.terminal.refreshRenderBuffer();
+    auto const buf = mock.terminal.renderBuffer();
+
+    // The label replaces the match's first cell.
+    auto const labelCell =
+        std::ranges::find_if(buf.get().cells, [&](auto const& cell) { return cell.position == match.start; });
+    REQUIRE(labelCell != buf.get().cells.end());
+    CHECK(labelCell->codepoints == U"a");
+}
+
+TEST_CASE("Terminal.hint_mode_overlay_reaches_a_line_without_the_cursor", "[terminal][hintmode]")
+{
+    // A plain, uniformly-coloured line with no cursor and no selection is rendered through the
+    // trivial-line fast path, which emits one RenderLine instead of per-cell RenderCells. The hint
+    // overlay only rewrites cells, so the label must not be lost to that path.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) }, LineCount(10) };
+    mock.writeToScreen("visit https://example.com now\r\n");
+    mock.writeToScreen("second line holds the cursor");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    REQUIRE(match.start.line == LineOffset(0));
+
+    mock.terminal.refreshRenderBuffer();
+    auto const buf = mock.terminal.renderBuffer();
+
+    auto const labelCell =
+        std::ranges::find_if(buf.get().cells, [&](auto const& cell) { return cell.position == match.start; });
+    REQUIRE(labelCell != buf.get().cells.end());
+    CHECK(labelCell->codepoints == U"a");
+}
+
+TEST_CASE("Terminal.hint_mode_overlay_highlights_a_wrapped_match_on_both_rows", "[terminal][hintmode]")
+{
+    // The overlay's match body is a run of text, not a rectangle: a wrapped match must be
+    // highlighted on its continuation row too, and only up to the column it actually ends on.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(20) }, LineCount(10) };
+    mock.writeToScreen("https://example.com/wrapped");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+    REQUIRE(mock.terminal.hintMatches().size() == 1);
+    auto const& match = mock.terminal.hintMatches().at(0);
+    REQUIRE(match.start.line == LineOffset(0));
+    REQUIRE(match.end.line == LineOffset(1));
+
+    mock.terminal.refreshRenderBuffer();
+    auto const buf = mock.terminal.renderBuffer();
+
+    auto const backgroundAt = [&](CellLocation pos) -> std::optional<vtbackend::RGBColor> {
+        auto const it =
+            std::ranges::find_if(buf.get().cells, [&](auto const& cell) { return cell.position == pos; });
+        if (it == buf.get().cells.end())
+            return std::nullopt;
+        return it->attributes.backgroundColor;
+    };
+
+    // Compared within the continuation row, so cursorline colouring (the Vi cursor sits on the
+    // last written row) cannot confound it: the cells the match covers are highlighted, and the
+    // first cell past its end is not.
+    auto const firstInside = backgroundAt(CellLocation { .line = match.end.line, .column = ColumnOffset(0) });
+    auto const lastInside = backgroundAt(CellLocation { .line = match.end.line, .column = match.end.column });
+    auto const firstOutside =
+        backgroundAt(CellLocation { .line = match.end.line, .column = match.end.column + ColumnOffset(1) });
+
+    REQUIRE(firstInside.has_value());
+    REQUIRE(lastInside.has_value());
+    REQUIRE(firstOutside.has_value());
+    CHECK(*firstInside == *lastInside);   // the whole run on this row is highlighted
+    CHECK(*firstOutside != *firstInside); // and the highlight stops where the match does
+}
+
+TEST_CASE("Terminal.hint_mode_dispatches_each_action", "[terminal][hintmode]")
+{
+    // Every HintAction routed through HintModeExecutor::onHintSelected, so a new one cannot be
+    // added without a home here.
+    auto const activate = [](auto& mock, vtbackend::HintAction action) {
+        mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+            .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = action });
+        REQUIRE(mock.terminal.hintMatches().size() == 1);
+        mock.sendCharEvent(U'a');
+    };
+
+    SECTION("Copy")
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) } };
+        mock.writeToScreen("go https://example.com now");
+        mock.terminal.flushInput();
+        activate(mock, vtbackend::HintAction::Copy);
+        CHECK(mock.clipboardData == "https://example.com");
+    }
+
+    SECTION("Open")
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) } };
+        mock.writeToScreen("go https://example.com now");
+        mock.terminal.flushInput();
+        activate(mock, vtbackend::HintAction::Open);
+        CHECK(mock.openedDocument == "https://example.com");
+    }
+
+    SECTION("Paste")
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) } };
+        mock.writeToScreen("go https://example.com now");
+        mock.terminal.flushInput();
+        mock.resetReplyData();
+        activate(mock, vtbackend::HintAction::Paste);
+        CHECK(mock.replyData() == "https://example.com");
+    }
+
+    SECTION("CopyAndPaste")
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) } };
+        mock.writeToScreen("go https://example.com now");
+        mock.terminal.flushInput();
+        mock.resetReplyData();
+        activate(mock, vtbackend::HintAction::CopyAndPaste);
+        CHECK(mock.clipboardData == "https://example.com");
+        CHECK(mock.replyData() == "https://example.com");
+    }
+
+    SECTION("Select")
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(40) } };
+        mock.writeToScreen("go https://example.com now");
+        mock.terminal.flushInput();
+        activate(mock, vtbackend::HintAction::Select);
+
+        // Visual mode with the match pre-selected, ready for manual adjustment before yanking.
+        CHECK(mock.terminal.inputHandler().mode() == vtbackend::ViMode::Visual);
+        REQUIRE(mock.terminal.selector() != nullptr);
+        CHECK(mock.terminal.selector()->from()
+              == CellLocation { .line = LineOffset(0), .column = ColumnOffset(3) });
+    }
+}
+
+TEST_CASE("Terminal.hint_mode_validates_and_resolves_paths_against_the_working_directory",
+          "[terminal][hintmode]")
+{
+    // With a working directory known (OSC 7), the filepath pattern broadens to bare names and a
+    // filesystem-existence validator keeps only the ones that are really there; the match is then
+    // transformed to an absolute path so Copy and Open get something usable. The validator is
+    // memoized per activation, so a name repeated across rows is stat()ed once.
+    namespace fs = std::filesystem;
+
+    auto const tmpRoot =
+        fs::temp_directory_path()
+        / std::format("contour-hint-cwd-{}", std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(tmpRoot);
+    {
+        auto file = std::ofstream(tmpRoot / "Makefile");
+        file << "all:\n";
+    }
+    auto const cleanup = crispy::finally { [&]() { fs::remove_all(tmpRoot); } };
+
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(60) }, LineCount(10) };
+    mock.terminal.setCurrentWorkingDirectory("file://" + tmpRoot.generic_string());
+
+    // "Makefile" exists and must be offered; "Nonexistent" does not and must be filtered out. The
+    // repeat is what the memo cache collapses.
+    mock.writeToScreen("edit Makefile please\r\n");
+    mock.writeToScreen("also Makefile again\r\n");
+    mock.writeToScreen("but Nonexistent is absent");
+    mock.terminal.flushInput();
+
+    mock.terminal.activateHintMode(vtbackend::HintModeRequest {
+        .patterns = vtbackend::HintModeHandler::builtinPatterns(), .action = vtbackend::HintAction::Copy });
+
+    auto const& matches = mock.terminal.hintMatches();
+    auto const expected = (tmpRoot / "Makefile").generic_string();
+    REQUIRE(matches.size() == 2); // the two Makefile mentions, not the missing name
+    CHECK(matches[0].matchedText == expected);
+    CHECK(matches[1].matchedText == expected);
+    CHECK(std::ranges::none_of(matches, [](auto const& m) { return m.matchedText.contains("Nonexistent"); }));
+}
+
+TEST_CASE("Terminal.hint_mode_extends_the_scan_past_the_viewport_to_finish_a_wrapped_line",
+          "[terminal][hintmode]")
+{
+    // A one-row viewport so a two-row wrapped match can only ever straddle its edge.
+    auto mock = MockTerm { PageSize { LineCount(1), ColumnCount(20) }, LineCount(10) };
+    mock.writeToScreen("https://example.com/wrapped");
+    mock.writeToScreen("\r\n\r\n\r\n");
+    mock.terminal.flushInput();
+
+    auto const history = unbox<int>(mock.terminal.currentScreen().historyLineCount());
+    REQUIRE(history >= 3);
+
+    // Grid rows: the URL head, then its continuation, then the blank rows the line feeds added.
+    auto const head = LineOffset(-history);
+    REQUIRE_FALSE(mock.terminal.currentScreen().isLineWrapped(head));
+    REQUIRE(mock.terminal.currentScreen().isLineWrapped(head + LineOffset(1)));
+
+    auto const activateAt = [&](int scrollOffset) {
+        mock.terminal.viewport().scrollTo(vtbackend::ScrollOffset(scrollOffset));
+        mock.terminal.activateHintMode(
+            vtbackend::HintModeRequest { .patterns = vtbackend::HintModeHandler::builtinPatterns(),
+                                         .action = vtbackend::HintAction::Copy });
+    };
+
+    SECTION("the head is visible: the scan reaches down for the tail and yields the whole URL")
+    {
+        activateAt(history);
+
+        REQUIRE(mock.terminal.hintMatches().size() == 1);
+        auto const& match = mock.terminal.hintMatches().at(0);
+        CHECK(match.matchedText == "https://example.com/wrapped");
+        CHECK(match.start.line == head);
+        CHECK(match.end.line == head + LineOffset(1)); // the tail is off screen, but it is matched
+    }
+
+    SECTION("only the tail is visible: the hint is not offered, because its label cannot be drawn")
+    {
+        activateAt(history - 1);
+
+        CHECK(mock.terminal.hintMatches().empty());
+    }
 }

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -320,8 +320,14 @@ void ViCommands::searchCurrentWord()
 
 void ViCommands::enterHintMode(HintAction action)
 {
-    auto const patterns = HintModeHandler::builtinPatterns();
-    _terminal->activateHintMode(patterns, action);
+    // `gh`/`gH` scan the visible page with the built-in patterns; the scrollback scope is reachable
+    // only through an input_mapping, which can name the limit.
+    _terminal->activateHintMode(HintModeRequest {
+        .patterns = HintModeHandler::builtinPatterns(),
+        .action = action,
+        .scope = HintScope::Visible,
+        .scrollbackLimit = LineCount(0),
+    });
 }
 
 void ViCommands::executeYank(ViMotion motion, unsigned count)


### PR DESCRIPTION
Hint mode scanned one physical row at a time, so a URL or path the terminal had broken across rows
because the window was too narrow could not be matched at all — and it could only ever see the
visible page. Long URLs are precisely what hint mode exists for, so this closes both gaps: patterns
are now matched against the logical line, and a new `scope` parameter lets an activation reach into
scrollback history.

## Changes

- A pattern is matched against the **logical** line: consecutive wrapped rows are joined before
  scanning, and each match's offsets are mapped back to grid cells. A match may therefore span rows,
  yields its complete text rather than the fragment on one row, and its highlight follows it across
  the line break.
- A hint is offered only where its label can be drawn, since a label the user cannot see is one they
  cannot type. A match that begins inside the visible region and runs past it is still offered, in
  full.
- `HintMode` gains `scope: Visible|Scrollback`. Scrollback scans history as well as the page, bounded
  by a new `hint_scrollback_lines` profile option (default 1000). Its labels are assigned once and
  stay put, so scrolling reveals other rows' labels instead of renaming the ones already read; the
  default Visible scope, whose scan region *is* the viewport, keeps re-scanning.
- `HintMatch` positions moved from viewport to grid-absolute coordinates — needed by both of the
  above, and it removes the conversion the `Select` action had to perform.

Three defects the new reach exposed:

- `assignLabels()` hardcoded one- or two-character labels, so match 676 got `'a' + 26 == '{'` — a
  label the input handler can never accept, and duplicates beyond that. It now encodes base-26 at
  whatever fixed width the match count needs.
- The render overlay swept every cell once per match, twice over. It now projects the matches into
  render rows once and buckets them by row, so per-frame cost no longer scales with a
  scrollback-sized match count.
- Converting a match's byte offset to a codepoint index restarted from the beginning of the string
  every time, which is quadratic over a long logical line: joining 1000 wrapped rows took 188ms
  where the same text as separate rows took 40ms. Both now measure ~43ms.

The filesystem-existence validator attached to the filepath pattern memoizes per activation: the
broadened regex matches every bare word and repetition is the norm in terminal output, so a thousand
history rows would otherwise `stat()` the same paths again and again.

Closes #1864