### PR TITLE
fix(build): make GuiPrivate conditional on Qt >= 6.10

### DIFF
--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -25,8 +25,14 @@ NumberToHex(${PROJECT_VERSION_PATCH} HEX_PATCH)
 # NB: without the GUI frontend none of that is reachable -- what is left is `contour daemon` and
 #     the CLI verbs, which need Core alone. Asking for the rest anyway would make a headless build
 #     require a Qt that renders, which is the whole point of not building the frontend.
+# NB: Qt6_VERSION (used below) is set by find_package(Qt6). We find Core first — unconditionally
+#     and before building the component list — so the version check is available for all gates.
+find_package(Qt6 COMPONENTS Core REQUIRED)
 if(CONTOUR_FRONTEND_GUI)
-    set(QT_COMPONENTS Core Gui GuiPrivate Qml Quick QuickControls2 Network Multimedia Widgets DBus)
+    set(QT_COMPONENTS Core Gui Qml Quick QuickControls2 Network Multimedia Widgets DBus)
+    if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+        list(APPEND QT_COMPONENTS GuiPrivate)
+    endif()
 else()
     set(QT_COMPONENTS Core)
 endif()

--- a/src/contour/display/CMakeLists.txt
+++ b/src/contour/display/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(Qt6 COMPONENTS Core Gui GuiPrivate Quick QuickControls2 Multimedia REQUIRED)
+find_package(Qt6 COMPONENTS Core Gui Quick QuickControls2 Multimedia REQUIRED)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
+endif()
 find_package(Qt6 COMPONENTS ShaderTools REQUIRED)
 
 set(QT_RESOURCES DisplayResources.qrc)


### PR DESCRIPTION
## Description

<!-- Describe your changes: what and why. -->
Qt 6.8/6.9 packaging does not expose GuiPrivate as a separate find_package component. Gate all GuiPrivate usage behind a version check so the build succeeds on older Qt without it.

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] Breaking changes (if any) are documented
