### PR TITLE
Fix curly underlines being drawn too large and over the text

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -234,6 +234,8 @@
           <li>Adds a scope parameter to the HintMode action: scope: Scrollback scans the scrollback history as well as the visible page, capped by the new hint_scrollback_lines profile option (default 1000). Its labels are assigned once and stay put, so you can activate hint mode, scroll to older output, and then type the label you see; scope: Visible remains the default</li>
           <li>Fixes selecting text changing how wide a glyph is drawn, so that emoji and other multi-codepoint characters no longer gain padding and push the rest of the line to the right when highlighted (#1752)</li>
           <li>Fixes combining marks vanishing from uniformly styled lines: a character written in decomposed form, such as a Greek or Cyrillic letter followed by a combining accent, was drawn as its base letter alone, because the batched rendering path those lines take can only carry one codepoint per column</li>
+          <li>Fixes curly underlines being drawn almost as tall as a lowercase letter and running into the text above them on fonts that declare line spacing, such as the default "monospace" on many Linux systems. The wave was sized from the whole space below the baseline, which includes that spacing; it is now sized from where the font puts its underline, and never reaches higher than a straight underline would (#1754)</li>
+          <li>Fixes the other underline styles sitting one row too high, on the baseline itself: the upper stroke of a double underline could be drawn inside the letters, a dotted underline came out as dashes or vanished entirely where the font's underline sits close to the cell bottom, and a double underline's strokes were a pixel too thin at even thicknesses</li>
         </ul>
       </description>
     </release>

--- a/src/vtrasterizer/CMakeLists.txt
+++ b/src/vtrasterizer/CMakeLists.txt
@@ -15,6 +15,7 @@ set(_header_files
     TextClusterGrouper.h
     TextRenderer.h
     TextureAtlas.h
+    UnderlineGeometry.h
     utils.h
 )
 
@@ -36,12 +37,14 @@ set(_source_files
 set(_test_files
     TextClusterGrouper_test.cpp
     BoxDrawingRenderer_test.cpp
+    DecorationRenderer_test.cpp
     GlyphAdvance_test.cpp
     GlyphScaling_test.cpp
     GlyphSlicing_test.cpp
     ImageRenderer_test.cpp
     ReGISFontRasterizer_test.cpp
     TextRenderer_test.cpp
+    UnderlineGeometry_test.cpp
 )
 
 source_group(Sources FILES ${_source_files})

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -154,8 +154,14 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             });
         }
         case Decorator::DoubleUnderline: {
-            auto const thickness = max(1u, unsigned(ceil(double(underlineThickness()) * 2.0) / 3.0));
-            auto const y1 = max(0u, underlinePosition() + thickness);
+            // Two thirds of the underline's thickness per stroke. The parentheses used to close
+            // after ceil(), so this truncated instead of rounding up and an even thickness lost a
+            // pixel: at thickness 2 it yielded 1.
+            auto const thickness = max(1u, unsigned(ceil(double(underlineThickness()) * 2.0 / 3.0)));
+            // The upper stroke's top is the underline position, as it is for every other
+            // decoration. It used to be `position + thickness`, which placed the stroke's top two
+            // thicknesses higher -- above the baseline, and so inside the glyphs.
+            auto const y1 = static_cast<unsigned>(max(0, underlinePosition() - int(thickness)));
             // y1 - 3 thickness can be negative
             auto const y0 = max(0, static_cast<int>(y1) - (3 * static_cast<int>(thickness)));
             auto const height = vtbackend::Height(y1 + thickness);

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -240,7 +240,10 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             // whereas the middle one is being skipped.
             auto const thicknessHalf = max(1u, unsigned(ceil(underlineThickness() / 2.0)));
             auto const thickness = max(1u, thicknessHalf * 2);
-            auto const y0 = max(0, underlinePosition() - static_cast<int>(thicknessHalf));
+            // Subtracting the whole thickness, not half of it: the dashes' top is the underline
+            // position, as it is for every other decoration. Half left them one row higher, on the
+            // baseline itself.
+            auto const y0 = max(0, underlinePosition() - static_cast<int>(thickness));
             auto const height = vtbackend::Height(y0 + thickness);
             auto const imageSize = ImageSize { width, height };
             return create(imageSize, [&]() -> atlas::Buffer {

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -3,6 +3,7 @@
 
 #include <vtrasterizer/GridMetrics.h>
 #include <vtrasterizer/Pixmap.h>
+#include <vtrasterizer/UnderlineGeometry.h>
 #include <vtrasterizer/shared_defines.h>
 
 #include <crispy/times.h>
@@ -11,6 +12,7 @@
 #include <array>
 #include <cmath>
 #include <iostream>
+#include <numbers>
 #include <optional>
 #include <utility>
 
@@ -171,28 +173,34 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             });
         }
         case Decorator::CurlyUnderline: {
-            auto const height = vtbackend::Height::cast_from(_gridMetrics.baseline);
-            auto const h2 = max(unbox<int>(height) / 2, 1);
-            auto const yScalar = h2 - 1;
-            auto const xScalar = 2 * M_PI / *width;
-            auto const yBase = h2;
+            // The wave is sized from the underline position rather than from the baseline: the
+            // latter is `lineHeight - ascender` and so folds in the font's whole line gap, which
+            // grew the curl to the height of a lowercase letter on a font with leading (#1754).
+            auto const geometry = curlyUnderlineGeometry(
+                underlinePosition(), underlineThickness(), unbox<int>(_gridMetrics.cellSize.height));
+            auto const height = vtbackend::Height::cast_from(geometry.tileHeight);
+            // One full cycle per cell, so adjacent cells join crest to crest.
+            auto const xScalar = 2 * std::numbers::pi / unbox<double>(width);
             auto const imageSize = ImageSize { width, height };
             auto block = blockElement(imageSize);
             return create(block.downsampledSize, [&]() -> atlas::Buffer {
-                auto const thicknessHalf = max(1, int(ceil(underlineThickness() / 2.0)));
                 for (auto x: crispy::times(unbox(width)))
                 {
                     // Using Wu's antialiasing algorithm to paint the curved line.
                     // See: https://dl.acm.org/doi/pdf/10.1145/127719.122734
-                    auto const y = yScalar * cos(xScalar * x);
+                    auto const y = geometry.amplitude * cos(xScalar * static_cast<double>(x));
                     auto const y1 = static_cast<int>(floor(y));
                     auto const y2 = static_cast<int>(ceil(y));
                     auto const intensity = static_cast<uint8_t>(255 * fabs(y - y1));
-                    // block.paintOver(x, yBase + y1, 255 - intensity);
-                    // block.paintOver(x, yBase + y2, intensity);
+                    // The stroke thickens along y, not x: a near-horizontal cosine widened
+                    // sideways gains no weight and leaves holes where the curve is steepest.
+                    block.paintOverThick(static_cast<int>(x),
+                                         geometry.centerY + y1,
+                                         uint8_t(255 - intensity),
+                                         0,
+                                         geometry.strokeRadius);
                     block.paintOverThick(
-                        static_cast<int>(x), yBase + y1, uint8_t(255 - intensity), thicknessHalf, 0);
-                    block.paintOverThick(static_cast<int>(x), yBase + y2, intensity, thicknessHalf, 0);
+                        static_cast<int>(x), geometry.centerY + y2, intensity, 0, geometry.strokeRadius);
                 }
                 return block.take();
             });

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <numbers>
 #include <optional>
