### PR TITLE
Build the speech engine once per app, and only when something is spoken

### DIFF
--- a/src/contour/ContourGuiApp.cpp
+++ b/src/contour/ContourGuiApp.cpp
@@ -71,13 +71,15 @@ namespace contour
 ContourGuiApp::ContourGuiApp(std::unique_ptr<SessionFactory> sessionFactory,
                              std::unique_ptr<ExternalLauncher> externalLauncher,
                              std::unique_ptr<LayoutStore> layoutStore,
-                             std::unique_ptr<CommandHistoryStore> commandHistoryStore):
+                             std::unique_ptr<CommandHistoryStore> commandHistoryStore,
+                             std::unique_ptr<SpeechSynthesizer> speechSynthesizer):
     _sessionFactory(sessionFactory ? std::move(sessionFactory) : std::make_unique<AppSessionFactory>(*this)),
     _externalLauncher(externalLauncher ? std::move(externalLauncher)
                                        : std::make_unique<QtExternalLauncher>()),
     _layoutStore(layoutStore ? std::move(layoutStore) : std::make_unique<FileLayoutStore>()),
     _commandHistoryStore(commandHistoryStore ? std::move(commandHistoryStore)
                                              : std::make_unique<FileCommandHistoryStore>()),
+    _speechSynthesizer(speechSynthesizer ? std::move(speechSynthesizer) : makeSpeechSynthesizer()),
     _sessionManager(*this, *_sessionFactory, *_layoutStore, *_commandHistoryStore)
 {
     link("contour.terminal", bind(&ContourGuiApp::terminalGuiAction, this));

--- a/src/contour/ContourGuiApp.h
+++ b/src/contour/ContourGuiApp.h
@@ -7,6 +7,7 @@
 #include <contour/ExitCode.h>
 #include <contour/ExternalLauncher.h>
 #include <contour/LayoutStore.h>
+#include <contour/SpeechSynthesizer.h>
 #include <contour/TerminalSessionManager.h>
 #include <contour/helper.h>
 
@@ -59,10 +60,15 @@ class ContourGuiApp: public QObject, public ContourApp
     ///                       (the default) wires the production FileCommandHistoryStore (an atomically-
     ///                       replaced `command-history.yml`); tests pass an in-memory store to drive the
     ///                       record -> persist -> reload cycle without touching the disk.
+    /// @param speechSynthesizer The voice every session in this app reads selections through. Null
+    ///                       (the default) wires the production one; tests pass a
+    ///                       NullSpeechSynthesizer, which keeps the suite off the platform's speech
+    ///                       service (on Linux that is a speech-dispatcher connection per use).
     explicit ContourGuiApp(std::unique_ptr<SessionFactory> sessionFactory = nullptr,
                            std::unique_ptr<ExternalLauncher> externalLauncher = nullptr,
                            std::unique_ptr<LayoutStore> layoutStore = nullptr,
-                           std::unique_ptr<CommandHistoryStore> commandHistoryStore = nullptr);
+                           std::unique_ptr<CommandHistoryStore> commandHistoryStore = nullptr,
+                           std::unique_ptr<SpeechSynthesizer> speechSynthesizer = nullptr);
 
     static ContourGuiApp* instance() { return static_cast<ContourGuiApp*>(ContourApp::instance()); }
 
@@ -138,6 +144,13 @@ class ContourGuiApp: public QObject, public ContourApp
     /// The external-resource launcher (URL opening, child-process spawning) for this app's sessions.
     [[nodiscard]] ExternalLauncher& externalLauncher() noexcept { return *_externalLauncher; }
 
+    /// The voice this app's sessions read selections through.
+    ///
+    /// One per app rather than one per session, because a machine has one voice: two sessions
+    /// speaking at once is not a thing the platform can do, and with an engine each, "Stop Speaking"
+    /// in one tab could not stop what another tab had started.
+    [[nodiscard]] SpeechSynthesizer& speechSynthesizer() noexcept { return *_speechSynthesizer; }
+
     [[nodiscard]] static QUrl resolveResource(std::string_view path);
 
     [[nodiscard]] vtbackend::ColorPreference colorPreference() const noexcept { return _colorPreference; }
