### PR TITLE
Fix combining marks vanishing from uniformly styled lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,13 @@ compile_commands.json
 /Testing/
 CMakeUserPresets.json
 
+# The Unicode Character Database, downloaded into the source root by libunicode's tablegen when
+# it is built as a dependency. libunicode ignores it in its own tree for the same reason; it must
+# be ignored here too, both so a multi-megabyte download cannot be committed and because the
+# spell gate walks the working tree honouring .gitignore -- and the UCD is Unicode's data, not
+# our prose ("WOMENS SYMBOL", "Santa Claus", and hex ranges that spell words: 1F9BA reads as BA).
+/_ucd/
+
 # This is a workspace-local sandbox directory with test files not to be included in Git.
 sandbox
 sandbox/**

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -228,6 +228,8 @@
           <li>Fixes passive mouse tracking (DEC mode 2029) surviving a terminal reset: after RIS the mode read as off while mouse reports still carried its extra parameter, which applications cannot parse, and wheel scrolling on the alternate screen emitted nothing</li>
           <li>Fixes hint mode missing any URL or path that the terminal broke across two rows because the window was too narrow: patterns are now matched against the whole logical line, so such a match is one hint whose highlight follows it across the line break and which yields the complete text rather than the fragment on one row</li>
           <li>Adds a scope parameter to the HintMode action: scope: Scrollback scans the scrollback history as well as the visible page, capped by the new hint_scrollback_lines profile option (default 1000). Its labels are assigned once and stay put, so you can activate hint mode, scroll to older output, and then type the label you see; scope: Visible remains the default</li>
+          <li>Fixes selecting text changing how wide a glyph is drawn, so that emoji and other multi-codepoint characters no longer gain padding and push the rest of the line to the right when highlighted (#1752)</li>
+          <li>Fixes combining marks vanishing from uniformly styled lines: a character written in decomposed form, such as a Greek or Cyrillic letter followed by a combining accent, was drawn as its base letter alone, because the batched rendering path those lines take can only carry one codepoint per column</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/Line.h
+++ b/src/vtbackend/Line.h
@@ -348,6 +348,21 @@ class Line
 
     /// Build a TrivialLineBuffer for the render fast path.
     /// Only valid when isTrivialBuffer() returns true.
+    ///
+    /// @c textOut carries exactly ONE codepoint per column, which is what makes this cheap and what
+    /// bounds when it may be used: a cell holding a grapheme cluster cannot be represented here,
+    /// because the flat text has no cell boundaries for the renderer to recover the extra codepoints
+    /// from. Such a line therefore never reaches this function -- appending a continuation codepoint
+    /// clears the trivial flag (@see appendCodepointToCluster), as writing a wide cell's
+    /// continuation and an image fragment already do. Without that, everything after each cluster's
+    /// base codepoint is silently dropped from the rendered text.
+    ///
+    /// One codepoint per column is NOT the same as one COLUMN per cell, and the difference is
+    /// reachable: a wide character leaves the batched path only through the continuation cell it
+    /// writes, and @c Screen::clearAndAdvance skips that fill when a single column is left, so a
+    /// full-width character on the last writable column stays here as a two-column cell. Consumers
+    /// must therefore measure each codepoint rather than assume it is one column wide.
+    ///
     /// @param textOut receives the codepoints directly from SoA (no UTF-8 encoding).
     [[nodiscard]] TrivialLineBuffer trivialBuffer(std::u32string& textOut) const
     {

--- a/src/vtbackend/LineSoA.cpp
+++ b/src/vtbackend/LineSoA.cpp
@@ -314,6 +314,35 @@ int appendCodepointToCluster(LineSoA& line, size_t col, char32_t codepoint, Clus
 
             line.clusterPool.push_back(codepoint);
             line.clusterSize[col] = currentSize + 1;
+
+            // The batched RenderLine path stores ONE codepoint per column (@see
+            // Line::trivialBuffer), so a cell holding a cluster cannot be expressed there at all:
+            // everything after the base is silently dropped, and a decomposed "e" + U+0301 draws
+            // without its accent. Leave the fast path, exactly as a wide cell's continuation
+            // (@see fillWideCharContinuation) and an image fragment (@see CellProxy::setImageFragment)
+            // already do.
+            //
+            // Independent of @p policy and of any width change: under FirstCodepoint the cluster
+            // keeps its width, but the codepoint still joins it -- and it is the codepoint, not the
+            // width, that the batched representation cannot carry.
+            //
+            // Only when a cluster is actually FORMED. Appending to a cell with no base codepoint
+            // (currentSize == 0) leaves the pool entry unreferenced -- clusterPoolIndex is set only
+            // on the transition from 1 -- so the cell still reads back as its single (empty) base
+            // and stays perfectly expressible. Clearing the flag there would cost the line its fast
+            // path for a codepoint nothing can read.
+            //
+            // The flag also gates the PARSER's bulk-write path (@see
+            // Terminal::maxBulkTextSequenceWidth), so a cluster costs its line that too, for the
+            // rest of the line. Measured (clang-release, 1.46 MB): text carrying combining marks
+            // throughout is unaffected (8.0 vs 8.3 ms) because such a line already takes the
+            // per-codepoint write path; the worst case -- ONE mark followed by 480 ASCII columns --
+            // costs about 45% on that line, 21 ms to 31 ms. That is the price of not dropping the
+            // codepoints, and it is paid only by lines that carry a cluster. Separating "may the
+            // parser bulk-write here" from "can the renderer batch this line" would recover it, but
+            // they are one flag today and splitting them is not this change.
+            if (currentSize >= 1)
+                line.trivial = false;
         }
     }
 

--- a/src/vtbackend/LineSoA.h
+++ b/src/vtbackend/LineSoA.h
@@ -115,9 +115,20 @@ struct LineSoA
     /// Number of columns populated with content (for efficient trim operations).
     ColumnCount usedColumns {};
 
-    /// Cached: true when all written cells share uniform SGR attributes.
-    /// Set to true on line init/reset, set to false when a cell is written
-    /// with different SGR than the first cell. Read as O(1) by the render path.
+    /// Cached: true while this line can be rendered as ONE batched RenderLine.
+    ///
+    /// That representation is a flat string of one codepoint per column with uniform attributes, so
+    /// the flag answers "is the line still expressible that way", not merely "is its SGR uniform".
+    /// Set to true on line init/reset, and cleared when a cell becomes inexpressible:
+    ///
+    /// - its SGR or hyperlink differs from the first cell's (@see writeCellToSoA)
+    /// - it is a wide cell's continuation (@see fillWideCharContinuation)
+    /// - it carries an image fragment (@see BasicCellProxy::setImageFragment)
+    /// - it holds a grapheme cluster, i.e. more than one codepoint (@see appendCodepointToCluster)
+    ///
+    /// Anything that makes a cell fail that test must clear this, or @c Line::trivialBuffer will
+    /// silently drop what it cannot represent. Read as O(1) by the render path -- and by
+    /// @c Terminal::maxBulkTextSequenceWidth, which gates the parser's bulk-write path on it.
     bool trivial = true;
 
     /// The GraphicsAttributes used in the most recent full-line reset/clear.
@@ -244,6 +255,11 @@ enum class ClusterWidthPolicy : uint8_t
 };
 
 /// Appends @p codepoint to the grapheme cluster at @p col.
+///
+/// Also clears @c LineSoA::trivial, because a cell holding more than one codepoint cannot be
+/// represented on the batched render path (@see Line::trivialBuffer, which keeps one codepoint per
+/// column). Any future path that grows a cluster without going through here owes the same clear;
+/// without it the extra codepoints are dropped from the rendered text with no diagnostic.
 ///
 /// @return by how many columns the cluster's width changed, which is always 0 under
 ///         ClusterWidthPolicy::FirstCodepoint.

--- a/src/vtbackend/LineSoA_test.cpp
+++ b/src/vtbackend/LineSoA_test.cpp
@@ -269,6 +269,45 @@ TEST_CASE("LineSoA.graphemeCluster.multiCodepoint", "[LineSoA]")
     CHECK(collected[1] == U'\u0301');
 }
 
+TEST_CASE("LineSoA.graphemeCluster.appendLeavesTheTrivialPath", "[LineSoA]")
+{
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(10));
+    REQUIRE(line.trivial);
+
+    line.codepoints[0] = U'e';
+    line.clusterSize[0] = 1;
+    CHECK(line.trivial); // a single-codepoint cell is still expressible
+
+    // The batched RenderLine path stores one codepoint per column (@see Line::trivialBuffer), so a
+    // cell holding a cluster cannot be represented there and its line must leave that path -- the
+    // same reason a wide cell's continuation and an image fragment already clear the flag. Note the
+    // cluster stays ONE column wide here: it is the extra codepoint, not any width change, that the
+    // batched representation cannot carry.
+    auto const widthChange = appendCodepointToCluster(line, 0, U'\u0301');
+    CHECK(widthChange == 0);
+    CHECK(line.widths[0] == 1);
+    CHECK_FALSE(line.trivial);
+}
+
+TEST_CASE("LineSoA.graphemeCluster.appendLeavesTheTrivialPathUnderFirstCodepoint", "[LineSoA]")
+{
+    // Under ClusterWidthPolicy::FirstCodepoint (DEC mode 2027 reset) the cluster keeps its width,
+    // and appendCodepointToCluster returns early -- but the codepoint still joined the cluster, so
+    // the line is just as inexpressible as above.
+    LineSoA line;
+    initializeLineSoA(line, ColumnCount(10));
+
+    line.codepoints[0] = U'\U0001F441'; // EYE
+    line.clusterSize[0] = 1;
+    line.widths[0] = 1;
+
+    auto const widthChange = appendCodepointToCluster(line, 0, U'\uFE0F', ClusterWidthPolicy::FirstCodepoint);
+    CHECK(widthChange == 0);
+    CHECK(line.widths[0] == 1); // VS16 may not widen it under this policy
+    CHECK_FALSE(line.trivial);
+}
+
 TEST_CASE("LineSoA.graphemeCluster.clearExtras", "[LineSoA]")
 {
     LineSoA line;
@@ -396,13 +435,13 @@ TEST_CASE("LineSoA.appendCodepointToCluster.width_never_reaches_zero", "[LineSoA
     initializeLineSoA(line, ColumnCount(10));
 
     auto cell = CellProxy(line, 0);
-    cell.write(GraphicsAttributes {}, U'́', 1); // a combining mark as the cluster BASE
+    cell.write(GraphicsAttributes {}, U'\u0301', 1); // a combining mark as the cluster BASE
     auto const delta = cell.appendCharacter(U'̂');
 
     CHECK(line.widths[0] >= 1);
     CHECK(delta >= 0);
     CHECK(cell.codepointCount() == 2);
-    CHECK(cell.codepoint(0) == U'́');
+    CHECK(cell.codepoint(0) == U'\u0301');
 }
 
 TEST_CASE("LineSoA.appendCodepointToCluster.pool_survives_more_appends_than_the_index_can_address",
@@ -421,7 +460,7 @@ TEST_CASE("LineSoA.appendCodepointToCluster.pool_survives_more_appends_than_the_
     {
         auto cell = CellProxy(line, 0);
         cell.write(GraphicsAttributes {}, U'e', 1);
-        (void) cell.appendCharacter(U'́');
+        (void) cell.appendCharacter(U'\u0301');
         (void) cell.appendCharacter(U'̂');
     }
 
@@ -430,12 +469,12 @@ TEST_CASE("LineSoA.appendCodepointToCluster.pool_survives_more_appends_than_the_
     // into the abandoned garbage -- which the repetitive filler above would otherwise match by luck.
     auto cell = CellProxy(line, 0);
     cell.write(GraphicsAttributes {}, U'e', 1);
-    (void) cell.appendCharacter(U'́');
+    (void) cell.appendCharacter(U'\u0301');
     (void) cell.appendCharacter(U'⃣');
 
     REQUIRE(cell.codepointCount() == 3);
     CHECK(cell.codepoint(0) == U'e');
-    CHECK(cell.codepoint(1) == U'́');
+    CHECK(cell.codepoint(1) == U'\u0301');
     CHECK(cell.codepoint(2) == U'⃣');
 }
 

--- a/src/vtbackend/RenderBufferBuilder.cpp
+++ b/src/vtbackend/RenderBufferBuilder.cpp
@@ -10,6 +10,7 @@
 
 #include <libunicode/convert.h>
 #include <libunicode/utf8_grapheme_segmenter.h>
+#include <libunicode/width.h>
 
 using namespace std;
 
@@ -402,6 +403,15 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
     _useCursorlineColoring = isCursorLine(lineOffset);
     _currentLineFlags = flags;
 
+    // Same reason, and the same job startLine() does for a per-cell line: makeColorsForCell reads
+    // this pair to extend a block cursor across the second column of a wide glyph, so it describes
+    // the cell BEFORE the one being coloured. A new line has no such cell. Left carrying the
+    // previous line's values -- which is what happened while only startLine() cleared them -- a line
+    // whose predecessor ended in a wide glyph under the cursor gets its first cell, and with it the
+    // whole batched RenderLine or the whole fill run, painted in cursor colours.
+    _prevWidth = 0;
+    _prevHasCursor = false;
+
     auto const frontIndex = _output->cells.size();
 
     // Visual selection can alter colors for some columns in this line.
@@ -442,14 +452,15 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                                 ColumnOffset::cast_from(lineBuffer.usedColumns));
     auto const pageColumnsEnd = boxed_cast<ColumnOffset>(_terminal->pageSize().columns);
 
-    // render text — fallback path for selection/cursor, convert u32 to UTF-8
+    // Render the text cell by cell, because a selection or a cursor gives some column a colour of
+    // its own. The text comes from the grid, which has already decided where each cell begins, so
+    // it goes to the emitter that respects that -- re-deriving the boundaries here is what let the
+    // renderer and the grid disagree in GitHub #1752. An empty line has no text and only wants the
+    // fill loop below.
     _searchPatternOffset = 0;
-    auto const utf8Text =
-        textOverride.empty() ? std::string(lineBuffer.text.view()) : unicode::convert_to<char>(textOverride);
-    renderUtf8Text(CellLocation { .line = lineOffset, .column = ColumnOffset(0) },
+    renderGridText(CellLocation { .line = lineOffset, .column = ColumnOffset(0) },
                    lineBuffer.textAttributes,
-                   utf8Text,
-                   true);
+                   textOverride);
 
     // {{{ fill the remaining empty cells
     for (auto columnOffset = textMargin; columnOffset < pageColumnsEnd; ++columnOffset)
@@ -457,7 +468,6 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
         auto const pos = CellLocation { .line = lineOffset, .column = columnOffset };
         auto const gridPosition = _terminal->viewport().translateScreenToGridCoordinate(pos);
         auto renderAttributes = createRenderAttributes(gridPosition, lineBuffer.fillAttributes);
-        auto const scale = _currentLineFlags.test(LineFlag::DoubleWidth) ? 2 : 1;
 
         _output->cells.emplace_back(makeRenderCellExplicit(_terminal->colorPalette(),
                                                            char32_t { 0 },
@@ -467,7 +477,7 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                                                            renderAttributes.backgroundColor,
                                                            lineBuffer.fillAttributes.underlineColor,
                                                            _baseLine + lineOffset,
-                                                           columnOffset * scale));
+                                                           displayColumn(columnOffset)));
     }
     // }}}
 
@@ -582,10 +592,74 @@ void RenderBufferBuilder::endLine() noexcept
     }
 }
 
+void RenderBufferBuilder::renderGridText(CellLocation screenPosition,
+                                         GraphicsAttributes textAttributes,
+                                         std::u32string_view text)
+{
+    // @p text holds one codepoint per column, as Line::trivialBuffer produces it, and each codepoint
+    // is measured on its own -- exactly as TextClusterGrouper::renderLine measures the very same
+    // string when the line is drawn batched instead. That agreement is the point: a selection is
+    // what switches a line between the two, so any difference in how they measure shows up as text
+    // moving when it is selected, which is what GitHub #1752 reported.
+    //
+    // What must NOT happen here is re-segmenting the text into grapheme clusters, as renderUtf8Text
+    // does. The cell boundaries are already decided; re-deriving them can fuse two cells' codepoints
+    // into one cluster the grid never formed and pull the rest of the line leftwards.
+    for (auto column = screenPosition.column; auto const codepoint: text)
+    {
+        auto const gridPosition = _terminal->viewport().translateScreenToGridCoordinate(
+            CellLocation { .line = screenPosition.line, .column = column });
+        auto const [fg, bg] = makeColorsForCell(gridPosition,
+                                                textAttributes.flags,
+                                                textAttributes.foregroundColor,
+                                                textAttributes.backgroundColor);
+
+        // A cell always covers at least one column, and covers two when its codepoint is wide. The
+        // trivial path is not supposed to carry a wide cell -- writing one fills a continuation cell
+        // whose flags break the line's SGR uniformity -- but Screen::clearAndAdvance skips that fill
+        // when only one column is left, so a full-width character on the last writable column does
+        // reach here. Measuring it the same way the batched path does keeps the two in step.
+        auto const width = ColumnCount::cast_from(std::max(1u, unicode::width(codepoint)));
+
+        _output->cells.emplace_back(makeRenderCellExplicit(_terminal->colorPalette(),
+                                                           std::u32string(1, codepoint),
+                                                           width,
+                                                           textAttributes.flags,
+                                                           _currentLineFlags,
+                                                           fg,
+                                                           bg,
+                                                           textAttributes.underlineColor,
+                                                           _baseLine + screenPosition.line,
+                                                           displayColumn(column)));
+
+        // Spacer cells behind a wide glyph, so its background is painted across both columns.
+        for (auto i = ColumnCount(1); i < width; ++i)
+            _output->cells.emplace_back(makeRenderCellExplicit(_terminal->colorPalette(),
+                                                               U" ",
+                                                               ColumnCount(1),
+                                                               textAttributes.flags,
+                                                               _currentLineFlags,
+                                                               fg,
+                                                               bg,
+                                                               textAttributes.underlineColor,
+                                                               _baseLine + screenPosition.line,
+                                                               displayColumn(column + i.as<ColumnOffset>())));
+
+        column += width.as<ColumnOffset>();
+    }
+
+    _lineNr = screenPosition.line;
+
+    // _prevWidth/_prevHasCursor are NOT maintained here. renderTrivialLine clears them for the whole
+    // line, and nothing in the loop above sets them, so every cell is coloured against a cleared
+    // pair -- which is what the batched path this must agree with does too, having no per-cell state
+    // at all. The visible consequence, shared with master's renderUtf8Text: a block cursor sitting
+    // on a wide glyph is not extended across that glyph's second column on this path.
+}
+
 ColumnCount RenderBufferBuilder::renderUtf8Text(CellLocation screenPosition,
                                                 GraphicsAttributes textAttributes,
-                                                std::string_view text,
-                                                bool allowMatchSearchPattern)
+                                                std::string_view text)
 {
     auto columnCountRendered = ColumnCount(0);
 
@@ -605,8 +679,6 @@ ColumnCount RenderBufferBuilder::renderUtf8Text(CellLocation screenPosition,
         //            unicode::convert_to<char>(u32string_view(graphemeCluster)).size(),
         //            unicode::convert_to<char>(u32string_view(graphemeCluster)));
 
-        auto const scale = _currentLineFlags.test(LineFlag::DoubleWidth) ? 2 : 1;
-
         _output->cells.emplace_back(makeRenderCellExplicit(
             _terminal->colorPalette(),
             graphemeCluster,
@@ -617,7 +689,7 @@ ColumnCount RenderBufferBuilder::renderUtf8Text(CellLocation screenPosition,
             bg,
             textAttributes.underlineColor,
             _baseLine + screenPosition.line,
-            (screenPosition.column + ColumnOffset::cast_from(columnCountRendered)) * scale));
+            displayColumn(screenPosition.column + ColumnOffset::cast_from(columnCountRendered))));
 
         // Span filling cells for preceding wide glyphs to get the background color properly painted.
         for (auto i = ColumnCount(1); i < width; ++i)
@@ -632,16 +704,13 @@ ColumnCount RenderBufferBuilder::renderUtf8Text(CellLocation screenPosition,
                 bg,
                 textAttributes.underlineColor,
                 _baseLine + screenPosition.line,
-                (screenPosition.column + ColumnOffset::cast_from(columnCountRendered + i)) * scale));
+                displayColumn(screenPosition.column + ColumnOffset::cast_from(columnCountRendered + i))));
         }
 
         columnCountRendered += ColumnCount::cast_from(width);
         _lineNr = screenPosition.line;
         _prevWidth = 0;
         _prevHasCursor = false;
-
-        if (allowMatchSearchPattern)
-            matchSearchPattern(u32string_view(graphemeCluster));
     }
     return columnCountRendered;
 }
@@ -661,7 +730,7 @@ bool RenderBufferBuilder::tryRenderInputMethodEditor(CellLocation screenPosition
             _output->cells.back().groupEnd = true;
 
         _inputMethodSkipColumns =
-            renderUtf8Text(screenPosition, textAttributes, _inputMethodData.preeditString, false);
+            renderUtf8Text(screenPosition, textAttributes, _inputMethodData.preeditString);
         if (_inputMethodSkipColumns > ColumnCount(0))
         {
             if (_output->cursor.has_value())
@@ -694,8 +763,6 @@ void RenderBufferBuilder::renderCell(ConstCellProxy screenCell, LineOffset line,
     _prevWidth = screenCell.width();
     _prevHasCursor = _cursorPosition && gridPosition == *_cursorPosition;
 
-    auto const displayColumn = _currentLineFlags.test(LineFlag::DoubleWidth) ? column * 2 : column;
-
     _output->cells.emplace_back(makeRenderCell(_terminal->colorPalette(),
                                                _terminal->hyperlinks(),
                                                screenCell,
@@ -703,7 +770,7 @@ void RenderBufferBuilder::renderCell(ConstCellProxy screenCell, LineOffset line,
                                                fg,
                                                bg,
                                                _baseLine + line,
-                                               displayColumn));
+                                               displayColumn(column)));
 
     // A row that a tall block reaches down into carries no text of its own, so nothing would be drawn
     // there and the block would exist only as long as its HEAD row was on screen -- scroll the head

--- a/src/vtbackend/RenderBufferBuilder.h
+++ b/src/vtbackend/RenderBufferBuilder.h
@@ -117,10 +117,37 @@ class RenderBufferBuilder
 
     [[nodiscard]] bool tryRenderInputMethodEditor(CellLocation screenPosition, CellLocation gridPosition);
 
+    /// Emits one render cell per column for text taken from the grid.
+    ///
+    /// The grid has already decided where each cell begins and how wide it is, so this only counts
+    /// the columns off. Its counterpart @c renderUtf8Text is for text whose cell boundaries nobody
+    /// has determined yet, and measures them; using that one on grid text is what let the renderer
+    /// and the grid disagree about a cluster's width (GitHub #1752).
+    ///
+    /// @param screenPosition Where the first cell goes.
+    /// @param textAttributes The line's uniform SGR.
+    /// @param text One codepoint per column, as @c Line::trivialBuffer produces it.
+    void renderGridText(CellLocation screenPosition,
+                        GraphicsAttributes textAttributes,
+                        std::u32string_view text);
+
+    /// Emits render cells for text whose cell boundaries are not yet known -- the IME preedit
+    /// string -- segmenting it into grapheme clusters and measuring each.
+    /// @see renderGridText for text that comes from the grid.
+    /// @return How many columns were covered.
     ColumnCount renderUtf8Text(CellLocation screenPosition,
                                GraphicsAttributes attributes,
-                               std::string_view text,
-                               bool allowMatchSearchPattern);
+                               std::string_view text);
+
+    /// The display column a grid column draws at.
+    ///
+    /// DECDWL (@c LineFlag::DoubleWidth) doubles every cell's width, so cell N of such a line draws
+    /// at display column 2N. Lives here because every emitter needs it and four copies of the
+    /// expression is four places to miss when the mapping grows a case.
+    [[nodiscard]] ColumnOffset displayColumn(ColumnOffset column) const noexcept
+    {
+        return _currentLineFlags.test(LineFlag::DoubleWidth) ? column * 2 : column;
+    }
 
     template <typename T>
     void matchSearchPattern(T const& cellText);

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -1602,6 +1602,13 @@ size_t Terminal::maxBulkTextSequenceWidth() const noexcept
     // This matches the baseline behavior (isTrivialBuffer check) and avoids
     // a timing-sensitive race in screenUpdated() where TrySwapBuffers state
     // causes _screenDirty to not be set, leaving the display stale.
+    //
+    // NOTE: isTrivialBuffer() answers a RENDER question -- "can this line be emitted as one batched
+    // RenderLine" -- which is stricter than the uniform-SGR question asked here. A wide character,
+    // an image fragment or a grapheme cluster anywhere in the line therefore also costs the rest of
+    // that line its bulk write, even though none of them makes an ASCII bulk write unsafe.
+    // Measured worst case: about 45% on a line whose first cell holds a combining mark and whose
+    // remaining 480 columns are ASCII. @see LineSoA::trivial for what else clears it.
     if (!primaryScreen().currentLine().isTrivialBuffer())
         return 0;
 

--- a/src/vtbackend/Terminal_test.cpp
+++ b/src/vtbackend/Terminal_test.cpp
@@ -13,10 +13,12 @@
 #include <crispy/utils.h>
 
 #include <libunicode/convert.h>
+#include <libunicode/width.h>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <filesystem>
@@ -26,6 +28,7 @@
 #include <ranges>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace std;
@@ -3858,6 +3861,278 @@ TEST_CASE("Terminal.YankHighlight.trivialLineIsHighlighted", "[terminal][vi]")
 }
 // }}}
 
+// {{{ Grapheme cluster rendering (GitHub #1752)
+//
+// #1752: selecting text made a VS16 emoji grow padding, pushing the bracket behind it to the
+// right. A selection takes a uniform-SGR line off the batched RenderLine path and onto the
+// per-cell one, and the two measured differently -- the batched one per codepoint, the per-cell one
+// per grapheme cluster. Whatever else changes, the two must agree, so these tests compare the
+// LAYOUT the two states produce and assert which path each of them took.
+namespace
+{
+
+/// Which representation a line reached the render buffer through.
+enum class RenderPath : uint8_t
+{
+    /// Per-cell RenderCells. Taken by a line the batched form cannot express, and by any line
+    /// carrying a selection, a cursor or a highlight.
+    PerCell,
+    /// One batched RenderLine covering the whole line.
+    Batched,
+};
+
+/// One entry per drawn glyph on screen line @p line: the column it lands on, its text, and how many
+/// columns it covers.
+///
+/// Derived from whichever representation the render buffer used, so a batched line and a per-cell
+/// line are directly comparable -- which is the whole point, since a selection is what switches
+/// between them. Continuation and blank cells are skipped: they carry no glyph of their own.
+struct DrawnGlyph
+{
+    int column;
+    std::u32string codepoints;
+    int width;
+
+    bool operator==(DrawnGlyph const&) const = default;
+};
+
+std::vector<DrawnGlyph> renderedLayout(vtbackend::RenderBufferRef const& buf, vtbackend::LineOffset line)
+{
+    auto result = std::vector<DrawnGlyph> {};
+
+    for (auto const& cell: buf.get().cells)
+        if (cell.position.line == line && !cell.codepoints.empty() && cell.codepoints != U" ")
+            result.emplace_back(cell.position.column.value, cell.codepoints, int { cell.width });
+
+    if (!result.empty())
+        return result;
+
+    // Batched path: the rasterizer walks the flat text one codepoint per column, advancing by that
+    // codepoint's own width. @see vtrasterizer::TextClusterGrouper::renderLine.
+    for (auto const& renderLine: buf.get().lines)
+    {
+        if (renderLine.lineOffset != line)
+            continue;
+        auto column = 0;
+        for (auto const codepoint: renderLine.text)
+        {
+            auto const width = static_cast<int>(std::max(1u, unicode::width(codepoint)));
+            if (codepoint != U' ')
+                result.emplace_back(column, std::u32string(1, codepoint), width);
+            column += width;
+        }
+    }
+
+    return result;
+}
+
+/// A layout as `col:U+XXXX+U+YYYY(wN) ...`. Catch2 prints a u32string as `{?}`, which says nothing
+/// about a mismatch that is entirely about which codepoints landed where, and how wide.
+std::string describeLayout(std::vector<DrawnGlyph> const& layout)
+{
+    auto result = std::string {};
+    for (auto const& glyph: layout)
+    {
+        result += std::format("{}{}:", result.empty() ? "" : " ", glyph.column);
+        for (auto const [index, codepoint]: crispy::views::enumerate(glyph.codepoints))
+            result += std::format("{}U+{:04X}", index ? "+" : "", static_cast<uint32_t>(codepoint));
+        result += std::format("(w{})", glyph.width);
+    }
+    return result;
+}
+
+/// The layout of screen line @p line as rendered right now, plus which path produced it.
+/// Snapshotted so the render buffer's lock is released before the caller changes the terminal.
+std::pair<std::string, RenderPath> renderLineOf(vtbackend::Terminal& terminal, LineOffset line)
+{
+    terminal.refreshRenderBuffer();
+    auto const buf = terminal.renderBuffer();
+    auto const batched = std::ranges::any_of(
+        buf.get().lines, [&](auto const& renderLine) { return renderLine.lineOffset == line; });
+    return { describeLayout(renderedLayout(buf, line)), batched ? RenderPath::Batched : RenderPath::PerCell };
+}
+
+/// Selects columns [@p firstColumn, @p lastColumn] of screen line @p line, as a mouse drag would.
+void selectColumns(vtbackend::Terminal& terminal,
+                   LineOffset line,
+                   ColumnOffset firstColumn,
+                   ColumnOffset lastColumn)
+{
+    terminal.setSelector(std::make_unique<vtbackend::LinearSelection>(
+        terminal.selectionHelper(), CellLocation { .line = line, .column = firstColumn }, []() {}));
+    (void) terminal.selector()->extend(CellLocation { .line = line, .column = lastColumn });
+    terminal.selector()->complete();
+}
+
+} // namespace
+
+TEST_CASE("Terminal.GraphemeCluster.selectionDoesNotShiftLayout", "[terminal][unicode]")
+{
+    // Each case names the layout it must produce, unselected AND selected, and which path the
+    // unselected state must have taken. Naming the layout rather than comparing the two states
+    // against each other matters: both derive from the same line, so two equally wrong layouts
+    // would satisfy a self-consistency check without drawing the right thing. Naming the path
+    // matters just as much -- a case that never reaches the batched form is not testing the
+    // batched-vs-per-cell agreement it appears to be testing.
+    struct TestCase
+    {
+        std::string_view name;
+        std::string_view text;
+        std::string_view layout;
+        RenderPath unselectedPath;
+    };
+
+    // The first three are #1752's reproduction lines. The two that broke are the two whose BASE
+    // codepoint is one column wide and which only reach two columns through VS16 -- 1F441 EYE and
+    // 1F3F3 WAVING WHITE FLAG; 1F44D THUMBS UP is wide already, which is why the reporter saw it
+    // survive. In all three the closing bracket belongs at column 3. They widen through a
+    // continuation cell, which is what takes them off the batched path in BOTH states.
+    auto constexpr Cases = std::array {
+        TestCase { .name = "thumbs up + skin tone modifier",
+                   .text = "[\U0001F44D\U0001F3FB]"sv,
+                   .layout = "0:U+005B(w1) 1:U+1F44D+U+1F3FB(w2) 3:U+005D(w1)"sv,
+                   .unselectedPath = RenderPath::PerCell },
+        TestCase { .name = "rainbow flag: VS16, ZWJ, rainbow",
+                   .text = "[\U0001F3F3\uFE0F\u200D\U0001F308]"sv,
+                   .layout = "0:U+005B(w1) 1:U+1F3F3+U+FE0F+U+200D+U+1F308(w2) 3:U+005D(w1)"sv,
+                   .unselectedPath = RenderPath::PerCell },
+        TestCase { .name = "eye + VS16",
+                   .text = "[\U0001F441\uFE0F]"sv,
+                   .layout = "0:U+005B(w1) 1:U+1F441+U+FE0F(w2) 3:U+005D(w1)"sv,
+                   .unselectedPath = RenderPath::PerCell },
+        // Plain text stays on the batched path, so this is the case that actually compares the two
+        // representations against each other -- the comparison #1752 is about.
+        TestCase { .name = "plain text",
+                   .text = "abc"sv,
+                   .layout = "0:U+0061(w1) 1:U+0062(w1) 2:U+0063(w1)"sv,
+                   .unselectedPath = RenderPath::Batched },
+        // A cluster that stays ONE column wide writes no continuation cell, so only the cluster rule
+        // itself takes its line off the batched path -- and that path stores one codepoint per
+        // column (@see Line::trivialBuffer), silently discarding everything after the base. A
+        // decomposed alpha + COMBINING ACUTE therefore reached the renderer as a bare alpha.
+        TestCase { .name = "alpha + combining acute",
+                   .text = "\u03B1\u0301x"sv,
+                   .layout = "0:U+03B1+U+0301(w1) 1:U+0078(w1)"sv,
+                   .unselectedPath = RenderPath::PerCell },
+    };
+
+    for (auto const& testCase: Cases)
+    {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(20) }, LineCount(0) };
+        // Park the cursor on the NEXT line. Left on line 0, gridLineContainsCursor() forces the
+        // per-cell path even unselected, and the batched half of every comparison below silently
+        // stops happening.
+        mock.writeToScreen(testCase.text);
+        mock.writeToScreen("\r\n"sv);
+
+        auto const [unselected, unselectedPath] = renderLineOf(mock.terminal, LineOffset(0));
+        selectColumns(mock.terminal, LineOffset(0), ColumnOffset(0), ColumnOffset(19));
+        auto const [selected, selectedPath] = renderLineOf(mock.terminal, LineOffset(0));
+
+        INFO(testCase.name);
+        CHECK(unselectedPath == testCase.unselectedPath);
+        CHECK(selectedPath == RenderPath::PerCell); // a selection always forces per-cell
+        CHECK(unselected == testCase.layout);
+        CHECK(selected == testCase.layout);
+    }
+}
+
+TEST_CASE("Terminal.GraphemeCluster.aWideCellOnTheLastColumnKeepsItsWidth", "[terminal][unicode]")
+{
+    // A wide character leaves the batched path only through the continuation cell it writes, and
+    // Screen::clearAndAdvance skips that fill when a single column is left -- so a full-width
+    // character on the last writable column stays on a line the batched path still claims, as a
+    // TWO-column cell. The selection fallback must measure it the same way the batched path does;
+    // reporting one column shrinks the selection background and any underline behind the glyph.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(5) }, LineCount(0) };
+    mock.writeToScreen("\033[1;5H\u4E16"sv); // last column of a 5-column page
+    mock.writeToScreen("\033[2;1H"sv);       // cursor off the line under test
+
+    REQUIRE(mock.terminal.primaryScreen().grid().lineAt(LineOffset(0)).isTrivialBuffer());
+    REQUIRE(mock.terminal.primaryScreen().at(LineOffset(0), ColumnOffset(4)).width() == 2);
+
+    auto const [unselected, unselectedPath] = renderLineOf(mock.terminal, LineOffset(0));
+    selectColumns(mock.terminal, LineOffset(0), ColumnOffset(0), ColumnOffset(4));
+    auto const [selected, selectedPath] = renderLineOf(mock.terminal, LineOffset(0));
+
+    CHECK(unselectedPath == RenderPath::Batched);
+    CHECK(selectedPath == RenderPath::PerCell);
+    CHECK(unselected == "4:U+4E16(w2)");
+    CHECK(selected == unselected);
+}
+
+TEST_CASE("Terminal.GraphemeCluster.batchedFallbackDoesNotInheritTheCursor", "[terminal][unicode]")
+{
+    // makeColorsForCell extends a block cursor over the second column of a wide glyph by consulting
+    // _prevWidth/_prevHasCursor, which every emitter must reset per cell. startLine() resets them
+    // for a per-cell line, but renderTrivialLine has no such entry point -- so if its fallback
+    // resets only once, a line following one that ENDS in a wide glyph under the cursor is painted
+    // entirely in cursor colours.
+    //
+    // Asserted against a control that differs only in the previous line's last cell, so no palette
+    // value is hard-coded.
+    auto const colorsOfSecondLine = [](std::string_view lastCellOfFirstLine) {
+        auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(5) }, LineCount(0) };
+        auto constexpr ClockBase = chrono::steady_clock::time_point();
+        mock.terminal.tick(ClockBase);
+        // The block-cursor inversion this test is about is suppressed while a cursor MOTION
+        // animation is in flight (makeColorsForCell requires animationProgress >= 1). Writing text
+        // is exactly what starts one, so switch the animation off rather than race it.
+        mock.terminal.settings().cursorMotionAnimationDuration = chrono::milliseconds(0);
+
+        mock.writeToScreen("\033[2;1H"sv);
+        mock.writeToScreen("xyz"sv);                       // line 1: uniform text
+        mock.writeToScreen("\033[1;1H\033[31mab\033[m"sv); // line 0: mixed SGR -> per-cell path
+        mock.writeToScreen(std::format("\033[1;5H{}", lastCellOfFirstLine));
+
+        // The cursor must end ON line 0's last cell, so renderCell leaves _prevHasCursor set.
+        REQUIRE(mock.terminal.primaryScreen().cursor().position
+                == CellLocation { .line = LineOffset(0), .column = ColumnOffset(4) });
+        // Line 1 is selected in part, which sends it to renderTrivialLine's fallback; columns 0..2
+        // are outside the selection, so nothing may recolor them.
+        selectColumns(mock.terminal, LineOffset(1), ColumnOffset(3), ColumnOffset(4));
+
+        mock.terminal.tick(ClockBase + chrono::seconds(1));
+        mock.terminal.refreshRenderBuffer();
+        auto const buf = mock.terminal.renderBuffer();
+        auto result = std::vector<vtbackend::RGBColor> {};
+        for (auto const& cell: buf.get().cells)
+            if (cell.position.line == LineOffset(1) && cell.position.column < ColumnOffset(3))
+                result.push_back(cell.attributes.backgroundColor);
+        return result;
+    };
+
+    auto const afterWideGlyph = colorsOfSecondLine("\u4E16"sv); // two columns, cursor on it
+    auto const afterNarrowGlyph = colorsOfSecondLine("Z"sv);    // one column, cursor on it
+
+    REQUIRE(afterNarrowGlyph.size() == 3);
+    CHECK(afterWideGlyph == afterNarrowGlyph);
+}
+
+TEST_CASE("Terminal.GraphemeCluster.aClusterLeavesTheBatchedPath", "[terminal][unicode]")
+{
+    // Why the layouts above can agree at all: a line the batched RenderLine path cannot express
+    // must not take it. That path stores one codepoint per column, so a cell holding more than one
+    // -- whether or not the cluster also grew wider -- has to leave it, exactly as a wide cell and
+    // an image fragment already do. Stated on its own so a change that re-admits such a line fails
+    // HERE, naming the cause, rather than as a layout mismatch above or only in the GUI.
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(20) }, LineCount(0) };
+    auto const& screen = mock.terminal.primaryScreen();
+
+    mock.writeToScreen("[\U0001F441\uFE0F]"sv);
+    CHECK_FALSE(screen.grid().lineAt(LineOffset(0)).isTrivialBuffer());
+    // The eye is two columns: its own, plus the one VS16 claimed for it.
+    CHECK(screen.at(LineOffset(0), ColumnOffset(1)).width() == 2);
+
+    // The same must hold when the cluster stays one column wide, which is the case that has no
+    // continuation cell to break SGR uniformity on its behalf.
+    mock.writeToScreen("\r\n\u03B1\u0301x"sv);
+    CHECK(screen.at(LineOffset(1), ColumnOffset(0)).codepointCount() == 2);
+    CHECK_FALSE(screen.grid().lineAt(LineOffset(1)).isTrivialBuffer());
+    CHECK(screen.at(LineOffset(1), ColumnOffset(0)).width() == 1);
+}
+// }}}
+
 // {{{ mouse wheel alternate-scroll (GitHub #1951)
 
 TEST_CASE("Terminal.Wheel.AltScreen.NoProtocol.emits_cursor_keys", "[terminal]")
@@ -4540,7 +4815,7 @@ TEST_CASE("Terminal.IME queries answered under the state lock survive concurrent
                                           PageSize { LineCount(24), ColumnCount(80) } };
     for (auto const round: std::views::iota(0, 200))
     {
-        mc.writeToScreen("wide 世界 and combining ᬦᬸ é\r\n");
+        mc.writeToScreen("wide \u4E16界 and combining ᬦᬸ e\u0301\r\n");
         if (round % 25 == 24)
         {
             auto const usable = usableSizes[static_cast<size_t>((round / 25) % 2)];

--- a/src/vtrasterizer/TextClusterGrouper.cpp
+++ b/src/vtrasterizer/TextClusterGrouper.cpp
@@ -38,7 +38,14 @@ void TextClusterGrouper::renderLine(std::u32string_view text,
     _initialPenPosition = vtbackend::CellLocation { .line = lineOffset, .column = columnOffset };
 
     // Iterate char32_t codepoints directly — no UTF-8 decode needed.
-    // For trivial lines, each codepoint is a single-codepoint grapheme cluster.
+    //
+    // Each codepoint here is a grapheme cluster of its own: a cell holding more than one takes its
+    // line off the batched path before it ever gets here (@see vtbackend::appendCodepointToCluster).
+    // Its WIDTH is still a question — a wide character normally leaves the path too, through the
+    // continuation cell it writes, but Screen::clearAndAdvance skips that fill when only one column
+    // remains, so a full-width character on the last writable column does arrive. Hence the measure
+    // and the filler loop below, which RenderBufferBuilder::renderGridText mirrors exactly: the two
+    // draw the same line whenever a selection switches between them.
     for (auto const cp: text)
     {
         auto const gridPosition = vtbackend::CellLocation { .line = lineOffset, .column = columnOffset };


### PR DESCRIPTION
A line whose cells all share the same SGR is rendered as one batched `RenderLine`, whose payload is a flat string of one codepoint per column. A cell holding a grapheme cluster cannot be represented that way — `Line::trivialBuffer` copies only each cell's base codepoint, so everything after it is dropped without a trace. A decomposed letter such as a Greek alpha followed by a combining acute is drawn as a bare alpha, and the same goes for VS15 sequences. Wide cells and image fragments already leave the batched path for exactly this reason; clusters did not.

Note on #1752 itself: its reported symptom — a VS16 emoji gaining padding and pushing the rest of the line right when selected — no longer reproduces on master, closed as a side effect of the AoS→SoA migration. A VS16 that widens a narrow base now writes a continuation cell, which takes the line off the batched path, so selecting it no longer switches rendering paths. What that issue actually exposed was two independent width authorities in the render path, and that is what this branch closes; the tests pin the reported behaviour so it cannot come back.

## Changes

- `appendCodepointToCluster` clears `LineSoA::trivial` when a cell gains a second codepoint, independent of the cluster width policy and of any width change — it is the extra codepoint, not the width, that the batched form cannot carry.
- The trivial-line fallback, taken when a selection or cursor recolors part of a line, gets its own emitter. It walks the text one codepoint per column exactly as `TextClusterGrouper::renderLine` walks the same string when the line is drawn batched, so the two agree; re-segmenting it there could fuse two cells' codepoints into a cluster the grid never formed. `renderUtf8Text` stays grapheme-cluster-aware for the IME preedit string, whose cell boundaries are genuinely undetermined.
- `renderTrivialLine` now clears `_prevWidth`/`_prevHasCursor`, the job `startLine()` does for a per-cell line. Without it, a line following one that ends in a wide glyph under the block cursor was painted in cursor colours.
- Documents what `LineSoA::trivial` means where callers read it, and corrects comments claiming a wide cell always leaves the batched path — `Screen::clearAndAdvance` skips the continuation fill when one column is left, so a full-width character on the last writable column stays on a batched line.
- Removes a dead branch that rendered `TrivialLineBuffer::text` (nothing populates it) along with the bool parameter only it needed, and gathers four copies of the DECDWL column scale into one helper.

**Performance.** The flag also gates the parser's bulk-write path, so a cluster costs its line that for the remainder of the line. Measured over 1.46 MB in a release build: text carrying combining marks throughout is unaffected (8.0 vs 8.3 ms — such a line already takes the per-codepoint write path), while the worst case, one mark followed by 480 ASCII columns, costs about 45% on that line (21 → 31 ms). Recorded at both sites. Recovering it means separating "may the parser bulk-write here" from "can the renderer batch this line", which are one flag today; that felt like a separate change rather than something to bundle here.

One caveat worth knowing: a combining mark after an **ASCII** base still will not render, because libunicode's `scan_text` drops it before it reaches the grid. That is contour-terminal/libunicode#140; a non-ASCII base is unaffected and is what the tests here use.

Fixes #1752