+#include <ranges>
 #include <utility>
 
 using crispy::each_element;
@@ -206,21 +207,23 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             });
         }
         case Decorator::DottedUnderline: {
-            auto const dotHeight = (unsigned) _gridMetrics.underline.thickness;
-            auto const dotWidth = dotHeight;
-            auto const height =
-                vtbackend::Height::cast_from((unsigned) _gridMetrics.underline.position + dotHeight);
-            auto const y0 = (unsigned) _gridMetrics.underline.position - dotHeight;
-            auto const x0 = 0u;
-            auto const x1 = unbox(width) / 2;
+            // Signed throughout, and the dot shrinks to the room it has: computing the origin as
+            // `(unsigned) position - thickness` wrapped whenever a font put its underline within
+            // one thickness of the cell bottom, and Pixmap::paint then clipped every dot away --
+            // the decoration vanished silently rather than merely looking cramped.
+            auto const dotSize = std::clamp(underlineThickness(), 1, max(1, underlinePosition()));
+            auto const y0 = max(0, underlinePosition() - dotSize);
+            auto const height = vtbackend::Height::cast_from(y0 + dotSize);
+            auto const x0 = 0;
+            auto const x1 = unbox<int>(width) / 2;
             auto block = blockElement(ImageSize { width, height });
             return create(block.downsampledSize, [&]() -> atlas::Buffer {
-                for (auto y: crispy::times(dotHeight))
+                for (auto const y: std::views::iota(0, dotSize))
                 {
-                    for (auto x: crispy::times(dotWidth))
+                    for (auto const x: std::views::iota(0, dotSize))
                     {
-                        block.paint(int(x + x0), int(y + y0));
-                        block.paint(int(x + x1), int(y + y0));
+                        block.paint(x + x0, y + y0);
+                        block.paint(x + x1, y + y0);
                     }
                 }
                 return block.take();

--- a/src/vtrasterizer/DecorationRenderer.cpp
+++ b/src/vtrasterizer/DecorationRenderer.cpp
@@ -161,7 +161,9 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             // The upper stroke's top is the underline position, as it is for every other
             // decoration. It used to be `position + thickness`, which placed the stroke's top two
             // thicknesses higher -- above the baseline, and so inside the glyphs.
-            auto const y1 = static_cast<unsigned>(max(0, underlinePosition() - int(thickness)));
+            // Clamped before the cast to unsigned, never after: an unsigned subtraction wraps to a
+            // huge positive, which max() then happily keeps.
+            auto const y1 = static_cast<unsigned>(max(0, underlinePosition() - static_cast<int>(thickness)));
             // y1 - 3 thickness can be negative
             auto const y0 = max(0, static_cast<int>(y1) - (3 * static_cast<int>(thickness)));
             auto const height = vtbackend::Height(y1 + thickness);
@@ -220,7 +222,7 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             auto const dotSize = std::clamp(underlineThickness(), 1, max(1, underlinePosition()));
             auto const y0 = max(0, underlinePosition() - dotSize);
             auto const height = vtbackend::Height::cast_from(y0 + dotSize);
-            auto const x0 = 0;
+            // Two dots per cell: one flush with the left edge, one at the half-way mark.
             auto const x1 = unbox<int>(width) / 2;
             auto block = blockElement(ImageSize { width, height });
             return create(block.downsampledSize, [&]() -> atlas::Buffer {
@@ -228,7 +230,7 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
                 {
                     for (auto const x: std::views::iota(0, dotSize))
                     {
-                        block.paint(x + x0, y + y0);
+                        block.paint(x, y + y0);
                         block.paint(x + x1, y + y0);
                     }
                 }
@@ -239,7 +241,7 @@ auto DecorationRenderer::createTileData(Decorator decoration, atlas::TileLocatio
             // Divides a grid cell's underline in three sub-ranges and only renders first and third one,
             // whereas the middle one is being skipped.
             auto const thicknessHalf = max(1u, unsigned(ceil(underlineThickness() / 2.0)));
-            auto const thickness = max(1u, thicknessHalf * 2);
+            auto const thickness = thicknessHalf * 2; // at least 2, thicknessHalf being at least 1
             // Subtracting the whole thickness, not half of it: the dashes' top is the underline
             // position, as it is for every other decoration. Half left them one row higher, on the
             // baseline itself.

--- a/src/vtrasterizer/DecorationRenderer_test.cpp
+++ b/src/vtrasterizer/DecorationRenderer_test.cpp
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bitmap-level tests for the underline family of cell decorations.
+//
+// These drive the real DecorationRenderer headlessly: setTextureAtlas() triggers
+// initializeDirectMapping(), which rasterizes every Decorator once and uploads it. The uploads land
+// in each_element<Decorator>() order, so the enumerator is the index, and what the GPU would receive
+// is exactly what these tests read back.
+
+#include <vtrasterizer/DecorationRenderer.h>
+#include <vtrasterizer/GridMetrics.h>
+#include <vtrasterizer/RendererTestHelpers.h>
+#include <vtrasterizer/TextureAtlas.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <format>
+#include <ranges>
+#include <string>
+#include <vector>
+
+using namespace vtbackend;
+using namespace vtrasterizer;
+
+namespace
+{
+
+/// The grid metrics Contour derives from Nimbus Mono PS at 12pt/96dpi -- the font from issue #1754.
+///
+/// Reproduced rather than invented: the font declares (upem 1000) hhea ascender 603, descender -397
+/// and lineGap 200, so at 16 ppem FreeType reports lineHeight 20 and ascender 10, giving
+/// `baseline = lineHeight - ascender = 10` and `underline.position = baseline + (-1) = 9`. The
+/// lineGap is what makes this font interesting: 4 of those 10 pixels are leading, not descent.
+constexpr auto NimbusCellSize = ImageSize { Width(10), Height(20) };
+constexpr auto NimbusBaseline = 10;
+constexpr auto NimbusUnderlinePosition = 9;
+
+[[nodiscard]] GridMetrics gridMetricsFor(ImageSize cellSize, int baseline, int position, int thickness)
+{
+    return GridMetrics { .pageSize = PageSize { LineCount(24), ColumnCount(80) },
+                         .cellSize = cellSize,
+                         .baseline = baseline,
+                         .underline = { .position = position, .thickness = thickness } };
+}
+
+/// Holds the renderer and everything it borrows, so a test gets its uploads in one expression.
+///
+/// The atlas must outlive the renderer's use of it and the render target must outlive the atlas,
+/// which is why these are members rather than locals in a helper function.
+class DecorationProbe
+{
+  public:
+    explicit DecorationProbe(GridMetrics const& gridMetrics):
+        _gridMetrics { gridMetrics },
+        _renderer { _gridMetrics, Decorator::DottedUnderline, Decorator::Underline }
+    {
+        _renderer.setRenderTarget(_renderTarget, _allocator);
+        _atlas = std::make_unique<Renderable::TextureAtlas>(
+            _renderTarget.textureScheduler(),
+            atlas::AtlasProperties { .format = atlas::Format::RGBA,
+                                     .tileSize = _gridMetrics.cellSize,
+                                     .hashCount = crispy::strong_hashtable_size { 64 },
+                                     .tileCount = crispy::lru_capacity { 64 },
+                                     .directMappingCount = _allocator.currentlyAllocatedCount });
+        _renderer.setTextureAtlas(*_atlas);
+    }
+
+    /// The tile rasterized for @p decoration, as it was handed to the backend.
+    ///
+    /// Not const: MockRenderTarget hands out its recorded commands through a non-const accessor.
+    [[nodiscard]] atlas::UploadTile const& upload(Decorator decoration)
+    {
+        auto const& uploads = _renderTarget.getMockBackend().uploadCommands;
+        REQUIRE(uploads.size() == std::numeric_limits<Decorator>::count());
+        return uploads[static_cast<size_t>(decoration)];
+    }
+
+  private:
+    GridMetrics _gridMetrics;
+    MockRenderTarget _renderTarget;
+    Renderable::DirectMappingAllocator _allocator {};
+    DecorationRenderer _renderer;
+    std::unique_ptr<Renderable::TextureAtlas> _atlas;
+};
+
+/// Row @p row of @p tile as '#' (ink) and '.' (clear), top-origin, the way the bitmap is stored.
+[[nodiscard]] std::string rowOf(atlas::UploadTile const& tile, int row)
+{
+    auto const width = unbox<size_t>(tile.bitmapSize.width);
+    auto text = std::string {};
+    for (auto const x: std::views::iota(0uz, width))
+        text += tile.bitmap[(static_cast<size_t>(row) * width) + x] > 0 ? '#' : '.';
+    return text;
+}
+
+/// Every row of @p tile, so a failing CHECK prints the decoration instead of a number.
+[[nodiscard]] std::vector<std::string> renderedRows(atlas::UploadTile const& tile)
+{
+    auto rows = std::vector<std::string> {};
+    for (auto const y: std::views::iota(0, unbox<int>(tile.bitmapSize.height)))
+        rows.emplace_back(rowOf(tile, y));
+    return rows;
+}
+
+/// Cell-bottom offset of the highest inked row, or 0 when the tile is blank.
+///
+/// A decoration tile's bottom edge IS the cell's bottom edge (DecorationRenderer::renderDecoration
+/// draws it at `cellBottom - bitmapHeight`), so top-origin row `r` of a tile `H` tall sits at
+/// cell-bottom offset `H - r`. That identity is the whole reason these tests can talk about the
+/// baseline at all.
+[[nodiscard]] int topmostInkOffset(atlas::UploadTile const& tile)
+{
+    auto const height = unbox<int>(tile.bitmapSize.height);
+    for (auto const y: std::views::iota(0, height))
+        if (rowOf(tile, y).contains('#'))
+            return height - y;
+    return 0;
+}
+
+/// Cell-bottom offset of the lowest inked row, or 0 when the tile is blank.
+[[nodiscard]] int bottommostInkOffset(atlas::UploadTile const& tile)
+{
+    auto const height = unbox<int>(tile.bitmapSize.height);
+    for (auto const y: std::views::iota(0, height) | std::views::reverse)
+        if (rowOf(tile, y).contains('#'))
+            return height - y;
+    return 0;
+}
+
+/// How many rows of @p tile carry any ink.
+[[nodiscard]] int inkedRows(atlas::UploadTile const& tile)
+{
+    auto count = 0;
+    for (auto const y: std::views::iota(0, unbox<int>(tile.bitmapSize.height)))
+        if (rowOf(tile, y).contains('#'))
+            ++count;
+    return count;
+}
+
+/// How many columns of @p tile's LEFT half carry any ink -- the width of a dotted underline's first
+/// dot, the second one starting at the half-way mark.
+[[nodiscard]] int inkedColumnsInFirstHalf(atlas::UploadTile const& tile)
+{
+    auto const rows = std::views::iota(0, unbox<int>(tile.bitmapSize.height));
+    auto count = 0;
+    for (auto const x: std::views::iota(0, unbox<int>(tile.bitmapSize.width) / 2))
+        if (std::ranges::any_of(rows, [&](int y) { return rowOf(tile, y)[static_cast<size_t>(x)] == '#'; }))
+            ++count;
+    return count;
+}
+
+[[nodiscard]] size_t litPixels(atlas::UploadTile const& tile)
+{
+    return static_cast<size_t>(std::ranges::count_if(tile.bitmap, [](uint8_t v) { return v > 0; }));
+}
+
+/// The decorations that are supposed to live below the baseline, in the cell's descender region.
+constexpr auto UnderlineFamily = std::array {
+    Decorator::Underline,       Decorator::DoubleUnderline, Decorator::CurlyUnderline,
+    Decorator::DottedUnderline, Decorator::DashedUnderline,
+};
+
+} // namespace
+
+TEST_CASE("DecorationRenderer.underlineFamilyStaysBelowTheBaseline", "[decoration]")
+{
+    // The invariant the whole family shares: a straight underline puts its topmost ink at exactly
+    // `underline.position` above the cell bottom, and no sibling may reach higher -- reaching higher
+    // means reaching the baseline, which means painting into the glyphs. Asserted in a loop so a
+    // sixth decorator is a row in the table above rather than a sixth place to get this wrong.
+    auto const gridMetrics =
+        gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
+    auto probe = DecorationProbe { gridMetrics };
+
+    for (auto const decoration: UnderlineFamily)
+    {
+        auto const& tile = probe.upload(decoration);
+        INFO(std::format("{} tile {} in cell {}, baseline {}, underline position {}",
+                         decoration,
+                         tile.bitmapSize,
+                         gridMetrics.cellSize,
+                         gridMetrics.baseline,
+                         gridMetrics.underline.position));
+        for (auto const& row: renderedRows(tile))
+            UNSCOPED_INFO(row);
+
+        CHECK(litPixels(tile) > 0);
+        CHECK(topmostInkOffset(tile) <= gridMetrics.underline.position);
+        CHECK(unbox<int>(tile.bitmapSize.height) <= unbox<int>(gridMetrics.cellSize.height));
+    }
+}
+
+TEST_CASE("DecorationRenderer.curlyUnderlineIsNotAsTallAsTheDescender", "[decoration]")
+{
+    // Regression for #1754. The wave used to be sized from GridMetrics::baseline -- the whole
+    // descender PLUS the font's line gap -- so on Nimbus Mono PS it stood 9px tall in a 20px cell
+    // (taller than the x-height) with its crest exactly on the baseline. It must now be bounded by
+    // the room below the underline position instead.
+    auto const gridMetrics =
+        gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
+    auto probe = DecorationProbe { gridMetrics };
+    auto const& tile = probe.upload(Decorator::CurlyUnderline);
+
+    for (auto const& row: renderedRows(tile))
+        UNSCOPED_INFO(row);
+
+    auto const top = topmostInkOffset(tile);
+    auto const bottom = bottommostInkOffset(tile);
+    auto const bandHeight = top - bottom + 1;
+
+    INFO(std::format("wave occupies cell-bottom offsets {}..{} ({} rows); baseline is at {}",
+                     bottom,
+                     top,
+                     bandHeight,
+                     gridMetrics.baseline));
+
+    // It never reaches the baseline, and it sits no higher than a straight underline.
+    CHECK(top <= gridMetrics.underline.position);
+    CHECK(top < gridMetrics.baseline);
+
+    // Bounded by the room beneath the underline position rather than by the descender: at most half
+    // of it, which is the bound kitty settled on ("4 so as to be not too large") and which puts this
+    // font's wave at 5 rows rather than 9.
+    CHECK(bandHeight <= (gridMetrics.underline.position / 2) + 1);
+    CHECK(bottom >= 1);
+}
+
+TEST_CASE("DecorationRenderer.curlyUnderlineIsActuallyCurly", "[decoration]")
+{
+    // A test that only measured the wave's extent would pass just as happily on a straight line, so
+    // prove the shape engages: the wave is one cosine cycle per cell with its crest at x = 0, so the
+    // topmost inked row must be lit at the cell's edges and the bottom-most at its centre.
+    auto const gridMetrics =
+        gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
+    auto probe = DecorationProbe { gridMetrics };
+    auto const& tile = probe.upload(Decorator::CurlyUnderline);
+
+    for (auto const& row: renderedRows(tile))
+        UNSCOPED_INFO(row);
+
+    auto const height = unbox<int>(tile.bitmapSize.height);
+    auto const width = unbox<int>(tile.bitmapSize.width);
+    auto const crestRow = rowOf(tile, height - topmostInkOffset(tile));
+    auto const troughRow = rowOf(tile, height - bottommostInkOffset(tile));
+
+    INFO(std::format("crest '{}' trough '{}'", crestRow, troughRow));
+
+    CHECK(crestRow.front() == '#');
+    CHECK(crestRow[static_cast<size_t>(width / 2)] == '.');
+    CHECK(troughRow.front() == '.');
+    CHECK(troughRow[static_cast<size_t>(width / 2)] == '#');
+}
+
+TEST_CASE("DecorationRenderer.curlyUnderlineHonorsUnderlineThickness", "[decoration]")
+{
+    // The stroke used to be spread along x rather than y, so the font's underline thickness reached
+    // the wave in name only. A thicker underline must produce a heavier wave.
+    auto thin = DecorationProbe { gridMetricsFor(NimbusCellSize, NimbusBaseline, 9, 1) };
+    auto thick = DecorationProbe { gridMetricsFor(NimbusCellSize, NimbusBaseline, 9, 5) };
+
+    CHECK(litPixels(thick.upload(Decorator::CurlyUnderline))
+          > litPixels(thin.upload(Decorator::CurlyUnderline)));
+}
+
+TEST_CASE("DecorationRenderer.dottedUnderlineSurvivesAShallowUnderlinePosition", "[decoration]")
+{
+    // The dot origin was computed as `(unsigned) position - thickness`, which wraps whenever a font
+    // puts its underline CLOSER to the cell bottom than one thickness. Most of the dot's rows then
+    // addressed a wrapped-around y that Pixmap::paint dropped, leaving a dot that was still as WIDE
+    // as the thickness asked but only as tall as whatever survived -- a dash, not a dot. At
+    // position 0 nothing survived at all.
+    //
+    // Squareness is therefore the assertion, not mere presence: a test that only counted lit pixels
+    // would pass on either side of the fix.
+    SECTION("underline closer to the cell bottom than one thickness")
+    {
+        auto const gridMetrics = gridMetricsFor(
+            ImageSize { Width(10), Height(16) }, /*baseline*/ 2, /*position*/ 1, /*thickness*/ 3);
+        auto probe = DecorationProbe { gridMetrics };
+        auto const& tile = probe.upload(Decorator::DottedUnderline);
+
+        for (auto const& row: renderedRows(tile))
+            UNSCOPED_INFO(row);
+
+        CHECK(litPixels(tile) > 0);
+        CHECK(inkedRows(tile) == inkedColumnsInFirstHalf(tile)); // the dot is square
+        // The dot shrinks to the room it has rather than overhanging it, so the anchor still holds.
+        CHECK(topmostInkOffset(tile) == gridMetrics.underline.position);
+    }
+
+    SECTION("underline flush with the cell bottom")
+    {
+        auto const gridMetrics = gridMetricsFor(
+            ImageSize { Width(10), Height(16) }, /*baseline*/ 1, /*position*/ 0, /*thickness*/ 1);
+        auto probe = DecorationProbe { gridMetrics };
+        auto const& tile = probe.upload(Decorator::DottedUnderline);
+
+        for (auto const& row: renderedRows(tile))
+            UNSCOPED_INFO(row);
+
+        CHECK(litPixels(tile) > 0); // drew nothing whatsoever before the fix
+    }
+}
+
+TEST_CASE("DecorationRenderer.doubleUnderlineIsTwoSeparatedStrokes", "[decoration]")
+{
+    // Both strokes must sit below the underline position -- the upper one used to be placed at
+    // `position + 2 * thickness`, i.e. inside the glyph body on a font like Nimbus Mono PS -- and
+    // there must still be a visible gap between them, or it is not a double underline.
+    auto const gridMetrics =
+        gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
+    auto probe = DecorationProbe { gridMetrics };
+    auto const& tile = probe.upload(Decorator::DoubleUnderline);
+
+    auto const rows = renderedRows(tile);
+    for (auto const& row: rows)
+        UNSCOPED_INFO(row);
+
+    CHECK(topmostInkOffset(tile) <= gridMetrics.underline.position);
+
+    // Two runs of inked rows, separated by at least one clear row.
+    auto inkedRuns = 0;
+    auto previousWasInked = false;
+    for (auto const& row: rows)
+    {
+        auto const inked = row.contains('#');
+        if (inked && !previousWasInked)
+            ++inkedRuns;
+        previousWasInked = inked;
+    }
+    CHECK(inkedRuns == 2);
+}
+
+TEST_CASE("DecorationRenderer.doubleUnderlineThicknessFollowsTwoThirds", "[decoration]")
+{
+    // `unsigned(ceil(t * 2.0) / 3.0)` truncated where `ceil(t * 2.0 / 3.0)` was meant, so an even
+    // underline thickness produced a stroke one pixel too thin: at t=2 it yielded 1 instead of 2.
+    auto const gridMetrics = gridMetricsFor(
+        ImageSize { Width(10), Height(40) }, /*baseline*/ 18, /*position*/ 16, /*thickness*/ 2);
+    auto probe = DecorationProbe { gridMetrics };
+    auto const& tile = probe.upload(Decorator::DoubleUnderline);
+
+    auto const rows = renderedRows(tile);
+    for (auto const& row: rows)
+        UNSCOPED_INFO(row);
+
+    auto const inkedRows = std::ranges::count_if(rows, [](auto const& row) { return row.contains('#'); });
+    CHECK(inkedRows == 4); // two strokes of ceil(2 * 2/3) == 2 rows each
+}

--- a/src/vtrasterizer/DecorationRenderer_test.cpp
+++ b/src/vtrasterizer/DecorationRenderer_test.cpp
@@ -84,24 +84,11 @@ class DecorationProbe
     std::unique_ptr<Renderable::TextureAtlas> _atlas;
 };
 
-/// Row @p row of @p tile as '#' (ink) and '.' (clear), top-origin, the way the bitmap is stored.
-[[nodiscard]] std::string rowOf(atlas::UploadTile const& tile, int row)
-{
-    auto const width = unbox<size_t>(tile.bitmapSize.width);
-    auto text = std::string {};
-    for (auto const x: std::views::iota(0uz, width))
-        text += tile.bitmap[(static_cast<size_t>(row) * width) + x] > 0 ? '#' : '.';
-    return text;
-}
-
-/// Every row of @p tile, so a failing CHECK prints the decoration instead of a number.
-[[nodiscard]] std::vector<std::string> renderedRows(atlas::UploadTile const& tile)
-{
-    auto rows = std::vector<std::string> {};
-    for (auto const y: std::views::iota(0, unbox<int>(tile.bitmapSize.height)))
-        rows.emplace_back(rowOf(tile, y));
-    return rows;
-}
+/// A decoration as rendered: one '#'/'.' string per row, top-origin.
+///
+/// Every measurement below reads these rows rather than the bitmap, so the tile is walked once and
+/// a failing CHECK can print the decoration instead of a number. @see bitmapRows.
+using Rendered = std::vector<std::string>;
 
 /// Cell-bottom offset of the highest inked row, or 0 when the tile is blank.
 ///
@@ -109,50 +96,50 @@ class DecorationProbe
 /// draws it at `cellBottom - bitmapHeight`), so top-origin row `r` of a tile `H` tall sits at
 /// cell-bottom offset `H - r`. That identity is the whole reason these tests can talk about the
 /// baseline at all.
-[[nodiscard]] int topmostInkOffset(atlas::UploadTile const& tile)
+[[nodiscard]] int topmostInkOffset(Rendered const& rows)
 {
-    auto const height = unbox<int>(tile.bitmapSize.height);
+    auto const height = static_cast<int>(rows.size());
     for (auto const y: std::views::iota(0, height))
-        if (rowOf(tile, y).contains('#'))
+        if (rows[static_cast<size_t>(y)].contains('#'))
             return height - y;
     return 0;
 }
 
 /// Cell-bottom offset of the lowest inked row, or 0 when the tile is blank.
-[[nodiscard]] int bottommostInkOffset(atlas::UploadTile const& tile)
+[[nodiscard]] int bottommostInkOffset(Rendered const& rows)
 {
-    auto const height = unbox<int>(tile.bitmapSize.height);
+    auto const height = static_cast<int>(rows.size());
     for (auto const y: std::views::iota(0, height) | std::views::reverse)
-        if (rowOf(tile, y).contains('#'))
+        if (rows[static_cast<size_t>(y)].contains('#'))
             return height - y;
     return 0;
 }
 
-/// How many rows of @p tile carry any ink.
-[[nodiscard]] int inkedRows(atlas::UploadTile const& tile)
+/// How many rows carry any ink.
+[[nodiscard]] int inkedRows(Rendered const& rows)
 {
+    return static_cast<int>(std::ranges::count_if(rows, [](auto const& row) { return row.contains('#'); }));
+}
+
+/// How many columns of the LEFT half carry any ink -- the width of a dotted underline's first dot,
+/// the second one starting at the half-way mark.
+[[nodiscard]] int inkedColumnsInFirstHalf(Rendered const& rows)
+{
+    if (rows.empty())
+        return 0;
     auto count = 0;
-    for (auto const y: std::views::iota(0, unbox<int>(tile.bitmapSize.height)))
-        if (rowOf(tile, y).contains('#'))
+    for (auto const x: std::views::iota(0uz, rows.front().size() / 2))
+        if (std::ranges::any_of(rows, [x](auto const& row) { return row[x] == '#'; }))
             ++count;
     return count;
 }
 
-/// How many columns of @p tile's LEFT half carry any ink -- the width of a dotted underline's first
-/// dot, the second one starting at the half-way mark.
-[[nodiscard]] int inkedColumnsInFirstHalf(atlas::UploadTile const& tile)
+[[nodiscard]] int litPixels(Rendered const& rows)
 {
-    auto const rows = std::views::iota(0, unbox<int>(tile.bitmapSize.height));
     auto count = 0;
-    for (auto const x: std::views::iota(0, unbox<int>(tile.bitmapSize.width) / 2))
-        if (std::ranges::any_of(rows, [&](int y) { return rowOf(tile, y)[static_cast<size_t>(x)] == '#'; }))
-            ++count;
+    for (auto const& row: rows)
+        count += static_cast<int>(std::ranges::count(row, '#'));
     return count;
-}
-
-[[nodiscard]] size_t litPixels(atlas::UploadTile const& tile)
-{
-    return static_cast<size_t>(std::ranges::count_if(tile.bitmap, [](uint8_t v) { return v > 0; }));
 }
 
 /// The decorations that are supposed to live below the baseline, in the cell's descender region.
@@ -176,17 +163,18 @@ TEST_CASE("DecorationRenderer.underlineFamilyStaysBelowTheBaseline", "[decoratio
     for (auto const decoration: UnderlineFamily)
     {
         auto const& tile = probe.upload(decoration);
+        auto const rows = bitmapRows(tile);
         INFO(std::format("{} tile {} in cell {}, baseline {}, underline position {}",
                          decoration,
                          tile.bitmapSize,
                          gridMetrics.cellSize,
                          gridMetrics.baseline,
                          gridMetrics.underline.position));
-        for (auto const& row: renderedRows(tile))
+        for (auto const& row: rows)
             UNSCOPED_INFO(row);
 
-        CHECK(litPixels(tile) > 0);
-        CHECK(topmostInkOffset(tile) <= gridMetrics.underline.position);
+        CHECK(litPixels(rows) > 0);
+        CHECK(topmostInkOffset(rows) <= gridMetrics.underline.position);
         CHECK(unbox<int>(tile.bitmapSize.height) <= unbox<int>(gridMetrics.cellSize.height));
     }
 }
@@ -200,13 +188,13 @@ TEST_CASE("DecorationRenderer.curlyUnderlineIsNotAsTallAsTheDescender", "[decora
     auto const gridMetrics =
         gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
     auto probe = DecorationProbe { gridMetrics };
-    auto const& tile = probe.upload(Decorator::CurlyUnderline);
+    auto const rows = bitmapRows(probe.upload(Decorator::CurlyUnderline));
 
-    for (auto const& row: renderedRows(tile))
+    for (auto const& row: rows)
         UNSCOPED_INFO(row);
 
-    auto const top = topmostInkOffset(tile);
-    auto const bottom = bottommostInkOffset(tile);
+    auto const top = topmostInkOffset(rows);
+    auto const bottom = bottommostInkOffset(rows);
     auto const bandHeight = top - bottom + 1;
 
     INFO(std::format("wave occupies cell-bottom offsets {}..{} ({} rows); baseline is at {}",
@@ -234,15 +222,15 @@ TEST_CASE("DecorationRenderer.curlyUnderlineIsActuallyCurly", "[decoration]")
     auto const gridMetrics =
         gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
     auto probe = DecorationProbe { gridMetrics };
-    auto const& tile = probe.upload(Decorator::CurlyUnderline);
+    auto const rows = bitmapRows(probe.upload(Decorator::CurlyUnderline));
 
-    for (auto const& row: renderedRows(tile))
+    for (auto const& row: rows)
         UNSCOPED_INFO(row);
 
-    auto const height = unbox<int>(tile.bitmapSize.height);
-    auto const width = unbox<int>(tile.bitmapSize.width);
-    auto const crestRow = rowOf(tile, height - topmostInkOffset(tile));
-    auto const troughRow = rowOf(tile, height - bottommostInkOffset(tile));
+    auto const height = static_cast<int>(rows.size());
+    auto const width = static_cast<int>(rows.front().size());
+    auto const& crestRow = rows[static_cast<size_t>(height - topmostInkOffset(rows))];
+    auto const& troughRow = rows[static_cast<size_t>(height - bottommostInkOffset(rows))];
 
     INFO(std::format("crest '{}' trough '{}'", crestRow, troughRow));
 
@@ -259,8 +247,8 @@ TEST_CASE("DecorationRenderer.curlyUnderlineHonorsUnderlineThickness", "[decorat
     auto thin = DecorationProbe { gridMetricsFor(NimbusCellSize, NimbusBaseline, 9, 1) };
     auto thick = DecorationProbe { gridMetricsFor(NimbusCellSize, NimbusBaseline, 9, 5) };
 
-    CHECK(litPixels(thick.upload(Decorator::CurlyUnderline))
-          > litPixels(thin.upload(Decorator::CurlyUnderline)));
+    CHECK(litPixels(bitmapRows(thick.upload(Decorator::CurlyUnderline)))
+          > litPixels(bitmapRows(thin.upload(Decorator::CurlyUnderline))));
 }
 
 TEST_CASE("DecorationRenderer.dottedUnderlineSurvivesAShallowUnderlinePosition", "[decoration]")
@@ -278,15 +266,15 @@ TEST_CASE("DecorationRenderer.dottedUnderlineSurvivesAShallowUnderlinePosition",
         auto const gridMetrics = gridMetricsFor(
             ImageSize { Width(10), Height(16) }, /*baseline*/ 2, /*position*/ 1, /*thickness*/ 3);
         auto probe = DecorationProbe { gridMetrics };
-        auto const& tile = probe.upload(Decorator::DottedUnderline);
+        auto const rows = bitmapRows(probe.upload(Decorator::DottedUnderline));
 
-        for (auto const& row: renderedRows(tile))
+        for (auto const& row: rows)
             UNSCOPED_INFO(row);
 
-        CHECK(litPixels(tile) > 0);
-        CHECK(inkedRows(tile) == inkedColumnsInFirstHalf(tile)); // the dot is square
+        CHECK(litPixels(rows) > 0);
+        CHECK(inkedRows(rows) == inkedColumnsInFirstHalf(rows)); // the dot is square
         // The dot shrinks to the room it has rather than overhanging it, so the anchor still holds.
-        CHECK(topmostInkOffset(tile) == gridMetrics.underline.position);
+        CHECK(topmostInkOffset(rows) == gridMetrics.underline.position);
     }
 
     SECTION("underline flush with the cell bottom")
@@ -294,12 +282,12 @@ TEST_CASE("DecorationRenderer.dottedUnderlineSurvivesAShallowUnderlinePosition",
         auto const gridMetrics = gridMetricsFor(
             ImageSize { Width(10), Height(16) }, /*baseline*/ 1, /*position*/ 0, /*thickness*/ 1);
         auto probe = DecorationProbe { gridMetrics };
-        auto const& tile = probe.upload(Decorator::DottedUnderline);
+        auto const rows = bitmapRows(probe.upload(Decorator::DottedUnderline));
 
-        for (auto const& row: renderedRows(tile))
+        for (auto const& row: rows)
             UNSCOPED_INFO(row);
 
-        CHECK(litPixels(tile) > 0); // drew nothing whatsoever before the fix
+        CHECK(litPixels(rows) > 0); // drew nothing whatsoever before the fix
     }
 }
 
@@ -311,13 +299,11 @@ TEST_CASE("DecorationRenderer.doubleUnderlineIsTwoSeparatedStrokes", "[decoratio
     auto const gridMetrics =
         gridMetricsFor(NimbusCellSize, NimbusBaseline, NimbusUnderlinePosition, /*thickness*/ 1);
     auto probe = DecorationProbe { gridMetrics };
-    auto const& tile = probe.upload(Decorator::DoubleUnderline);
-
-    auto const rows = renderedRows(tile);
+    auto const rows = bitmapRows(probe.upload(Decorator::DoubleUnderline));
     for (auto const& row: rows)
         UNSCOPED_INFO(row);
 
-    CHECK(topmostInkOffset(tile) <= gridMetrics.underline.position);
+    CHECK(topmostInkOffset(rows) <= gridMetrics.underline.position);
 
     // Two runs of inked rows, separated by at least one clear row.
     auto inkedRuns = 0;
@@ -339,12 +325,10 @@ TEST_CASE("DecorationRenderer.doubleUnderlineThicknessFollowsTwoThirds", "[decor
     auto const gridMetrics = gridMetricsFor(
         ImageSize { Width(10), Height(40) }, /*baseline*/ 18, /*position*/ 16, /*thickness*/ 2);
     auto probe = DecorationProbe { gridMetrics };
-    auto const& tile = probe.upload(Decorator::DoubleUnderline);
+    auto const rows = bitmapRows(probe.upload(Decorator::DoubleUnderline));
 
-    auto const rows = renderedRows(tile);
     for (auto const& row: rows)
         UNSCOPED_INFO(row);
 
-    auto const inkedRows = std::ranges::count_if(rows, [](auto const& row) { return row.contains('#'); });
-    CHECK(inkedRows == 4); // two strokes of ceil(2 * 2/3) == 2 rows each
+    CHECK(inkedRows(rows) == 4); // two strokes of ceil(2 * 2/3) == 2 rows each
 }

--- a/src/vtrasterizer/RendererTestHelpers.h
+++ b/src/vtrasterizer/RendererTestHelpers.h
@@ -152,6 +152,31 @@ class MockRenderTarget: public vtrasterizer::RenderTarget
     MockImageTextureBackend _imageScheduler;
 };
 
+/// Renders @p tileData as one '#' (ink) / '.' (clear) string per row, top-origin, the way the bitmap
+/// is stored.
+///
+/// Shared so that a test which ASSERTS a shape (verifyBitmap) and one which MEASURES a shape read
+/// the same pixels the same way -- and so a failing check can print the decoration rather than a
+/// number.
+template <typename TileCreateData>
+[[nodiscard]] std::vector<std::string> bitmapRows(TileCreateData const& tileData)
+{
+    auto const width = tileData.bitmapSize.width.template as<size_t>();
+    auto const height = tileData.bitmapSize.height.template as<size_t>();
+    auto const componentCount = atlas::element_count(tileData.bitmapFormat);
+
+    auto rows = std::vector<std::string> {};
+    rows.reserve(height);
+    for (auto const y: std::views::iota(0zu, height))
+    {
+        auto& row = rows.emplace_back();
+        row.reserve(width);
+        for (auto const x: std::views::iota(0zu, width))
+            row += tileData.bitmap[((y * width) + x) * componentCount] > 0 ? '#' : '.';
+    }
+    return rows;
+}
+
 template <typename TileCreateData>
 void verifyBitmap(TileCreateData const& tileData, std::vector<std::string> const& pattern)
 {
@@ -160,27 +185,14 @@ void verifyBitmap(TileCreateData const& tileData, std::vector<std::string> const
     if (!pattern.empty())
         REQUIRE(tileData.bitmapSize.width.template as<int>() == static_cast<int>(pattern[0].size()));
 
-    auto const width = tileData.bitmapSize.width.template as<size_t>();
-    auto const height = tileData.bitmapSize.height.template as<size_t>();
-    auto const componentCount = atlas::element_count(tileData.bitmapFormat);
-
     // Assuming AlphaMask (Red) format from BDF / BoxDrawing
     REQUIRE(tileData.bitmapFormat == atlas::Format::Red);
 
-    for (auto const y: std::views::iota(0zu, height))
+    auto const rows = bitmapRows(tileData);
+    for (auto const y: std::views::iota(0zu, rows.size()))
     {
-        std::string actualRow;
-        actualRow.reserve(width);
-
-        for (auto const x: std::views::iota(0zu, width))
-        {
-            auto const pixelIndex = ((y * width) + x) * componentCount;
-            auto const pixelValue = tileData.bitmap[pixelIndex];
-            actualRow += (pixelValue > 0 ? '#' : '.');
-        }
-
         INFO("Row: " << y);
-        CHECK(actualRow == pattern[y]);
+        CHECK(rows[y] == pattern[y]);
     }
 }
 

--- a/src/vtrasterizer/UnderlineGeometry.h
+++ b/src/vtrasterizer/UnderlineGeometry.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <algorithm>
+
+namespace vtrasterizer
+{
+
+/// Where the curly (wavy) underline's wave sits inside the tile that carries it.
+///
+/// Coordinates are bottom-origin, matching Pixmap: row 0 is the tile's BOTTOM row. A decoration
+/// tile is drawn flush with the cell's bottom edge (@see DecorationRenderer::renderDecoration draws
+/// it at `cellBottom - bitmapHeight`), so tile row @c y lands at cell-bottom offset `y + 1` and the
+/// tile's height is how far up the decoration reaches.
+struct CurlyUnderlineGeometry
+{
+    /// The tile's height in pixels.
+    int tileHeight = 1;
+
+    /// The wave's centre line.
+    int centerY = 0;
+
+    /// How far the centre line travels above and below @c centerY.
+    int amplitude = 1;
+
+    /// Rows painted above AND below the centre line, so the stroke is `2 * strokeRadius + 1` rows
+    /// thick. Applied along y: a near-horizontal cosine thickened along x gains nothing and leaves
+    /// holes where the curve is steepest.
+    int strokeRadius = 0;
+};
+
+/// Sizes and places the curly underline's wave, so that it reads as a wave without colliding with
+/// the text above it.
+///
+/// The wave's topmost painted row is the row a straight underline's top occupies, and it descends
+/// from there -- so toggling `SGR 4:1` and `SGR 4:3` keeps the same top edge, and neither can reach
+/// the baseline. This is what foot (render.c, `draw_styled_underline`) and ghostty
+/// (sprite/draw/special.zig, `underline_curly`) both do.
+///
+/// The amplitude is a quarter of the room between the underline position and the cell bottom. That
+/// bound is kitty's (decorations.c: `half_height = max(1u, max_height / 4u); // 4 so as to be not
+/// too large`), and it is the crux of issue #1754: sizing the wave from @c GridMetrics::baseline
+/// instead made it as tall as the whole descender. `baseline` is a poor proxy for descender depth
+/// because it is `lineHeight - ascender`, which folds in the font's entire line gap -- Nimbus Mono
+/// PS declares 200/1000 em of leading, so its 10px "descender" is really 6px of descent plus 4px of
+/// leading, and the wave grew to 9px in a 20px cell (see issue #2030).
+///
+/// @param underlinePosition the straight underline's top edge, in pixels above the cell bottom.
+/// @param underlineThickness the font's underline thickness in pixels; values below one are treated
+///                           as one, since a stroke must be drawn to be seen.
+/// @param cellHeight the grid cell's height in pixels, the hard bound on the tile.
+///
+/// @return a geometry whose painted band `[centerY - amplitude - strokeRadius,
+///         centerY + amplitude + strokeRadius]` always lies within `[0, tileHeight - 1]`, so that
+///         nothing is silently clipped by Pixmap::paint.
+[[nodiscard]] constexpr CurlyUnderlineGeometry curlyUnderlineGeometry(int underlinePosition,
+                                                                      int underlineThickness,
+                                                                      int cellHeight) noexcept
+{
+    auto const cell = std::max(1, cellHeight);
+
+    // The room the wave has to live in: everything between the underline position and the cell
+    // bottom. Clamped into the cell, because a font may report an underline position outside it.
+    auto const room = std::clamp(underlinePosition, 1, cell);
+
+    // A stroke `2 * radius + 1` rows thick. The minimum wave is a crest row, a trough row and one
+    // row between them, so a stroke that leaves no space for those three has to give way first --
+    // a fat straight line is a worse answer than a thin curl.
+    auto const thickness = std::max(1, underlineThickness);
+    auto strokeRadius = (thickness - 1) / 2;
+    if ((2 * strokeRadius) + 3 > room)
+        strokeRadius = std::max(0, (room - 3) / 2);
+
+    // A quarter of the room, so the wave is a wave and not a ribbon; never below one, or there is
+    // no wave at all; and never so large that the trough falls out of the tile.
+    auto const headroom = std::max(1, (room - 1 - (2 * strokeRadius)) / 2);
+    auto const amplitude = std::clamp(room / 4, 1, headroom);
+
+    // The band is `2 * amplitude + 2 * strokeRadius + 1` rows. It normally fits under the underline
+    // position; where it does not the tile grows to hold it, but never past the cell.
+    auto const band = (2 * amplitude) + (2 * strokeRadius) + 1;
+    auto const tileHeight = std::min(cell, std::max(room, band));
+
+    // Fit the band to the tile that was actually granted. A cell too short to hold even the minimum
+    // wave degrades to a flatter, ultimately straight stroke -- which is visible, where a curl
+    // clipped away by Pixmap::paint would not be.
+    auto const halfBand = (tileHeight - 1) / 2;
+    auto const stroke = std::min(strokeRadius, halfBand);
+    auto const wave = std::min(amplitude, halfBand - stroke);
+
+    return CurlyUnderlineGeometry { .tileHeight = tileHeight,
+                                    .centerY = tileHeight - 1 - wave - stroke,
+                                    .amplitude = wave,
+                                    .strokeRadius = stroke };
+}
+
+} // namespace vtrasterizer

--- a/src/vtrasterizer/UnderlineGeometry_test.cpp
+++ b/src/vtrasterizer/UnderlineGeometry_test.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the curly underline's geometry -- the decision issue #1754 got wrong.
+
+#include <vtrasterizer/UnderlineGeometry.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <ranges>
+
+using namespace vtrasterizer;
+
+namespace
+{
+
+/// The topmost painted row, bottom-origin. A tile row @c y sits at cell-bottom offset `y + 1`, so
+/// this being `tileHeight - 1` is what puts the crest at the underline position.
+[[nodiscard]] constexpr int crestRow(CurlyUnderlineGeometry const& g) noexcept
+{
+    return g.centerY + g.amplitude + g.strokeRadius;
+}
+
+/// The bottom-most painted row, bottom-origin.
+[[nodiscard]] constexpr int troughRow(CurlyUnderlineGeometry const& g) noexcept
+{
+    return g.centerY - g.amplitude - g.strokeRadius;
+}
+
+/// How many rows the wave paints in total.
+[[nodiscard]] constexpr int bandHeight(CurlyUnderlineGeometry const& g) noexcept
+{
+    return crestRow(g) - troughRow(g) + 1;
+}
+
+} // namespace
+
+TEST_CASE("UnderlineGeometry.nimbusMonoPS", "[underlinegeometry]")
+{
+    // The font from #1754, at 12pt/96dpi: cell 20px tall, baseline 10px above the cell bottom (of
+    // which 4px is line gap, not descent), underline position 9, thickness 1.
+    auto const geometry = curlyUnderlineGeometry(/*position*/ 9, /*thickness*/ 1, /*cellHeight*/ 20);
+
+    CHECK(geometry.tileHeight == 9);
+    CHECK(geometry.centerY == 6);
+    CHECK(geometry.amplitude == 2);
+    CHECK(geometry.strokeRadius == 0);
+
+    // Five rows spanning cell-bottom offsets 5..9 -- against the nine rows ending ON the baseline
+    // that the pre-fix code produced, in a cell whose x-height is about seven pixels.
+    CHECK(bandHeight(geometry) == 5);
+    CHECK(crestRow(geometry) + 1 == 9); // the row a straight underline's top occupies
+}
+
+TEST_CASE("UnderlineGeometry.jetBrainsMono", "[underlinegeometry]")
+{
+    // A font with no line gap: baseline 5, underline position 3. The issue reports this one as
+    // already looking right, so the fix must not change its character.
+    auto const geometry = curlyUnderlineGeometry(/*position*/ 3, /*thickness*/ 1, /*cellHeight*/ 22);
+
+    CHECK(geometry.tileHeight == 3);
+    CHECK(geometry.amplitude == 1);
+    CHECK(bandHeight(geometry) == 3);
+}
+
+TEST_CASE("UnderlineGeometry.crestSitsWhereAStraightUnderlineDoes", "[underlinegeometry]")
+{
+    // The property that keeps the curl off the text: its top row is the straight underline's top
+    // row, so toggling SGR 4:1 and 4:3 keeps the same top edge and neither reaches the baseline.
+    for (auto const position: std::views::iota(3, 40))
+    {
+        auto const geometry = curlyUnderlineGeometry(position, 1, 64);
+        INFO("underline position " << position);
+        CHECK(geometry.tileHeight == position);
+        CHECK(crestRow(geometry) == geometry.tileHeight - 1);
+    }
+}
+
+TEST_CASE("UnderlineGeometry.amplitudeIsBoundedByTheRoomBelowTheUnderline", "[underlinegeometry]")
+{
+    // The defect itself: the wave used to be half the descender tall. It must instead be a quarter
+    // of the room beneath the underline position, so the band is about half that room -- or the
+    // three-row minimum where the room is too shallow even for that, since a crest, a middle and a
+    // trough are what make a curl a curl.
+    for (auto const position: std::views::iota(1, 60))
+    {
+        auto const geometry = curlyUnderlineGeometry(position, 1, 64);
+        INFO("underline position " << position);
+        CHECK(geometry.amplitude <= std::max(1, position / 4));
+        CHECK(bandHeight(geometry) <= std::max(3, (position / 2) + 1));
+    }
+}
+
+TEST_CASE("UnderlineGeometry.strokeFollowsUnderlineThickness", "[underlinegeometry]")
+{
+    // The stroke used to be spread along x, so thickness never reached the wave. Deep enough room
+    // that the thickness is what decides, not the clamps.
+    CHECK(curlyUnderlineGeometry(30, 1, 64).strokeRadius == 0);
+    CHECK(curlyUnderlineGeometry(30, 2, 64).strokeRadius == 0);
+    CHECK(curlyUnderlineGeometry(30, 3, 64).strokeRadius == 1);
+    CHECK(curlyUnderlineGeometry(30, 5, 64).strokeRadius == 2);
+    CHECK(curlyUnderlineGeometry(30, 7, 64).strokeRadius == 3);
+
+    // A thickness of zero still draws: a stroke that is not painted cannot be seen.
+    CHECK(curlyUnderlineGeometry(30, 0, 64).strokeRadius == 0);
+    CHECK(bandHeight(curlyUnderlineGeometry(30, 0, 64)) >= 3);
+}
+
+TEST_CASE("UnderlineGeometry.everyBandFitsItsTile", "[underlinegeometry]")
+{
+    // Pixmap::paint silently drops out-of-range rows, so a geometry that does not fit its tile
+    // loses part of the curl without any diagnostic. Swept over the degenerate corners too: a
+    // position outside the cell, a thickness larger than the cell, a one-pixel cell.
+    for (auto const cellHeight: { 1, 2, 3, 4, 8, 16, 20, 64 })
+    {
+        for (auto const position: std::views::iota(-2, 24))
+        {
+            for (auto const thickness: { -1, 0, 1, 2, 3, 8, 40 })
+            {
+                auto const geometry = curlyUnderlineGeometry(position, thickness, cellHeight);
+                INFO("cell " << cellHeight << " position " << position << " thickness " << thickness);
+
+                CHECK(geometry.tileHeight >= 1);
+                CHECK(geometry.tileHeight <= cellHeight);
+                CHECK(geometry.amplitude >= 0);
+                CHECK(geometry.strokeRadius >= 0);
+                CHECK(troughRow(geometry) >= 0);
+                CHECK(crestRow(geometry) == geometry.tileHeight - 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A curly underline could be drawn almost as tall as a lowercase letter, with its crest sitting on the baseline so that it ran into the bottom of the glyphs. It only showed up on some fonts, which is why it was hard to reproduce: the wave was sized from `GridMetrics::baseline`, and that value is `lineHeight - ascender`, which folds in the font's entire `hhea.lineGap`. A font that declares line spacing therefore reports far more room below the baseline than it actually has — Nimbus Mono PS (the default `monospace` on many Linux systems) declares 200/1000 em of leading, so 4 of its 10 "descender" pixels at 12pt are leading, and the curl grew to 9px in a 20px cell. A font with no line gap, such as JetBrains Mono, shows none of this.

Decoration tiles are drawn flush with the cell's bottom edge, so a tile's height is how far up it reaches. Every other decoration anchors on `underline.position`; the curly one alone did not. Chasing that down turned up the same class of mistake in its three siblings, each off in its own direction, so this fixes the family rather than the one case that was reported.

Fixes #1754

## Changes

- Curly underlines are sized from the underline position instead of the baseline: the crest occupies the row a straight underline's top occupies and the wave descends from there, bounded by a quarter of the room beneath it. Toggling `SGR 4:1` and `SGR 4:3` now keeps the same top edge. The geometry lives in a new dependency-free `UnderlineGeometry.h`, with the reasoning and the reference implementations it follows recorded at the declaration.
- The curly stroke thickens along y rather than x. Widening a near-horizontal cosine sideways added no weight and left the band holed where the curve is steepest, so `underline_thickness` reached the wave in name only.
- The upper stroke of a double underline no longer lands above the baseline, inside the glyph bodies, and its per-stroke thickness no longer loses a pixel at even thicknesses — the parentheses in `unsigned(ceil(t * 2.0) / 3.0)` closed after `ceil()`, truncating where two thirds rounded up was meant.
- A dotted underline stays square where the font puts its underline close to the cell bottom. The dot origin was computed as `(unsigned) position - thickness`, which wrapped and left most of the dot's rows addressing a y that `Pixmap::paint` silently dropped, so the dot came out as a dash — or, with the underline flush against the cell bottom, drew nothing at all.
- Dashed underlines are anchored at the underline position rather than half a thickness above it.

With all four corrected, the whole underline family shares one rule — no ink above `underline.position`, and therefore none on the baseline — which `DecorationRenderer_test.cpp` asserts in a loop over the family, so a sixth decoration is a row in a table rather than a sixth chance to get this wrong. These are the first tests this renderer has had; the pure geometry is covered separately.

Whether `GridMetrics::baseline` should keep the whole line gap at all is a separate design question, filed as #2030 — the fix here is correct either way, since it no longer reads that value.