@@ -174,6 +187,8 @@ class ContourGuiApp: public QObject, public ContourApp
     std::unique_ptr<LayoutStore> _layoutStore;
     // Likewise: the manager holds a reference to the command-history store.
     std::unique_ptr<CommandHistoryStore> _commandHistoryStore;
+    // Shared by every session, reached via _app; @see speechSynthesizer().
+    std::unique_ptr<SpeechSynthesizer> _speechSynthesizer;
     TerminalSessionManager _sessionManager;
     std::unique_ptr<display::ForcedFontDpiProvider> _forcedFontDpiProvider;
     // Spawn context: the screen the next window should open on (QPointer: screens can be unplugged

--- a/src/contour/SpeechSynthesizer.cpp
+++ b/src/contour/SpeechSynthesizer.cpp
@@ -69,6 +69,13 @@ std::string speakableText(std::string_view text, size_t maxChars)
 namespace
 {
     /// Speaks through Qt's TextToSpeech module.
+    ///
+    /// The engine is built on first use rather than with this object. Constructing a QTextToSpeech
+    /// loads the platform's speech plugin and opens a connection to its service — speech-dispatcher on
+    /// Linux — to enumerate the installed voices, and that connection leaks its voice-list reply
+    /// inside libspeechd. A contour nobody ever asks to read anything aloud should pay none of that,
+    /// so holding this object stays free and the engine appears only when something is actually said
+    /// or asked about.
     class QtSpeechSynthesizer final: public SpeechSynthesizer
     {
       public:
@@ -77,21 +84,42 @@ namespace
             // Built in, but a platform with no engine or no installed voice still cannot speak; on Linux
             // that is a machine without speech-dispatcher or flite. Asked rather than assumed, so the
             // menu row does not offer silence.
-            return _speech.state() != QTextToSpeech::Error && !_speech.availableVoices().isEmpty();
+            auto const& speech = engine();
+            return speech.state() != QTextToSpeech::Error && !speech.availableVoices().isEmpty();
         }
 
         void say(std::string_view text) override
         {
             // say() already replaces what is being spoken; stopping first makes that explicit and is
             // what makes a second invocation feel like "read THIS" rather than "queue this up".
-            _speech.stop();
-            _speech.say(QString::fromUtf8(text.data(), static_cast<qsizetype>(text.size())));
+            auto& speech = engine();
+            speech.stop();
+            speech.say(QString::fromUtf8(text.data(), static_cast<qsizetype>(text.size())));
         }
 
-        void stop() override { _speech.stop(); }
+        void stop() override
+        {
+            // Deliberately does NOT build the engine: nothing has been spoken through one that does not
+            // exist, so there is nothing to stop, and constructing it here to stop it immediately would
+            // undo the deferral this class exists for.
+            if (_speech)
+                _speech->stop();
+        }
 
       private:
-        QTextToSpeech _speech;
+        /// The engine, constructed on the first call. @see the class description for why it waits.
+        /// @return The engine, which from here on outlives every use of it.
+        [[nodiscard]] QTextToSpeech& engine() const
+        {
+            if (!_speech)
+                _speech = std::make_unique<QTextToSpeech>();
+            return *_speech;
+        }
+
+        /// Mutable because asking whether speech is possible is a const question whose answer only the
+        /// engine knows. Deferring construction is an implementation detail; it must not force the call
+        /// sites into a non-const path, nor into sequencing a setup call of their own.
+        mutable std::unique_ptr<QTextToSpeech> _speech;
     };
 } // namespace
 

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -2,6 +2,7 @@
 #include <contour/Actions.h>
 #include <contour/ContourGuiApp.h>
 #include <contour/ExternalLauncher.h>
+#include <contour/SpeechSynthesizer.h>
 #include <contour/TerminalSession.h>
 #include <contour/display/CaretGeometry.h>
 #include <contour/display/TerminalDisplay.h>
@@ -1893,7 +1894,7 @@ ContextMenuState TerminalSession::contextMenuState()
             .inputProtected = !terminal().allowInput(),
             // A property of the build and the machine, asked once here so the menu itself stays a pure
             // function of this snapshot.
-            .canSpeak = _speech->available(),
+            .canSpeak = _app.speechSynthesizer().available(),
             // Taken now, while the pointer is still on the cell the user clicked. The rows built from this
             // carry the URI with them, because by the time one is picked the pointer has moved to the menu.
             .hyperlinkUnderCursor = hyperlink ? hyperlink->uri : std::string {},
