### PR TITLE
Fix the spell gate failing on the downloaded Unicode database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,13 @@ compile_commands.json
 /Testing/
 CMakeUserPresets.json
 
+# The Unicode Character Database, downloaded into the source root by libunicode's tablegen when
+# it is built as a dependency. libunicode ignores it in its own tree for the same reason; it must
+# be ignored here too, both so a multi-megabyte download cannot be committed and because the
+# spell gate walks the working tree honouring .gitignore -- and the UCD is Unicode's data, not
+# our prose ("WOMENS SYMBOL", "Santa Claus", and hex ranges that spell words: 1F9BA reads as BA).
+/_ucd/
+
 # This is a workspace-local sandbox directory with test files not to be included in Git.
 sandbox
 sandbox/**


### PR DESCRIPTION
Every build job on `master` currently fails its `check_spelling` test. The gate walks the working
tree honouring `.gitignore`, and libunicode's tablegen downloads the Unicode Character Database
into the source root when libunicode is built as a dependency. Nothing ignored it there, so the
gate spell-checked Unicode's own data and reported it as misspelled prose — `WOMENS SYMBOL`,
`Santa Claus`, and hex ranges that happen to spell words, such as `1F9BA` reading as `BA`.

It does not reproduce in a checkout that builds libunicode from a sibling source directory,
because the download then lands outside this tree. That is why it passed review and fails in CI:
there, libunicode is fetched and the UCD lands in the repository root.

libunicode already ignores `/_ucd/` in its own tree for the same reason, so this is the same
one-line rule applied here. Ignoring it is independently correct — a multi-megabyte download
should not be committable — and the spell gate honouring `.gitignore` means the one rule covers
both concerns rather than needing a second exclusion list.