### PR TITLE
Fix crash when a pane closes: resizing an already-closed ConPTY

### DIFF
--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -373,6 +373,12 @@ void TerminalSession::attachDisplay(display::TerminalDisplay& newDisplay)
     // cursorPositionChanged() early-return, freezing IME rectangle tracking and the a11y caret.
     _cursorMovedPostPending.clear(std::memory_order_release);
 
+    // A closed session has nothing to resize: its PTY is gone. Closing a pane makes QML re-run the
+    // Loader binding for the surviving panes, which re-enters setSession() -> attachDisplay() while
+    // onClosed() is still unwinding, so this path really is reached after the PTY has been closed.
+    // Skipping the resize keeps a dead session from pushing a geometry change down to it; ConPty
+    // additionally refuses the resize on its own side, since attachDisplay() is not the only caller.
+    if (!isClosed())
     {
         // NB: Inform connected TTY and local Screen instance about initial cell pixel size.
         auto const l = scoped_lock { _terminal };

--- a/src/contour/test/DisplayRendering_test.cpp
+++ b/src/contour/test/DisplayRendering_test.cpp
@@ -1412,6 +1412,50 @@ TEST_CASE("display: a session re-bound onto a resized display adopts the live gr
     second.reset();
 }
 
+TEST_CASE("display: attaching a display to an already-closed session does not resize its dead PTY",
+          "[display][session][close]")
+{
+    // Regression pin for the ConPTY teardown crash: closing a pane makes QML re-run the Loader
+    // binding for the surviving panes, which re-enters TerminalDisplay::setSession() ->
+    // TerminalSession::attachDisplay() while onClosed() is still unwinding. attachDisplay()
+    // unconditionally called Terminal::resizeScreen(), so the resize reached a PTY that had already
+    // been closed. On Windows that is fatal rather than merely pointless: ConPty::close()
+    // invalidates the HPCON but leaves the slave alive, so the resize passed INVALID_HANDLE_VALUE
+    // to ResizePseudoConsole, which dereferences it (access violation reading 0xffffffffffffffff).
+    //
+    // The unit-level half of this lives in vtpty's ConPty_test; here the whole GUI path is driven:
+    // a real display re-attached to a real closed session must push no resize down to the device.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.pump();
+
+    // Close the session the way the shell exiting does: terminate() closes the PTY device and drives
+    // the session to its closed state.
+    h.session->terminate();
+    for (int i = 0; i < 50 && !h.session->isClosed(); ++i)
+    {
+        QTest::qWait(10);
+        QCoreApplication::processEvents();
+    }
+    REQUIRE(h.pty->isClosed());
+    REQUIRE(h.session->isClosed());
+
+    // Whatever the close path itself did is not what this test is about; only what the *re-attach*
+    // does after it.
+    auto const resizesBeforeReattach = h.pty->resizesAfterClose();
+
+    // The re-attach QML performs on the surviving panes. Detach first so setSession() takes the
+    // full attachDisplay() path rather than an early-out on an unchanged session pointer.
+    h.display->setSession(nullptr);
+    h.pump();
+    h.display->setSession(h.session.get());
+    h.pump();
+
+    // Attached, and no geometry was pushed into the closed device.
+    CHECK(h.session->display() == h.display);
+    CHECK(h.pty->resizesAfterClose() == resizesBeforeReattach);
+}
+
 TEST_CASE("display: IME cursor-position and surrounding-text queries read the live grid", "[display][ime]")
 {
     REQUIRE_DISPLAY_OR_SKIP();

--- a/src/contour/test/GuiTestFixtures.h
+++ b/src/contour/test/GuiTestFixtures.h
@@ -328,8 +328,19 @@ class BlockingMockPty: public vtpty::Pty
     void resizeScreen(vtbackend::PageSize cells, std::optional<vtpty::ImageSize> pixels) override
     {
         auto const lock = std::lock_guard { _mutex };
+        if (_closed)
+            ++_resizesAfterClose;
         _pageSize = cells;
         _pixelSize = pixels;
+    }
+
+    /// How many resizes arrived after close(). A real PTY has no device left to resize by then --
+    /// ConPty crashed outright on one (it handed the invalidated HPCON to ResizePseudoConsole) --
+    /// so this must stay zero.
+    [[nodiscard]] int resizesAfterClose() const noexcept
+    {
+        auto const lock = std::lock_guard { _mutex };
+        return _resizesAfterClose;
     }
 
     vtpty::StartResult start() override { return {}; }
@@ -390,6 +401,7 @@ class BlockingMockPty: public vtpty::Pty
     std::string _inputBuffer;
     std::string _outputBuffer;
     std::size_t _outputReadOffset = 0;
+    int _resizesAfterClose = 0; ///< Resizes that arrived once _closed; see resizesAfterClose().
     bool _closed = false;
     bool _woken = false; ///< One-shot wakeupReader() flag (teardown wake), cleared on read.
     vtpty::PtySlaveDummy _slave;

--- a/src/vtpty/CMakeLists.txt
+++ b/src/vtpty/CMakeLists.txt
@@ -103,6 +103,10 @@ if(VTPTY_TESTING)
         ImageSize_test.cpp
         SpawnLadder_test.cpp
     )
+    if(WIN32)
+        # ConPty is the Windows-only PTY backend.
+        target_sources(vtpty_test PRIVATE ConPty_test.cpp)
+    endif()
     target_link_libraries(vtpty_test vtpty crispy::core Catch2::Catch2)
     add_test(NAME vtpty_test COMMAND $<TARGET_FILE:vtpty_test>)
 

--- a/src/vtpty/ConPty.cpp
+++ b/src/vtpty/ConPty.cpp
@@ -288,15 +288,21 @@ void ConPty::resizeScreen(PageSize cells, std::optional<ImageSize> pixels)
 {
     (void) pixels; // TODO Can we pass that information, too?
 
-    if (!_slave)
+    // No live pseudoconsole to resize: remember the size rather than drop it, so a subsequent
+    // start() creates the pseudoconsole at it. attachDisplay() is what first tells a PTY its size,
+    // and it now runs before start() -- dropping the size here left the child born at whatever the
+    // constructor was handed (the profile's configured terminal size), so the shell's first prompt,
+    // and any program launched before the first window-geometry change, wrapped at the wrong column.
+    // UnixPty stashes the same way; only the pixel half is ConPTY's to ignore.
+    //
+    // This must test the master handle, not _slave: close() invalidates _master but leaves _slave
+    // alive, so a _slave-based guard let a post-close resize through and handed
+    // INVALID_HANDLE_VALUE to ResizePseudoConsole, which dereferences it. That is a real crash on
+    // the session-teardown path -- closing a pane makes QML re-run the Loader binding, which calls
+    // setSession() -> attachDisplay() -> Terminal::resizeScreen() on the already-closed PTY.
+    if (isClosed())
     {
-        // Not started yet: remember the size rather than drop it, so start() creates the
-        // pseudoconsole at it. attachDisplay() is what first tells a PTY its size, and it now runs
-        // before start() -- dropping the size here left the child born at whatever the constructor
-        // was handed (the profile's configured terminal size), so the shell's first prompt, and any
-        // program launched before the first window-geometry change, wrapped at the wrong column.
-        // UnixPty stashes the same way; only the pixel half is ConPTY's to ignore.
-        ptyLog()("Recording pre-start terminal size: {}x{}", cells.columns, cells.lines);
+        ptyLog()("Recording terminal size while no pseudoconsole is live: {}x{}", cells.columns, cells.lines);
         _size = cells;
         return;
     }

--- a/src/vtpty/ConPty_test.cpp
+++ b/src/vtpty/ConPty_test.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtpty/ConPty.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using vtpty::ColumnCount;
+using vtpty::ConPty;
+using vtpty::LineCount;
+using vtpty::PageSize;
+
+namespace
+{
+
+constexpr PageSize pageSize(int columns, int lines) noexcept
+{
+    return PageSize { .lines = LineCount(lines), .columns = ColumnCount(columns) };
+}
+
+} // namespace
+
+// A ConPty that was never started has no pseudoconsole to resize. Rather than drop the size, it
+// records it so that start() can create the pseudoconsole at the size the display asked for --
+// attachDisplay() is what first tells a PTY its size, and it runs before start().
+TEST_CASE("ConPty.resizeScreen.beforeStart", "[vtpty][conpty]")
+{
+    auto pty = ConPty { pageSize(80, 24) };
+    REQUIRE(pty.isClosed());
+    REQUIRE(pty.pageSize() == pageSize(80, 24));
+
+    pty.resizeScreen(pageSize(132, 50));
+
+    CHECK(pty.pageSize() == pageSize(132, 50));
+}
+
+// Regression test: resizing a *closed* ConPty must not reach ResizePseudoConsole.
+//
+// close() invalidates _master but leaves _slave alive, so the old `if (!_slave)` guard let a
+// post-close resize through and passed INVALID_HANDLE_VALUE to ResizePseudoConsole, which
+// dereferences it -- an access violation reading 0xffffffffffffffff. It was reached on the ordinary
+// session-teardown path: closing a pane makes QML re-run the Loader binding for the surviving
+// panes, which re-enters setSession() -> attachDisplay() -> Terminal::resizeScreen() while the PTY
+// is already closed.
+//
+// Without the fix this test crashes the runner rather than failing an assertion, which is precisely
+// the behaviour being guarded against.
+TEST_CASE("ConPty.resizeScreen.afterClose", "[vtpty][conpty]")
+{
+    auto pty = ConPty { pageSize(80, 24) };
+
+    REQUIRE(pty.start().has_value());
+    REQUIRE_FALSE(pty.isClosed());
+
+    // A resize on the live pseudoconsole is forwarded and remembered.
+    pty.resizeScreen(pageSize(100, 30));
+    CHECK(pty.pageSize() == pageSize(100, 30));
+
+    pty.close();
+    REQUIRE(pty.isClosed());
+
+    // The slave outlives close(); it is the master handle that decides whether a resize can be
+    // forwarded. Guarding on the slave is what let the invalidated handle through.
+    pty.resizeScreen(pageSize(132, 50));
+
+    // The size is still recorded, matching the not-yet-started branch and UnixPty's behaviour.
+    CHECK(pty.pageSize() == pageSize(132, 50));
+}
+
+// close() is reachable more than once (explicitly, then again from ~ConPty), and a resize may
+// arrive between the two. Neither the second close nor the resize may touch the stale handle.
+TEST_CASE("ConPty.resizeScreen.afterRepeatedClose", "[vtpty][conpty]")
+{
+    auto pty = ConPty { pageSize(80, 24) };
+
+    REQUIRE(pty.start().has_value());
+    pty.close();
+    pty.close();
+
+    REQUIRE(pty.isClosed());
+
+    pty.resizeScreen(pageSize(20, 10));
+
+    CHECK(pty.pageSize() == pageSize(20, 10));
+}


### PR DESCRIPTION
## Summary

Closing a pane crashed contour on Windows with an access violation reading `0xffffffffffffffff`:

```
conpty!_ResizePseudoConsole+0xb [inlined in conpty!ConptyResizePseudoConsole+0x3a]:
    mov rcx,qword ptr [rcx]   ds:ffffffff`ffffffff=????????????????
```

Found by running `contour.exe` under CDB and hitting it on an ordinary shell exit.

**Cause.** `ConPty::close()` invalidates `_master` but leaves `_slave` alive. `ConPty::resizeScreen()` guarded on `if (!_slave)`, so after a close the guard did not fire and `INVALID_HANDLE_VALUE` was passed to `ResizePseudoConsole`, which dereferences it. That guard was written to separate *not started yet* from *running*; the third state — *started, then closed* — fell through to the running branch.

**How it is reached.** Closing a pane makes QML re-run the `Loader` binding for the surviving panes, which re-enters `setSession()` → `attachDisplay()` → `Terminal::resizeScreen()` while `onClosed()` is still unwinding — i.e. on an already-closed PTY:

```
conpty!ConptyResizePseudoConsole
vtpty::ConPty::resizeScreen              src/vtpty/ConPty.cpp
vtbackend::Terminal::resizeScreen
contour::TerminalSession::attachDisplay  src/contour/TerminalSession.cpp
contour::display::TerminalDisplay::setSession
  … QML Loader re-instantiating the pane …
contour::TerminalSessionManager::paneClosed
contour::TerminalSession::onClosed
```

**Fix**, at both ends of that path:

- `ConPty::resizeScreen()` now tests the master handle through the existing `isClosed()` predicate rather than `_slave`. That covers the pre-start *and* post-close cases in one branch, and matches `UnixPty`, whose `_masterFd < 0` check already lands in the record-the-size branch after a close. `UnixPty` was therefore never affected — `ConPty` was the outlier.
- `TerminalSession::attachDisplay()` skips the resize when the session is already closed, so a dead session stops pushing geometry at a gone device on every platform. Kept as well as the `vtpty` guard because `attachDisplay()` is not the only caller of `resizeScreen()`.

## Testing

New `src/vtpty/ConPty_test.cpp` (Windows-only, wired into `vtpty_test`):

- `ConPty.resizeScreen.beforeStart` — the pre-start branch still records the size.
- `ConPty.resizeScreen.afterClose` — the regression. Start, resize live, close, resize again.
- `ConPty.resizeScreen.afterRepeatedClose` — double close, then a resize.

New GUI test in `DisplayRendering_test.cpp` covering the whole path: a real display re-attached to a real closed session must push no resize down to the device. `BlockingMockPty` gains a `resizesAfterClose()` counter so the assertion is that the resize is *absent*, not merely harmless.

Both tests were confirmed to fail without the fix and pass with it:

- Unit test without the fix: `SIGSEGV`, exit `0xC0000005` — the production crash, reproduced in the runner.
- GUI test without the fix: `CHECK( h.pty->resizesAfterClose() == resizesBeforeReattach )` → `1 == 0`.

Full suite on `clangcl-release`, build clean under `-Werror`:

```
crispy_test, text_shaper_test, vtpty_test, vtparser_test,
vtbackend_test, vtconformance_test, vtmux_test, vtrasterizer_test .. Passed
contour_gui_test ... 656/657
```

The one `contour_gui_test` failure (`display: the deferred screenshot readback delivers a real image`) is **pre-existing and unrelated** — a temp-PNG file lock. Verified by stashing this fix and reproducing the identical failure on a clean tree.

**Open issue — not yet attributed.** A run of the suite via `ctest` ended in a segfault in `contour_gui_test` that does *not* occur when the same binary is run standalone (clean there, apart from the screenshot failure above). I have not isolated it, so I cannot yet say whether it is related to this change. Flagging it rather than assuming it is unrelated; this is the main reason the PR is a draft.

## Manual test checklist

- [ ] Attribute or rule out the ctest-only `contour_gui_test` segfault above.
- [ ] On Windows, split a pane and close it — confirm no crash (the original repro).
- [ ] Exit the shell in the last pane and confirm clean teardown.
- [ ] Sanity-check on Linux that pane close/split still behaves (`UnixPty` path unchanged, but `attachDisplay()` is shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)