@@ -2631,11 +2632,11 @@ bool TerminalSession::operator()(actions::SpeakSelection)
     // way to skip ahead.
     auto constexpr MaxSpokenChars = size_t { 4000 };
 
-    if (!_speech->available())
+    if (!_app.speechSynthesizer().available())
         return false;
 
     // Locked around the extraction only: it reads the selection and the grid cells behind it, both of
-    // which the parser thread mutates. _speech->say() below is Qt and must not hold the lock.
+    // which the parser thread mutates. The say() below is Qt and must not hold the lock.
     auto const text = [&]() {
         auto const l = scoped_lock { _terminal };
         return speakableText(terminal().extractSelectionText(), MaxSpokenChars);
@@ -2643,13 +2644,13 @@ bool TerminalSession::operator()(actions::SpeakSelection)
     if (text.empty())
         return false;
 
-    _speech->say(text);
+    _app.speechSynthesizer().say(text);
     return true;
 }
 
 bool TerminalSession::operator()(actions::StopSpeaking)
 {
-    _speech->stop();
+    _app.speechSynthesizer().stop();
     return true;
 }
 

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -8,7 +8,6 @@
 #include <contour/ContextMenu.h>
 #include <contour/HorizontalWheelGesture.h>
 #include <contour/HyperlinkTooltip.h>
-#include <contour/SpeechSynthesizer.h>
 #include <contour/display/Announcer.h>
 #ifdef __linux__
     #include <contour/FreeDesktopNotifier.h>
@@ -805,9 +804,6 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     /// Never null: a NullAnnouncer stands in wherever there is nothing to announce through, so the call
     /// sites never have to ask whether announcing is possible.
     std::unique_ptr<display::Announcer> _announcer = std::make_unique<display::NullAnnouncer>();
-    /// Built once per session rather than per invocation: a QTextToSpeech probes the platform's engines
-    /// on construction, which is far too much work to redo on every keypress.
-    std::unique_ptr<SpeechSynthesizer> _speech = makeSpeechSynthesizer();
     QString _hyperlinkTooltipText;
     QRectF _hyperlinkTooltipAnchor;
 

--- a/src/contour/test/GuiTestFixtures.h
+++ b/src/contour/test/GuiTestFixtures.h
@@ -237,6 +237,26 @@ class RecordingExternalLauncher final: public contour::ExternalLauncher
     bool openUrlResult = true;
 };
 
+/// A SpeechSynthesizer that records what it was asked to say instead of saying it.
+///
+/// The read-aloud path cannot otherwise be driven headlessly: the real synthesizer answers
+/// available() only by connecting to the machine's speech service and enumerating its voices, so a
+/// test would depend on the developer's installed voices and would speak out loud when they have one.
+class RecordingSpeechSynthesizer final: public contour::SpeechSynthesizer
+{
+  public:
+    [[nodiscard]] bool available() const override { return isAvailable; }
+    void say(std::string_view text) override { spoken.emplace_back(text); }
+    void stop() override { ++stopCount; }
+
+    /// Everything say() was handed, in order — already passed through speakableText().
+    std::vector<std::string> spoken;
+    /// How many times stop() was asked for.
+    size_t stopCount = 0;
+    /// What available() reports (flip to false for the "no voice on this machine" path).
+    bool isAvailable = true;
+};
+
 /// In-memory PTY with REAL blocking-read semantics, for a test that runs a LIVE session read loop
 /// (the render harness, where TerminalDisplay::setSession starts the session's threads).
 ///
@@ -449,13 +469,19 @@ class TestApp
     /// @param commandHistoryStore Optional command-history override; pass an
     ///                InMemoryCommandHistoryStore (keep a raw observation pointer first) to drive the
     ///                command palette's MRU persistence without touching the disk.
+    ///
+    /// @param speech Optional speech override; pass a RecordingSpeechSynthesizer (keep a raw
+    ///                observation pointer first) to drive the read-aloud path. @see defaultSpeech()
+    ///                for what a test app gets without one.
     explicit TestApp(std::unique_ptr<contour::SessionFactory> factory = nullptr,
                      std::unique_ptr<contour::LayoutStore> layoutStore = nullptr,
-                     std::unique_ptr<contour::CommandHistoryStore> commandHistoryStore = nullptr):
+                     std::unique_ptr<contour::CommandHistoryStore> commandHistoryStore = nullptr,
+                     std::unique_ptr<contour::SpeechSynthesizer> speech = nullptr):
         _app(std::move(factory),
              makeRecordingLauncher(),
              std::move(layoutStore),
-             std::move(commandHistoryStore))
+             std::move(commandHistoryStore),
+             speech ? std::move(speech) : defaultSpeech())
     {
         char const* argv[] = { "contour", "terminal" };
         // Parse the "terminal" subcommand so parameters() carries every contour.terminal.* default
@@ -468,7 +494,7 @@ class TestApp
     /// @param args The command tokens after the program name (e.g. {"font-locator"}).
     explicit TestApp(std::initializer_list<char const*> args,
                      std::unique_ptr<contour::SessionFactory> factory = nullptr):
-        _app(std::move(factory), makeRecordingLauncher())
+        _app(std::move(factory), makeRecordingLauncher(), nullptr, nullptr, defaultSpeech())
     {
         std::vector<char const*> argv;
         argv.reserve(args.size() + 1);
@@ -484,6 +510,18 @@ class TestApp
     [[nodiscard]] RecordingExternalLauncher& launcher() noexcept { return *_launcher; }
 
   private:
+    /// The synthesizer a test app gets when the test does not name one.
+    ///
+    /// The NULL one, never the production synthesizer -- and this is the single place that decides
+    /// so, because it is an invariant of the suite rather than a default anyone should vary. A real
+    /// synthesizer connects to the machine's speech service (speech-dispatcher on Linux) as soon as
+    /// a session is asked for its context-menu state: surprising for a headless suite, audible if
+    /// the machine has a voice, and a leak inside libspeechd on every connection.
+    [[nodiscard]] static std::unique_ptr<contour::SpeechSynthesizer> defaultSpeech()
+    {
+        return std::make_unique<contour::NullSpeechSynthesizer>();
+    }
+
     /// Builds the recording launcher, stashing a raw observation pointer before handing ownership to
     /// the app. Runs in the member-initializer list, so _launcher is set before _app is constructed.
     std::unique_ptr<contour::ExternalLauncher> makeRecordingLauncher()

--- a/src/contour/test/TerminalSession_test.cpp
+++ b/src/contour/test/TerminalSession_test.cpp
@@ -529,6 +529,59 @@ TEST_CASE("TerminalSession: the context-menu actions and the state they are gate
     }
 }
 
+TEST_CASE("TerminalSession: the selection is read aloud through the app's one voice",
+          "[contour][session][actions][speech]")
+{
+    auto speech = std::make_unique<contour::test::RecordingSpeechSynthesizer>();
+    auto* const voice = speech.get();
+    TestApp testApp(nullptr, nullptr, nullptr, std::move(speech));
+    auto session = makeDisplaylessSession(testApp.app());
+
+    SECTION("what is spoken is the prepared text, not the grid")
+    {
+        for (auto i = 0; i < 3; ++i)
+            session->terminal().writeToScreen(std::format("line {}\r\n", i));
+        REQUIRE((*session)(contour::actions::SelectAll {}));
+
+        CHECK((*session)(contour::actions::SpeakSelection {}));
+        REQUIRE(voice->spoken.size() == 1);
+        // Passed through speakableText: the padding every terminal line carries out to the right
+        // margin is silence, and the blank rows below the text are not read as pauses.
+        CHECK(voice->spoken.front() == "line 0\nline 1\nline 2");
+    }
+
+    SECTION("with nothing selected there is nothing to say")
+    {
+        CHECK_FALSE((*session)(contour::actions::SpeakSelection {}));
+        CHECK(voice->spoken.empty());
+    }
+
+    SECTION("a machine with no voice neither offers the row nor speaks")
+    {
+        voice->isAvailable = false;
+        session->terminal().writeToScreen("hello\r\n");
+        REQUIRE((*session)(contour::actions::SelectAll {}));
+
+        CHECK_FALSE(session->contextMenuState().canSpeak);
+        CHECK_FALSE((*session)(contour::actions::SpeakSelection {}));
+        CHECK(voice->spoken.empty());
+    }
+
+    SECTION("a second session speaks and stops through the same voice")
+    {
+        // A machine has one voice, so the synthesizer belongs to the app rather than the session.
+        // With one engine per session, StopSpeaking in this tab could not stop what another started.
+        auto other = makeDisplaylessSession(testApp.app());
+        session->terminal().writeToScreen("hello\r\n");
+        REQUIRE((*session)(contour::actions::SelectAll {}));
+        REQUIRE((*session)(contour::actions::SpeakSelection {}));
+
+        CHECK((*other)(contour::actions::StopSpeaking {}));
+        CHECK(voice->stopCount == 1);
+        CHECK(voice->spoken.size() == 1);
+    }
+}
+
 TEST_CASE("TerminalSession: scrollback actions move the viewport over seeded history",
           "[contour][session][actions][scroll]")
 {


### PR DESCRIPTION
Every `TerminalSession` constructed its own `QTextToSpeech`. Constructing one loads the platform's speech plugin and opens a connection to its service — speech-dispatcher on Linux — to enumerate the installed voices, so a window of twenty tabs opened twenty such connections before anyone had asked for a word to be read aloud.

Each connection also leaks its voice-list reply inside libspeechd, which is how the cost became visible:

```
$ ctest --preset=clang-asan          # on master, 80c8efbb7
All tests passed (10446 assertions in 662 test cases)
SUMMARY: AddressSanitizer: 81510 byte(s) leaked in 390 allocation(s).
```

Every leak stack was rooted in a session's constructor:

```
#1 spd_execute_command_with_list_reply   (libspeechd.so.2)
#2 libqtexttospeech_speechd.so
#5 QTextToSpeech::QTextToSpeech(QObject*)
#6 contour::(anonymous namespace)::QtSpeechSynthesizer::QtSpeechSynthesizer()
#8 contour::makeSpeechSynthesizer()
#9 contour::TerminalSession::TerminalSession(...)
```

### One voice per app

A machine has one voice. Two sessions speaking at once is not something the platform can do, and `say()` already stops whatever is being spoken — so an engine per session was not merely wasteful but *wrong*: **"Stop Speaking" in one tab could not stop what another tab had started.**

The synthesizer therefore moves to `ContourGuiApp`, alongside the session factory, the launcher and the two stores it already owns and injects with the same `x ? std::move(x) : make_unique<Real>()` shape. Sessions reach it through the app reference they already hold.

### Built on first use

That alone would still build an engine per process at startup. The engine is now created on first use instead, so a contour nobody asks to read anything aloud never connects to the speech service at all. `stop()` deliberately does *not* create one: with nothing ever spoken there is nothing to stop, and building an engine in order to stop it would undo the deferral.

### Tests

Being injected, the voice is also the first thing about the read-aloud path a test can pin — previously it needed a real engine and a real installed voice. The suite gets a `RecordingSpeechSynthesizer`, and with it the first coverage of `SpeakSelection` itself: that what reaches the voice is the prepared text rather than the padded grid, that an empty selection says nothing, that a machine without a voice neither offers the menu row nor speaks, and that a second session speaks and stops through the same voice.

The default for a test app is the null synthesizer, never the production one, decided in a single place — so no test can wander onto the developer's speech service again.

### Verification

- `ctest --preset=clang-asan`: **18/18 passed**, `contour_gui_test` exits 0 with **no LeakSanitizer report** (was 81510 bytes / 390 allocations).
- clang-format, `check-includes.sh`, `check-pr-todos.sh`, editorconfig: clean.
- clang-tidy against the repo's own config on every changed TU: clean.

### Note on CI

CI could not have caught this. It builds `clang-debug`, `gcc-debug` and `gcc-release` — no job configures `clang-asan`, so `ctest` in CI never runs under ASan/LSan. `ctest --preset=clang-asan`, which `AGENT.md` asks developers to run, is a strictly stronger gate than CI. Worth considering a sanitized job separately; this PR does not add one.

No changelog entry: the read-aloud feature itself is still in the unreleased `0.7.0` block, so from a user's point of view neither the leak nor the cross-tab stop bug ever existed.
