### PR TITLE
Make src/coro and src/net the single source of truth for the async stack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -671,7 +671,14 @@ jobs:
             https://github.com/tmux/tmux/releases/download/3.7b/tmux-3.7b.tar.gz
           tar xzf "$RUNNER_TEMP/tmux.tar.gz" -C "$RUNNER_TEMP"
           # The release tarball ships a generated configure, so no autotools are needed here.
-          cd "$RUNNER_TEMP/tmux-3.7b" && ./configure && make -j"$(sysctl -n hw.ncpu)" && sudo make install
+          # --disable-utf8proc is required, not merely a choice: 3.7b's configure hard-errors
+          # ("must give --enable-utf8proc or --disable-utf8proc") rather than defaulting, and this
+          # oracle only has to speak the control-mode protocol -- how tmux measures east-Asian
+          # width does not enter into it. Stated on both platforms so they build the same binary.
+          cd "$RUNNER_TEMP/tmux-3.7b" \
+            && ./configure --disable-utf8proc \
+            && make -j"$(sysctl -n hw.ncpu)" \
+            && sudo make install
           tmux -V
       - name: "Generate build files"
         run: |
@@ -1061,7 +1068,12 @@ jobs:
             https://github.com/tmux/tmux/releases/download/3.7b/tmux-3.7b.tar.gz
           tar xzf "$RUNNER_TEMP/tmux.tar.gz" -C "$RUNNER_TEMP"
           # The release tarball ships a generated configure, so no autotools are needed here.
-          cd "$RUNNER_TEMP/tmux-3.7b" && ./configure && make -j"$(nproc)" && sudo make install
+          # --disable-utf8proc: see the macOS job for why it must be stated rather than defaulted.
+          # Passing it here too keeps both platforms measuring against the same tmux build.
+          cd "$RUNNER_TEMP/tmux-3.7b" \
+            && ./configure --disable-utf8proc \
+            && make -j"$(nproc)" \
+            && sudo make install
           tmux -V
       - name: "Post-fix embedded dependency permissions."
         run: sudo find _deps/sources -exec chown $UID {} \;

--- a/src/coro/CMakeLists.txt
+++ b/src/coro/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(coro INTERFACE
     UniqueCoroHandle.hpp
     WhenAll.hpp
     WhenAny.hpp
+    testing/SuppressWindowsDialogs.hpp
 )
 target_include_directories(coro INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
@@ -20,7 +21,7 @@ if(CORO_TESTING)
         WhenAll_test.cpp
         WhenAny_test.cpp
     )
-    target_link_libraries(coro_test coro crispy::core Catch2::Catch2)
+    target_link_libraries(coro_test coro Catch2::Catch2)
     add_test(NAME coro_test COMMAND $<TARGET_FILE:coro_test>)
     set_tests_properties(coro_test PROPERTIES LABELS daemon)
 

--- a/src/coro/README.md
+++ b/src/coro/README.md
@@ -1,32 +1,45 @@
 # coro — C++23 coroutine vocabulary types
 
-`Task`, `WhenAll`, `WhenAny`, `Cancellation`, `Awaitable`: the dependency-free coroutine
-building blocks used by `src/net`'s reactor and the multiplexer daemon.
+`Task`, `WhenAll`, `WhenAny`, `Cancellation`, `Awaitable`, `UniqueCoroHandle`: the
+dependency-free coroutine building blocks used by `src/net`'s reactor and the multiplexer
+daemon.
 
-## Provenance and re-sync
+`coro` has **no first-party dependencies** — its shipped headers include nothing but the
+standard library. Keep it that way; `src/net` is the layer that is allowed to know about
+sockets, and neither may depend on anything above it in the tree.
 
-This module is a near-verbatim copy of `src/coro/` from the
-[Endo](https://github.com/christianparpart/endo) project (Apache-2.0, same author),
-taken at commit `178cb496`. Keep it byte-close to upstream so fixes flow both ways.
+## Provenance — this copy is canonical
 
-To re-sync against a newer Endo checkout:
+This module and `src/net` originated in the [Endo](https://github.com/contour-terminal/endo)
+project (Apache-2.0, same author), which in turn drew on the async layer in
+[fastcached](https://github.com/LASTRADA-Software/fastcached). **Contour's copy is now the
+source of truth for all three.** It has since gained `UniqueCoroHandle`, the `net::EventLoop`
+/ `net::EventSource` split (replacing Endo's TUI-coupled `TuiRuntime`), TLS, Unix-domain
+sockets, fd passing, and a much larger test suite.
 
-```sh
-for f in Awaitable.hpp Cancellation.hpp Task.hpp WhenAll.hpp WhenAny.hpp \
-         Task_test.cpp WhenAny_test.cpp; do
-    sed 's/endo::coro/coro/g' "$ENDO/src/coro/$f" > "src/coro/$f"
-done
-git diff   # expected deltas: this rename, a few de-Endo'd doc comments, test_main.cpp
-```
+Changes therefore flow **outward** — fix here first, then propagate. Do not re-sync *from*
+Endo or fastcached: their copies are older and, in Endo's case, a strict subset.
 
-Deliberate local deltas (re-created on every re-sync, keep them small):
+> An earlier revision of this file prescribed a `sed`-based re-sync *from* Endo. That recipe
+> is destructive as of the divergence above — running it would silently revert
+> `UniqueCoroHandle`, `EventLoop`, TLS and Unix-socket support. It has been removed.
 
-- namespace `endo::coro` → `coro`;
-- doc comments no longer reference Endo-only types (`endo::Generator`);
-- `test_main.cpp` follows this repository's Catch2 runner template
-  (`crispy::suppressWindowsDialogs`);
-- `WhenAll_test.cpp` is Contour-only (upstream has no dedicated WhenAll test).
+Consuming projects are expected to pull this code in at CMake configure time rather than
+vendor a copy into their own `src/`, so that a downstream edit cannot quietly fork it again.
 
-Conventions inherited from upstream and enforced by this repository's clang-tidy:
-coroutine parameters are pointers, never references
-(`cppcoreguidelines-avoid-reference-coroutine-parameters`).
+## Conventions
+
+- Coroutine parameters are **pointers, never references** — a reference parameter dangles once
+  the coroutine suspends (`cppcoreguidelines-avoid-reference-coroutine-parameters`, enforced by
+  the root `.clang-tidy`). Non-coroutine functions keep references: `listen(EventLoop&, …)` but
+  `connect(EventLoop*, …)`.
+- Coroutine awaiter and promise hooks (`await_ready`, `await_suspend`, `await_resume`,
+  `initial_suspend`, `final_suspend`, `return_value`, …) are named by the language, so each
+  carries a `// NOLINTNEXTLINE(readability-identifier-naming)` at its declaration. They must
+  also stay non-static instance methods: a static `initial_suspend`/`final_suspend` makes the
+  compiler-generated `promise.hook()` call trip `readability-static-accessed-through-instance`.
+  `readability-convert-member-functions-to-static`, which would otherwise flag the stateless
+  ones, is disabled tree-wide in the root `./.clang-tidy` — there is no directory-local config.
+- Cancellation is the standard `<stop_token>` facility, re-exported as `coro::StopToken` /
+  `StopSource` / `StopCallback` so call sites stay stable. A cancelled frame unwinds by
+  throwing `coro::OperationCancelled`.

--- a/src/coro/Task.hpp
+++ b/src/coro/Task.hpp
@@ -54,8 +54,8 @@ namespace detail
         // names are fixed snake_case by the language, and the promise hooks must
         // be instance methods (a static initial_suspend/final_suspend would make
         // the compiler-generated promise.hook() calls trip static-accessed-through-
-        // instance). readability-convert-member-functions-to-static is therefore
-        // disabled for this directory (see src/coro/.clang-tidy).
+        // instance). readability-convert-member-functions-to-static would flag the
+        // stateless ones anyway; it is disabled tree-wide in the root .clang-tidy.
         // NOLINTNEXTLINE(readability-identifier-naming): coroutine machinery, looked up by spelling.
         [[nodiscard]] bool await_ready() const noexcept { return false; }
 

--- a/src/coro/test_main.cpp
+++ b/src/coro/test_main.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <crispy/SuppressWindowsDialogs.hpp>
+#include <coro/testing/SuppressWindowsDialogs.hpp>
 
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch_session.hpp>
@@ -7,7 +7,7 @@
 
 int main(int argc, char const* argv[])
 {
-    crispy::suppressWindowsDialogs();
+    coro::testing::suppressWindowsDialogs();
 
     int const result = Catch::Session().run(argc, argv);
     return result;

--- a/src/coro/testing/SuppressWindowsDialogs.hpp
+++ b/src/coro/testing/SuppressWindowsDialogs.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// Suppresses Windows GUI dialogs (assert, abort, crash) for non-interactive runs.
+///
+/// Call @c suppressWindowsDialogs() at the start of a test runner's `main()` so a
+/// modal CRT assert/abort/crash dialog cannot block a headless run; the reports go
+/// to stderr instead, so they stay visible.
+///
+/// `coro` keeps its own copy (used by `net`'s runner too) rather than using Contour's `crispy` one,
+/// so the modules — including their test runners — stay dependency-free and can be
+/// consumed by other projects unchanged. It is a handful of CRT calls, so the
+/// duplication is cheaper than the coupling.
+
+#ifdef _WIN32
+    #include <cstdlib>
+
+    #include <Windows.h>
+    #include <crtdbg.h>
+#endif
+
+namespace coro::testing
+{
+
+/// Suppresses the Windows GUI dialogs that can block an unattended run:
+/// CRT assert/error/warning reports (redirected to stderr), the `abort()` message
+/// box, Windows Error Reporting, and the invalid-parameter handler dialog.
+/// A no-op on every other platform.
+inline void suppressWindowsDialogs()
+{
+#ifdef _WIN32
+    // Redirect CRT debug reports (assert, error, warning) to stderr instead of showing dialogs.
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+
+    // Prevent the abort() message box and Windows Error Reporting fault dialog.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+
+    // Suppress the Windows "critical error" and "program has stopped working" dialogs.
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+
+    // Suppress the invalid parameter handler dialog (e.g. from invalid CRT function arguments).
+    _set_invalid_parameter_handler([]([[maybe_unused]] wchar_t const* expression,
+                                      [[maybe_unused]] wchar_t const* function,
+                                      [[maybe_unused]] wchar_t const* file,
+                                      [[maybe_unused]] unsigned int line,
+                                      [[maybe_unused]] uintptr_t reserved) {});
+#endif
+}
+
+} // namespace coro::testing

--- a/src/net/AsyncBufferedReader.cpp
+++ b/src/net/AsyncBufferedReader.cpp
@@ -20,6 +20,7 @@ namespace
 
 coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readLine()
 {
+    beginScan(Scanner::Line);
     while (true)
     {
         // Search ONLY the bytes that arrived since the last search: everything in
@@ -70,6 +71,7 @@ coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readUntil(
     if (delimiter.empty())
         co_return std::unexpected(makeNetError(NetErrorCode::Other, 0, "empty delimiter"));
 
+    beginScan(Scanner::Until);
     while (true)
     {
         auto const found = _buffer.find(delimiter, _scanOffset);

--- a/src/net/AsyncBufferedReader.cpp
+++ b/src/net/AsyncBufferedReader.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <net/AsyncBufferedReader.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <span>
@@ -71,6 +72,77 @@ coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readLine()
 
         _buffer.append(reinterpret_cast<char const*>(chunk.data()), *got);
     }
+}
+
+coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readUntil(std::string_view delimiter)
+{
+    // An empty delimiter would match at every position and never consume input.
+    if (delimiter.empty())
+        co_return std::unexpected(makeNetError(NetErrorCode::Other, 0, "empty delimiter"));
+
+    while (true)
+    {
+        auto const found = _buffer.find(delimiter, _scanOffset);
+        if (found != std::string::npos)
+        {
+            _scannedBytes += (found + delimiter.size()) - _scanOffset;
+            auto payload = _buffer.substr(_consumed, found - _consumed);
+            _consumed = found + delimiter.size();
+            _scanOffset = _consumed;
+            co_return payload;
+        }
+
+        // Resume the next search where a delimiter split across two reads could
+        // still start: the last (delimiter.size() - 1) bytes may be a prefix of it.
+        auto const keep = delimiter.size() - 1;
+        auto const scanned = _buffer.size() - _scanOffset;
+        _scannedBytes += scanned > keep ? scanned - keep : 0;
+        _scanOffset = _buffer.size() > keep ? _buffer.size() - keep : _consumed;
+        _scanOffset = std::max(_scanOffset, _consumed);
+
+        if (_buffer.size() - _consumed > _maxLineLength)
+            co_return std::unexpected(
+                makeNetError(NetErrorCode::MessageTooLarge, 0, "delimited message exceeds bound"));
+
+        if (!co_await fill())
+            co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed"));
+    }
+}
+
+coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readExactly(std::size_t count)
+{
+    while (_buffer.size() - _consumed < count)
+        if (!co_await fill())
+            // A truncated body is not a body: drop the partial tail rather than
+            // hand the caller fewer bytes than it asked for.
+            co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed mid-message"));
+
+    auto payload = _buffer.substr(_consumed, count);
+    _consumed += count;
+    _scanOffset = std::max(_scanOffset, _consumed);
+    _scannedBytes += count;
+    co_return payload;
+}
+
+coro::Task<bool> AsyncBufferedReader::fill()
+{
+    // Reclaim the already-delivered prefix before growing. Compacting only here —
+    // when we actually go back to the socket — bounds the buffer to the in-progress
+    // message plus one chunk, without a per-message memmove.
+    if (_consumed > 0)
+    {
+        _buffer.erase(0, _consumed);
+        _scanOffset -= std::min(_scanOffset, _consumed);
+        _consumed = 0;
+    }
+
+    auto chunk = std::array<std::byte, 4096> {};
+    auto const got = co_await _socket->read(chunk);
+    if (!got.has_value() || *got == 0)
+        co_return false;
+
+    _buffer.append(reinterpret_cast<char const*>(chunk.data()), *got);
+    co_return true;
 }
 
 coro::Task<IoResult> appendReadChunk(ISocket* socket, std::vector<std::byte>* buffer)

--- a/src/net/AsyncBufferedReader.cpp
+++ b/src/net/AsyncBufferedReader.cpp
@@ -12,6 +12,12 @@
 namespace net
 {
 
+namespace
+{
+    /// How many bytes one refill asks the socket for.
+    constexpr std::size_t ReadChunkSize = 4096;
+} // namespace
+
 coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readLine()
 {
     while (true)
@@ -51,26 +57,10 @@ coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readLine()
         if (_buffer.size() - _consumed > _maxLineLength)
             co_return std::unexpected(makeNetError(NetErrorCode::MessageTooLarge, 0, "line exceeds bound"));
 
-        // Reclaim the already-delivered prefix before growing the buffer. Compacting
-        // here — only when we actually go back to the socket — bounds the buffer to
-        // the in-progress line plus one chunk, without a per-line memmove.
-        if (_consumed > 0)
-        {
-            _buffer.erase(0, _consumed);
-            _scanOffset -= _consumed;
-            _consumed = 0;
-        }
-
-        auto chunk = std::array<std::byte, 4096> {};
-        auto const got = co_await _socket->read(chunk);
-        if (!got.has_value())
-            co_return std::unexpected(got.error());
-        if (*got == 0)
-            // Peer closed. A buffered unterminated tail is dropped deliberately:
-            // the connection died mid-line, so there is no valid line to deliver.
-            co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed"));
-
-        _buffer.append(reinterpret_cast<char const*>(chunk.data()), *got);
+        // A buffered unterminated tail is dropped deliberately on EOF: the
+        // connection died mid-line, so there is no valid line to deliver.
+        if (auto filled = co_await fill(); !filled.has_value())
+            co_return std::unexpected(filled.error());
     }
 }
 
@@ -104,18 +94,18 @@ coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readUntil(
             co_return std::unexpected(
                 makeNetError(NetErrorCode::MessageTooLarge, 0, "delimited message exceeds bound"));
 
-        if (!co_await fill())
-            co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed"));
+        if (auto filled = co_await fill(); !filled.has_value())
+            co_return std::unexpected(filled.error());
     }
 }
 
 coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readExactly(std::size_t count)
 {
+    // A truncated body is not a body: on EOF drop the partial tail rather than
+    // hand the caller fewer bytes than it asked for.
     while (_buffer.size() - _consumed < count)
-        if (!co_await fill())
-            // A truncated body is not a body: drop the partial tail rather than
-            // hand the caller fewer bytes than it asked for.
-            co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed mid-message"));
+        if (auto filled = co_await fill(); !filled.has_value())
+            co_return std::unexpected(filled.error());
 
     auto payload = _buffer.substr(_consumed, count);
     _consumed += count;
@@ -124,7 +114,7 @@ coro::Task<std::expected<std::string, NetError>> AsyncBufferedReader::readExactl
     co_return payload;
 }
 
-coro::Task<bool> AsyncBufferedReader::fill()
+coro::Task<std::expected<void, NetError>> AsyncBufferedReader::fill()
 {
     // Reclaim the already-delivered prefix before growing. Compacting only here —
     // when we actually go back to the socket — bounds the buffer to the in-progress
@@ -136,13 +126,15 @@ coro::Task<bool> AsyncBufferedReader::fill()
         _consumed = 0;
     }
 
-    auto chunk = std::array<std::byte, 4096> {};
+    auto chunk = std::array<std::byte, ReadChunkSize> {};
     auto const got = co_await _socket->read(chunk);
-    if (!got.has_value() || *got == 0)
-        co_return false;
+    if (!got.has_value())
+        co_return std::unexpected(got.error());
+    if (*got == 0)
+        co_return std::unexpected(makeNetError(NetErrorCode::Eof, 0, "peer closed"));
 
     _buffer.append(reinterpret_cast<char const*>(chunk.data()), *got);
-    co_return true;
+    co_return {};
 }
 
 coro::Task<IoResult> appendReadChunk(ISocket* socket, std::vector<std::byte>* buffer)

--- a/src/net/AsyncBufferedReader.hpp
+++ b/src/net/AsyncBufferedReader.hpp
@@ -15,6 +15,7 @@
 /// payloads (capture-pane output) may carry arbitrary bytes.
 
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <string>
 #include <string_view>
@@ -38,7 +39,10 @@ class AsyncBufferedReader
 
     /// @param socket The transport to read from (not owned; must outlive the reader).
     /// @param maxLineLength Reject any line longer than this many bytes
-    ///        (terminator excluded) with @c NetErrorCode::MessageTooLarge.
+    ///        (terminator excluded) with @c NetErrorCode::MessageTooLarge. The bound
+    ///        is checked between refills, so the buffer may reach the bound plus one
+    ///        read chunk before the refusal fires — it caps memory, and is not an
+    ///        exact byte count of what was accepted.
     explicit AsyncBufferedReader(ISocket* socket, std::size_t maxLineLength = DefaultMaxLineLength) noexcept:
         _socket(socket), _maxLineLength(maxLineLength)
     {
@@ -103,12 +107,37 @@ class AsyncBufferedReader
     ///         simply ended when in fact the transport failed.
     [[nodiscard]] coro::Task<std::expected<void, NetError>> fill();
 
-    ISocket* _socket;              ///< The transport read from (not owned).
-    std::size_t _maxLineLength;    ///< Reject lines longer than this.
-    std::string _buffer;           ///< Received bytes; [0, _consumed) already delivered.
-    std::size_t _consumed = 0;     ///< First buffer index not yet delivered (a read cursor).
-    std::size_t _scanOffset = 0;   ///< First buffer index not yet searched for LF.
-    std::size_t _scannedBytes = 0; ///< Lifetime count of bytes examined (see scannedBytes()).
+    /// Which scanner last set @c _scanOffset. The offset is an optimization private
+    /// to one scanning strategy — "not yet searched for LF" for @c readLine, "could
+    /// still begin a delimiter match" for @c readUntil — so a switch must reset it
+    /// rather than inherit a bound that means something else. Without this, a
+    /// @c readLine that ends past a buffered delimiter (its MessageTooLarge exit
+    /// returns without compacting) makes the next @c readUntil skip data it holds.
+    enum class Scanner : std::uint8_t
+    {
+        None = 0, ///< Nothing scanned yet; the offset carries no meaning.
+        Line,     ///< @c readLine set it: everything before it holds no LF.
+        Until,    ///< @c readUntil set it: no match can begin before it.
+    };
+
+    /// Resets @c _scanOffset when the scanning strategy changes.
+    /// @param scanner The scanner about to run.
+    void beginScan(Scanner scanner) noexcept
+    {
+        if (_scanner != scanner)
+        {
+            _scanOffset = _consumed;
+            _scanner = scanner;
+        }
+    }
+
+    ISocket* _socket;                 ///< The transport read from (not owned).
+    std::size_t _maxLineLength;       ///< Reject lines longer than this.
+    std::string _buffer;              ///< Received bytes; [0, _consumed) already delivered.
+    std::size_t _consumed = 0;        ///< First buffer index not yet delivered (a read cursor).
+    std::size_t _scanOffset = 0;      ///< Scan resume point; meaning depends on _scanner.
+    Scanner _scanner = Scanner::None; ///< Which scanner _scanOffset belongs to.
+    std::size_t _scannedBytes = 0;    ///< Lifetime count of bytes examined (see scannedBytes()).
 };
 
 } // namespace net

--- a/src/net/AsyncBufferedReader.hpp
+++ b/src/net/AsyncBufferedReader.hpp
@@ -97,8 +97,11 @@ class AsyncBufferedReader
 
   private:
     /// Compacts the delivered prefix and appends one chunk read from the socket.
-    /// @return False if the peer closed or the read failed; true if bytes arrived.
-    [[nodiscard]] coro::Task<bool> fill();
+    /// @return Nothing on success; @c NetErrorCode::Eof once the peer closed, or the
+    ///         socket's own error. The two are kept distinct on purpose: reporting a
+    ///         connection reset as a clean EOF would tell the caller the message
+    ///         simply ended when in fact the transport failed.
+    [[nodiscard]] coro::Task<std::expected<void, NetError>> fill();
 
     ISocket* _socket;              ///< The transport read from (not owned).
     std::size_t _maxLineLength;    ///< Reject lines longer than this.

--- a/src/net/AsyncBufferedReader.hpp
+++ b/src/net/AsyncBufferedReader.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <expected>
 #include <string>
+#include <string_view>
 
 #include <coro/Task.hpp>
 #include <net/ISocket.hpp>
@@ -55,6 +56,28 @@ class AsyncBufferedReader
     ///         the socket's own read error.
     [[nodiscard]] coro::Task<std::expected<std::string, NetError>> readLine();
 
+    /// Reads until @p delimiter is seen, filling from the socket as needed.
+    ///
+    /// Like @c readLine, every buffered byte is examined at most once across
+    /// refills: the scan resumes at the last position that could still begin a
+    /// match, so a delimiter split across two reads is still found without
+    /// re-searching the prefix.
+    /// @param delimiter The byte sequence to stop after (must not be empty).
+    /// @return The bytes preceding @p delimiter, with the delimiter consumed but
+    ///         not returned; or @c NetErrorCode::Eof once the peer closed before
+    ///         the delimiter arrived (the buffered tail is dropped);
+    ///         @c NetErrorCode::MessageTooLarge if the bound is exceeded first; or
+    ///         the socket's own read error.
+    [[nodiscard]] coro::Task<std::expected<std::string, NetError>> readUntil(std::string_view delimiter);
+
+    /// Reads exactly @p count bytes, filling from the socket as needed.
+    /// @param count The number of bytes to deliver (0 returns an empty string).
+    /// @return The bytes; or @c NetErrorCode::Eof if the peer closed first (the
+    ///         partial tail is dropped — a truncated message is not a message); or
+    ///         the socket's own read error. Not subject to the line-length bound:
+    ///         the caller has already agreed to @p count (e.g. from Content-Length).
+    [[nodiscard]] coro::Task<std::expected<std::string, NetError>> readExactly(std::size_t count);
+
     /// @return The number of bytes buffered but not yet consumed (tests/diagnostics).
     [[nodiscard]] std::size_t buffered() const noexcept { return _buffer.size() - _consumed; }
 
@@ -73,6 +96,10 @@ class AsyncBufferedReader
     [[nodiscard]] std::size_t scannedBytes() const noexcept { return _scannedBytes; }
 
   private:
+    /// Compacts the delivered prefix and appends one chunk read from the socket.
+    /// @return False if the peer closed or the read failed; true if bytes arrived.
+    [[nodiscard]] coro::Task<bool> fill();
+
     ISocket* _socket;              ///< The transport read from (not owned).
     std::size_t _maxLineLength;    ///< Reject lines longer than this.
     std::string _buffer;           ///< Received bytes; [0, _consumed) already delivered.

--- a/src/net/AsyncBufferedReader_test.cpp
+++ b/src/net/AsyncBufferedReader_test.cpp
@@ -36,10 +36,19 @@ class FakeSocket final: public net::ISocket
     /// chunks are the fragmentation under test).
     void pushChunk(std::string_view bytes) { _chunks.emplace_back(bytes); }
 
+    /// Makes the read AFTER the scripted chunks fail with @p code instead of
+    /// reporting a clean EOF — the transport-failure case, distinct from the peer
+    /// simply closing.
+    void failAfterChunks(net::NetErrorCode code) { _failure = code; }
+
     Task<net::IoResult> read(std::span<std::byte> buffer) override
     {
         if (_chunks.empty())
+        {
+            if (_failure.has_value())
+                co_return std::unexpected(net::makeNetError(*_failure, 0, "injected failure"));
             co_return std::size_t { 0 }; // clean EOF
+        }
         auto& front = _chunks.front();
         auto const n = std::min(front.size(), buffer.size());
         std::memcpy(buffer.data(), front.data(), n);
@@ -60,6 +69,7 @@ class FakeSocket final: public net::ISocket
 
   private:
     std::deque<std::string> _chunks;
+    std::optional<net::NetErrorCode> _failure;
     bool _closed = false;
 };
 
@@ -454,4 +464,65 @@ TEST_CASE("readExactly and readLine interleave over one buffer", "[net][reader]"
     loop.blockOn(readOneLine(&reader, &last, &error));
     REQUIRE(last == "trailer");
     REQUIRE_FALSE(error.has_value());
+}
+
+TEST_CASE("a transport failure is reported as itself, not as EOF", "[net][reader]")
+{
+    // A connection reset must not be delivered as a clean end-of-message: the
+    // caller would conclude the peer finished sending when the transport actually
+    // failed. Each reader shares one refill path, so all three are checked.
+    SECTION("readLine")
+    {
+        auto fake = FakeSocket {};
+        fake.pushChunk("no terminator");
+        fake.failAfterChunks(NetErrorCode::ConnReset);
+
+        auto source = net::testing::ScriptedEventSource {};
+        auto loop = EventLoop { source };
+        auto reader = AsyncBufferedReader { &fake };
+
+        auto got = std::string {};
+        auto error = std::optional<net::NetError> {};
+        loop.blockOn(readOneLine(&reader, &got, &error));
+
+        REQUIRE(error.has_value());
+        REQUIRE(error->code == NetErrorCode::ConnReset);
+    }
+
+    SECTION("readUntil")
+    {
+        auto fake = FakeSocket {};
+        fake.pushChunk("head");
+        fake.failAfterChunks(NetErrorCode::ConnReset);
+
+        auto source = net::testing::ScriptedEventSource {};
+        auto loop = EventLoop { source };
+        auto reader = AsyncBufferedReader { &fake };
+
+        auto const delimiter = std::string { "\r\n\r\n" };
+        auto got = std::string {};
+        auto error = std::optional<net::NetError> {};
+        loop.blockOn(readOneUntil(&reader, &delimiter, &got, &error));
+
+        REQUIRE(error.has_value());
+        REQUIRE(error->code == NetErrorCode::ConnReset);
+    }
+
+    SECTION("readExactly")
+    {
+        auto fake = FakeSocket {};
+        fake.pushChunk("abc");
+        fake.failAfterChunks(NetErrorCode::ConnReset);
+
+        auto source = net::testing::ScriptedEventSource {};
+        auto loop = EventLoop { source };
+        auto reader = AsyncBufferedReader { &fake };
+
+        auto got = std::string {};
+        auto error = std::optional<net::NetError> {};
+        loop.blockOn(readOneExactly(&reader, 16, &got, &error));
+
+        REQUIRE(error.has_value());
+        REQUIRE(error->code == NetErrorCode::ConnReset);
+    }
 }

--- a/src/net/AsyncBufferedReader_test.cpp
+++ b/src/net/AsyncBufferedReader_test.cpp
@@ -466,6 +466,65 @@ TEST_CASE("readExactly and readLine interleave over one buffer", "[net][reader]"
     REQUIRE_FALSE(error.has_value());
 }
 
+TEST_CASE("readUntil finds a delimiter buffered before readLine hit its bound", "[net][reader]")
+{
+    // The two scanners share _scanOffset but mean different things by it. readLine
+    // leaves it at buffer end when it finds no LF; every other exit either matches
+    // (leaving it at _consumed) or refills (fill() rebases it), so the one way to
+    // observe the contaminated state is readLine's MessageTooLarge return, which
+    // exits with _scanOffset past the buffer and does NOT compact. A readUntil on
+    // that same connection then resumes scanning past a delimiter it already has.
+    auto fake = FakeSocket {};
+    fake.pushChunk("xxENDyyyyyy"); // holds "END", but no LF at all
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake, 4 }; // bound smaller than the chunk
+
+    // readLine scans the whole buffer, finds no LF, and refuses to grow past the
+    // bound — returning with _scanOffset == buffer.size().
+    auto line = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneLine(&reader, &line, &error));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::MessageTooLarge);
+
+    // "END" is buffered at index 2. readUntil must find it rather than resuming at
+    // the stale offset and reporting EOF for data it is already holding.
+    error.reset();
+    auto head = std::string {};
+    auto const delimiter = std::string { "END" };
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(head == "xx");
+}
+
+TEST_CASE("readUntil does not skip a delimiter left behind by readLine", "[net][reader]")
+{
+    // Same contamination, in the order that actually loses data: readLine consumes
+    // a line and parks _scanOffset, then readUntil must still see a delimiter that
+    // lies in the bytes readLine already scanned past.
+    auto fake = FakeSocket {};
+    fake.pushChunk("first\nxxENDyy"); // one line, then a delimiter with no LF after it
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto line = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneLine(&reader, &line, &error));
+    REQUIRE(line == "first");
+
+    // "END" is buffered right now. readUntil must find it rather than reporting
+    // EOF because it resumed scanning past it.
+    auto head = std::string {};
+    auto const delimiter = std::string { "END" };
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(head == "xx");
+}
+
 TEST_CASE("a transport failure is reported as itself, not as EOF", "[net][reader]")
 {
     // A connection reset must not be delivered as a clean end-of-message: the

--- a/src/net/AsyncBufferedReader_test.cpp
+++ b/src/net/AsyncBufferedReader_test.cpp
@@ -74,6 +74,32 @@ Task<void> readOneLine(AsyncBufferedReader* reader, std::string* line, std::opti
         *error = result.error();
 }
 
+/// Reads up to @p delimiter and reports the outcome through pointers.
+Task<void> readOneUntil(AsyncBufferedReader* reader,
+                        std::string const* delimiter,
+                        std::string* payload,
+                        std::optional<net::NetError>* error)
+{
+    auto result = co_await reader->readUntil(*delimiter);
+    if (result.has_value())
+        *payload = std::move(*result);
+    else
+        *error = result.error();
+}
+
+/// Reads exactly @p count bytes and reports the outcome through pointers.
+Task<void> readOneExactly(AsyncBufferedReader* reader,
+                          std::size_t count,
+                          std::string* payload,
+                          std::optional<net::NetError>* error)
+{
+    auto result = co_await reader->readExactly(count);
+    if (result.has_value())
+        *payload = std::move(*result);
+    else
+        *error = result.error();
+}
+
 } // namespace
 
 TEST_CASE("readLine assembles lines across fragmented reads without re-scanning", "[net][reader]")
@@ -246,4 +272,186 @@ TEST_CASE("readLine works over a real transport through the reactor", "[net][rea
     loop.blockOn(writeThenRead(pair->first.get(), pair->second.get(), &got));
 
     REQUIRE(got == "over the wire");
+}
+
+TEST_CASE("readUntil finds a delimiter split across two reads", "[net][reader]")
+{
+    // The scan-offset optimization must not skip a delimiter straddling a read
+    // boundary: "\r\n\r\n" arrives as "..\r\n" + "\r\n..", so the match begins
+    // in bytes already scanned once.
+    auto fake = FakeSocket {};
+    fake.pushChunk("GET / HTTP/1.1\r\nHost: x\r\n");
+    fake.pushChunk("\r\nbody");
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto const delimiter = std::string { "\r\n\r\n" };
+    auto head = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(head == "GET / HTTP/1.1\r\nHost: x");
+    REQUIRE(reader.buffered() == 4); // "body" stays for the caller
+}
+
+TEST_CASE("readUntil consumes the delimiter and leaves the remainder buffered", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    fake.pushChunk("head\r\n\r\ntail");
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto const delimiter = std::string { "\r\n\r\n" };
+    auto head = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(head == "head");
+
+    // The delimiter itself is consumed, so a following readExactly sees only "tail".
+    auto body = std::string {};
+    loop.blockOn(readOneExactly(&reader, 4, &body, &error));
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(body == "tail");
+}
+
+TEST_CASE("readUntil reports EOF when the delimiter never arrives", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    fake.pushChunk("no terminator here");
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto const delimiter = std::string { "\r\n\r\n" };
+    auto head = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Eof);
+}
+
+TEST_CASE("readUntil rejects a message exceeding the bound", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    fake.pushChunk(std::string(64, 'x'));
+    fake.pushChunk(std::string(64, 'y'));
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake, 32 };
+
+    auto const delimiter = std::string { "\r\n\r\n" };
+    auto head = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::MessageTooLarge);
+}
+
+TEST_CASE("readUntil rejects an empty delimiter", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    fake.pushChunk("anything");
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto const delimiter = std::string {};
+    auto head = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneUntil(&reader, &delimiter, &head, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("readExactly assembles a payload across fragmented reads", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    auto const payload = std::string(100, 'z');
+    for (std::size_t i = 0; i < payload.size(); i += 3)
+        fake.pushChunk(std::string_view { payload }.substr(i, 3));
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto got = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneExactly(&reader, payload.size(), &got, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(got == payload);
+}
+
+TEST_CASE("readExactly of zero bytes returns empty without reading", "[net][reader]")
+{
+    auto fake = FakeSocket {}; // no chunks: any read would be EOF
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto got = std::string { "sentinel" };
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneExactly(&reader, 0, &got, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(got.empty());
+}
+
+TEST_CASE("readExactly reports EOF rather than delivering a truncated payload", "[net][reader]")
+{
+    auto fake = FakeSocket {};
+    fake.pushChunk("only ten!!"); // 10 bytes, 20 requested
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto got = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneExactly(&reader, 20, &got, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Eof);
+    REQUIRE(got.empty());
+}
+
+TEST_CASE("readExactly and readLine interleave over one buffer", "[net][reader]")
+{
+    // The framing pattern HttpServer relies on: a delimited head, then a
+    // length-prefixed body, then more lines — all sharing one read cursor.
+    auto fake = FakeSocket {};
+    fake.pushChunk("header\nAB");
+    fake.pushChunk("CDtrailer\n");
+
+    auto source = net::testing::ScriptedEventSource {};
+    auto loop = EventLoop { source };
+    auto reader = AsyncBufferedReader { &fake };
+
+    auto first = std::string {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(readOneLine(&reader, &first, &error));
+    REQUIRE(first == "header");
+
+    auto body = std::string {};
+    loop.blockOn(readOneExactly(&reader, 4, &body, &error));
+    REQUIRE(body == "ABCD");
+
+    auto last = std::string {};
+    loop.blockOn(readOneLine(&reader, &last, &error));
+    REQUIRE(last == "trailer");
+    REQUIRE_FALSE(error.has_value());
 }

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -36,6 +36,7 @@ set(net_SOURCES
     platform/WinsockInit.hpp
     testing/InMemoryTransport.cpp
     testing/InMemoryTransport.hpp
+    testing/EventSourceBackends.hpp
     testing/ScriptedEventSource.hpp
 )
 if(WIN32)

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -1,12 +1,23 @@
 set(net_SOURCES
     AsyncBufferedReader.cpp
     AsyncBufferedReader.hpp
+    DefaultEventSource.cpp
+    DefaultEventSource.hpp
+    Diagnostics.cpp
+    Diagnostics.hpp
+    EpollEventSource.cpp
+    EpollEventSource.hpp
     EventLoop.cpp
     EventLoop.hpp
     EventSource.hpp
+    HttpServer.cpp
+    HttpServer.hpp
     IListener.hpp
     ISocket.hpp
     IoResult.hpp
+    KqueueEventSource.cpp
+    KqueueEventSource.hpp
+    detail/ScopeGuard.hpp
     WriteQueue.cpp
     WriteQueue.hpp
     PollEventSource.cpp
@@ -55,7 +66,7 @@ add_library(net STATIC ${net_SOURCES})
 # OpenSSL backs the TLS ISocket decorator (net/Tls.*). It stays behind the
 # ITlsContext DI seam, so it is PRIVATE: no OpenSSL type crosses net's headers.
 find_package(OpenSSL REQUIRED)
-target_link_libraries(net PUBLIC coro crispy::core)
+target_link_libraries(net PUBLIC coro)
 target_link_libraries(net PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 if(WIN32)
     target_link_libraries(net PUBLIC ws2_32)
@@ -72,6 +83,8 @@ if(NET_TESTING)
         test_main.cpp
         AsyncBufferedReader_test.cpp
         EventLoop_test.cpp
+        EventSourceParity_test.cpp
+        HttpServer_test.cpp
         Socket_test.cpp
         Tls_test.cpp
         WriteQueue_test.cpp
@@ -80,7 +93,7 @@ if(NET_TESTING)
         list(APPEND net_TEST_SOURCES FdPassing_test.cpp UnixSocket_test.cpp)
     endif()
     add_executable(net_test ${net_TEST_SOURCES})
-    target_link_libraries(net_test net crispy::core Catch2::Catch2)
+    target_link_libraries(net_test net Catch2::Catch2)
     add_test(NAME net_test COMMAND $<TARGET_FILE:net_test>)
     set_tests_properties(net_test PROPERTIES LABELS daemon)
 

--- a/src/net/DefaultEventSource.cpp
+++ b/src/net/DefaultEventSource.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <net/DefaultEventSource.hpp>
+
+#include <memory>
+
+#include <net/PollEventSource.hpp>
+
+#ifdef __linux__
+    #include <net/EpollEventSource.hpp>
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    #include <net/KqueueEventSource.hpp>
+#endif
+
+namespace net
+{
+
+EventSourceKind preferredEventSourceKind() noexcept
+{
+#ifdef __linux__
+    return EventSourceKind::Epoll;
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    return EventSourceKind::Kqueue;
+#else
+    return EventSourceKind::Poll;
+#endif
+}
+
+std::unique_ptr<EventSource> makeEventSource(EventSourceKind kind)
+{
+    switch (kind)
+    {
+        case EventSourceKind::Poll: return std::make_unique<PollEventSource>();
+
+        case EventSourceKind::Epoll: {
+#ifdef __linux__
+            auto source = std::make_unique<EpollEventSource>();
+            // A source whose kernel object failed to materialize would refuse every
+            // attach; report it as unavailable so the caller can fall back.
+            return source->good() ? std::unique_ptr<EventSource> { std::move(source) } : nullptr;
+#else
+            return nullptr;
+#endif
+        }
+
+        case EventSourceKind::Kqueue: {
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+            auto source = std::make_unique<KqueueEventSource>();
+            return source->good() ? std::unique_ptr<EventSource> { std::move(source) } : nullptr;
+#else
+            return nullptr;
+#endif
+        }
+    }
+    return std::make_unique<PollEventSource>();
+}
+
+std::unique_ptr<EventSource> makeDefaultEventSource()
+{
+    if (auto native = makeEventSource(preferredEventSourceKind()))
+        return native;
+    // poll(2) is always available and behaviourally identical, just costlier.
+    return std::make_unique<PollEventSource>();
+}
+
+} // namespace net

--- a/src/net/DefaultEventSource.cpp
+++ b/src/net/DefaultEventSource.cpp
@@ -51,7 +51,11 @@ std::unique_ptr<EventSource> makeEventSource(EventSourceKind kind)
 #endif
         }
     }
-    return std::make_unique<PollEventSource>();
+    // Every enumerator returns above, so this is only reached for a value outside
+    // the enumeration. Report it as unavailable rather than quietly substituting a
+    // working poll source: a new enumerator added without a case here must surface
+    // as a null (and fall back explicitly in makeDefaultEventSource), not be masked.
+    return nullptr;
 }
 
 std::unique_ptr<EventSource> makeDefaultEventSource()

--- a/src/net/DefaultEventSource.hpp
+++ b/src/net/DefaultEventSource.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// Picks the @c EventSource to drive an @c EventLoop with.
+///
+/// Every backend implements the same interface and behaves identically; they differ
+/// only in what a wait costs. This is the one place that knows which exist, so call
+/// sites say @c makeDefaultEventSource() rather than carrying `#ifdef`s of their own.
+
+#include <memory>
+
+#include <net/EventSource.hpp>
+
+namespace net
+{
+
+/// Which multiplexing backend an @c EventSource uses.
+///
+/// There is deliberately no IOCP entry. IOCP is a *completion* port, not a
+/// readiness poller: a caller issues an overlapped `WSARecv`/`WSASend` and is told
+/// when that specific operation finished, whereas @c EventSource answers "which
+/// registered descriptor is ready now". Expressing IOCP here would mean rewriting
+/// @c WindowsSocket (today `WSAEventSelect` + `recv`) and the @c ISocket contract
+/// around completions — a socket-layer redesign, not another event source. Windows
+/// therefore stays on @c Poll, whose `WaitForMultipleObjects` path already handles
+/// the >64-handle case via @c WaitChunking.
+enum class EventSourceKind : std::uint8_t
+{
+    Poll = 0, ///< poll(2) / WaitForMultipleObjects. Portable; a wait is O(registered).
+    Epoll,    ///< epoll(7), Linux only. A wait is O(ready).
+    Kqueue,   ///< kqueue(2), macOS/BSD only. A wait is O(ready).
+};
+
+/// Creates the best @c EventSource available on this platform.
+///
+/// Prefers the scalable native backend and falls back to @c PollEventSource when it
+/// is unavailable — either because the platform has none or because the kernel
+/// refused to create one (fd exhaustion). The fallback is silent by design: every
+/// backend is behaviourally equivalent, so a caller has nothing to decide.
+/// @return An event source, never null.
+[[nodiscard]] std::unique_ptr<EventSource> makeDefaultEventSource();
+
+/// Creates an @c EventSource of a specific kind — for tests that need to exercise
+/// one backend in particular rather than whatever this platform prefers.
+/// @param kind The backend to build.
+/// @return The event source, or nullptr if @p kind is unavailable here or its
+///         underlying kernel object could not be created.
+[[nodiscard]] std::unique_ptr<EventSource> makeEventSource(EventSourceKind kind);
+
+/// @return The kind @c makeDefaultEventSource() prefers on this platform, ignoring
+///         whether construction would actually succeed.
+[[nodiscard]] EventSourceKind preferredEventSourceKind() noexcept;
+
+} // namespace net

--- a/src/net/DefaultEventSource.hpp
+++ b/src/net/DefaultEventSource.hpp
@@ -8,6 +8,7 @@
 /// only in what a wait costs. This is the one place that knows which exist, so call
 /// sites say @c makeDefaultEventSource() rather than carrying `#ifdef`s of their own.
 
+#include <cstdint>
 #include <memory>
 
 #include <net/EventSource.hpp>

--- a/src/net/Diagnostics.cpp
+++ b/src/net/Diagnostics.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <net/Diagnostics.hpp>
+
+#include <utility>
+
+namespace net
+{
+
+namespace
+{
+    /// The installed sink. A function-local static in an accessor rather than a
+    /// namespace-scope object, so it is initialized on first use and cannot be read
+    /// before its constructor runs during static initialization.
+    /// @return The sink slot.
+    DiagnosticSink& sinkSlot() noexcept
+    {
+        static auto sink = DiagnosticSink {};
+        return sink;
+    }
+} // namespace
+
+void setDiagnosticSink(DiagnosticSink sink)
+{
+    sinkSlot() = std::move(sink);
+}
+
+bool hasDiagnosticSink() noexcept
+{
+    return static_cast<bool>(sinkSlot());
+}
+
+void reportDiagnostic(std::string_view message)
+{
+    if (auto const& sink = sinkSlot())
+        sink(message);
+}
+
+} // namespace net

--- a/src/net/Diagnostics.cpp
+++ b/src/net/Diagnostics.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <net/Diagnostics.hpp>
 
+#include <memory>
+#include <mutex>
 #include <utility>
 
 namespace net
@@ -8,31 +10,58 @@ namespace net
 
 namespace
 {
-    /// The installed sink. A function-local static in an accessor rather than a
-    /// namespace-scope object, so it is initialized on first use and cannot be read
-    /// before its constructor runs during static initialization.
+    /// The installed sink, held by shared_ptr so a reporting thread can take its own
+    /// reference and keep the target alive for the duration of the call. Reading the
+    /// raw std::function while another thread assigned it would be a use-after-free
+    /// of the callable's captures; swapping a whole pointer is atomic instead.
+    ///
+    /// A function-local static in an accessor rather than a namespace-scope object,
+    /// so it is initialized on first use and cannot be read before its constructor
+    /// runs during static initialization.
     /// @return The sink slot.
-    DiagnosticSink& sinkSlot() noexcept
+    std::shared_ptr<DiagnosticSink const>& sinkSlot() noexcept
     {
-        static auto sink = DiagnosticSink {};
+        static auto sink = std::shared_ptr<DiagnosticSink const> {};
         return sink;
+    }
+
+    /// Guards the slot itself. Held only for the pointer read or write, never across
+    /// the sink invocation — a sink that reports while reporting would otherwise
+    /// deadlock, and a slow sink would serialize every reporting thread.
+    /// @return The slot's mutex.
+    std::mutex& sinkMutex() noexcept
+    {
+        static auto mutex = std::mutex {};
+        return mutex;
+    }
+
+    /// @return The current sink, or nullptr if none is installed.
+    [[nodiscard]] std::shared_ptr<DiagnosticSink const> currentSink() noexcept
+    {
+        auto const lock = std::lock_guard { sinkMutex() };
+        return sinkSlot();
     }
 } // namespace
 
 void setDiagnosticSink(DiagnosticSink sink)
 {
-    sinkSlot() = std::move(sink);
+    auto next = sink ? std::make_shared<DiagnosticSink const>(std::move(sink))
+                     : std::shared_ptr<DiagnosticSink const> {};
+    auto const lock = std::lock_guard { sinkMutex() };
+    sinkSlot() = std::move(next);
 }
 
 bool hasDiagnosticSink() noexcept
 {
-    return static_cast<bool>(sinkSlot());
+    return currentSink() != nullptr;
 }
 
 void reportDiagnostic(std::string_view message)
 {
-    if (auto const& sink = sinkSlot())
-        sink(message);
+    // Hold a reference for the whole call, so a concurrent setDiagnosticSink
+    // replacing the sink cannot destroy the callable under us.
+    if (auto const sink = currentSink())
+        (*sink)(message);
 }
 
 } // namespace net

--- a/src/net/Diagnostics.hpp
+++ b/src/net/Diagnostics.hpp
@@ -34,11 +34,13 @@ using DiagnosticSink = std::function<void(std::string_view message)>;
 /// threading a sink through every one of them would put an observability concern
 /// into signatures that have nothing else to do with it.
 ///
-/// **Call it once, before any loop runs.** The sink is plain process-wide state
-/// with no lock: concurrent @c reportDiagnostic calls against an already-installed
-/// sink are fine, but installing one while another thread may be reporting is a
-/// data race. Nothing enforces this, because the cost of guarding a pointer read
-/// on every wait would outweigh what the guard buys for a startup-time decision.
+/// **Prefer installing once, before any loop runs** — it is a startup decision, and
+/// treating it as one keeps the reporting order across threads predictable. It is
+/// nevertheless safe to install at any time: the sink is held behind a shared
+/// pointer, so a reporting thread keeps its target alive for the duration of the
+/// call and a concurrent replacement cannot destroy the callable under it. The lock
+/// is held only while reading or writing the pointer, never across the invocation,
+/// so a slow sink does not serialize reporting threads.
 /// @param sink The sink to install; an empty target restores the discarding default.
 void setDiagnosticSink(DiagnosticSink sink);
 

--- a/src/net/Diagnostics.hpp
+++ b/src/net/Diagnostics.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// Where `net` reports a failure it cannot return to a caller.
+///
+/// Almost everything here is `std::expected`, delivered to whoever asked. A few
+/// places have no such caller — a multiplexed wait failing mid-sweep, for instance,
+/// is nobody's operation — and those would otherwise fail silently.
+///
+/// This is a dependency-injection seam rather than a direct call into a logging
+/// library so `net` stays free of Contour's `crispy` and can be consumed by other
+/// projects unchanged. The default sink discards, so a caller that never sets one
+/// pays only a null check.
+
+#include <functional>
+#include <string_view>
+
+namespace net
+{
+
+/// Receives diagnostics that have no caller to return them to.
+///
+/// Invoked from whichever thread hit the condition — an implementation that
+/// touches shared state must do its own synchronization. Never invoked with a
+/// null target; @c setDiagnosticSink resets to the discarding default instead.
+using DiagnosticSink = std::function<void(std::string_view message)>;
+
+/// Installs the process-wide diagnostic sink.
+///
+/// A process-wide setter rather than a constructor parameter is a deliberate
+/// exception to the configuration-at-construction rule: the reporting sites are
+/// deep inside platform code reached through the @c EventSource interface, and
+/// threading a sink through every one of them would put an observability concern
+/// into signatures that have nothing else to do with it. It is set once at startup.
+/// @param sink The sink to install; an empty target restores the discarding default.
+void setDiagnosticSink(DiagnosticSink sink);
+
+/// Reports a diagnostic to the installed sink.
+/// @param message The message; formatted by the caller, since the default sink
+///        discards it and most callers never fire.
+void reportDiagnostic(std::string_view message);
+
+/// @return True if a non-discarding sink is installed. Check this before doing
+///         formatting work whose only purpose is the message.
+[[nodiscard]] bool hasDiagnosticSink() noexcept;
+
+} // namespace net

--- a/src/net/Diagnostics.hpp
+++ b/src/net/Diagnostics.hpp
@@ -32,7 +32,13 @@ using DiagnosticSink = std::function<void(std::string_view message)>;
 /// exception to the configuration-at-construction rule: the reporting sites are
 /// deep inside platform code reached through the @c EventSource interface, and
 /// threading a sink through every one of them would put an observability concern
-/// into signatures that have nothing else to do with it. It is set once at startup.
+/// into signatures that have nothing else to do with it.
+///
+/// **Call it once, before any loop runs.** The sink is plain process-wide state
+/// with no lock: concurrent @c reportDiagnostic calls against an already-installed
+/// sink are fine, but installing one while another thread may be reporting is a
+/// data race. Nothing enforces this, because the cost of guarding a pointer read
+/// on every wait would outweigh what the guard buys for a startup-time decision.
 /// @param sink The sink to install; an empty target restores the discarding default.
 void setDiagnosticSink(DiagnosticSink sink);
 

--- a/src/net/EpollEventSource.cpp
+++ b/src/net/EpollEventSource.cpp
@@ -5,7 +5,9 @@
 
     #include <sys/epoll.h>
 
+    #include <algorithm>
     #include <array>
+    #include <ranges>
     #include <span>
 
     #include <unistd.h>
@@ -55,9 +57,11 @@ EpollEventSource::EpollEventSource() noexcept: _epollFd { ::epoll_create1(EPOLL_
 
 EpollEventSource::~EpollEventSource()
 {
-    // Close the duplicates this source owns; the caller's own descriptors are not ours.
-    for (auto const& [token, owned]: _registered)
-        ::close(owned);
+    // Close only the duplicates this source made; the caller's own descriptors are
+    // registered directly and are not ours to close.
+    for (auto const& [token, watched]: _registered)
+        if (watched.owned)
+            ::close(watched.fd);
     if (_epollFd >= 0)
         ::close(_epollFd);
 }
@@ -81,24 +85,35 @@ FdToken EpollEventSource::attach(NativeHandle fd, FdInterest interest)
     if (!token)
         return FdToken::invalid();
 
-    // Register a private duplicate: an epoll set is keyed by descriptor, so adding
-    // the same one twice fails with EEXIST, while poll(2) happily takes two entries.
-    // The registry allows two registrations on one descriptor, so without this the
-    // backends would disagree about what is even registrable.
-    auto const owned = ::dup(fd);
+    // Register the CALLER'S descriptor whenever we can. A dup() would share the
+    // underlying open file description, so closing the caller's copy while this
+    // registration lives would not release it: no FIN would reach the peer, whose
+    // read would then block forever instead of seeing EOF. Only a genuine duplicate
+    // registration needs a private descriptor, because an epoll set is keyed by
+    // descriptor and rejects the same one twice with EEXIST (poll(2) simply takes
+    // two entries, and the registry permits it).
+    auto const duplicate =
+        std::ranges::any_of(_registered, [fd](auto const& entry) { return entry.second.fd == fd; });
+    auto watched = fd;
+    auto owned = false;
+    if (duplicate)
+    {
+        watched = ::dup(fd);
+        owned = true;
+    }
 
     // A failed registration must not leave the registry claiming the fd is watched:
     // the awaiting flow has to fail rather than park on an interest the kernel never
     // accepted, which nothing could ever resume.
-    if (owned < 0 || !applyInterest(owned, interest, token))
+    if (watched < 0 || !applyInterest(watched, interest, token))
     {
-        if (owned >= 0)
-            ::close(owned);
+        if (owned && watched >= 0)
+            ::close(watched);
         _registry.detach(token);
         return FdToken::invalid();
     }
 
-    _registered.emplace(token.value, owned);
+    _registered.emplace(token.value, EpollEventSource::Watched { .fd = watched, .owned = owned });
     return token;
 }
 
@@ -107,8 +122,9 @@ void EpollEventSource::detach(FdToken token)
     if (auto const it = _registered.find(token.value); it != _registered.end())
     {
         auto event = epoll_event {};
-        ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, it->second, &event);
-        ::close(it->second); // the duplicate this source owns, not the caller's fd
+        ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, it->second.fd, &event);
+        if (it->second.owned)
+            ::close(it->second.fd); // a duplicate we made, never the caller's fd
         _registered.erase(it);
     }
     _registry.detach(token);

--- a/src/net/EpollEventSource.cpp
+++ b/src/net/EpollEventSource.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <net/EpollEventSource.hpp>
+
+#ifdef __linux__
+
+    #include <sys/epoll.h>
+
+    #include <array>
+    #include <span>
+
+    #include <unistd.h>
+
+namespace net
+{
+
+namespace
+{
+    /// The largest number of ready events one epoll_wait call reports. A wait that
+    /// fills the batch simply reports the rest on the next call — level-triggered
+    /// interest means nothing is lost by capping it.
+    constexpr std::size_t ReadyBatchSize = 64;
+
+    /// Translates a readiness interest mask into epoll event bits.
+    /// @param interest The interest to translate.
+    /// @return The corresponding EPOLLIN/EPOLLOUT bits.
+    [[nodiscard]] std::uint32_t toEpollEvents(FdInterest interest) noexcept
+    {
+        auto events = std::uint32_t { 0 };
+        if (hasInterest(interest, FdInterest::Read))
+            events |= EPOLLIN;
+        if (hasInterest(interest, FdInterest::Write))
+            events |= EPOLLOUT;
+        return events;
+    }
+
+    /// Routes an fd's reported epoll events into a wait outcome's token lists.
+    ///
+    /// EPOLLHUP / EPOLLERR are reported as readable — like poll(2)'s POLLHUP, they
+    /// must wake a parked reader so it can observe EOF rather than the loop spinning.
+    /// @param token The registration's token.
+    /// @param events The events epoll reported.
+    /// @param outcome The outcome to append the token to.
+    void routeEpollEvents(FdToken token, std::uint32_t events, WaitOutcome& outcome)
+    {
+        if ((events & (EPOLLIN | EPOLLHUP | EPOLLERR)) != 0)
+            outcome.readyRead.push_back(token);
+        if ((events & EPOLLOUT) != 0)
+            outcome.readyWrite.push_back(token);
+    }
+} // namespace
+
+EpollEventSource::EpollEventSource() noexcept: _epollFd { ::epoll_create1(EPOLL_CLOEXEC) }
+{
+}
+
+EpollEventSource::~EpollEventSource()
+{
+    if (_epollFd >= 0)
+        ::close(_epollFd);
+}
+
+bool EpollEventSource::applyInterest(int op,
+                                     NativeHandle fd,
+                                     FdInterest interest,
+                                     FdToken token) const noexcept
+{
+    auto event = epoll_event {};
+    event.events = toEpollEvents(interest);
+    // The token, not the fd, identifies the registration: two registrations may
+    // share an fd, and the token is what the loop maps back to a parked coroutine.
+    event.data.u64 = token.value;
+    return ::epoll_ctl(_epollFd, op, fd, &event) == 0;
+}
+
+FdToken EpollEventSource::attach(NativeHandle fd, FdInterest interest)
+{
+    if (_epollFd < 0 || fd == InvalidHandle)
+        return FdToken::invalid();
+
+    auto const token = _registry.attach(fd, interest);
+    if (!token)
+        return FdToken::invalid();
+
+    // A failed registration must not leave the registry claiming the fd is watched:
+    // the awaiting flow has to fail rather than park on an interest the kernel never
+    // accepted, which nothing could ever resume.
+    if (!applyInterest(EPOLL_CTL_ADD, fd, interest, token))
+    {
+        _registry.detach(token);
+        return FdToken::invalid();
+    }
+
+    _applied.emplace(token.value, interest);
+    return token;
+}
+
+void EpollEventSource::detach(FdToken token)
+{
+    if (auto const it = _applied.find(token.value); it != _applied.end())
+    {
+        // Find the fd this token names before dropping it from the registry.
+        for (auto const& reg: _registry.registrations())
+        {
+            if (reg.token != token)
+                continue;
+            auto event = epoll_event {};
+            ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, reg.fd, &event);
+            break;
+        }
+        _applied.erase(it);
+    }
+    _registry.detach(token);
+}
+
+WaitOutcome EpollEventSource::wait(int timeoutMs)
+{
+    auto outcome = WaitOutcome {};
+    if (_epollFd < 0)
+        return outcome;
+
+    // Reconcile any interest the loop changed since the last wait. The registry is
+    // the source of truth; the kernel holds a cached copy that only this loop edits.
+    for (auto const& reg: _registry.registrations())
+    {
+        auto const it = _applied.find(reg.token.value);
+        if (it == _applied.end() || it->second == reg.interest)
+            continue;
+        if (applyInterest(EPOLL_CTL_MOD, reg.fd, reg.interest, reg.token))
+            it->second = reg.interest;
+    }
+
+    // Nothing to watch: honour the timeout so a parked timer can still fire, and
+    // treat an infinite timeout as a benign timeout rather than blocking forever
+    // with no wakeable source. Mirrors PollEventSource.
+    auto events = std::array<epoll_event, ReadyBatchSize> {};
+    if (_registry.size() == 0)
+    {
+        // epoll_wait requires a valid buffer even when nothing can be reported, so
+        // wait on the real array with room for one event rather than passing null.
+        if (timeoutMs > 0)
+            ::epoll_wait(_epollFd, events.data(), 1, timeoutMs);
+        return outcome;
+    }
+
+    auto const ready = ::epoll_wait(_epollFd, events.data(), static_cast<int>(events.size()), timeoutMs);
+    if (ready <= 0)
+        // 0: timed out. <0: EINTR or error — nothing ready this round. Level-triggered
+        // interest re-reports a still-ready fd on the next wait, so nothing is lost.
+        return outcome;
+
+    for (auto const& event: std::span { events.data(), static_cast<std::size_t>(ready) })
+        routeEpollEvents(FdToken { event.data.u64 }, event.events, outcome);
+    return outcome;
+}
+
+} // namespace net
+
+#endif // __linux__

--- a/src/net/EpollEventSource.cpp
+++ b/src/net/EpollEventSource.cpp
@@ -59,17 +59,14 @@ EpollEventSource::~EpollEventSource()
         ::close(_epollFd);
 }
 
-bool EpollEventSource::applyInterest(int op,
-                                     NativeHandle fd,
-                                     FdInterest interest,
-                                     FdToken token) const noexcept
+bool EpollEventSource::applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept
 {
     auto event = epoll_event {};
     event.events = toEpollEvents(interest);
     // The token, not the fd, identifies the registration: two registrations may
     // share an fd, and the token is what the loop maps back to a parked coroutine.
     event.data.u64 = token.value;
-    return ::epoll_ctl(_epollFd, op, fd, &event) == 0;
+    return ::epoll_ctl(_epollFd, EPOLL_CTL_ADD, fd, &event) == 0;
 }
 
 FdToken EpollEventSource::attach(NativeHandle fd, FdInterest interest)
@@ -84,30 +81,23 @@ FdToken EpollEventSource::attach(NativeHandle fd, FdInterest interest)
     // A failed registration must not leave the registry claiming the fd is watched:
     // the awaiting flow has to fail rather than park on an interest the kernel never
     // accepted, which nothing could ever resume.
-    if (!applyInterest(EPOLL_CTL_ADD, fd, interest, token))
+    if (!applyInterest(fd, interest, token))
     {
         _registry.detach(token);
         return FdToken::invalid();
     }
 
-    _applied.emplace(token.value, interest);
+    _registered.emplace(token.value, fd);
     return token;
 }
 
 void EpollEventSource::detach(FdToken token)
 {
-    if (auto const it = _applied.find(token.value); it != _applied.end())
+    if (auto const it = _registered.find(token.value); it != _registered.end())
     {
-        // Find the fd this token names before dropping it from the registry.
-        for (auto const& reg: _registry.registrations())
-        {
-            if (reg.token != token)
-                continue;
-            auto event = epoll_event {};
-            ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, reg.fd, &event);
-            break;
-        }
-        _applied.erase(it);
+        auto event = epoll_event {};
+        ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, it->second, &event);
+        _registered.erase(it);
     }
     _registry.detach(token);
 }
@@ -117,17 +107,6 @@ WaitOutcome EpollEventSource::wait(int timeoutMs)
     auto outcome = WaitOutcome {};
     if (_epollFd < 0)
         return outcome;
-
-    // Reconcile any interest the loop changed since the last wait. The registry is
-    // the source of truth; the kernel holds a cached copy that only this loop edits.
-    for (auto const& reg: _registry.registrations())
-    {
-        auto const it = _applied.find(reg.token.value);
-        if (it == _applied.end() || it->second == reg.interest)
-            continue;
-        if (applyInterest(EPOLL_CTL_MOD, reg.fd, reg.interest, reg.token))
-            it->second = reg.interest;
-    }
 
     // Nothing to watch: honour the timeout so a parked timer can still fire, and
     // treat an infinite timeout as a benign timeout rather than blocking forever

--- a/src/net/EpollEventSource.cpp
+++ b/src/net/EpollEventSource.cpp
@@ -55,6 +55,9 @@ EpollEventSource::EpollEventSource() noexcept: _epollFd { ::epoll_create1(EPOLL_
 
 EpollEventSource::~EpollEventSource()
 {
+    // Close the duplicates this source owns; the caller's own descriptors are not ours.
+    for (auto const& [token, owned]: _registered)
+        ::close(owned);
     if (_epollFd >= 0)
         ::close(_epollFd);
 }
@@ -78,16 +81,24 @@ FdToken EpollEventSource::attach(NativeHandle fd, FdInterest interest)
     if (!token)
         return FdToken::invalid();
 
+    // Register a private duplicate: an epoll set is keyed by descriptor, so adding
+    // the same one twice fails with EEXIST, while poll(2) happily takes two entries.
+    // The registry allows two registrations on one descriptor, so without this the
+    // backends would disagree about what is even registrable.
+    auto const owned = ::dup(fd);
+
     // A failed registration must not leave the registry claiming the fd is watched:
     // the awaiting flow has to fail rather than park on an interest the kernel never
     // accepted, which nothing could ever resume.
-    if (!applyInterest(fd, interest, token))
+    if (owned < 0 || !applyInterest(owned, interest, token))
     {
+        if (owned >= 0)
+            ::close(owned);
         _registry.detach(token);
         return FdToken::invalid();
     }
 
-    _registered.emplace(token.value, fd);
+    _registered.emplace(token.value, owned);
     return token;
 }
 
@@ -97,6 +108,7 @@ void EpollEventSource::detach(FdToken token)
     {
         auto event = epoll_event {};
         ::epoll_ctl(_epollFd, EPOLL_CTL_DEL, it->second, &event);
+        ::close(it->second); // the duplicate this source owns, not the caller's fd
         _registered.erase(it);
     }
     _registry.detach(token);

--- a/src/net/EpollEventSource.hpp
+++ b/src/net/EpollEventSource.hpp
@@ -80,19 +80,29 @@ class EpollEventSource: public EventSource
     /// @return True if the epoll_ctl call succeeded.
     [[nodiscard]] bool applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept;
 
+    /// The descriptor a registration is watched through, and whether this source
+    /// created it and must therefore close it.
+    struct Watched
+    {
+        NativeHandle fd = InvalidHandle; ///< The descriptor handed to epoll_ctl.
+        bool owned = false;              ///< True if this is our dup(), false if the caller's fd.
+    };
+
     FdRegistry _registry; ///< Watched fds, in registration order.
     int _epollFd = -1;    ///< The epoll instance (owned).
-    /// The private descriptor each live registration owns, so detach can drop the
-    /// kernel registration in O(1) without scanning the registry, and close the
-    /// duplicate. Interest itself is fixed at attach — EventLoop only ever attaches
-    /// and detaches — so there is nothing to reconcile per wait.
+    /// The descriptor each live registration is watched through, so detach can drop
+    /// the kernel registration in O(1) without scanning the registry. Interest itself
+    /// is fixed at attach — EventLoop only ever attaches and detaches — so there is
+    /// nothing to reconcile per wait.
     ///
-    /// Each entry is a `dup()` of the caller's descriptor rather than the descriptor
-    /// itself: an epoll set is keyed by descriptor, so registering the same one
-    /// twice fails with `EEXIST`, whereas poll(2) simply takes two entries. The
-    /// registry permits two registrations on one descriptor, so without the dup this
-    /// backend would refuse a registration that @c PollEventSource accepts.
-    std::unordered_map<std::uint64_t, NativeHandle> _registered;
+    /// Normally this is the CALLER'S descriptor. A `dup()` would share the underlying
+    /// open file description, so the caller closing its copy would not release it —
+    /// no FIN would reach the peer, whose read would block forever rather than
+    /// observe EOF (poll(2), which holds no descriptor of its own, has no such
+    /// effect). A duplicate is therefore made only for a genuine second registration
+    /// of one descriptor, which an epoll set rejects with `EEXIST` while poll(2)
+    /// simply takes two entries; the registry permits it, so this backend must too.
+    std::unordered_map<std::uint64_t, Watched> _registered;
 };
 
 } // namespace net

--- a/src/net/EpollEventSource.hpp
+++ b/src/net/EpollEventSource.hpp
@@ -80,8 +80,8 @@ class EpollEventSource: public EventSource
     /// @return True if the epoll_ctl call succeeded.
     [[nodiscard]] bool applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept;
 
-    FdRegistry _registry;                                   ///< Watched fds, in registration order.
-    int _epollFd = -1;                                      ///< The epoll instance (owned).
+    FdRegistry _registry; ///< Watched fds, in registration order.
+    int _epollFd = -1;    ///< The epoll instance (owned).
     /// The fd each live registration names, so detach can drop the kernel
     /// registration in O(1) without scanning the registry. Interest itself is
     /// fixed at attach — EventLoop only ever attaches and detaches — so there

--- a/src/net/EpollEventSource.hpp
+++ b/src/net/EpollEventSource.hpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// The Linux @c EventSource: multiplexes the registered file descriptors with
+/// epoll(7) instead of poll(2).
+///
+/// Same contract and same observable behaviour as @c PollEventSource — it is a
+/// drop-in alternative, selected by @c makeDefaultEventSource(). The difference is
+/// cost: poll(2) hands the kernel the whole watch set on every call and scans it
+/// again on return, so a wait is O(registered); epoll keeps the set in the kernel
+/// and reports only what became ready, so a wait is O(ready). That is irrelevant
+/// for a terminal watching a handful of descriptors and decisive for a server
+/// holding thousands of idle connections.
+///
+/// Interest is **level-triggered** (no `EPOLLET`), matching what @c PosixSocket and
+/// the accept loop assume: a descriptor that stays ready is reported again on the
+/// next wait, so a partial read does not have to drain to `EAGAIN` to stay live.
+///
+/// Ported from the reactor in the fastcached project (Apache-2.0, same author).
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef __linux__
+
+    #include <unordered_map>
+
+    #include <net/EventSource.hpp>
+    #include <net/platform/NativeHandle.hpp>
+
+namespace net
+{
+
+/// An @c EventSource backed by an epoll instance.
+///
+/// The epoll set is kept in step with the @c FdRegistry: @c attach adds the
+/// descriptor, @c detach removes it, and a changed interest mask is pushed with
+/// `EPOLL_CTL_MOD` on the next @c wait. Registration failures surface as
+/// @c FdToken::invalid() so the awaiting flow fails rather than parking on an
+/// interest the kernel never accepted.
+class EpollEventSource: public EventSource
+{
+  public:
+    /// Creates the epoll instance.
+    /// @note Construction cannot fail usefully — if `epoll_create1` fails, @c good()
+    ///       reports false and every @c attach refuses, so a caller can fall back to
+    ///       @c PollEventSource. Use @c makeDefaultEventSource() to get that for free.
+    EpollEventSource() noexcept;
+    ~EpollEventSource() override;
+
+    EpollEventSource(EpollEventSource const&) = delete;
+    EpollEventSource& operator=(EpollEventSource const&) = delete;
+    EpollEventSource(EpollEventSource&&) = delete;
+    EpollEventSource& operator=(EpollEventSource&&) = delete;
+
+    [[nodiscard]] WaitOutcome wait(int timeoutMs) override;
+
+    [[nodiscard]] FdToken attach(NativeHandle fd, FdInterest interest) override;
+
+    void detach(FdToken token) override;
+
+    /// @return True if the epoll instance was created successfully.
+    [[nodiscard]] bool good() const noexcept { return _epollFd >= 0; }
+
+    /// @return The number of fds currently attached.
+    [[nodiscard]] std::size_t attachedCount() const noexcept { return _registry.size(); }
+
+  private:
+    /// Pushes @p interest for @p fd into the kernel with @p op.
+    /// @return True if the epoll_ctl call succeeded.
+    [[nodiscard]] bool applyInterest(int op,
+                                     NativeHandle fd,
+                                     FdInterest interest,
+                                     FdToken token) const noexcept;
+
+    FdRegistry _registry;                                   ///< Watched fds, in registration order.
+    int _epollFd = -1;                                      ///< The epoll instance (owned).
+    std::unordered_map<std::uint64_t, FdInterest> _applied; ///< Interest last pushed, keyed by token.
+};
+
+} // namespace net
+
+#endif // __linux__

--- a/src/net/EpollEventSource.hpp
+++ b/src/net/EpollEventSource.hpp
@@ -82,10 +82,16 @@ class EpollEventSource: public EventSource
 
     FdRegistry _registry; ///< Watched fds, in registration order.
     int _epollFd = -1;    ///< The epoll instance (owned).
-    /// The fd each live registration names, so detach can drop the kernel
-    /// registration in O(1) without scanning the registry. Interest itself is
-    /// fixed at attach — EventLoop only ever attaches and detaches — so there
-    /// is nothing to reconcile per wait.
+    /// The private descriptor each live registration owns, so detach can drop the
+    /// kernel registration in O(1) without scanning the registry, and close the
+    /// duplicate. Interest itself is fixed at attach — EventLoop only ever attaches
+    /// and detaches — so there is nothing to reconcile per wait.
+    ///
+    /// Each entry is a `dup()` of the caller's descriptor rather than the descriptor
+    /// itself: an epoll set is keyed by descriptor, so registering the same one
+    /// twice fails with `EEXIST`, whereas poll(2) simply takes two entries. The
+    /// registry permits two registrations on one descriptor, so without the dup this
+    /// backend would refuse a registration that @c PollEventSource accepts.
     std::unordered_map<std::uint64_t, NativeHandle> _registered;
 };
 

--- a/src/net/EpollEventSource.hpp
+++ b/src/net/EpollEventSource.hpp
@@ -35,10 +35,11 @@ namespace net
 /// An @c EventSource backed by an epoll instance.
 ///
 /// The epoll set is kept in step with the @c FdRegistry: @c attach adds the
-/// descriptor, @c detach removes it, and a changed interest mask is pushed with
-/// `EPOLL_CTL_MOD` on the next @c wait. Registration failures surface as
-/// @c FdToken::invalid() so the awaiting flow fails rather than parking on an
-/// interest the kernel never accepted.
+/// descriptor with its interest, @c detach removes it. Interest is fixed for a
+/// registration's lifetime — @c EventLoop only ever attaches and detaches, and
+/// @c FdRegistry exposes no way to change it — so a wait costs nothing beyond the
+/// epoll_wait itself. Registration failures surface as @c FdToken::invalid() so the
+/// awaiting flow fails rather than parking on an interest the kernel never accepted.
 class EpollEventSource: public EventSource
 {
   public:
@@ -67,16 +68,25 @@ class EpollEventSource: public EventSource
     [[nodiscard]] std::size_t attachedCount() const noexcept { return _registry.size(); }
 
   private:
-    /// Pushes @p interest for @p fd into the kernel with @p op.
+    /// Registers @p fd with @p interest.
+    ///
+    /// Returns `bool` rather than `std::expected` deliberately: this is a private
+    /// helper whose only caller turns a failure into @c FdToken::invalid(), which
+    /// is all the @c EventSource interface can express. There is nowhere for a
+    /// richer error to go, so carrying one would be discarded at the next frame.
+    /// @param fd The descriptor to register.
+    /// @param interest The readiness bits to watch.
+    /// @param token The registration's identity, echoed back by @c wait.
     /// @return True if the epoll_ctl call succeeded.
-    [[nodiscard]] bool applyInterest(int op,
-                                     NativeHandle fd,
-                                     FdInterest interest,
-                                     FdToken token) const noexcept;
+    [[nodiscard]] bool applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept;
 
     FdRegistry _registry;                                   ///< Watched fds, in registration order.
     int _epollFd = -1;                                      ///< The epoll instance (owned).
-    std::unordered_map<std::uint64_t, FdInterest> _applied; ///< Interest last pushed, keyed by token.
+    /// The fd each live registration names, so detach can drop the kernel
+    /// registration in O(1) without scanning the registry. Interest itself is
+    /// fixed at attach — EventLoop only ever attaches and detaches — so there
+    /// is nothing to reconcile per wait.
+    std::unordered_map<std::uint64_t, NativeHandle> _registered;
 };
 
 } // namespace net

--- a/src/net/EventLoop.cpp
+++ b/src/net/EventLoop.cpp
@@ -114,26 +114,7 @@ FdToken EventLoop::registerFdWaiter(NativeHandle fd, FdInterest interest, std::c
         return FdToken::invalid();
     _fdWaiters.emplace(token, waiter);
     _waiterToToken.emplace(waiter, token);
-    _tokenToFd.emplace(token, fd);
     return token;
-}
-
-void EventLoop::notifyHandleClosing(NativeHandle fd)
-{
-    if (fd == InvalidHandle)
-        return;
-
-    // A readiness poller cannot report a descriptor that has been closed: epoll drops
-    // it from the set and kqueue drops its filters, both silently, so a flow parked on
-    // it would never be resumed. (poll(2) reports POLLNVAL and resumes it, which is
-    // why this was invisible until the native backends landed.) The owner therefore
-    // tells us BEFORE closing, and we resume those flows here — they observe the
-    // closed socket and unwind, exactly as they do under poll(2).
-    auto woken = std::vector<FdToken> {};
-    for (auto const& [token, handle]: _tokenToFd)
-        if (handle == fd)
-            woken.push_back(token);
-    wakeFdWaiters(woken);
 }
 
 void EventLoop::unregisterFdWaiter(FdToken token) noexcept
@@ -141,7 +122,6 @@ void EventLoop::unregisterFdWaiter(FdToken token) noexcept
     if (!token)
         return;
     _source.detach(token);
-    _tokenToFd.erase(token);
     if (auto const it = _fdWaiters.find(token); it != _fdWaiters.end())
     {
         _waiterToToken.erase(it->second);
@@ -160,7 +140,6 @@ void EventLoop::requeueForCancellation(std::coroutine_handle<> waiter)
     {
         _source.detach(rt->second);
         _fdWaiters.erase(rt->second);
-        _tokenToFd.erase(rt->second);
         _waiterToToken.erase(rt);
     }
 
@@ -249,7 +228,6 @@ void EventLoop::wakeAllWaiters()
     // frame re-entering the loop cannot mutate the container mid-iteration.
     auto parked = std::exchange(_fdWaiters, {});
     _waiterToToken.clear();
-    _tokenToFd.clear();
     for (auto const& [token, handle]: parked)
     {
         _source.detach(token);

--- a/src/net/EventLoop.cpp
+++ b/src/net/EventLoop.cpp
@@ -32,6 +32,13 @@ EventLoop::~EventLoop()
     // the spawned-flow Tasks destroy already-finished frames. Cancelled re-awaits
     // resume synchronously (await_suspend returns false when stop is requested), so
     // a single drain converges. No-op and effectively free when nothing is parked.
+    //
+    // Note what is deliberately NOT done here: _closedTokens is left unconsumed.
+    // Those wakes resume a flow on its NORMAL path, which is right while the loop
+    // runs (the owner just called close) and wrong now — an owner declared after the
+    // loop is already destroyed by the time this runs, so the flow must unwind via
+    // the cancellation below instead. wakeAllWaiters still finds every such waiter,
+    // because notifyHandleClosing leaves the park in place.
     _rootStop.request_stop();
     wakeAllWaiters();
     drainReadyQueue();
@@ -112,20 +119,67 @@ FdToken EventLoop::registerFdWaiter(NativeHandle fd, FdInterest interest, std::c
     auto const token = _source.attach(fd, interest);
     if (!token)
         return FdToken::invalid();
-    _fdWaiters.emplace(token, waiter);
+    _fdWaiters.emplace(token, ParkedWaiter { .handle = waiter, .fd = fd });
     _waiterToToken.emplace(waiter, token);
+    _fdToTokens.emplace(fd, token);
     return token;
 }
 
-void EventLoop::unregisterFdWaiter(FdToken token) noexcept
+std::coroutine_handle<> EventLoop::dropParkedWaiter(FdToken token) noexcept
+{
+    auto const it = _fdWaiters.find(token);
+    if (it == _fdWaiters.end())
+        return {};
+
+    auto const parked = it->second;
+    _waiterToToken.erase(parked.handle);
+    // Erase this token alone: a descriptor may carry a second park (a reader beside
+    // a writer), and erasing by key would silently drop that one too.
+    auto const [first, last] = _fdToTokens.equal_range(parked.fd);
+    for (auto entry = first; entry != last; ++entry)
+        if (entry->second == token)
+        {
+            _fdToTokens.erase(entry);
+            break;
+        }
+    _fdWaiters.erase(it);
+    return parked.handle;
+}
+
+FdWakeReason EventLoop::unregisterFdWaiter(FdToken token) noexcept
 {
     if (!token)
-        return;
+        return FdWakeReason::Ready;
     _source.detach(token);
-    if (auto const it = _fdWaiters.find(token); it != _fdWaiters.end())
+    static_cast<void>(dropParkedWaiter(token));
+    // Consume the mark rather than merely reading it: the awaiter asks exactly once,
+    // and a token left behind here would outlive its registration and could collide
+    // with nothing — but would grow without bound on a long-lived loop.
+    return _abandoned.erase(token) != 0 ? FdWakeReason::Abandoned : FdWakeReason::Ready;
+}
+
+void EventLoop::notifyHandleClosing(NativeHandle fd, FdWakePolicy policy)
+{
+    if (fd == InvalidHandle)
+        return;
+
+    auto const [first, last] = _fdToTokens.equal_range(fd);
+    for (auto entry = first; entry != last; ++entry)
     {
-        _waiterToToken.erase(it->second);
-        _fdWaiters.erase(it);
+        auto const token = entry->second;
+        // Drop the kernel registration NOW, while the descriptor is still open. Left
+        // to the awaiter's own detach it would be issued after the close, against a
+        // descriptor number the kernel may already have reassigned — unregistering
+        // whichever socket now holds it. Detaching here also releases the private
+        // dup() a duplicate registration holds, which would otherwise keep the peer's
+        // connection open past the close.
+        _source.detach(token);
+        // The park itself stays in _fdWaiters: requestStop() and ~EventLoop find their
+        // waiters there, and must still be able to cancel this one if either runs
+        // before the next pump.
+        _closedTokens.push_back(token);
+        if (policy == FdWakePolicy::Cancel)
+            _abandoned.insert(token);
     }
 }
 
@@ -136,11 +190,12 @@ void EventLoop::requeueForCancellation(std::coroutine_handle<> waiter)
 
     // If parked as an fd waiter, drop and detach its registration so the stale
     // entry cannot also fire. Use the reverse map for O(1) lookup.
+    auto wasParked = false;
     if (auto const rt = _waiterToToken.find(waiter); rt != _waiterToToken.end())
     {
         _source.detach(rt->second);
-        _fdWaiters.erase(rt->second);
-        _waiterToToken.erase(rt);
+        static_cast<void>(dropParkedWaiter(rt->second));
+        wasParked = true;
     }
 
     // If parked on a timer, remove its heap entry too. We re-queue the waiter below
@@ -150,26 +205,31 @@ void EventLoop::requeueForCancellation(std::coroutine_handle<> waiter)
     // use-after-free. Detaching it here mirrors the fd branch above. (A coroutine is
     // parked on at most one source, so at most one of these two branches matches.)
     if (std::erase_if(_timers, [waiter](TimerEntry const& entry) { return entry.handle == waiter; }) != 0)
+    {
         std::ranges::make_heap(_timers, soonestFirst);
+        wasParked = true;
+    }
 
-    // Re-queue once. drainReadyQueue skips already-done handles, so a single push
-    // is safe.
-    _ready.push_back(waiter);
+    // Re-queue ONLY a waiter this call actually unparked. A waiter that was already
+    // woken is sitting in _ready with its frame intact but its cancellation callback
+    // still armed — await_resume, which disarms it, has not run yet — so a stop
+    // requested in that window lands here and would queue it a SECOND time. The first
+    // resume runs the flow to completion and its owner destroys the frame; the second
+    // then calls .done() on freed memory. That is the use-after-free that made the
+    // first attempt at close-wakeup segfault, and this guard is what removes it.
+    if (wasParked)
+        _ready.push_back(waiter);
 }
 
 void EventLoop::wakeFdWaiters(std::vector<FdToken> const& tokens)
 {
     for (auto const token: tokens)
     {
-        auto const it = _fdWaiters.find(token);
-        if (it == _fdWaiters.end())
-            continue; // unknown token (e.g. the post self-pipe) — not a parked flow
-        auto const handle = it->second;
         // Drop the parked slot now; the awaiter detaches the source registration in
         // its await_resume. Erasing first keeps the map consistent if the resumed
-        // frame re-enters the loop.
-        _waiterToToken.erase(it->second);
-        _fdWaiters.erase(it);
+        // frame re-enters the loop. A token with no park (e.g. the post self-pipe,
+        // or one already woken this pump) yields a null handle and is skipped.
+        auto const handle = dropParkedWaiter(token);
         if (handle && !handle.done())
             _ready.push_back(handle);
     }
@@ -228,11 +288,12 @@ void EventLoop::wakeAllWaiters()
     // frame re-entering the loop cannot mutate the container mid-iteration.
     auto parked = std::exchange(_fdWaiters, {});
     _waiterToToken.clear();
-    for (auto const& [token, handle]: parked)
+    _fdToTokens.clear();
+    for (auto const& [token, waiter]: parked)
     {
         _source.detach(token);
-        if (handle && !handle.done())
-            _ready.push_back(handle);
+        if (waiter.handle && !waiter.handle.done())
+            _ready.push_back(waiter.handle);
     }
 }
 
@@ -241,6 +302,23 @@ void EventLoop::pumpOnce()
     reapFinishedSpawns();
     runPostedCallbacks();
     drainReadyQueue();
+
+    // Descriptors closed since the last pump. The source cannot report these — epoll
+    // drops a closed descriptor from its set and kqueue drops its filters, both
+    // silently — so the loop supplies that readiness itself and MERGES it into this
+    // pump's wait outcome below.
+    //
+    // Merging rather than short-circuiting is load-bearing. Returning early here
+    // would skip the wait, and every other descriptor that became ready in the same
+    // instant — a peer's EOF, most importantly — would go unreported until some
+    // later pump that may never come, because the caller's blockOn exits as soon as
+    // its root flow is done. poll(2) never had that problem: it reports POLLNVAL for
+    // the closed descriptor alongside every other revent, in one call. This keeps
+    // every backend doing the same.
+    //
+    // Taken BEFORE the wait so a pending close can turn it into a non-blocking poll:
+    // blocking would wait for readiness that can no longer arrive.
+    auto const closed = std::exchange(_closedTokens, {});
 
     // Nothing is parked on a source: a well-formed root flow either completed
     // (the caller's loop will observe `done()`) or is awaiting a child task that
@@ -256,7 +334,9 @@ void EventLoop::pumpOnce()
         return;
     }
 
-    auto const outcome = _source.wait(computeTimeoutMs());
+    // A pending close polls instead of blocking: the closed descriptor can no longer
+    // produce readiness, so an indefinite wait would never return on its account.
+    auto const outcome = _source.wait(closed.empty() ? computeTimeoutMs() : 0);
 
     // A cross-thread post may have both queued work and signalled the self-pipe.
     if (_postToken && std::ranges::find(outcome.readyRead, _postToken) != outcome.readyRead.end())
@@ -267,6 +347,10 @@ void EventLoop::pumpOnce()
     // self-pipe's token has no parked waiter and is skipped naturally.
     wakeFdWaiters(outcome.readyRead);
     wakeFdWaiters(outcome.readyWrite);
+    // Then the closed descriptors, as one more source of readiness. Last, so a token
+    // the source also reported is woken exactly once — the first wake drops its park,
+    // and a token with no park is skipped.
+    wakeFdWaiters(closed);
 
     fireExpiredTimers();
 

--- a/src/net/EventLoop.cpp
+++ b/src/net/EventLoop.cpp
@@ -114,7 +114,26 @@ FdToken EventLoop::registerFdWaiter(NativeHandle fd, FdInterest interest, std::c
         return FdToken::invalid();
     _fdWaiters.emplace(token, waiter);
     _waiterToToken.emplace(waiter, token);
+    _tokenToFd.emplace(token, fd);
     return token;
+}
+
+void EventLoop::notifyHandleClosing(NativeHandle fd)
+{
+    if (fd == InvalidHandle)
+        return;
+
+    // A readiness poller cannot report a descriptor that has been closed: epoll drops
+    // it from the set and kqueue drops its filters, both silently, so a flow parked on
+    // it would never be resumed. (poll(2) reports POLLNVAL and resumes it, which is
+    // why this was invisible until the native backends landed.) The owner therefore
+    // tells us BEFORE closing, and we resume those flows here — they observe the
+    // closed socket and unwind, exactly as they do under poll(2).
+    auto woken = std::vector<FdToken> {};
+    for (auto const& [token, handle]: _tokenToFd)
+        if (handle == fd)
+            woken.push_back(token);
+    wakeFdWaiters(woken);
 }
 
 void EventLoop::unregisterFdWaiter(FdToken token) noexcept
@@ -122,6 +141,7 @@ void EventLoop::unregisterFdWaiter(FdToken token) noexcept
     if (!token)
         return;
     _source.detach(token);
+    _tokenToFd.erase(token);
     if (auto const it = _fdWaiters.find(token); it != _fdWaiters.end())
     {
         _waiterToToken.erase(it->second);
@@ -140,6 +160,7 @@ void EventLoop::requeueForCancellation(std::coroutine_handle<> waiter)
     {
         _source.detach(rt->second);
         _fdWaiters.erase(rt->second);
+        _tokenToFd.erase(rt->second);
         _waiterToToken.erase(rt);
     }
 
@@ -228,6 +249,7 @@ void EventLoop::wakeAllWaiters()
     // frame re-entering the loop cannot mutate the container mid-iteration.
     auto parked = std::exchange(_fdWaiters, {});
     _waiterToToken.clear();
+    _tokenToFd.clear();
     for (auto const& [token, handle]: parked)
     {
         _source.detach(token);

--- a/src/net/EventLoop.hpp
+++ b/src/net/EventLoop.hpp
@@ -173,6 +173,21 @@ class EventLoop
     /// @param token The registration to remove.
     void unregisterFdWaiter(FdToken token) noexcept;
 
+    /// Resumes every flow parked on @p fd, because that descriptor is about to be
+    /// closed.
+    ///
+    /// **The owner of a descriptor must call this before closing it** while any flow
+    /// may be parked on it. A readiness poller cannot report a closed descriptor:
+    /// epoll removes it from the set and kqueue drops its filters, both silently, so
+    /// the parked flow would never be resumed and would hang forever. poll(2) reports
+    /// `POLLNVAL` and resumes it, which is why this is not needed there — and why the
+    /// gap was invisible until the native backends landed.
+    ///
+    /// The resumed flows observe the closed socket and unwind, exactly as under
+    /// poll(2). Safe to call with no waiters parked, and safe to call more than once.
+    /// @param fd The descriptor about to be closed.
+    void notifyHandleClosing(NativeHandle fd);
+
     /// Re-queues @p waiter for resumption because its cancellation token fired while
     /// it was parked on a timer or fd. Used by the timed/fd awaiters' stop-callbacks
     /// so a `whenAny`/`withTimeout` loser parked on `delay`/`waitReadable` unwinds
@@ -243,7 +258,12 @@ class EventLoop
     std::unordered_map<FdToken, std::coroutine_handle<>>
         _fdWaiters; ///< Flows parked on a generic fd, by token.
     std::unordered_map<std::coroutine_handle<>, FdToken>
-        _waiterToToken;                   ///< Reverse map for O(1) cancellation.
+        _waiterToToken; ///< Reverse map for O(1) cancellation.
+    /// The descriptor each live registration watches, so @c notifyHandleClosing can
+    /// find the flows parked on a descriptor that is about to be closed. Kept here
+    /// rather than asked of the source: @c EventSource exposes no token→fd lookup,
+    /// and adding one would put a query on the interface that only this needs.
+    std::unordered_map<FdToken, NativeHandle> _tokenToFd;
     std::vector<coro::Task<void>> _roots; ///< Keeps live spawned background flows alive.
     coro::StopSource _rootStop;           ///< Root cancellation source.
 

--- a/src/net/EventLoop.hpp
+++ b/src/net/EventLoop.hpp
@@ -173,21 +173,6 @@ class EventLoop
     /// @param token The registration to remove.
     void unregisterFdWaiter(FdToken token) noexcept;
 
-    /// Resumes every flow parked on @p fd, because that descriptor is about to be
-    /// closed.
-    ///
-    /// **The owner of a descriptor must call this before closing it** while any flow
-    /// may be parked on it. A readiness poller cannot report a closed descriptor:
-    /// epoll removes it from the set and kqueue drops its filters, both silently, so
-    /// the parked flow would never be resumed and would hang forever. poll(2) reports
-    /// `POLLNVAL` and resumes it, which is why this is not needed there — and why the
-    /// gap was invisible until the native backends landed.
-    ///
-    /// The resumed flows observe the closed socket and unwind, exactly as under
-    /// poll(2). Safe to call with no waiters parked, and safe to call more than once.
-    /// @param fd The descriptor about to be closed.
-    void notifyHandleClosing(NativeHandle fd);
-
     /// Re-queues @p waiter for resumption because its cancellation token fired while
     /// it was parked on a timer or fd. Used by the timed/fd awaiters' stop-callbacks
     /// so a `whenAny`/`withTimeout` loser parked on `delay`/`waitReadable` unwinds
@@ -258,12 +243,7 @@ class EventLoop
     std::unordered_map<FdToken, std::coroutine_handle<>>
         _fdWaiters; ///< Flows parked on a generic fd, by token.
     std::unordered_map<std::coroutine_handle<>, FdToken>
-        _waiterToToken; ///< Reverse map for O(1) cancellation.
-    /// The descriptor each live registration watches, so @c notifyHandleClosing can
-    /// find the flows parked on a descriptor that is about to be closed. Kept here
-    /// rather than asked of the source: @c EventSource exposes no token→fd lookup,
-    /// and adding one would put a query on the interface that only this needs.
-    std::unordered_map<FdToken, NativeHandle> _tokenToFd;
+        _waiterToToken;                   ///< Reverse map for O(1) cancellation.
     std::vector<coro::Task<void>> _roots; ///< Keeps live spawned background flows alive.
     coro::StopSource _rootStop;           ///< Root cancellation source.
 

--- a/src/net/EventLoop.hpp
+++ b/src/net/EventLoop.hpp
@@ -23,12 +23,14 @@
 #include <chrono>
 #include <coroutine>
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <coro/Cancellation.hpp>
@@ -47,6 +49,36 @@ namespace net
 /// deliberate cancellation.
 struct FdRegistrationFailed
 {
+};
+
+/// How a flow parked on a descriptor is resumed when that descriptor closes.
+///
+/// A readiness poller cannot report a CLOSED descriptor: epoll drops it from the
+/// set and kqueue drops its filters, both silently, so a parked flow would never
+/// be resumed at all (poll(2) reports POLLNVAL and Windows reports the handle as
+/// failed, which is why those two backends never had the bug). @c
+/// EventLoop::notifyHandleClosing is how a closing descriptor supplies that
+/// missing readiness — and this says what the flow should observe once it wakes.
+enum class FdWakePolicy : std::uint8_t
+{
+    /// Resume on the flow's normal path. For an explicit `close()`, where the
+    /// owner is alive — it is the one that called close — so the flow can safely
+    /// re-read the owner's closed flag and report the close as an error.
+    Resume = 0,
+
+    /// Resume by throwing @c OperationCancelled. For a destructor, where the owner
+    /// is already gone: unwinding through @c await_resume never re-enters the flow
+    /// body, so nothing dereferences the dead owner. This is the same reason
+    /// ~EventLoop requests stop BEFORE waking its parked waiters.
+    Cancel,
+};
+
+/// Why a parked fd waiter was resumed, reported back to the awaiter by
+/// @c EventLoop::unregisterFdWaiter.
+enum class FdWakeReason : std::uint8_t
+{
+    Ready = 0, ///< Ordinary readiness (or an explicit close under FdWakePolicy::Resume).
+    Abandoned, ///< The descriptor closed under FdWakePolicy::Cancel; unwind instead of resuming.
 };
 
 class DelayAwaiter;
@@ -150,6 +182,30 @@ class EventLoop
     ///         @c OperationCancelled if the flow is cancelled while parked.
     [[nodiscard]] WaitFdAwaiter waitWritable(NativeHandle fd) noexcept;
 
+    /// Announces that @p fd is ABOUT TO BE CLOSED, so any flow parked on it is
+    /// resumed instead of waiting forever for readiness that can no longer arrive.
+    ///
+    /// Call this BEFORE the `close()` syscall, on the loop thread: the descriptor
+    /// must still be valid so the event source can drop its kernel registration
+    /// cleanly. Deferring that to the awaiter's own detach would issue the removal
+    /// against a descriptor number the kernel may already have handed to a new
+    /// socket, silently unregistering that one instead.
+    ///
+    /// The wake is only RECORDED here and delivered by the next pump as ordinary
+    /// readiness. It is deliberately not queued for resumption from this call: a
+    /// coroutine queued outside the pump still has its cancellation callback armed,
+    /// so a later `requestStop()` would queue it a second time and the pump would
+    /// then resume a frame the first resume had already destroyed.
+    /// Not @c noexcept, though every caller is: recording a wake appends to a vector
+    /// (and, for @c Cancel, a set), so allocation failure propagates as termination
+    /// from a `close()` that cannot report it. Swallowing it would be worse — the
+    /// wake would be lost and the flow would hang, which is the bug this exists to
+    /// fix — and by that point the process is out of memory anyway.
+    /// @param fd The descriptor about to be closed.
+    /// @param policy How a flow parked on @p fd should observe the close — normally
+    ///        (an explicit close, owner alive) or as cancellation (a destructor).
+    void notifyHandleClosing(NativeHandle fd, FdWakePolicy policy);
+
     /// @name Awaiter-facing scheduler primitives (internal)
     /// Called by the loop's awaitables; not part of the consumer API.
     /// @{
@@ -171,7 +227,11 @@ class EventLoop
     /// Detaches @p token from the event source and drops its parked waiter, if any.
     /// Idempotent. Called by the awaiter on resume (ready or cancelled).
     /// @param token The registration to remove.
-    void unregisterFdWaiter(FdToken token) noexcept;
+    /// @return @c FdWakeReason::Abandoned if the descriptor was closed under
+    ///         @c FdWakePolicy::Cancel while this waiter was parked on it — the
+    ///         awaiter then unwinds instead of resuming into an owner that is gone.
+    ///         @c FdWakeReason::Ready otherwise.
+    [[nodiscard]] FdWakeReason unregisterFdWaiter(FdToken token) noexcept;
 
     /// Re-queues @p waiter for resumption because its cancellation token fired while
     /// it was parked on a timer or fd. Used by the timed/fd awaiters' stop-callbacks
@@ -236,14 +296,45 @@ class EventLoop
     /// Wakes every parked flow so cancelled awaitables can unwind.
     void wakeAllWaiters();
 
-    EventSource& _source;                       ///< The injected multiplexed wait.
-    IClock& _clock;                             ///< The injected monotonic time source.
-    std::deque<std::coroutine_handle<>> _ready; ///< Coroutines ready to resume now.
-    std::vector<TimerEntry> _timers;            ///< Min-heap by deadline (soonest at front).
-    std::unordered_map<FdToken, std::coroutine_handle<>>
-        _fdWaiters; ///< Flows parked on a generic fd, by token.
+    /// Forgets the parked waiter behind @p token, across all three indices that
+    /// describe it. The single place that does so: four call sites would otherwise
+    /// each have to remember every container a park is recorded in, and one that
+    /// forgot would leave a stale entry pointing at a frame about to be destroyed.
+    /// @param token The registration whose park is being dropped.
+    /// @return The coroutine that was parked, or a null handle if @p token had none.
+    [[nodiscard]] std::coroutine_handle<> dropParkedWaiter(FdToken token) noexcept;
+
+    /// One parked fd waiter: the coroutine to resume, and the descriptor it parked
+    /// on. The descriptor is kept so a park can be found by fd (see @c _fdToTokens)
+    /// and so dropping it can also clear that reverse index.
+    struct ParkedWaiter
+    {
+        std::coroutine_handle<> handle;  ///< The suspended coroutine.
+        NativeHandle fd = InvalidHandle; ///< The descriptor it is parked on.
+    };
+
+    EventSource& _source;                                 ///< The injected multiplexed wait.
+    IClock& _clock;                                       ///< The injected monotonic time source.
+    std::deque<std::coroutine_handle<>> _ready;           ///< Coroutines ready to resume now.
+    std::vector<TimerEntry> _timers;                      ///< Min-heap by deadline (soonest at front).
+    std::unordered_map<FdToken, ParkedWaiter> _fdWaiters; ///< Flows parked on a generic fd, by token.
     std::unordered_map<std::coroutine_handle<>, FdToken>
-        _waiterToToken;                   ///< Reverse map for O(1) cancellation.
+        _waiterToToken; ///< Reverse map for O(1) cancellation.
+    /// Reverse index from descriptor to the registrations parked on it, so a closing
+    /// descriptor finds its waiters in O(1) rather than scanning every park. A
+    /// multimap because one descriptor can carry two parks at once — a reader and a
+    /// writer — and closing it must resume both.
+    std::unordered_multimap<NativeHandle, FdToken> _fdToTokens;
+    /// Registrations whose descriptor closed since the last pump, merged into the
+    /// next pump's wait outcome as one more source of readiness. Consumed ONLY in
+    /// pumpOnce: ~EventLoop must resume parked flows through its own
+    /// request_stop()-first path, not on their normal path, because by then their
+    /// owners are already destroyed.
+    std::vector<FdToken> _closedTokens;
+    /// The subset of @c _closedTokens whose descriptor closed under
+    /// @c FdWakePolicy::Cancel, so @c unregisterFdWaiter can tell the awaiter to
+    /// unwind rather than resume.
+    std::unordered_set<FdToken> _abandoned;
     std::vector<coro::Task<void>> _roots; ///< Keeps live spawned background flows alive.
     coro::StopSource _rootStop;           ///< Root cancellation source.
 
@@ -346,20 +437,25 @@ class WaitFdAwaiter
         return true;
     }
 
-    /// Detaches the fd and, if the flow was cancelled while parked or the attach
-    /// failed, reports the failure.
+    /// Detaches the fd and, if the flow was cancelled while parked, the descriptor
+    /// was abandoned under it, or the attach failed, reports the failure.
     /// @throws FdRegistrationFailed if the fd could not be registered with the
     ///         event source (resource exhaustion — distinct from cancellation).
-    /// @throws OperationCancelled if cancelled while parked or the fd was invalid.
+    /// @throws OperationCancelled if cancelled while parked, the fd was invalid, or
+    ///         the fd was closed under @c FdWakePolicy::Cancel while parked. That
+    ///         last case is what keeps a destructor from resuming this flow into an
+    ///         owner that no longer exists: throwing here unwinds the frame without
+    ///         ever re-entering its body.
     // NOLINTNEXTLINE(readability-identifier-naming): coroutine machinery, looked up by spelling.
     void await_resume()
     {
         _cancelReg.reset();
+        auto reason = FdWakeReason::Ready;
         if (_registration)
-            _loop.unregisterFdWaiter(_registration);
+            reason = _loop.unregisterFdWaiter(_registration);
         else if (_fd != InvalidHandle && !_token.stop_requested())
             throw FdRegistrationFailed {};
-        if (_token.stop_requested() || _fd == InvalidHandle)
+        if (_token.stop_requested() || _fd == InvalidHandle || reason == FdWakeReason::Abandoned)
             throw coro::OperationCancelled {};
     }
 

--- a/src/net/EventLoop_test.cpp
+++ b/src/net/EventLoop_test.cpp
@@ -99,6 +99,13 @@ Task<void> incrementAndFinish(int* counter)
     co_return;
 }
 
+/// A root flow that completes at once, so `blockOn` pumps exactly as far as the
+/// spawned flows need and no further.
+Task<void> justReturn()
+{
+    co_return;
+}
+
 /// Sets *destroyed = true when its frame unwinds (RAII), so a test can prove a
 /// parked flow was cancelled-and-unwound rather than raw-destroyed.
 struct UnwindFlag
@@ -266,6 +273,86 @@ TEST_CASE("waitReadable resumes when the registered fd becomes readable", "[Even
     auto const result = loop.blockOn(awaitReadableOrCancel(&loop, (*pipe)->readFd(), Cancelled));
 
     REQUIRE(result == 1);
+}
+
+TEST_CASE("notifyHandleClosing on an unwatched fd records nothing", "[EventLoop][fd][closehang]")
+{
+    // Closing a descriptor nobody is parked on must not schedule any wake. If it
+    // did, the next pump would deliver a token naming a registration that no longer
+    // exists — harmless today only because wakeFdWaiters skips unknown tokens, but a
+    // token can be reused, and then the wake would land on an unrelated flow.
+    auto pipe = net::createSystemPipe();
+    REQUIRE(pipe.has_value());
+
+    auto source = ScriptedEventSource {};
+    auto loop = EventLoop { source };
+
+    loop.notifyHandleClosing((*pipe)->readFd(), net::FdWakePolicy::Resume);
+
+    // Nothing parked and nothing recorded, so this pump neither waits nor resumes.
+    // A recorded wake would have turned the wait into a poll; an exhausted script
+    // would have thrown had one been attempted.
+    auto counter = 0;
+    loop.blockOn(incrementAndFinish(&counter));
+    REQUIRE(counter == 1);
+    REQUIRE(source.waitCount() == 0);
+}
+
+TEST_CASE("notifyHandleClosing detaches the registration while the fd is still valid",
+          "[EventLoop][fd][closehang]")
+{
+    // The kernel registration has to be dropped at CLOSE time, not left for the
+    // awaiter's own detach. By then the descriptor number may have been reassigned
+    // to a new socket, and epoll_ctl(EPOLL_CTL_DEL) / kqueue's delete-by-descriptor
+    // would unregister THAT one instead. attachedCount is the observable proof.
+    auto pipe = net::createSystemPipe();
+    REQUIRE(pipe.has_value());
+
+    // Declared BEFORE the loop, so it outlives it: ~EventLoop resumes the still-
+    // parked flow, whose RAII guard writes here as it unwinds.
+    auto destroyed = false;
+
+    auto source = ScriptedEventSource {};
+    source.pushTimeout(); // the park's first wait reports nothing
+    auto loop = EventLoop { source };
+
+    loop.spawn(waitReadableWithGuard(&loop, (*pipe)->readFd(), &destroyed));
+    loop.blockOn(justReturn()); // let the spawned flow reach its park
+
+    // The loop's self-pipe plus the parked waiter.
+    REQUIRE(source.attachedCount() == 2);
+
+    loop.notifyHandleClosing((*pipe)->readFd(), net::FdWakePolicy::Resume);
+    REQUIRE(source.attachedCount() == 1); // detached immediately, not at resume
+}
+
+TEST_CASE("a recorded close is delivered without blocking the pump", "[EventLoop][fd][closehang]")
+{
+    // A closed descriptor can no longer produce readiness, so the pump must not
+    // block waiting for it. It still performs its wait — merged, not skipped, so
+    // nothing else ready in the same instant is starved — but with a zero timeout.
+    auto pipe = net::createSystemPipe();
+    REQUIRE(pipe.has_value());
+
+    // Declared BEFORE the loop, so it outlives it (see the case above).
+    auto destroyed = false;
+
+    auto source = ScriptedEventSource {};
+    source.pushTimeout(); // the park's wait
+    source.pushTimeout(); // the close-wake pump's wait, which must be a poll
+    auto loop = EventLoop { source };
+
+    loop.spawn(waitReadableWithGuard(&loop, (*pipe)->readFd(), &destroyed));
+    loop.blockOn(justReturn());
+    auto const waitsBeforeClose = source.waitCount();
+
+    loop.notifyHandleClosing((*pipe)->readFd(), net::FdWakePolicy::Resume);
+    loop.blockOn(justReturn());
+
+    REQUIRE(source.waitCount() == waitsBeforeClose + 1);
+    // Zero, not -1: an indefinite wait would never return on the closed fd's account.
+    REQUIRE(source.recordedTimeouts().back() == 0);
+    REQUIRE(destroyed); // the parked flow resumed and unwound
 }
 
 TEST_CASE("waitReadable on an invalid fd resolves immediately as cancelled", "[EventLoop][fd]")

--- a/src/net/EventLoop_test.cpp
+++ b/src/net/EventLoop_test.cpp
@@ -288,6 +288,10 @@ TEST_CASE("notifyHandleClosing on an unwatched fd records nothing", "[EventLoop]
     auto loop = EventLoop { source };
 
     loop.notifyHandleClosing((*pipe)->readFd(), net::FdWakePolicy::Resume);
+    // And an invalid handle is refused outright rather than looked up: on Windows a
+    // NativeHandle is a pointer, so a null one would otherwise be a perfectly good
+    // multimap key that any other unset handle could collide with.
+    loop.notifyHandleClosing(net::InvalidHandle, net::FdWakePolicy::Cancel);
 
     // Nothing parked and nothing recorded, so this pump neither waits nor resumes.
     // A recorded wake would have turned the wait into a poll; an exhausted script

--- a/src/net/EventSource.hpp
+++ b/src/net/EventSource.hpp
@@ -144,6 +144,15 @@ class EventSource
     [[nodiscard]] virtual WaitOutcome wait(int timeoutMs) = 0;
 
     /// Registers @p fd for multiplexing in subsequent waits.
+    ///
+    /// The same handle may be registered more than once; each call yields its own
+    /// token and its own lifetime, and detaching one leaves the others watching.
+    /// What is deliberately NOT promised is how a single readiness event is spread
+    /// across duplicate registrations: one wait may report all of them or only one,
+    /// because the underlying multiplexers differ (Linux's poll(2) fills in every
+    /// matching pollfd; macOS's reports the descriptor once). A caller that parks a
+    /// coroutine per token is unaffected — the next wait reports whoever is still
+    /// registered, since every backend here is level-triggered.
     /// @param fd The native handle to watch (not owned; the caller keeps it valid
     ///        and detaches before closing it).
     /// @param interest The readiness bits to start watching.

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -477,6 +477,54 @@ TEST_CASE("an invalid handle is refused by every event source", "[net][eventsour
     }
 }
 
+TEST_CASE("the default source drives the scenarios Socket_test pins to poll", "[net][eventsource][parity]")
+{
+    // Socket_test hardcodes PollEventSource in all of its cases, which is why two
+    // native-backend defects (a registration holding the peer's connection open, and
+    // a parked reader never resuming after close) passed a green suite. These run the
+    // same shapes against whatever makeDefaultEventSource picks -- epoll on Linux,
+    // kqueue on macOS/BSD -- so the backend production actually uses is exercised.
+    auto source = net::makeDefaultEventSource();
+    REQUIRE(source != nullptr);
+
+    SECTION("loopback echo")
+    {
+        auto loop = EventLoop { *source };
+        auto listener = net::listen(loop, "127.0.0.1", 0);
+        REQUIRE(listener.has_value());
+        auto const port = (*listener)->localPort();
+        REQUIRE(port != 0);
+
+        auto got = std::string {};
+        loop.blockOn(echoOverListener(&loop, listener->get(), port, &got));
+        CHECK(got == "parity");
+    }
+
+    SECTION("close resumes a parked reader")
+    {
+        auto loop = EventLoop { *source };
+        auto pair = net::testing::makeSocketPair(loop);
+        REQUIRE(pair.has_value());
+
+        auto resumedWithError = false;
+        loop.blockOn(closeWhileParked(&loop, pair->second.get(), &resumedWithError));
+        CHECK(resumedWithError);
+    }
+
+    SECTION("a peer's close reads as EOF")
+    {
+        auto loop = EventLoop { *source };
+        auto pair = net::testing::makeSocketPair(loop);
+        REQUIRE(pair.has_value());
+
+        pair->first->close();
+
+        auto outcome = -99;
+        loop.blockOn(readOnce(pair->second.get(), &outcome));
+        CHECK(outcome == 0);
+    }
+}
+
 TEST_CASE("makeDefaultEventSource yields a usable source", "[net][eventsource]")
 {
     auto source = net::makeDefaultEventSource();

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -5,6 +5,14 @@
 /// what a wait costs. These cases therefore run the SAME scenario against every
 /// backend available on this platform, so a divergence fails here rather than
 /// surfacing as a hang in whatever happens to use the native source.
+///
+/// The `[closehang]` tag selects the family that guards one such divergence: a
+/// descriptor CLOSED under a parked flow. poll(2) reports POLLNVAL for it and
+/// Windows reports the handle as failed, but epoll silently drops it from the set
+/// and kqueue silently drops its filters — so on those two the flow was never
+/// resumed at all, and the cases below hung rather than failed. They are named for
+/// that symptom because it is what a regression looks like: `net_test [closehang]`
+/// runs the lot. See @c EventLoop::notifyHandleClosing for the mechanism.
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
@@ -12,6 +20,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
@@ -20,12 +29,14 @@
 
 #include <coro/Task.hpp>
 #include <coro/WhenAll.hpp>
+#include <coro/WhenAny.hpp>
 #include <net/DefaultEventSource.hpp>
 #include <net/EventLoop.hpp>
 #include <net/EventSource.hpp>
 #include <net/ISocket.hpp>
 #include <net/Sockets.hpp>
 #include <net/platform/SystemPipe.hpp>
+#include <net/testing/EventSourceBackends.hpp>
 #include <net/testing/InMemoryTransport.hpp>
 
 #ifndef _WIN32
@@ -40,22 +51,10 @@ using coro::Task;
 using net::EventLoop;
 using net::EventSourceKind;
 using net::FdInterest;
+using net::testing::AllBackends;
 
 namespace
 {
-
-/// One backend to exercise, with a label so a failure names which one broke.
-struct Backend
-{
-    EventSourceKind kind;  ///< The backend to construct.
-    std::string_view name; ///< Its name, for the section label.
-};
-
-constexpr auto AllBackends = std::array {
-    Backend { EventSourceKind::Poll, "poll" },
-    Backend { EventSourceKind::Epoll, "epoll" },
-    Backend { EventSourceKind::Kqueue, "kqueue" },
-};
 
 /// Writes to a pipe, then waits for the read end to become readable.
 Task<void> waitThenRead(EventLoop* loop, net::SystemPipe* pipe, bool* observed)
@@ -168,6 +167,215 @@ Task<void> acceptThenClose(EventLoop* loop, net::IListener* listener, bool* acce
                            closeListenerAfterParked(loop, listener));
 }
 
+/// Writes until the peer's receive buffer and this socket's send buffer are both
+/// full, so the write parks on writability, then records whether it resumed with an
+/// error rather than hanging once the socket is closed under it.
+/// @param sock The socket to write to (its peer never reads).
+/// @param resumedWithError Set to true if the write resumed and reported a failure.
+Task<void> parkThenObserveWriteClose(net::ISocket* sock, bool* resumedWithError)
+{
+    // Far larger than any default SO_SNDBUF/SO_RCVBUF pair, so the write cannot
+    // complete without the peer reading — which it never does.
+    constexpr auto PayloadBytes = std::size_t { 4 } * 1024 * 1024;
+    auto const payload = std::vector<std::byte>(PayloadBytes, std::byte { 'x' });
+    auto const result = co_await sock->write(payload);
+    *resumedWithError = !result.has_value();
+}
+
+/// Runs the parked writer and the close concurrently on one loop.
+Task<void> closeWhileWriteParked(EventLoop* loop, net::ISocket* sock, bool* resumedWithError)
+{
+    co_await coro::whenAll(parkThenObserveWriteClose(sock, resumedWithError), closeAfterParked(loop, sock));
+}
+
+/// Parks a reader AND a writer on ONE socket, then closes it under both. Two
+/// registrations on one descriptor is the case epoll and kqueue cannot express
+/// natively (an epoll set rejects a duplicate with EEXIST; a kqueue filter is keyed
+/// by descriptor), so each keeps a private dup() for the second one — and a close
+/// has to resume both flows and release that duplicate.
+/// @param loop The loop driving both parks.
+/// @param sock The socket both flows park on.
+/// @param readerResumed Set when the reader resumed with an error.
+/// @param writerResumed Set when the writer resumed with an error.
+Task<void> closeWhileBothParked(EventLoop* loop, net::ISocket* sock, bool* readerResumed, bool* writerResumed)
+{
+    co_await coro::whenAll(parkThenObserveClose(sock, readerResumed),
+                           parkThenObserveWriteClose(sock, writerResumed),
+                           closeAfterParked(loop, sock));
+}
+
+/// Closes @p sock twice with nothing parked on it, then proves the loop still
+/// works by running a delay to completion. A close that recorded a wake for a
+/// registration that no longer exists — or recorded one twice — would strand or
+/// double-resume whatever ran next.
+/// @param loop The loop to keep using afterwards.
+/// @param sock The socket to close (twice).
+/// @param stillPumps Set to true once the trailing delay completed.
+Task<void> closeTwiceThenKeepPumping(EventLoop* loop, net::ISocket* sock, bool* stillPumps)
+{
+    sock->close();
+    sock->close(); // idempotent: the second must not record a second wake
+    co_await loop->delay(std::chrono::milliseconds { 1 });
+    *stillPumps = true;
+}
+
+/// Parks a reader on @p idle, closes @p closing under its own parked reader, and
+/// checks that only the closed one resumed — the wake must be routed by descriptor,
+/// not broadcast.
+/// @param loop The loop driving both parks.
+/// @param closing The socket to close.
+/// @param idle The socket that stays open with a reader parked on it.
+/// @param closedResumed Set when the reader on @p closing resumed.
+/// @param idleResumed Set when the reader on @p idle resumed (it must not).
+Task<void> closeOneOfTwo(
+    EventLoop* loop, net::ISocket* closing, net::ISocket* idle, bool* closedResumed, bool* idleResumed)
+{
+    // whenAny, not whenAll: the reader on `idle` is expected NEVER to resume, so
+    // waiting for it would hang by design. The losing branch is cancelled.
+    static_cast<void>(co_await coro::whenAny(closeWhileParked(loop, closing, closedResumed),
+                                             parkThenObserveClose(idle, idleResumed)));
+}
+
+/// Parks a reader on a socket that is closed under it, while a timer is also
+/// pending. A close-wake must not swallow the pump's wait: the timer has to fire
+/// too, in the same pump or the next one.
+/// @param loop The loop driving both.
+/// @param sock The socket to park on and close.
+/// @param readerResumed Set when the reader resumed.
+/// @param timerFired Set when the pending delay elapsed.
+Task<void> closeWhileTimerPending(EventLoop* loop, net::ISocket* sock, bool* readerResumed, bool* timerFired)
+{
+    auto tick = [](EventLoop* inner, bool* fired) -> Task<void> {
+        co_await inner->delay(std::chrono::milliseconds { 40 });
+        *fired = true;
+    };
+    co_await coro::whenAll(
+        parkThenObserveClose(sock, readerResumed), closeAfterParked(loop, sock), tick(loop, timerFired));
+}
+
+/// Parks reading a socket and records that it unwound through OperationCancelled
+/// rather than resuming on its normal path. That distinction is the whole point of
+/// @c FdWakePolicy::Cancel: the normal path would re-read the socket's members
+/// through a `this` that no longer exists.
+/// @param sock The socket to park on (destroyed under this flow).
+/// @param cancelled Set to true if the read unwound as cancelled.
+Task<void> parkThenRecordCancellation(net::ISocket* sock, bool* cancelled)
+{
+    auto buffer = std::array<std::byte, 64> {};
+    try
+    {
+        static_cast<void>(co_await sock->read(buffer));
+    }
+    catch (coro::OperationCancelled const&)
+    {
+        *cancelled = true;
+    }
+}
+
+/// Lets the reader reach its park, then DESTROYS the socket it is parked on.
+/// @param loop The loop driving the delay.
+/// @param owner The owning pointer to reset.
+Task<void> destroySocketAfterParked(EventLoop* loop, std::unique_ptr<net::ISocket>* owner)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+    owner->reset(); // ~PosixSocket -> close(FdWakePolicy::Cancel)
+}
+
+/// Runs the parked reader and the socket's destruction concurrently on one loop.
+Task<void> destroyWhileParked(EventLoop* loop, std::unique_ptr<net::ISocket>* owner, bool* cancelled)
+{
+    co_await coro::whenAll(parkThenRecordCancellation(owner->get(), cancelled),
+                           destroySocketAfterParked(loop, owner));
+}
+
+/// Lets the accept reach its park, then DESTROYS the listener beneath it.
+Task<void> destroyListenerAfterParked(EventLoop* loop, std::unique_ptr<net::IListener>* owner)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+    owner->reset(); // ~PosixListener -> close(FdWakePolicy::Cancel)
+}
+
+/// Runs the parked accept and the listener's destruction concurrently on one loop.
+Task<void> destroyListenerWhileParked(EventLoop* loop, std::unique_ptr<net::IListener>* owner, bool* accepted)
+{
+    co_await coro::whenAll(parkThenObserveListenerClose(owner->get(), accepted),
+                           destroyListenerAfterParked(loop, owner));
+}
+
+/// Reads once and counts the resume, however it arrives. A count above one means
+/// the same coroutine was queued twice — the use-after-free the close-wake path had
+/// to be designed around.
+/// @param sock The socket to park on.
+/// @param count Incremented exactly once, when the read resolves or unwinds.
+Task<void> countOneResume(net::ISocket* sock, int* count)
+{
+    auto buffer = std::array<std::byte, 64> {};
+    try
+    {
+        static_cast<void>(co_await sock->read(buffer));
+        ++*count;
+    }
+    catch (coro::OperationCancelled const&)
+    {
+        // Cancellation is a resume too — and the one ~EventLoop delivers. Counted
+        // in both arms, so either route through here registers exactly once.
+        ++*count;
+    }
+}
+
+/// Like @c countOneResume, but requests stop the moment it wakes — while a sibling
+/// woken by the same close is still sitting in the ready queue with its cancellation
+/// callback armed. That is exactly the window in which the previous attempt queued
+/// the sibling a SECOND time and then resumed a frame the first resume had
+/// destroyed.
+/// @param loop The loop to stop.
+/// @param sock The socket to park on.
+/// @param count Incremented once, when the read resolves or unwinds.
+Task<void> countOneResumeThenRequestStop(EventLoop* loop, net::ISocket* sock, int* count)
+{
+    co_await countOneResume(sock, count);
+    loop->requestStop();
+}
+
+/// Accepts once and counts the resume, however it arrives.
+Task<void> countOneAccept(net::IListener* listener, int* count)
+{
+    static_cast<void>(co_await listener->accept());
+    ++*count;
+}
+
+/// Closes both sockets in one go, then keeps the pump alive long enough for the
+/// resulting wakes to be delivered.
+/// @param loop The loop driving both delays.
+/// @param first The first socket to close.
+/// @param second The second socket to close.
+/// @param stopRequested Set when the trailing delay was cancelled — which proves a
+///        woken reader ran and called requestStop() while its sibling was still
+///        queued, i.e. that the case actually reached the window it exists to test.
+Task<void> closeBothThenSettle(EventLoop* loop,
+                               net::ISocket* first,
+                               net::ISocket* second,
+                               bool* stopRequested)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+    first->close();
+    second->close();
+    try
+    {
+        co_await loop->delay(std::chrono::milliseconds { 20 });
+    }
+    catch (coro::OperationCancelled const&)
+    {
+        *stopRequested = true;
+    }
+}
+
+/// Suspends briefly so spawned flows reach their parks before the caller acts.
+Task<void> settle(EventLoop* loop)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+}
+
 } // namespace
 
 TEST_CASE("every available event source reports pipe readability", "[net][eventsource][parity]")
@@ -243,23 +451,14 @@ TEST_CASE("every available event source serves a loopback listener", "[net][even
     }
 }
 
-// KNOWN FAILURE on epoll/kqueue, HIDDEN ([.]) rather than merely expected-to-fail:
-// these do not fail fast, they HANG until the harness kills them, so running them by
-// default would cost minutes of CI time and end in a timeout. Run them deliberately
-// with `net_test [closehang]` when working on the fix.
-//
-// A readiness poller cannot report a CLOSED descriptor: epoll
-// drops it from the set and kqueue drops its filters, both silently, so a flow
-// parked on it is never resumed. poll(2) reports POLLNVAL and resumes it.
-//
-// The obvious fix -- have close() tell the loop, which resumes the parked flow --
-// was tried and reverted: it resumes a flow OUTSIDE the pump, and a coroutine
-// resumed there can be destroyed by normal control flow while still queued
-// (ConnectionAcceptor::serve documents relying on exactly one final resume during
-// ~EventLoop). That traded a hang for a use-after-free, which is worse. A correct
-// fix has to deliver the wake through the source as ordinary readiness.
+// Regression guard for the close-wake path. A readiness poller cannot report a
+// CLOSED descriptor: epoll drops it from the set and kqueue drops its filters, both
+// silently, so a flow parked on it used to hang for ever. poll(2) reports POLLNVAL
+// and Windows reports the handle as failed, which is why only the native backends
+// were broken. EventLoop::notifyHandleClosing supplies the missing readiness, and
+// these cases HUNG until it existed.
 TEST_CASE("closing a socket resumes a parked reader on every event source",
-          "[.][net][eventsource][parity][closehang]")
+          "[net][eventsource][parity][closehang]")
 {
     // Socket_test covers this only for PollEventSource, so it stayed green while the
     // native backends were broken. Driving it through the loop on every backend is
@@ -279,6 +478,304 @@ TEST_CASE("closing a socket resumes a parked reader on every event source",
             auto resumedWithError = false;
             loop.blockOn(closeWhileParked(&loop, pair->second.get(), &resumedWithError));
             CHECK(resumedWithError); // resumed at all (no hang) AND saw the close
+        }
+    }
+}
+
+TEST_CASE("closing a socket resumes a parked writer on every event source",
+          "[net][eventsource][parity][closehang]")
+{
+    // The write direction of the same hazard. A writer parks on WRITABILITY, so it
+    // is registered with a different interest than the reader above — and a backend
+    // that only routed the read side of a close would hang here instead.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto resumedWithError = false;
+            loop.blockOn(closeWhileWriteParked(&loop, pair->second.get(), &resumedWithError));
+            CHECK(resumedWithError);
+        }
+    }
+}
+
+TEST_CASE("closing a socket resumes BOTH flows parked on it on every event source",
+          "[net][eventsource][parity][closehang]")
+{
+    // Two registrations on one descriptor is the shape epoll and kqueue cannot hold
+    // natively, so each keeps a private dup() for the second. A close must resume
+    // both flows -- and detach both registrations, or that duplicate would keep the
+    // peer's connection open past the close it was supposed to end.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto readerResumed = false;
+            auto writerResumed = false;
+            loop.blockOn(closeWhileBothParked(&loop, pair->second.get(), &readerResumed, &writerResumed));
+            CHECK(readerResumed);
+            CHECK(writerResumed);
+        }
+    }
+}
+
+TEST_CASE("closing a socket wakes only the flows parked on it", "[net][eventsource][parity][closehang]")
+{
+    // The wake is routed by descriptor, not broadcast: a reader on an untouched
+    // socket must stay parked. A close that woke every waiter would look like it
+    // worked -- until an unrelated flow resumed early and read from a live socket
+    // that had nothing to give.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto closing = net::testing::makeSocketPair(loop);
+            auto idle = net::testing::makeSocketPair(loop);
+            REQUIRE(closing.has_value());
+            REQUIRE(idle.has_value());
+
+            auto closedResumed = false;
+            auto idleResumed = false;
+            loop.blockOn(closeOneOfTwo(
+                &loop, closing->second.get(), idle->second.get(), &closedResumed, &idleResumed));
+            CHECK(closedResumed);
+            CHECK_FALSE(idleResumed); // never woken: nothing closed under it
+        }
+    }
+}
+
+TEST_CASE("closing a socket with nothing parked leaves the loop usable",
+          "[net][eventsource][parity][closehang]")
+{
+    // Closing an idle socket records no wake at all, and closing it twice records
+    // no second one. Either mistake would leave a token queued for a registration
+    // that no longer exists, and the next pump would resume whatever now answers to
+    // it -- or spin delivering a wake nobody claims.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto stillPumps = false;
+            loop.blockOn(closeTwiceThenKeepPumping(&loop, pair->second.get(), &stillPumps));
+            CHECK(stillPumps);
+        }
+    }
+}
+
+TEST_CASE("a close-wake does not swallow a pending timer", "[net][eventsource][parity][closehang]")
+{
+    // The pump merges close-wakes INTO its wait outcome rather than short-circuiting
+    // and returning early. Skipping the wait would strand every other thing due in
+    // that pump -- a peer's EOF, or this timer -- until some later pump that may
+    // never come, because blockOn exits as soon as its root flow is done.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto readerResumed = false;
+            auto timerFired = false;
+            loop.blockOn(closeWhileTimerPending(&loop, pair->second.get(), &readerResumed, &timerFired));
+            CHECK(readerResumed);
+            CHECK(timerFired);
+        }
+    }
+}
+
+TEST_CASE("destroying a socket under a parked reader cancels it", "[net][eventsource][parity][closehang]")
+{
+    // A destructor cannot use the same wake an explicit close() does. Resuming the
+    // flow on its NORMAL path would send it back into PosixSocket::read, which
+    // re-reads _closed and _fd through a `this` that has just stopped existing.
+    // FdWakePolicy::Cancel makes await_resume throw instead, so the frame unwinds
+    // without ever re-entering its body. Run under ASan, this case is the guard.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto cancelled = false;
+            loop.blockOn(destroyWhileParked(&loop, &pair->second, &cancelled));
+            CHECK(cancelled); // unwound as cancelled, not resumed into a dead object
+        }
+    }
+}
+
+TEST_CASE("destroying a listener under a parked accept cancels it", "[net][eventsource][parity][closehang]")
+{
+    // The listener form of the same rule, and the sharper one: acceptOne holds
+    // `int const* fd` and `bool const* closed` pointing INTO the listener, and
+    // re-reads both at the top of every turn. A normal-path resume would dereference
+    // them after the listener was destroyed; the cancelling resume returns from the
+    // catch without touching either.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto listener = net::listen(loop, "127.0.0.1", 0);
+            REQUIRE(listener.has_value());
+
+            auto accepted = true;
+            loop.blockOn(destroyListenerWhileParked(&loop, &*listener, &accepted));
+            CHECK_FALSE(accepted);
+        }
+    }
+}
+
+TEST_CASE("a close recorded before the loop dies resumes its flow exactly once",
+          "[net][eventsource][parity][closehang]")
+{
+    // close() records a wake for the next pump — but if the loop is destroyed first
+    // that pump never comes. ~EventLoop must then be the ONLY thing that resumes the
+    // flow, through its own request_stop()-first path. Consuming the recorded wake
+    // there as well would resume the same coroutine twice: the first resume runs it
+    // to completion and its owner destroys the frame, and the second calls .done()
+    // on freed memory.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto resumeCount = 0;
+            {
+                auto loop = EventLoop { *source };
+                auto pair = net::testing::makeSocketPair(loop);
+                REQUIRE(pair.has_value());
+
+                loop.spawn(countOneResume(pair->second.get(), &resumeCount));
+                loop.blockOn(settle(&loop)); // the reader reaches its park
+                REQUIRE(resumeCount == 0);
+
+                pair->second->close(); // records a wake no pump will ever consume
+            } // ~EventLoop: cancels and drains
+            CHECK(resumeCount == 1);
+        }
+    }
+}
+
+TEST_CASE("closing every listener and then requesting stop resumes each accept once",
+          "[net][eventsource][parity][closehang]")
+{
+    // requestDaemonShutdown's sequence, verbatim: close every listener, THEN
+    // requestStop(). This is the shape that segfaulted vthost_test and
+    // contour_gui_test on every platform when close() queued the parked flow itself:
+    // the queued coroutine still had its cancellation callback armed, so
+    // request_stop() queued it a second time.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto resumeCount = 0;
+            {
+                auto loop = EventLoop { *source };
+                auto listeners = std::vector<std::unique_ptr<net::IListener>> {};
+                for ([[maybe_unused]] auto const each: std::views::iota(0, 3))
+                {
+                    auto listener = net::listen(loop, "127.0.0.1", 0);
+                    REQUIRE(listener.has_value());
+                    listeners.push_back(std::move(*listener));
+                }
+                for (auto const& listener: listeners)
+                    loop.spawn(countOneAccept(listener.get(), &resumeCount));
+                loop.blockOn(settle(&loop)); // all three accepts reach their parks
+                REQUIRE(resumeCount == 0);
+
+                for (auto const& listener: listeners)
+                    listener->close();
+                loop.requestStop();
+            } // ~EventLoop: drains what is left
+            CHECK(resumeCount == 3); // once each -- never twice
+        }
+    }
+}
+
+TEST_CASE("a close-woken flow may request stop while a sibling is still queued",
+          "[net][eventsource][parity][closehang]")
+{
+    // Both readers are woken by the same pump. The first to resume requests stop
+    // while the second is still sitting in the ready queue, un-resumed and with its
+    // cancellation callback still armed — the callback only disarms in await_resume.
+    // requeueForCancellation must recognise that the sibling is already queued and
+    // NOT push it again.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto resumeCount = 0;
+            auto stopRequested = false;
+            {
+                auto loop = EventLoop { *source };
+                auto first = net::testing::makeSocketPair(loop);
+                auto second = net::testing::makeSocketPair(loop);
+                REQUIRE(first.has_value());
+                REQUIRE(second.has_value());
+
+                loop.spawn(countOneResumeThenRequestStop(&loop, first->second.get(), &resumeCount));
+                loop.spawn(countOneResume(second->second.get(), &resumeCount));
+                loop.blockOn(
+                    closeBothThenSettle(&loop, first->second.get(), second->second.get(), &stopRequested));
+            }
+            CHECK(stopRequested);    // the woken reader really did request stop
+            CHECK(resumeCount == 2); // once each -- never twice
         }
     }
 }
@@ -515,11 +1012,8 @@ TEST_CASE("an invalid handle is refused by every event source", "[net][eventsour
     }
 }
 
-// Its close-shaped sections are KNOWN FAILURES on epoll/kqueue, same cause as the
-// parked-reader case above, so the whole case is hidden until that is fixed.
-// Run with `net_test [closehang]`.
 TEST_CASE("the default source drives the scenarios Socket_test pins to poll",
-          "[.][net][eventsource][parity][closehang]")
+          "[net][eventsource][parity][closehang]")
 {
     // Socket_test hardcodes PollEventSource in all of its cases, which is why two
     // native-backend defects (a registration holding the peer's connection open, and
@@ -567,10 +1061,10 @@ TEST_CASE("the default source drives the scenarios Socket_test pins to poll",
     }
 }
 
-// KNOWN FAILURE on epoll/kqueue, same cause as the parked-reader case above; hidden
-// for the same reason (it hangs rather than failing). Run with `net_test [closehang]`.
+// Same hazard as the parked reader, one layer up; it HUNG on epoll/kqueue until
+// notifyHandleClosing existed.
 TEST_CASE("closing a listener resumes a parked accept on every event source",
-          "[.][net][eventsource][parity][closehang]")
+          "[net][eventsource][parity][closehang]")
 {
     // Same hazard as a parked reader, one layer up: accept() parks on waitReadable,
     // so a listener closed while an accept is pending must resume it rather than

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -27,6 +27,13 @@
 #include <net/platform/SystemPipe.hpp>
 #include <net/testing/InMemoryTransport.hpp>
 
+#ifndef _WIN32
+    #include <sys/socket.h>
+
+    #include <fcntl.h>
+    #include <unistd.h>
+#endif
+
 using coro::Task;
 using net::EventLoop;
 using net::EventSourceKind;
@@ -264,6 +271,44 @@ TEST_CASE("two registrations on one descriptor are accepted by every event sourc
         }
     }
 }
+
+#ifndef _WIN32
+TEST_CASE("a registration does not keep a closed descriptor's connection alive", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto sv = std::array<int, 2> {};
+            REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv.data()) == 0);
+
+            // Attach one end, then close it WITHOUT detaching first — the ordering
+            // a cancelled flow or an early socket destructor produces. A backend
+            // that registers a dup() of the descriptor keeps the underlying open
+            // file description alive, so no FIN reaches the peer: its read blocks
+            // forever instead of reporting EOF, and the connection leaks.
+            auto const token = source->attach(sv[0], FdInterest::Read);
+            REQUIRE(token);
+            ::close(sv[0]);
+
+            // The peer must see EOF now. Read non-blocking so a backend that holds
+            // the description open fails the assertion instead of hanging the suite.
+            auto const flags = ::fcntl(sv[1], F_GETFL, 0);
+            ::fcntl(sv[1], F_SETFL, flags | O_NONBLOCK);
+            auto buffer = std::array<char, 16> {};
+            auto const got = ::read(sv[1], buffer.data(), buffer.size());
+            CHECK(got == 0); // 0 == EOF; -1/EAGAIN means the FIN never arrived
+
+            source->detach(token);
+            ::close(sv[1]);
+        }
+    }
+}
+#endif
 
 TEST_CASE("an invalid handle is refused by every event source", "[net][eventsource][parity]")
 {

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -212,6 +212,44 @@ TEST_CASE("an attached token is reported and a detached one is not", "[net][even
     }
 }
 
+TEST_CASE("two registrations on one descriptor are accepted by every event source",
+          "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto pipe = net::createSystemPipe();
+            REQUIRE(pipe.has_value());
+
+            // FdRegistry permits it and poll(2) takes two entries, so the native
+            // backends must too — an epoll set is keyed by descriptor and would
+            // otherwise refuse the second with EEXIST, and a kqueue filter is keyed
+            // by (descriptor, filter) and would replace rather than add.
+            auto const first = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+            auto const second = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+            REQUIRE(first);
+            REQUIRE(second);
+            REQUIRE(first != second);
+
+            auto const one = std::array<std::byte, 1> { std::byte { 'x' } };
+            REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
+
+            // Both registrations must observe the readiness, not just one.
+            auto const ready = source->wait(200);
+            CHECK(std::ranges::find(ready.readyRead, first) != ready.readyRead.end());
+            CHECK(std::ranges::find(ready.readyRead, second) != ready.readyRead.end());
+
+            source->detach(first);
+            source->detach(second);
+        }
+    }
+}
+
 TEST_CASE("an invalid handle is refused by every event source", "[net][eventsource][parity]")
 {
     for (auto const& backend: AllBackends)

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -146,6 +146,28 @@ Task<void> readOnce(net::ISocket* sock, int* outcome)
     *outcome = result.has_value() ? static_cast<int>(*result) : -1;
 }
 
+/// Parks on accept() and records whether it resumed (with a failure) rather than
+/// hanging once the listener beneath it is closed.
+Task<void> parkThenObserveListenerClose(net::IListener* listener, bool* accepted)
+{
+    auto const result = co_await listener->accept();
+    *accepted = result.has_value();
+}
+
+/// Lets the accept reach its park, then closes the listener it is parked on.
+Task<void> closeListenerAfterParked(EventLoop* loop, net::IListener* listener)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+    listener->close();
+}
+
+/// Runs the parked accept and the listener close concurrently on one loop.
+Task<void> acceptThenClose(EventLoop* loop, net::IListener* listener, bool* accepted)
+{
+    co_await coro::whenAll(parkThenObserveListenerClose(listener, accepted),
+                           closeListenerAfterParked(loop, listener));
+}
+
 } // namespace
 
 TEST_CASE("every available event source reports pipe readability", "[net][eventsource][parity]")
@@ -522,6 +544,30 @@ TEST_CASE("the default source drives the scenarios Socket_test pins to poll", "[
         auto outcome = -99;
         loop.blockOn(readOnce(pair->second.get(), &outcome));
         CHECK(outcome == 0);
+    }
+}
+
+TEST_CASE("closing a listener resumes a parked accept on every event source", "[net][eventsource][parity]")
+{
+    // Same hazard as a parked reader, one layer up: accept() parks on waitReadable,
+    // so a listener closed while an accept is pending must resume it rather than
+    // leave it parked on a descriptor the poller can no longer report.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto listener = net::listen(loop, "127.0.0.1", 0);
+            REQUIRE(listener.has_value());
+
+            auto accepted = true;
+            loop.blockOn(acceptThenClose(&loop, listener->get(), &accepted));
+            CHECK_FALSE(accepted); // it resumed at all, and reported the close
+        }
     }
 }
 

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -28,6 +28,7 @@
 #include <net/testing/InMemoryTransport.hpp>
 
 #ifndef _WIN32
+    #include <sys/resource.h>
     #include <sys/socket.h>
 
     #include <fcntl.h>
@@ -305,6 +306,70 @@ TEST_CASE("a registration does not keep a closed descriptor's connection alive",
 
             source->detach(token);
             ::close(sv[1]);
+        }
+    }
+}
+#endif
+
+#ifndef _WIN32
+TEST_CASE("a duplicate registration refuses cleanly when descriptors run out", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto pipe = net::createSystemPipe();
+            REQUIRE(pipe.has_value());
+
+            // The first registration watches the caller's descriptor directly, so it
+            // needs no descriptor of its own.
+            auto const first = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+            REQUIRE(first);
+
+            // A second registration on the same descriptor needs a private dup().
+            // Lower the soft descriptor limit to what is already open so that dup()
+            // must fail, and require a refusal rather than a token for a registration
+            // the kernel never accepted — parking on one of those is unresumable.
+            // The soft limit is restored below, so this stays scoped to this case
+            // rather than starving the rest of the suite.
+            auto limit = rlimit {};
+            REQUIRE(::getrlimit(RLIMIT_NOFILE, &limit) == 0);
+            auto const originalSoft = limit.rlim_cur;
+
+            auto const probe = ::dup(0); // the lowest descriptor still free
+            REQUIRE(probe >= 0);
+            auto squeezed = limit;
+            squeezed.rlim_cur = static_cast<rlim_t>(probe); // no descriptor >= probe may be opened
+            REQUIRE(::setrlimit(RLIMIT_NOFILE, &squeezed) == 0);
+            ::close(probe);
+
+            auto const underPressure = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+
+            limit.rlim_cur = originalSoft;
+            REQUIRE(::setrlimit(RLIMIT_NOFILE, &limit) == 0);
+
+            // What must hold on EVERY backend is that the answer is honest: either
+            // the registration was refused, or it was genuinely armed. What must
+            // never happen is a valid token for a registration the kernel does not
+            // have. poll(2) needs no descriptor of its own, so it legitimately
+            // succeeds here; epoll and kqueue must dup() and so must refuse.
+            if (backend.kind == EventSourceKind::Poll)
+                CHECK(underPressure);
+            else
+                CHECK_FALSE(underPressure);
+
+            // Recovery: with descriptors available again, a duplicate must work.
+            auto const afterRecovery = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+            CHECK(afterRecovery);
+
+            source->detach(afterRecovery);
+            if (underPressure)
+                source->detach(underPressure); // poll(2) succeeded above
+            source->detach(first);
         }
     }
 }

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+///
+/// Every @c EventSource backend must be behaviourally interchangeable — the whole
+/// point of the interface is that swapping poll(2) for epoll/kqueue changes only
+/// what a wait costs. These cases therefore run the SAME scenario against every
+/// backend available on this platform, so a divergence fails here rather than
+/// surfacing as a hang in whatever happens to use the native source.
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <coro/Task.hpp>
+#include <coro/WhenAll.hpp>
+#include <net/DefaultEventSource.hpp>
+#include <net/EventLoop.hpp>
+#include <net/EventSource.hpp>
+#include <net/ISocket.hpp>
+#include <net/Sockets.hpp>
+#include <net/platform/SystemPipe.hpp>
+#include <net/testing/InMemoryTransport.hpp>
+
+using coro::Task;
+using net::EventLoop;
+using net::EventSourceKind;
+using net::FdInterest;
+
+namespace
+{
+
+/// One backend to exercise, with a label so a failure names which one broke.
+struct Backend
+{
+    EventSourceKind kind;  ///< The backend to construct.
+    std::string_view name; ///< Its name, for the section label.
+};
+
+constexpr auto AllBackends = std::array {
+    Backend { EventSourceKind::Poll, "poll" },
+    Backend { EventSourceKind::Epoll, "epoll" },
+    Backend { EventSourceKind::Kqueue, "kqueue" },
+};
+
+/// Writes to a pipe, then waits for the read end to become readable.
+Task<void> waitThenRead(EventLoop* loop, net::SystemPipe* pipe, bool* observed)
+{
+    co_await loop->waitReadable(pipe->waitHandle());
+    auto byte = std::array<std::byte, 1> {};
+    auto const got = pipe->read(byte.data(), byte.size());
+    *observed = got.has_value() && *got == 1;
+}
+
+/// Echoes one message over a connected socket pair, exercising both readiness
+/// directions through whichever source the loop was built with.
+Task<void> echoOnce(net::ISocket* client, net::ISocket* server, std::string* out)
+{
+    constexpr auto Message = std::string_view { "parity" };
+    auto const bytes =
+        std::span<std::byte const> { reinterpret_cast<std::byte const*>(Message.data()), Message.size() };
+    static_cast<void>(co_await client->write(bytes));
+
+    auto buffer = std::array<std::byte, 64> {};
+    auto const got = co_await server->read(buffer);
+    if (got.has_value())
+        out->assign(reinterpret_cast<char const*>(buffer.data()), *got);
+}
+
+/// The server flow: accept one connection and read the message it sends.
+Task<void> acceptAndEcho(net::IListener* listener, std::string* out)
+{
+    auto accepted = co_await listener->accept();
+    if (!accepted.has_value())
+        co_return;
+    auto socket = std::move(*accepted);
+    auto buffer = std::array<std::byte, 64> {};
+    auto const got = co_await socket->read(buffer);
+    if (got.has_value())
+        out->assign(reinterpret_cast<char const*>(buffer.data()), *got);
+}
+
+/// Runs the accept and connect flows concurrently to completion.
+Task<void> echoOverListener(EventLoop* loop, net::IListener* listener, std::uint16_t port, std::string* out);
+
+/// The client flow: connect to @p port and send the message the server expects.
+Task<void> connectAndSend(EventLoop* loop, std::uint16_t port)
+{
+    auto connected = co_await net::connect(loop, "127.0.0.1", port);
+    if (!connected.has_value())
+        co_return;
+    auto socket = std::move(*connected);
+    constexpr auto Message = std::string_view { "parity" };
+    auto const bytes =
+        std::span<std::byte const> { reinterpret_cast<std::byte const*>(Message.data()), Message.size() };
+    static_cast<void>(co_await socket->write(bytes));
+}
+
+Task<void> echoOverListener(EventLoop* loop, net::IListener* listener, std::uint16_t port, std::string* out)
+{
+    co_await coro::whenAll(acceptAndEcho(listener, out), connectAndSend(loop, port));
+}
+
+} // namespace
+
+TEST_CASE("every available event source reports pipe readability", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pipe = net::createSystemPipe();
+            REQUIRE(pipe.has_value());
+
+            auto const one = std::array<std::byte, 1> { std::byte { 'x' } };
+            REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
+
+            auto observed = false;
+            loop.blockOn(waitThenRead(&loop, pipe->get(), &observed));
+            REQUIRE(observed);
+        }
+    }
+}
+
+TEST_CASE("every available event source drives a socket round-trip", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto got = std::string {};
+            loop.blockOn(echoOnce(pair->first.get(), pair->second.get(), &got));
+            REQUIRE(got == "parity");
+        }
+    }
+}
+
+TEST_CASE("every available event source serves a loopback listener", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto listener = net::listen(loop, "127.0.0.1", 0);
+            REQUIRE(listener.has_value());
+            auto const port = (*listener)->localPort();
+            REQUIRE(port != 0);
+
+            // accept() and connect() park on opposite readiness directions, so this
+            // exercises the attach/interest-update path the reconciliation covers.
+            // They must run as CONCURRENT flows: a Task is lazy, so a connect that
+            // is merely created (not awaited) never runs, and accept would wait for
+            // a connection nobody initiated.
+            auto got = std::string {};
+            loop.blockOn(echoOverListener(&loop, listener->get(), port, &got));
+            REQUIRE(got == "parity");
+        }
+    }
+}
+
+TEST_CASE("an attached token is reported and a detached one is not", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto pipe = net::createSystemPipe();
+            REQUIRE(pipe.has_value());
+
+            auto const token = source->attach((*pipe)->waitHandle(), FdInterest::Read);
+            REQUIRE(token);
+
+            auto const one = std::array<std::byte, 1> { std::byte { 'x' } };
+            REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
+
+            auto const ready = source->wait(200);
+            REQUIRE(std::ranges::find(ready.readyRead, token) != ready.readyRead.end());
+
+            // After detaching, the same still-readable fd must not be reported.
+            source->detach(token);
+            auto const afterDetach = source->wait(0);
+            REQUIRE(afterDetach.readyRead.empty());
+            REQUIRE(afterDetach.readyWrite.empty());
+        }
+    }
+}
+
+TEST_CASE("an invalid handle is refused by every event source", "[net][eventsource][parity]")
+{
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            // A refused registration must report invalid rather than succeeding:
+            // the awaiting flow has to fail instead of parking on an interest the
+            // kernel never accepted, which nothing could resume.
+            auto const token = source->attach(net::InvalidHandle, FdInterest::Read);
+            REQUIRE_FALSE(token);
+        }
+    }
+}
+
+TEST_CASE("makeDefaultEventSource yields a usable source", "[net][eventsource]")
+{
+    auto source = net::makeDefaultEventSource();
+    REQUIRE(source != nullptr);
+
+    // Whatever it picked must drive a real round-trip.
+    auto loop = EventLoop { *source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto got = std::string {};
+    loop.blockOn(echoOnce(pair->first.get(), pair->second.get(), &got));
+    REQUIRE(got == "parity");
+}
+
+TEST_CASE("the preferred backend is constructible on this platform", "[net][eventsource]")
+{
+    // If the platform names a native backend, it must actually build here — a
+    // silent permanent fallback to poll would mean the port is not exercised at all.
+    auto const preferred = net::preferredEventSourceKind();
+    auto source = net::makeEventSource(preferred);
+    REQUIRE(source != nullptr);
+}

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -167,25 +167,43 @@ Task<void> acceptThenClose(EventLoop* loop, net::IListener* listener, bool* acce
                            closeListenerAfterParked(loop, listener));
 }
 
-/// Writes until the peer's receive buffer and this socket's send buffer are both
-/// full, so the write parks on writability, then records whether it resumed with an
-/// error rather than hanging once the socket is closed under it.
+/// Writes to a socket whose peer never reads, until the socket refuses.
+///
+/// Deliberately a LOOP rather than one enormous write. On a POSIX socket pair the
+/// send and receive buffers fill within a turn or two and the write parks on
+/// writability, which is the case this exercises. Windows auto-tunes its buffers
+/// far higher, so a fixed payload — 4 MiB was the first attempt — is simply
+/// absorbed and the write succeeds, never parking; the assertion then failed for a
+/// reason that had nothing to do with the code under test. Looping with a yield
+/// between turns makes the outcome the same everywhere: whether the writer parks
+/// and the close resumes it, or the close simply lands between two turns, a writer
+/// must end up learning the socket is gone rather than hanging.
+/// @param loop The loop to yield to between turns.
 /// @param sock The socket to write to (its peer never reads).
-/// @param resumedWithError Set to true if the write resumed and reported a failure.
-Task<void> parkThenObserveWriteClose(net::ISocket* sock, bool* resumedWithError)
+/// @param resumedWithError Set to true once a write reports a failure.
+Task<void> parkThenObserveWriteClose(EventLoop* loop, net::ISocket* sock, bool* resumedWithError)
 {
-    // Far larger than any default SO_SNDBUF/SO_RCVBUF pair, so the write cannot
-    // complete without the peer reading — which it never does.
-    constexpr auto PayloadBytes = std::size_t { 4 } * 1024 * 1024;
-    auto const payload = std::vector<std::byte>(PayloadBytes, std::byte { 'x' });
-    auto const result = co_await sock->write(payload);
-    *resumedWithError = !result.has_value();
+    constexpr auto ChunkBytes = std::size_t { 256 } * 1024;
+    auto const chunk = std::vector<std::byte>(ChunkBytes, std::byte { 'x' });
+    // Bounded so a backend that never refuses fails the CHECK instead of hanging.
+    for ([[maybe_unused]] auto const turn: std::views::iota(0, 512))
+    {
+        if (auto const result = co_await sock->write(chunk); !result.has_value())
+        {
+            *resumedWithError = true;
+            co_return;
+        }
+        // Yield, so the flow that closes the socket still gets to run on a platform
+        // where the write never had to park.
+        co_await loop->delay(std::chrono::milliseconds { 1 });
+    }
 }
 
 /// Runs the parked writer and the close concurrently on one loop.
 Task<void> closeWhileWriteParked(EventLoop* loop, net::ISocket* sock, bool* resumedWithError)
 {
-    co_await coro::whenAll(parkThenObserveWriteClose(sock, resumedWithError), closeAfterParked(loop, sock));
+    co_await coro::whenAll(parkThenObserveWriteClose(loop, sock, resumedWithError),
+                           closeAfterParked(loop, sock));
 }
 
 /// Parks a reader AND a writer on ONE socket, then closes it under both. Two
@@ -200,7 +218,7 @@ Task<void> closeWhileWriteParked(EventLoop* loop, net::ISocket* sock, bool* resu
 Task<void> closeWhileBothParked(EventLoop* loop, net::ISocket* sock, bool* readerResumed, bool* writerResumed)
 {
     co_await coro::whenAll(parkThenObserveClose(sock, readerResumed),
-                           parkThenObserveWriteClose(sock, writerResumed),
+                           parkThenObserveWriteClose(loop, sock, writerResumed),
                            closeAfterParked(loop, sock));
 }
 

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -239,13 +239,21 @@ TEST_CASE("two registrations on one descriptor are accepted by every event sourc
             auto const one = std::array<std::byte, 1> { std::byte { 'x' } };
             REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
 
-            // Both registrations must observe the readiness, not just one.
+            // At least one registration is reported. NOT both: whether a duplicated
+            // descriptor yields one ready entry or two is the multiplexer's own
+            // business — Linux's poll(2) fills in every matching pollfd, macOS's
+            // reports the descriptor once — and EventSource deliberately does not
+            // promise either. What it does promise is that a registration is
+            // accepted and that readiness reaches somebody.
             auto const ready = source->wait(200);
-            CHECK(std::ranges::find(ready.readyRead, first) != ready.readyRead.end());
-            CHECK(std::ranges::find(ready.readyRead, second) != ready.readyRead.end());
+            auto const sawFirst = std::ranges::find(ready.readyRead, first) != ready.readyRead.end();
+            auto const sawSecond = std::ranges::find(ready.readyRead, second) != ready.readyRead.end();
+            CHECK((sawFirst || sawSecond));
 
             // Detaching one must not disturb the other: they are separate kernel
             // registrations, so dropping one cannot take the survivor's with it.
+            // This is the property the dup() exists to provide, and it holds
+            // everywhere regardless of how duplicates are reported above.
             source->detach(first);
             REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
             auto const afterOne = source->wait(200);

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <span>
@@ -114,6 +115,37 @@ Task<void> echoOverListener(EventLoop* loop, net::IListener* listener, std::uint
     co_await coro::whenAll(acceptAndEcho(listener, out), connectAndSend(loop, port));
 }
 
+/// Parks reading an idle socket and records whether the read resumed with an error
+/// rather than hanging forever.
+Task<void> parkThenObserveClose(net::ISocket* sock, bool* resumedWithError)
+{
+    auto buffer = std::array<std::byte, 64> {};
+    auto const result = co_await sock->read(buffer);
+    *resumedWithError = !result.has_value();
+}
+
+/// Lets the reader reach its park, then closes the socket it is parked on.
+Task<void> closeAfterParked(EventLoop* loop, net::ISocket* sock)
+{
+    co_await loop->delay(std::chrono::milliseconds { 20 });
+    sock->close();
+}
+
+/// Runs the parked reader and the close concurrently on one loop.
+Task<void> closeWhileParked(EventLoop* loop, net::ISocket* sock, bool* resumedWithError)
+{
+    co_await coro::whenAll(parkThenObserveClose(sock, resumedWithError), closeAfterParked(loop, sock));
+}
+
+/// Reads once, recording the byte count so a clean EOF is distinguishable from an
+/// error and from a hang.
+Task<void> readOnce(net::ISocket* sock, int* outcome)
+{
+    auto buffer = std::array<std::byte, 64> {};
+    auto const result = co_await sock->read(buffer);
+    *outcome = result.has_value() ? static_cast<int>(*result) : -1;
+}
+
 } // namespace
 
 TEST_CASE("every available event source reports pipe readability", "[net][eventsource][parity]")
@@ -185,6 +217,57 @@ TEST_CASE("every available event source serves a loopback listener", "[net][even
             auto got = std::string {};
             loop.blockOn(echoOverListener(&loop, listener->get(), port, &got));
             REQUIRE(got == "parity");
+        }
+    }
+}
+
+TEST_CASE("closing a socket resumes a parked reader on every event source", "[net][eventsource][parity]")
+{
+    // Socket_test covers this only for PollEventSource, so it stayed green while the
+    // native backends were broken. Driving it through the loop on every backend is
+    // what catches a source that holds a descriptor the socket thinks it closed.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            auto resumedWithError = false;
+            loop.blockOn(closeWhileParked(&loop, pair->second.get(), &resumedWithError));
+            CHECK(resumedWithError); // resumed at all (no hang) AND saw the close
+        }
+    }
+}
+
+TEST_CASE("a peer's close is delivered as EOF on every event source", "[net][eventsource][parity]")
+{
+    // The end-to-end form of the descriptor-ownership rule: the reader goes through
+    // EventLoop and ISocket rather than touching the source directly, so a backend
+    // that keeps the peer's file description alive shows up as a read that never
+    // reports EOF.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue;
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
+
+            pair->first->close(); // the peer goes away
+
+            auto outcome = -99;
+            loop.blockOn(readOnce(pair->second.get(), &outcome));
+            CHECK(outcome == 0); // 0 == clean EOF; -1 would be an error, -99 a hang
         }
     }
 }

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -243,7 +243,23 @@ TEST_CASE("every available event source serves a loopback listener", "[net][even
     }
 }
 
-TEST_CASE("closing a socket resumes a parked reader on every event source", "[net][eventsource][parity]")
+// KNOWN FAILURE on epoll/kqueue, HIDDEN ([.]) rather than merely expected-to-fail:
+// these do not fail fast, they HANG until the harness kills them, so running them by
+// default would cost minutes of CI time and end in a timeout. Run them deliberately
+// with `net_test [closehang]` when working on the fix.
+//
+// A readiness poller cannot report a CLOSED descriptor: epoll
+// drops it from the set and kqueue drops its filters, both silently, so a flow
+// parked on it is never resumed. poll(2) reports POLLNVAL and resumes it.
+//
+// The obvious fix -- have close() tell the loop, which resumes the parked flow --
+// was tried and reverted: it resumes a flow OUTSIDE the pump, and a coroutine
+// resumed there can be destroyed by normal control flow while still queued
+// (ConnectionAcceptor::serve documents relying on exactly one final resume during
+// ~EventLoop). That traded a hang for a use-after-free, which is worse. A correct
+// fix has to deliver the wake through the source as ordinary readiness.
+TEST_CASE("closing a socket resumes a parked reader on every event source",
+          "[.][net][eventsource][parity][closehang]")
 {
     // Socket_test covers this only for PollEventSource, so it stayed green while the
     // native backends were broken. Driving it through the loop on every backend is
@@ -499,7 +515,11 @@ TEST_CASE("an invalid handle is refused by every event source", "[net][eventsour
     }
 }
 
-TEST_CASE("the default source drives the scenarios Socket_test pins to poll", "[net][eventsource][parity]")
+// Its close-shaped sections are KNOWN FAILURES on epoll/kqueue, same cause as the
+// parked-reader case above, so the whole case is hidden until that is fixed.
+// Run with `net_test [closehang]`.
+TEST_CASE("the default source drives the scenarios Socket_test pins to poll",
+          "[.][net][eventsource][parity][closehang]")
 {
     // Socket_test hardcodes PollEventSource in all of its cases, which is why two
     // native-backend defects (a registration holding the peer's connection open, and
@@ -547,7 +567,10 @@ TEST_CASE("the default source drives the scenarios Socket_test pins to poll", "[
     }
 }
 
-TEST_CASE("closing a listener resumes a parked accept on every event source", "[net][eventsource][parity]")
+// KNOWN FAILURE on epoll/kqueue, same cause as the parked-reader case above; hidden
+// for the same reason (it hangs rather than failing). Run with `net_test [closehang]`.
+TEST_CASE("closing a listener resumes a parked accept on every event source",
+          "[.][net][eventsource][parity][closehang]")
 {
     // Same hazard as a parked reader, one layer up: accept() parks on waitReadable,
     // so a listener closed while an accept is pending must resume it rather than

--- a/src/net/EventSourceParity_test.cpp
+++ b/src/net/EventSourceParity_test.cpp
@@ -244,7 +244,14 @@ TEST_CASE("two registrations on one descriptor are accepted by every event sourc
             CHECK(std::ranges::find(ready.readyRead, first) != ready.readyRead.end());
             CHECK(std::ranges::find(ready.readyRead, second) != ready.readyRead.end());
 
+            // Detaching one must not disturb the other: they are separate kernel
+            // registrations, so dropping one cannot take the survivor's with it.
             source->detach(first);
+            REQUIRE((*pipe)->write(one.data(), one.size()).has_value());
+            auto const afterOne = source->wait(200);
+            CHECK(std::ranges::find(afterOne.readyRead, second) != afterOne.readyRead.end());
+            CHECK(std::ranges::find(afterOne.readyRead, first) == afterOne.readyRead.end());
+
             source->detach(second);
         }
     }

--- a/src/net/HttpServer.cpp
+++ b/src/net/HttpServer.cpp
@@ -74,16 +74,25 @@ namespace
     [[nodiscard]] std::optional<std::size_t> parseHead(std::string_view headerText, HttpRequest* request)
     {
         auto contentLength = std::size_t { 0 };
+        auto sawContentLength = false;
         auto lineStart = std::size_t { 0 };
         auto firstLine = true;
 
         while (lineStart <= headerText.size())
         {
-            auto lineEnd = headerText.find("\r\n", lineStart);
+            // Split on LF and strip an optional CR, so a client using bare-LF line
+            // endings parses as the same set of lines rather than as one giant first
+            // line whose interior spaces would then populate method/path/version
+            // with garbage. readLine in this module is equally tolerant.
+            auto lineEnd = headerText.find('\n', lineStart);
+            auto const nextStart = (lineEnd == std::string_view::npos) ? headerText.size() + 1 : lineEnd + 1;
             if (lineEnd == std::string_view::npos)
                 lineEnd = headerText.size();
-            auto const line = headerText.substr(lineStart, lineEnd - lineStart);
-            lineStart = lineEnd + 2;
+            auto lineStop = lineEnd;
+            if (lineStop > lineStart && headerText[lineStop - 1] == '\r')
+                --lineStop;
+            auto const line = headerText.substr(lineStart, lineStop - lineStart);
+            lineStart = nextStart;
 
             if (firstLine)
             {
@@ -100,9 +109,18 @@ namespace
 
             if (line.empty())
                 continue;
+
+            // An obs-fold continuation (a header line starting with SP/HTAB) belongs
+            // to the previous header's value. RFC 9112 §5.2 deprecates it and permits
+            // rejecting the message; dropping it silently is the one thing we must
+            // not do, since a folded Content-Length would otherwise vanish and leave
+            // the body unread on a connection we believe fully parsed.
+            if (line.front() == ' ' || line.front() == '\t')
+                return std::nullopt;
+
             auto const colon = line.find(':');
             if (colon == std::string_view::npos)
-                continue; // tolerate a junk header line rather than failing the request
+                return std::nullopt; // a header line without a colon is not a header
             auto const name = trim(line.substr(0, colon));
             auto const value = trim(line.substr(colon + 1));
             request->headers.emplace_back(std::string { name }, std::string { value });
@@ -112,9 +130,21 @@ namespace
                 auto parsed = std::size_t { 0 };
                 auto const* const begin = value.data();
                 auto const [ptr, ec] = std::from_chars(begin, begin + value.size(), parsed);
-                if (ec == std::errc {} && ptr == begin + value.size())
-                    contentLength = parsed;
+                if (ec != std::errc {} || ptr != begin + value.size())
+                    return std::nullopt; // unparsable length: refuse rather than guess
+                // A repeated Content-Length is a request-smuggling vector when it
+                // disagrees with the first; RFC 9112 §6.3 requires rejecting it.
+                if (sawContentLength && parsed != contentLength)
+                    return std::nullopt;
+                contentLength = parsed;
+                sawContentLength = true;
             }
+
+            // Chunked bodies are out of scope for this server, so a request that
+            // announces one must be refused rather than parsed as a zero-length body
+            // that leaves its payload buffered as if it were the next request.
+            if (iequals(name, "Transfer-Encoding"))
+                return std::nullopt;
         }
         return contentLength;
     }
@@ -135,7 +165,23 @@ namespace
             co_return;
         }
 
-        auto response = (*handler)(*request);
+        // The handler is caller-supplied code. An exception escaping it would unwind
+        // through the accept loop and take the whole server down — one bad request
+        // ending every future connection — so it is contained here and answered as a
+        // 500. Cancellation is NOT caught: it is how a shutdown unwinds this flow.
+        auto response = HttpResponse {};
+        try
+        {
+            response = (*handler)(*request);
+        }
+        catch (coro::OperationCancelled const&)
+        {
+            throw;
+        }
+        catch (...)
+        {
+            response = HttpResponse::withStatus(500, std::string {});
+        }
         static_cast<void>(co_await writeResponse(socket, std::move(response)));
     }
 } // namespace
@@ -170,7 +216,9 @@ HttpResponse HttpResponse::withStatus(int status, std::string text)
 coro::Task<std::expected<HttpRequest, NetError>> readRequest(ISocket* socket, HttpLimits limits)
 {
     // The head bound doubles as the reader's message bound, so an unterminated
-    // header block is refused while it is still being buffered rather than after.
+    // header block is refused as it is buffered rather than after the fact. The
+    // reader checks between refills, so the refusal fires within one read chunk of
+    // the bound — a memory cap, not an exact byte count.
     auto reader = AsyncBufferedReader { socket, limits.maxHeadBytes };
 
     auto head = co_await reader.readUntil("\r\n\r\n");
@@ -180,7 +228,7 @@ coro::Task<std::expected<HttpRequest, NetError>> readRequest(ISocket* socket, Ht
     auto request = HttpRequest {};
     auto const contentLength = parseHead(*head, &request);
     if (!contentLength.has_value())
-        co_return std::unexpected(makeNetError(NetErrorCode::Other, 0, "malformed request line"));
+        co_return std::unexpected(makeNetError(NetErrorCode::Other, 0, "malformed request head"));
 
     if (*contentLength > limits.maxBodyBytes)
         co_return std::unexpected(
@@ -206,9 +254,15 @@ coro::Task<IoResult> writeResponse(ISocket* socket, HttpResponse response)
     out += response.reason.empty() ? std::string { reasonPhrase(response.status) } : response.reason;
     out += "\r\n";
 
+    // Framing headers are ours to decide: the body we are about to write determines
+    // the length, and this server always closes. A handler that set either would
+    // otherwise produce a response with two conflicting Content-Length headers,
+    // which clients reject and proxies read as a smuggling signal.
     auto hasContentType = false;
     for (auto const& [name, value]: response.headers)
     {
+        if (iequals(name, "Content-Length") || iequals(name, "Connection"))
+            continue;
         out += name;
         out += ": ";
         out += value;

--- a/src/net/HttpServer.cpp
+++ b/src/net/HttpServer.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <net/HttpServer.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <charconv>
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+
+#include <net/AsyncBufferedReader.hpp>
+
+namespace net
+{
+
+namespace
+{
+    /// The status codes this server names, and their reason phrases. Adding a code
+    /// is a row here, not a branch in the serializer.
+    struct StatusReason
+    {
+        int status;              ///< The HTTP status code.
+        std::string_view reason; ///< Its reason phrase.
+    };
+
+    constexpr auto StatusReasons = std::array {
+        StatusReason { 200, "OK" },
+        StatusReason { 201, "Created" },
+        StatusReason { 202, "Accepted" },
+        StatusReason { 204, "No Content" },
+        StatusReason { 301, "Moved Permanently" },
+        StatusReason { 302, "Found" },
+        StatusReason { 304, "Not Modified" },
+        StatusReason { 400, "Bad Request" },
+        StatusReason { 401, "Unauthorized" },
+        StatusReason { 403, "Forbidden" },
+        StatusReason { 404, "Not Found" },
+        StatusReason { 405, "Method Not Allowed" },
+        StatusReason { 408, "Request Timeout" },
+        StatusReason { 413, "Content Too Large" },
+        StatusReason { 415, "Unsupported Media Type" },
+        StatusReason { 429, "Too Many Requests" },
+        StatusReason { 500, "Internal Server Error" },
+        StatusReason { 501, "Not Implemented" },
+        StatusReason { 503, "Service Unavailable" },
+    };
+
+    /// Case-insensitively compares two ASCII strings for equality.
+    [[nodiscard]] bool iequals(std::string_view a, std::string_view b) noexcept
+    {
+        return std::ranges::equal(
+            a, b, [](unsigned char x, unsigned char y) { return std::tolower(x) == std::tolower(y); });
+    }
+
+    /// Trims leading and trailing ASCII whitespace from a view.
+    [[nodiscard]] std::string_view trim(std::string_view s) noexcept
+    {
+        constexpr auto Whitespace = std::string_view { " \t\r\n\f\v" };
+        auto const first = s.find_first_not_of(Whitespace);
+        if (first == std::string_view::npos)
+            return {};
+        auto const last = s.find_last_not_of(Whitespace);
+        return s.substr(first, last - first + 1);
+    }
+
+    /// Parses the request line and headers from @p headerText into @p request.
+    /// @param headerText The head block, delimiter excluded.
+    /// @param request The request to populate (not owned).
+    /// @return The advertised Content-Length, or std::nullopt if the request line
+    ///         was malformed (fewer than three space-separated tokens).
+    [[nodiscard]] std::optional<std::size_t> parseHead(std::string_view headerText, HttpRequest* request)
+    {
+        auto contentLength = std::size_t { 0 };
+        auto lineStart = std::size_t { 0 };
+        auto firstLine = true;
+
+        while (lineStart <= headerText.size())
+        {
+            auto lineEnd = headerText.find("\r\n", lineStart);
+            if (lineEnd == std::string_view::npos)
+                lineEnd = headerText.size();
+            auto const line = headerText.substr(lineStart, lineEnd - lineStart);
+            lineStart = lineEnd + 2;
+
+            if (firstLine)
+            {
+                firstLine = false;
+                auto const sp1 = line.find(' ');
+                auto const sp2 = (sp1 == std::string_view::npos) ? sp1 : line.find(' ', sp1 + 1);
+                if (sp1 == std::string_view::npos || sp2 == std::string_view::npos)
+                    return std::nullopt; // not a request line
+                request->method = std::string { line.substr(0, sp1) };
+                request->path = std::string { line.substr(sp1 + 1, sp2 - sp1 - 1) };
+                request->version = std::string { line.substr(sp2 + 1) };
+                continue;
+            }
+
+            if (line.empty())
+                continue;
+            auto const colon = line.find(':');
+            if (colon == std::string_view::npos)
+                continue; // tolerate a junk header line rather than failing the request
+            auto const name = trim(line.substr(0, colon));
+            auto const value = trim(line.substr(colon + 1));
+            request->headers.emplace_back(std::string { name }, std::string { value });
+
+            if (iequals(name, "Content-Length"))
+            {
+                auto parsed = std::size_t { 0 };
+                auto const* const begin = value.data();
+                auto const [ptr, ec] = std::from_chars(begin, begin + value.size(), parsed);
+                if (ec == std::errc {} && ptr == begin + value.size())
+                    contentLength = parsed;
+            }
+        }
+        return contentLength;
+    }
+
+    /// Handles one accepted connection: read a request, dispatch, write the response.
+    coro::Task<void> handleConnection(ISocket* socket, HttpHandler const* handler, HttpLimits limits)
+    {
+        auto request = co_await readRequest(socket, limits);
+        if (!request.has_value())
+        {
+            // Answer what we can diagnose; a peer that vanished gets nothing.
+            if (request.error().code != NetErrorCode::Eof)
+            {
+                auto const status = request.error().code == NetErrorCode::MessageTooLarge ? 413 : 400;
+                static_cast<void>(
+                    co_await writeResponse(socket, HttpResponse::withStatus(status, std::string {})));
+            }
+            co_return;
+        }
+
+        auto response = (*handler)(*request);
+        static_cast<void>(co_await writeResponse(socket, std::move(response)));
+    }
+} // namespace
+
+std::string HttpRequest::header(std::string_view name) const
+{
+    for (auto const& [key, value]: headers)
+        if (iequals(key, name))
+            return value;
+    return {};
+}
+
+std::string_view reasonPhrase(int status) noexcept
+{
+    auto const it = std::ranges::find(StatusReasons, status, &StatusReason::status);
+    return it != StatusReasons.end() ? it->reason : std::string_view { "Unknown" };
+}
+
+HttpResponse HttpResponse::ok(std::string text)
+{
+    return withStatus(200, std::move(text));
+}
+
+HttpResponse HttpResponse::withStatus(int status, std::string text)
+{
+    return HttpResponse { .status = status,
+                          .reason = std::string { reasonPhrase(status) },
+                          .headers = {},
+                          .body = std::move(text) };
+}
+
+coro::Task<std::expected<HttpRequest, NetError>> readRequest(ISocket* socket, HttpLimits limits)
+{
+    // The head bound doubles as the reader's message bound, so an unterminated
+    // header block is refused while it is still being buffered rather than after.
+    auto reader = AsyncBufferedReader { socket, limits.maxHeadBytes };
+
+    auto head = co_await reader.readUntil("\r\n\r\n");
+    if (!head.has_value())
+        co_return std::unexpected(head.error());
+
+    auto request = HttpRequest {};
+    auto const contentLength = parseHead(*head, &request);
+    if (!contentLength.has_value())
+        co_return std::unexpected(makeNetError(NetErrorCode::Other, 0, "malformed request line"));
+
+    if (*contentLength > limits.maxBodyBytes)
+        co_return std::unexpected(
+            makeNetError(NetErrorCode::MessageTooLarge, 0, "request body exceeds bound"));
+
+    if (*contentLength > 0)
+    {
+        auto body = co_await reader.readExactly(*contentLength);
+        if (!body.has_value())
+            co_return std::unexpected(body.error());
+        request.body = std::move(*body);
+    }
+
+    co_return request;
+}
+
+coro::Task<IoResult> writeResponse(ISocket* socket, HttpResponse response)
+{
+    auto out = std::string {};
+    out += "HTTP/1.1 ";
+    out += std::to_string(response.status);
+    out += ' ';
+    out += response.reason.empty() ? std::string { reasonPhrase(response.status) } : response.reason;
+    out += "\r\n";
+
+    auto hasContentType = false;
+    for (auto const& [name, value]: response.headers)
+    {
+        out += name;
+        out += ": ";
+        out += value;
+        out += "\r\n";
+        if (iequals(name, "Content-Type"))
+            hasContentType = true;
+    }
+    if (!hasContentType)
+        out += "Content-Type: text/plain; charset=utf-8\r\n";
+    out += "Content-Length: ";
+    out += std::to_string(response.body.size());
+    out += "\r\nConnection: close\r\n\r\n";
+    out += response.body;
+
+    auto const bytes =
+        std::span<std::byte const> { reinterpret_cast<std::byte const*>(out.data()), out.size() };
+    co_return co_await socket->write(bytes);
+}
+
+coro::Task<void> serve(IListener* listener, HttpHandler handler, HttpLimits limits)
+{
+    while (true)
+    {
+        auto accepted = co_await listener->accept();
+        if (!accepted.has_value())
+            co_return; // listener closed or cancelled
+        auto conn = std::move(*accepted);
+        co_await handleConnection(conn.get(), &handler, limits);
+    }
+}
+
+} // namespace net

--- a/src/net/HttpServer.hpp
+++ b/src/net/HttpServer.hpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// A minimal async HTTP/1.1 server built on the coroutine socket layer. Parses a
+/// request off an @c ISocket, invokes a handler, and writes the response back.
+/// Handlers are plain `std::function`s, so the layer is fully testable against an
+/// in-memory transport with no listener and no real socket.
+///
+/// Scope: `Content-Length` bodies only. Chunked transfer-encoding, keep-alive and
+/// pipelining are deliberately absent — every response carries `Connection: close`
+/// and the connection is dropped afterwards. Add them when a caller needs them
+/// rather than speculatively.
+
+#include <cstddef>
+#include <expected>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <coro/Task.hpp>
+#include <net/IListener.hpp>
+#include <net/ISocket.hpp>
+#include <net/IoResult.hpp>
+
+namespace net
+{
+
+/// Default cap on the request head (request line + headers, delimiter excluded).
+/// A peer that never terminates its headers must not grow the buffer unbounded.
+inline constexpr std::size_t DefaultMaxRequestHeadBytes = std::size_t { 64 } * 1024;
+
+/// Default cap on a request body, independent of what `Content-Length` claims.
+inline constexpr std::size_t DefaultMaxRequestBodyBytes = std::size_t { 8 } * 1024 * 1024;
+
+/// A parsed HTTP request (the subset the server exposes to handlers).
+struct HttpRequest
+{
+    std::string method;                                       ///< "GET", "POST", …
+    std::string path;                                         ///< Request target, e.g. "/index".
+    std::string version;                                      ///< "HTTP/1.1".
+    std::vector<std::pair<std::string, std::string>> headers; ///< Header name/value pairs, in order.
+    std::string body;                                         ///< Request body (may be empty).
+
+    /// Looks up a header value (case-insensitive name match).
+    /// @param name The header name to find.
+    /// @return The first matching header's value, or "" if absent.
+    [[nodiscard]] std::string header(std::string_view name) const;
+};
+
+/// @param status An HTTP status code.
+/// @return The registered reason phrase for @p status, or "Unknown" if the code is
+///         not one this server names. Never empty — a bare status line with an
+///         empty reason phrase is malformed.
+[[nodiscard]] std::string_view reasonPhrase(int status) noexcept;
+
+/// An HTTP response a handler produces.
+struct HttpResponse
+{
+    int status = 200;                                         ///< HTTP status code.
+    std::string reason = "OK";                                ///< Reason phrase.
+    std::vector<std::pair<std::string, std::string>> headers; ///< Extra headers (Content-Length is added).
+    std::string body;                                         ///< Response body.
+
+    /// @param text The body text.
+    /// @return A 200 OK response with @p text as a text/plain body.
+    [[nodiscard]] static HttpResponse ok(std::string text);
+
+    /// @param status The status code; its reason phrase comes from @c reasonPhrase.
+    /// @param text The body text.
+    /// @return A response with the given status and a text/plain body.
+    [[nodiscard]] static HttpResponse withStatus(int status, std::string text);
+};
+
+/// A request handler: maps a request to a response.
+using HttpHandler = std::function<HttpResponse(HttpRequest const&)>;
+
+/// Limits applied while parsing a request. Grouped into a struct so a new limit is
+/// a new field rather than another parameter at every call site.
+struct HttpLimits
+{
+    std::size_t maxHeadBytes = DefaultMaxRequestHeadBytes; ///< Cap on request line + headers.
+    std::size_t maxBodyBytes = DefaultMaxRequestBodyBytes; ///< Cap on the body.
+};
+
+/// Serves connections from @p listener until it is closed, dispatching each request
+/// to @p handler. Connections are handled in sequence on the loop thread (a slow
+/// handler stalls the accept loop), which suits the single-threaded model this
+/// layer targets. Returns when the listener is closed or the flow is cancelled.
+/// @param listener The bound listener to accept from (not owned).
+/// @param handler The request handler.
+/// @param limits Parsing limits applied to every request.
+/// @return A task that completes when serving stops.
+[[nodiscard]] coro::Task<void> serve(IListener* listener, HttpHandler handler, HttpLimits limits = {});
+
+/// Reads and parses a single HTTP/1.1 request from @p socket. Exposed so the
+/// framing can be tested without a listener.
+/// @param socket The connection to read from (not owned).
+/// @param limits Parsing limits.
+/// @return The parsed request, or a @c NetError: @c Eof if the peer closed before a
+///         complete request, @c MessageTooLarge if a limit was exceeded, or
+///         @c Other for a malformed request line.
+[[nodiscard]] coro::Task<std::expected<HttpRequest, NetError>> readRequest(ISocket* socket,
+                                                                           HttpLimits limits = {});
+
+/// Writes @p response to @p socket as an HTTP/1.1 response, adding `Content-Length`,
+/// `Connection: close`, and a default `Content-Type` when the handler set none.
+/// @param socket The connection to write to (not owned).
+/// @param response The response to serialize (taken by value: a coroutine must not
+///        hold a reference parameter across a suspend point).
+/// @return The bytes written, or a @c NetError on failure.
+[[nodiscard]] coro::Task<IoResult> writeResponse(ISocket* socket, HttpResponse response);
+
+} // namespace net

--- a/src/net/HttpServer_test.cpp
+++ b/src/net/HttpServer_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -235,6 +236,168 @@ TEST_CASE("readRequest rejects a malformed request line", "[net][http]")
     REQUIRE(error->code == NetErrorCode::Other);
 }
 
+TEST_CASE("readRequest rejects conflicting duplicate Content-Length headers", "[net][http]")
+{
+    // RFC 9112 6.3: two disagreeing lengths are a request-smuggling vector, since a
+    // proxy and an origin may pick different ones and disagree about where this
+    // request ends and the next begins.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire =
+        std::string { "POST / HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 100\r\n\r\nhello" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("readRequest accepts repeated but identical Content-Length headers", "[net][http]")
+{
+    // Repetition alone is not the hazard; disagreement is.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire =
+        std::string { "POST / HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\nhello" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(seen.has_value());
+    REQUIRE(seen->body == "hello");
+}
+
+TEST_CASE("readRequest refuses a chunked request rather than mis-framing it", "[net][http]")
+{
+    // Chunked bodies are out of scope. Parsing one as a zero-length body would leave
+    // the chunk data buffered as though it were the start of another request.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire =
+        std::string { "POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("readRequest rejects an obs-fold continuation line", "[net][http]")
+{
+    // A folded header has no colon. Dropping it silently would lose the folded
+    // Content-Length and leave the body unread on a connection we think we parsed.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "POST / HTTP/1.1\r\nContent-Length: 5\r\n\t0\r\n\r\nhello" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("readRequest parses a bare-LF request head", "[net][http]")
+{
+    // Hand-written clients and scripts routinely send LF-only endings. Splitting
+    // only on CRLF would make the whole head one "request line" whose interior
+    // spaces populate method/path/version with garbage.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "GET /plain HTTP/1.1\nHost: example\n\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(seen.has_value());
+    REQUIRE(seen->method == "GET");
+    REQUIRE(seen->path == "/plain");
+    REQUIRE(seen->header("Host") == "example");
+}
+
+TEST_CASE("readRequest rejects an unparsable Content-Length", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "POST / HTTP/1.1\r\nContent-Length: 12abc\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("writeResponse never emits duplicate framing headers", "[net][http]")
+{
+    // A handler that sets its own Content-Length or Connection is doing something
+    // natural; emitting both its value and ours would be malformed.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto response = HttpResponse::ok("hello");
+    response.headers.emplace_back("Content-Length", "999");
+    response.headers.emplace_back("Connection", "keep-alive");
+
+    auto reply = std::string {};
+    auto run =
+        [](net::ISocket* client, net::ISocket* server, HttpResponse* resp, std::string* out) -> Task<void> {
+        static_cast<void>(co_await net::writeResponse(server, std::move(*resp)));
+        server->close();
+        co_await drain(client, out);
+    };
+    loop.blockOn(run(pair->first.get(), pair->second.get(), &response, &reply));
+
+    // Exactly one of each, and the length must describe the body we actually wrote.
+    auto const countOf = [&reply](std::string_view needle) {
+        auto count = std::size_t { 0 };
+        for (auto pos = reply.find(needle); pos != std::string::npos;
+             pos = reply.find(needle, pos + needle.size()))
+            ++count;
+        return count;
+    };
+    CHECK(countOf("Content-Length:") == 1);
+    CHECK(countOf("Connection:") == 1);
+    CHECK(reply.contains("Content-Length: 5\r\n"));
+    CHECK_FALSE(reply.contains("999"));
+}
+
 TEST_CASE("readRequest reports EOF when the peer closes before a request", "[net][http]")
 {
     auto source = net::PollEventSource {};
@@ -348,4 +511,44 @@ TEST_CASE("serve dispatches a request through a handler and closes", "[net][http
     REQUIRE(seenPath == "/hello");
     REQUIRE(reply.starts_with("HTTP/1.1 200 OK\r\n"));
     REQUIRE(reply.ends_with("served:/hello"));
+}
+
+TEST_CASE("serve answers 500 when a handler throws rather than dying", "[net][http]")
+{
+    // The handler is caller-supplied code. An exception escaping it would unwind
+    // through the accept loop and end every future connection, so serve() must
+    // contain it and still answer this request.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto listener = net::listen(loop, "127.0.0.1", 0);
+    REQUIRE(listener.has_value());
+    auto const port = (*listener)->localPort();
+    REQUIRE(port != 0);
+
+    auto handler = net::HttpHandler { [](HttpRequest const&) -> HttpResponse {
+        throw std::runtime_error { "handler blew up" };
+    } };
+
+    auto reply = std::string {};
+    auto client = [](EventLoop* l, std::uint16_t p, std::string* out) -> Task<void> {
+        auto connected = co_await net::connect(l, "127.0.0.1", p);
+        if (!connected.has_value())
+            co_return;
+        auto socket = std::move(*connected);
+        auto const request = std::string { "GET /boom HTTP/1.1\r\nHost: x\r\n\r\n" };
+        co_await sendText(socket.get(), &request);
+        co_await drain(socket.get(), out);
+    };
+
+    auto run = [](EventLoop* l,
+                  net::IListener* lis,
+                  net::HttpHandler h,
+                  std::uint16_t p,
+                  std::string* out,
+                  auto clientFn) -> Task<void> {
+        static_cast<void>(co_await coro::whenAny(net::serve(lis, std::move(h)), clientFn(l, p, out)));
+    };
+    loop.blockOn(run(&loop, listener->get(), std::move(handler), port, &reply, client));
+
+    REQUIRE(reply.starts_with("HTTP/1.1 500 Internal Server Error\r\n"));
 }

--- a/src/net/HttpServer_test.cpp
+++ b/src/net/HttpServer_test.cpp
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <coro/Task.hpp>
+#include <coro/WhenAny.hpp>
+#include <net/HttpServer.hpp>
+#include <net/ISocket.hpp>
+#include <net/PollEventSource.hpp>
+#include <net/Sockets.hpp>
+#include <net/testing/InMemoryTransport.hpp>
+
+using coro::Task;
+using net::EventLoop;
+using net::HttpLimits;
+using net::HttpRequest;
+using net::HttpResponse;
+using net::NetErrorCode;
+
+namespace
+{
+
+/// Writes @p text to @p socket, then shuts the write side by closing, so the
+/// server observes EOF after the request.
+Task<void> sendText(net::ISocket* socket, std::string const* text)
+{
+    auto const bytes =
+        std::span<std::byte const> { reinterpret_cast<std::byte const*>(text->data()), text->size() };
+    static_cast<void>(co_await socket->write(bytes));
+}
+
+/// Drains @p socket to EOF into @p out.
+Task<void> drain(net::ISocket* socket, std::string* out)
+{
+    auto chunk = std::array<std::byte, 4096> {};
+    while (true)
+    {
+        auto const got = co_await socket->read(chunk);
+        if (!got.has_value() || *got == 0)
+            co_return;
+        out->append(reinterpret_cast<char const*>(chunk.data()), *got);
+    }
+}
+
+/// Feeds @p wire to a server endpoint, runs one request/response exchange through
+/// `readRequest` + the handler + `writeResponse`, and returns the raw reply.
+Task<void> exchange(net::ISocket* client,
+                    net::ISocket* server,
+                    std::string const* wire,
+                    std::string* reply,
+                    HttpLimits const* limits,
+                    std::optional<HttpRequest>* seen,
+                    std::optional<net::NetError>* error)
+{
+    co_await sendText(client, wire);
+
+    auto request = co_await net::readRequest(server, *limits);
+    if (request.has_value())
+    {
+        *seen = *request;
+        auto response = HttpResponse::ok("pong");
+        static_cast<void>(co_await net::writeResponse(server, std::move(response)));
+    }
+    else
+        *error = request.error();
+
+    server->close();
+    co_await drain(client, reply);
+}
+
+} // namespace
+
+TEST_CASE("reasonPhrase names known codes and never returns empty", "[net][http]")
+{
+    REQUIRE(net::reasonPhrase(200) == "OK");
+    REQUIRE(net::reasonPhrase(404) == "Not Found");
+    REQUIRE(net::reasonPhrase(500) == "Internal Server Error");
+    // The regression this port fixes: a non-200 status used to serialize with an
+    // EMPTY reason phrase ("HTTP/1.1 404 \r\n"), which is a malformed status line.
+    REQUIRE_FALSE(net::reasonPhrase(404).empty());
+    REQUIRE_FALSE(net::reasonPhrase(599).empty());
+    REQUIRE(net::reasonPhrase(599) == "Unknown");
+}
+
+TEST_CASE("withStatus carries a non-empty reason phrase for non-200 codes", "[net][http]")
+{
+    auto const notFound = HttpResponse::withStatus(404, "nope");
+    REQUIRE(notFound.status == 404);
+    REQUIRE(notFound.reason == "Not Found");
+    REQUIRE(notFound.body == "nope");
+
+    auto const ok = HttpResponse::ok("fine");
+    REQUIRE(ok.status == 200);
+    REQUIRE(ok.reason == "OK");
+}
+
+TEST_CASE("HttpRequest::header matches case-insensitively", "[net][http]")
+{
+    auto request = HttpRequest {};
+    request.headers.emplace_back("Content-Type", "text/plain");
+    request.headers.emplace_back("X-Trace", "abc");
+
+    REQUIRE(request.header("content-type") == "text/plain");
+    REQUIRE(request.header("CONTENT-TYPE") == "text/plain");
+    REQUIRE(request.header("X-Trace") == "abc");
+    REQUIRE(request.header("absent").empty());
+}
+
+TEST_CASE("readRequest parses a request line and headers", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "GET /index HTTP/1.1\r\nHost: example\r\nX-A: 1\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(seen.has_value());
+    REQUIRE(seen->method == "GET");
+    REQUIRE(seen->path == "/index");
+    REQUIRE(seen->version == "HTTP/1.1");
+    REQUIRE(seen->header("Host") == "example");
+    REQUIRE(seen->body.empty());
+}
+
+TEST_CASE("readRequest reads a Content-Length body", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "POST /submit HTTP/1.1\r\nContent-Length: 11\r\n\r\nhello world" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(seen.has_value());
+    REQUIRE(seen->method == "POST");
+    REQUIRE(seen->body == "hello world");
+}
+
+TEST_CASE("readRequest reads a body split across the header boundary", "[net][http]")
+{
+    // The body's first bytes ride in the same segment as the header delimiter —
+    // the case a naive "read headers, then read body" loop gets wrong.
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nabcde" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE_FALSE(error.has_value());
+    REQUIRE(seen->body == "abcde");
+}
+
+TEST_CASE("readRequest rejects a head exceeding the bound", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    // A header block that never terminates, larger than the (tiny) bound.
+    auto wire = std::string { "GET / HTTP/1.1\r\nX-Pad: " };
+    wire += std::string(512, 'p');
+    auto const limits = HttpLimits { .maxHeadBytes = 128, .maxBodyBytes = 1024 };
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::MessageTooLarge);
+}
+
+TEST_CASE("readRequest rejects a body exceeding the bound", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    // Content-Length advertises more than the limit allows: refused before the
+    // body is read, so a hostile length cannot be used to make us buffer it.
+    auto const wire = std::string { "POST / HTTP/1.1\r\nContent-Length: 9999\r\n\r\n" };
+    auto const limits = HttpLimits { .maxHeadBytes = 4096, .maxBodyBytes = 16 };
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::MessageTooLarge);
+}
+
+TEST_CASE("readRequest rejects a malformed request line", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "NOTAREQUESTLINE\r\nHost: x\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Other);
+}
+
+TEST_CASE("readRequest reports EOF when the peer closes before a request", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "GET / HTTP/1.1\r\n" }; // no terminator, then close
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+
+    auto run = [](net::ISocket* client,
+                  net::ISocket* server,
+                  std::string const* text,
+                  HttpLimits const* lim,
+                  std::optional<net::NetError>* err) -> Task<void> {
+        co_await sendText(client, text);
+        client->close(); // half-close so the server sees EOF
+        auto request = co_await net::readRequest(server, *lim);
+        if (!request.has_value())
+            *err = request.error();
+    };
+    loop.blockOn(run(pair->first.get(), pair->second.get(), &wire, &limits, &error));
+
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == NetErrorCode::Eof);
+}
+
+TEST_CASE("writeResponse serializes status, framing headers and body", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto const wire = std::string { "GET / HTTP/1.1\r\nHost: x\r\n\r\n" };
+    auto const limits = HttpLimits {};
+    auto reply = std::string {};
+    auto seen = std::optional<HttpRequest> {};
+    auto error = std::optional<net::NetError> {};
+    loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
+
+    REQUIRE(reply.starts_with("HTTP/1.1 200 OK\r\n"));
+    REQUIRE(reply.find("Content-Length: 4\r\n") != std::string::npos);
+    REQUIRE(reply.find("Content-Type: text/plain; charset=utf-8\r\n") != std::string::npos);
+    REQUIRE(reply.find("Connection: close\r\n") != std::string::npos);
+    REQUIRE(reply.ends_with("\r\n\r\npong"));
+}
+
+TEST_CASE("writeResponse keeps a handler-supplied Content-Type", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto response = HttpResponse::ok("{}");
+    response.headers.emplace_back("Content-Type", "application/json");
+
+    auto reply = std::string {};
+    auto run =
+        [](net::ISocket* server, net::ISocket* client, HttpResponse resp, std::string* out) -> Task<void> {
+        static_cast<void>(co_await net::writeResponse(server, std::move(resp)));
+        server->close();
+        co_await drain(client, out);
+    };
+    loop.blockOn(run(pair->second.get(), pair->first.get(), std::move(response), &reply));
+
+    REQUIRE(reply.find("Content-Type: application/json\r\n") != std::string::npos);
+    // The default must not also be emitted.
+    REQUIRE(reply.find("text/plain") == std::string::npos);
+}
+
+TEST_CASE("serve dispatches a request through a handler and closes", "[net][http]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+    auto listener = net::listen(loop, "127.0.0.1", 0);
+    REQUIRE(listener.has_value());
+    auto const port = (*listener)->localPort();
+    REQUIRE(port != 0);
+
+    auto seenPath = std::string {};
+    auto handler = net::HttpHandler { [&seenPath](HttpRequest const& request) {
+        seenPath = request.path;
+        return HttpResponse::ok("served:" + request.path);
+    } };
+
+    // Race the server against one client; the client's completion cancels serve().
+    auto reply = std::string {};
+    auto client = [](EventLoop* l, std::uint16_t p, std::string* out) -> Task<void> {
+        auto connected = co_await net::connect(l, "127.0.0.1", p);
+        if (!connected.has_value())
+            co_return;
+        auto socket = std::move(*connected);
+        auto const request = std::string { "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n" };
+        co_await sendText(socket.get(), &request);
+        co_await drain(socket.get(), out);
+    };
+
+    auto run = [](EventLoop* l,
+                  net::IListener* lis,
+                  net::HttpHandler h,
+                  std::uint16_t p,
+                  std::string* out,
+                  auto clientFn) -> Task<void> {
+        static_cast<void>(co_await coro::whenAny(net::serve(lis, std::move(h)), clientFn(l, p, out)));
+    };
+    loop.blockOn(run(&loop, listener->get(), std::move(handler), port, &reply, client));
+
+    REQUIRE(seenPath == "/hello");
+    REQUIRE(reply.starts_with("HTTP/1.1 200 OK\r\n"));
+    REQUIRE(reply.ends_with("served:/hello"));
+}

--- a/src/net/HttpServer_test.cpp
+++ b/src/net/HttpServer_test.cpp
@@ -244,8 +244,6 @@ TEST_CASE("readRequest reports EOF when the peer closes before a request", "[net
 
     auto const wire = std::string { "GET / HTTP/1.1\r\n" }; // no terminator, then close
     auto const limits = HttpLimits {};
-    auto reply = std::string {};
-    auto seen = std::optional<HttpRequest> {};
     auto error = std::optional<net::NetError> {};
 
     auto run = [](net::ISocket* client,
@@ -280,9 +278,9 @@ TEST_CASE("writeResponse serializes status, framing headers and body", "[net][ht
     loop.blockOn(exchange(pair->first.get(), pair->second.get(), &wire, &reply, &limits, &seen, &error));
 
     REQUIRE(reply.starts_with("HTTP/1.1 200 OK\r\n"));
-    REQUIRE(reply.find("Content-Length: 4\r\n") != std::string::npos);
-    REQUIRE(reply.find("Content-Type: text/plain; charset=utf-8\r\n") != std::string::npos);
-    REQUIRE(reply.find("Connection: close\r\n") != std::string::npos);
+    REQUIRE(reply.contains("Content-Length: 4\r\n"));
+    REQUIRE(reply.contains("Content-Type: text/plain; charset=utf-8\r\n"));
+    REQUIRE(reply.contains("Connection: close\r\n"));
     REQUIRE(reply.ends_with("\r\n\r\npong"));
 }
 
@@ -305,9 +303,9 @@ TEST_CASE("writeResponse keeps a handler-supplied Content-Type", "[net][http]")
     };
     loop.blockOn(run(pair->second.get(), pair->first.get(), std::move(response), &reply));
 
-    REQUIRE(reply.find("Content-Type: application/json\r\n") != std::string::npos);
+    REQUIRE(reply.contains("Content-Type: application/json\r\n"));
     // The default must not also be emitted.
-    REQUIRE(reply.find("text/plain") == std::string::npos);
+    REQUIRE_FALSE(reply.contains("text/plain"));
 }
 
 TEST_CASE("serve dispatches a request through a handler and closes", "[net][http]")

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -98,9 +98,11 @@ bool KqueueEventSource::applyInterest(NativeHandle fd, FdInterest interest, FdTo
     // armed — the normal steady state, not a failure.
     auto const reported = std::span { results.data(), static_cast<std::size_t>(applied) };
     return std::ranges::all_of(reported, [&interests](struct kevent const& result) noexcept {
-        if (result.data == 0)
+        // EV_RECEIPT sets EV_ERROR on every entry; `data` carries the errno, 0 when
+        // the change applied cleanly. An entry without EV_ERROR is not a report.
+        if ((result.flags & EV_ERROR) == 0 || result.data == 0)
             return true;
-        auto const* const row =
+        auto const row =
             std::ranges::find(interests, static_cast<std::int16_t>(result.filter), &FilterInterest::filter);
         return result.data == ENOENT && row != interests.end() && !row->wanted;
     });

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -150,22 +150,16 @@ FdToken KqueueEventSource::attach(NativeHandle fd, FdInterest interest)
         return FdToken::invalid();
     }
 
-    _applied.emplace(token.value, interest);
+    _registered.emplace(token.value, fd);
     return token;
 }
 
 void KqueueEventSource::detach(FdToken token)
 {
-    if (auto const it = _applied.find(token.value); it != _applied.end())
+    if (auto const it = _registered.find(token.value); it != _registered.end())
     {
-        for (auto const& reg: _registry.registrations())
-        {
-            if (reg.token != token)
-                continue;
-            dropFilters(reg.fd);
-            break;
-        }
-        _applied.erase(it);
+        dropFilters(it->second);
+        _registered.erase(it);
     }
     _registry.detach(token);
 }
@@ -175,17 +169,6 @@ WaitOutcome KqueueEventSource::wait(int timeoutMs)
     auto outcome = WaitOutcome {};
     if (_kq < 0)
         return outcome;
-
-    // Reconcile any interest the loop changed since the last wait. The registry is
-    // the source of truth; the kernel holds a cached copy that only this loop edits.
-    for (auto const& reg: _registry.registrations())
-    {
-        auto const it = _applied.find(reg.token.value);
-        if (it == _applied.end() || it->second == reg.interest)
-            continue;
-        if (applyInterest(reg.fd, reg.interest, reg.token))
-            it->second = reg.interest;
-    }
 
     auto const timeout = toTimespec(timeoutMs);
     auto const* const timeoutPtr = timeout.has_value() ? &*timeout : nullptr;

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -56,6 +56,9 @@ KqueueEventSource::KqueueEventSource() noexcept: _kq { ::kqueue() }
 
 KqueueEventSource::~KqueueEventSource()
 {
+    // Close the duplicates this source owns; the caller's own descriptors are not ours.
+    for (auto const& [token, owned]: _registered)
+        ::close(owned);
     if (_kq >= 0)
         ::close(_kq);
 }
@@ -143,16 +146,24 @@ FdToken KqueueEventSource::attach(NativeHandle fd, FdInterest interest)
     if (!token)
         return FdToken::invalid();
 
+    // Register a private duplicate, for the same reason as the epoll backend: a
+    // kqueue filter is keyed by (descriptor, filter), so a second registration on
+    // one descriptor would replace the first rather than stand beside it, while
+    // poll(2) takes two independent entries.
+    auto const owned = ::dup(fd);
+
     // A failed arm must not leave the registry claiming the fd is watched: the
     // awaiting flow has to fail rather than park on a filter the kernel never
     // armed, which nothing could ever resume.
-    if (!applyInterest(fd, interest, token))
+    if (owned < 0 || !applyInterest(owned, interest, token))
     {
+        if (owned >= 0)
+            ::close(owned);
         _registry.detach(token);
         return FdToken::invalid();
     }
 
-    _registered.emplace(token.value, fd);
+    _registered.emplace(token.value, owned);
     return token;
 }
 
@@ -161,6 +172,7 @@ void KqueueEventSource::detach(FdToken token)
     if (auto const it = _registered.find(token.value); it != _registered.end())
     {
         dropFilters(it->second);
+        ::close(it->second); // the duplicate this source owns, not the caller's fd
         _registered.erase(it);
     }
     _registry.detach(token);

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <net/KqueueEventSource.hpp>
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+
+    #include <sys/event.h>
+    #include <sys/types.h>
+
+    #include <algorithm>
+    #include <array>
+    #include <cerrno>
+    #include <chrono>
+    #include <iterator>
+    #include <optional>
+    #include <ranges>
+    #include <span>
+
+    #include <unistd.h>
+
+namespace net
+{
+
+namespace
+{
+    /// The largest number of ready events one kevent() call reports. Level-triggered
+    /// filters re-report a still-ready fd, so capping the batch loses nothing.
+    constexpr std::size_t ReadyBatchSize = 64;
+
+    /// One kqueue filter and whether the caller wants it armed. Lets the interest
+    /// update express "arm it or drop it" once and drive both filters from a table
+    /// rather than two hand-written EV_SET calls that must stay in sync.
+    struct FilterInterest
+    {
+        std::int16_t filter; ///< EVFILT_READ or EVFILT_WRITE.
+        bool wanted;         ///< True to arm the filter, false to drop it.
+    };
+
+    /// Converts a millisecond timeout into the timespec kevent() wants.
+    /// @param timeoutMs -1 to block indefinitely, else the wait in milliseconds.
+    /// @return The timespec, or nullopt for an indefinite wait.
+    [[nodiscard]] std::optional<timespec> toTimespec(int timeoutMs) noexcept
+    {
+        if (timeoutMs < 0)
+            return std::nullopt;
+        auto const duration = std::chrono::milliseconds { timeoutMs };
+        auto const seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+        auto const nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds);
+        return timespec { .tv_sec = static_cast<time_t>(seconds.count()),
+                          .tv_nsec = static_cast<long>(nanos.count()) };
+    }
+} // namespace
+
+KqueueEventSource::KqueueEventSource() noexcept: _kq { ::kqueue() }
+{
+}
+
+KqueueEventSource::~KqueueEventSource()
+{
+    if (_kq >= 0)
+        ::close(_kq);
+}
+
+bool KqueueEventSource::applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept
+{
+    if (_kq < 0 || fd == InvalidHandle)
+        return false;
+
+    auto const interests = std::array<FilterInterest, 2> { {
+        { .filter = EVFILT_READ, .wanted = hasInterest(interest, FdInterest::Read) },
+        { .filter = EVFILT_WRITE, .wanted = hasInterest(interest, FdInterest::Write) },
+    } };
+
+    auto changes = std::array<struct kevent, interests.size()> {};
+    for (auto const i: std::views::iota(std::size_t { 0 }, interests.size()))
+        EV_SET(std::next(changes.data(), static_cast<std::ptrdiff_t>(i)),
+               static_cast<uintptr_t>(fd),
+               interests[i].filter,
+               (interests[i].wanted ? (EV_ADD | EV_ENABLE) : EV_DELETE) | EV_RECEIPT,
+               0,
+               0,
+               // The token, not the fd, identifies the registration back to the loop.
+               reinterpret_cast<void*>(static_cast<uintptr_t>(token.value)));
+
+    auto results = std::array<struct kevent, interests.size()> {};
+    auto const applied = ::kevent(_kq,
+                                  changes.data(),
+                                  static_cast<int>(changes.size()),
+                                  results.data(),
+                                  static_cast<int>(results.size()),
+                                  nullptr);
+    if (applied < 0)
+        return false;
+
+    // With EV_RECEIPT every returned entry carries EV_ERROR and `data` holds the
+    // errno (0 when the change applied cleanly). Results are matched back by filter
+    // rather than by position, so the check does not depend on the kernel preserving
+    // changelist order. ENOENT on a filter we asked to drop just means it was not
+    // armed — the normal steady state, not a failure.
+    auto const reported = std::span { results.data(), static_cast<std::size_t>(applied) };
+    return std::ranges::all_of(reported, [&interests](struct kevent const& result) noexcept {
+        if (result.data == 0)
+            return true;
+        auto const* const row =
+            std::ranges::find(interests, static_cast<std::int16_t>(result.filter), &FilterInterest::filter);
+        return result.data == ENOENT && row != interests.end() && !row->wanted;
+    });
+}
+
+void KqueueEventSource::dropFilters(NativeHandle fd) const noexcept
+{
+    if (_kq < 0 || fd == InvalidHandle)
+        return;
+    // EV_RECEIPT for the same reason as applyInterest: without an eventlist an
+    // ENOENT on the first delete (a filter that was never armed) would abort the
+    // changelist and leave the second filter registered against a registration
+    // that is going away.
+    auto changes = std::array<struct kevent, 2> {};
+    EV_SET(changes.data(), static_cast<uintptr_t>(fd), EVFILT_READ, EV_DELETE | EV_RECEIPT, 0, 0, nullptr);
+    EV_SET(std::next(changes.data()),
+           static_cast<uintptr_t>(fd),
+           EVFILT_WRITE,
+           EV_DELETE | EV_RECEIPT,
+           0,
+           0,
+           nullptr);
+    auto results = std::array<struct kevent, 2> {};
+    static_cast<void>(::kevent(_kq,
+                               changes.data(),
+                               static_cast<int>(changes.size()),
+                               results.data(),
+                               static_cast<int>(results.size()),
+                               nullptr));
+}
+
+FdToken KqueueEventSource::attach(NativeHandle fd, FdInterest interest)
+{
+    if (_kq < 0 || fd == InvalidHandle)
+        return FdToken::invalid();
+
+    auto const token = _registry.attach(fd, interest);
+    if (!token)
+        return FdToken::invalid();
+
+    // A failed arm must not leave the registry claiming the fd is watched: the
+    // awaiting flow has to fail rather than park on a filter the kernel never
+    // armed, which nothing could ever resume.
+    if (!applyInterest(fd, interest, token))
+    {
+        _registry.detach(token);
+        return FdToken::invalid();
+    }
+
+    _applied.emplace(token.value, interest);
+    return token;
+}
+
+void KqueueEventSource::detach(FdToken token)
+{
+    if (auto const it = _applied.find(token.value); it != _applied.end())
+    {
+        for (auto const& reg: _registry.registrations())
+        {
+            if (reg.token != token)
+                continue;
+            dropFilters(reg.fd);
+            break;
+        }
+        _applied.erase(it);
+    }
+    _registry.detach(token);
+}
+
+WaitOutcome KqueueEventSource::wait(int timeoutMs)
+{
+    auto outcome = WaitOutcome {};
+    if (_kq < 0)
+        return outcome;
+
+    // Reconcile any interest the loop changed since the last wait. The registry is
+    // the source of truth; the kernel holds a cached copy that only this loop edits.
+    for (auto const& reg: _registry.registrations())
+    {
+        auto const it = _applied.find(reg.token.value);
+        if (it == _applied.end() || it->second == reg.interest)
+            continue;
+        if (applyInterest(reg.fd, reg.interest, reg.token))
+            it->second = reg.interest;
+    }
+
+    auto const timeout = toTimespec(timeoutMs);
+    auto const* const timeoutPtr = timeout.has_value() ? &*timeout : nullptr;
+
+    // Nothing to watch: honour the timeout so a parked timer can still fire, and
+    // treat an infinite timeout as a benign timeout rather than blocking forever
+    // with no wakeable source. Mirrors PollEventSource.
+    auto events = std::array<struct kevent, ReadyBatchSize> {};
+    if (_registry.size() == 0)
+    {
+        if (timeoutMs > 0)
+            static_cast<void>(::kevent(_kq, nullptr, 0, events.data(), 1, timeoutPtr));
+        return outcome;
+    }
+
+    auto const ready = ::kevent(_kq, nullptr, 0, events.data(), static_cast<int>(events.size()), timeoutPtr);
+    if (ready <= 0)
+        // 0: timed out. <0: EINTR or error — nothing ready this round. Level-triggered
+        // filters re-report a still-ready fd on the next wait, so nothing is lost.
+        return outcome;
+
+    for (auto const& event: std::span { events.data(), static_cast<std::size_t>(ready) })
+    {
+        auto const token = FdToken { static_cast<std::uint64_t>(reinterpret_cast<uintptr_t>(event.udata)) };
+        // EV_EOF is reported as readable so a parked reader wakes and observes EOF,
+        // matching how poll(2)'s POLLHUP is routed.
+        if (event.filter == EVFILT_READ || (event.flags & EV_EOF) != 0)
+            outcome.readyRead.push_back(token);
+        if (event.filter == EVFILT_WRITE)
+            outcome.readyWrite.push_back(token);
+    }
+    return outcome;
+}
+
+} // namespace net
+
+#endif // kqueue platforms

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -56,9 +56,11 @@ KqueueEventSource::KqueueEventSource() noexcept: _kq { ::kqueue() }
 
 KqueueEventSource::~KqueueEventSource()
 {
-    // Close the duplicates this source owns; the caller's own descriptors are not ours.
-    for (auto const& [token, owned]: _registered)
-        ::close(owned);
+    // Close only the duplicates this source made; the caller's own descriptors are
+    // armed directly and are not ours to close.
+    for (auto const& [token, watched]: _registered)
+        if (watched.owned)
+            ::close(watched.fd);
     if (_kq >= 0)
         ::close(_kq);
 }
@@ -94,16 +96,24 @@ bool KqueueEventSource::applyInterest(NativeHandle fd, FdInterest interest, FdTo
     if (applied < 0)
         return false;
 
-    // With EV_RECEIPT every returned entry carries EV_ERROR and `data` holds the
-    // errno (0 when the change applied cleanly). Results are matched back by filter
-    // rather than by position, so the check does not depend on the kernel preserving
-    // changelist order. ENOENT on a filter we asked to drop just means it was not
-    // armed — the normal steady state, not a failure.
+    // With EV_RECEIPT the kernel reports one entry per submitted change, so anything
+    // short means a change went unreported and we cannot claim the filter was armed.
+    if (static_cast<std::size_t>(applied) != changes.size())
+        return false;
+
+    // Every returned entry carries EV_ERROR and `data` holds the errno (0 when the
+    // change applied cleanly). Results are matched back by filter rather than by
+    // position, so the check does not depend on the kernel preserving changelist
+    // order. ENOENT on a filter we asked to drop just means it was not armed — the
+    // normal steady state, not a failure.
     auto const reported = std::span { results.data(), static_cast<std::size_t>(applied) };
     return std::ranges::all_of(reported, [&interests](struct kevent const& result) noexcept {
-        // EV_RECEIPT sets EV_ERROR on every entry; `data` carries the errno, 0 when
-        // the change applied cleanly. An entry without EV_ERROR is not a report.
-        if ((result.flags & EV_ERROR) == 0 || result.data == 0)
+        // EV_RECEIPT guarantees EV_ERROR on every entry. An entry without it is not
+        // the receipt we asked for, so treat it as a failure rather than assume the
+        // change applied — parking on a filter the kernel never armed is unresumable.
+        if ((result.flags & EV_ERROR) == 0)
+            return false;
+        if (result.data == 0)
             return true;
         auto const row =
             std::ranges::find(interests, static_cast<std::int16_t>(result.filter), &FilterInterest::filter);
@@ -146,24 +156,36 @@ FdToken KqueueEventSource::attach(NativeHandle fd, FdInterest interest)
     if (!token)
         return FdToken::invalid();
 
-    // Register a private duplicate, for the same reason as the epoll backend: a
-    // kqueue filter is keyed by (descriptor, filter), so a second registration on
-    // one descriptor would replace the first rather than stand beside it, while
-    // poll(2) takes two independent entries.
-    auto const owned = ::dup(fd);
+    // Arm the CALLER'S descriptor whenever we can. A dup() would share the
+    // underlying open file description, so closing the caller's copy while this
+    // registration lives would not release it: no FIN would reach the peer, whose
+    // read would then block forever instead of seeing EOF. Only a genuine duplicate
+    // registration needs a private descriptor, because a kqueue filter is keyed by
+    // (descriptor, filter): a second registration would replace the first's filters
+    // rather than stand beside them, and dropFilters deletes by descriptor, so
+    // detaching either would tear down both.
+    auto const duplicate =
+        std::ranges::any_of(_registered, [fd](auto const& entry) { return entry.second.fd == fd; });
+    auto watched = fd;
+    auto owned = false;
+    if (duplicate)
+    {
+        watched = ::dup(fd);
+        owned = true;
+    }
 
     // A failed arm must not leave the registry claiming the fd is watched: the
     // awaiting flow has to fail rather than park on a filter the kernel never
     // armed, which nothing could ever resume.
-    if (owned < 0 || !applyInterest(owned, interest, token))
+    if (watched < 0 || !applyInterest(watched, interest, token))
     {
-        if (owned >= 0)
-            ::close(owned);
+        if (owned && watched >= 0)
+            ::close(watched);
         _registry.detach(token);
         return FdToken::invalid();
     }
 
-    _registered.emplace(token.value, owned);
+    _registered.emplace(token.value, KqueueEventSource::Watched { .fd = watched, .owned = owned });
     return token;
 }
 
@@ -171,8 +193,9 @@ void KqueueEventSource::detach(FdToken token)
 {
     if (auto const it = _registered.find(token.value); it != _registered.end())
     {
-        dropFilters(it->second);
-        ::close(it->second); // the duplicate this source owns, not the caller's fd
+        dropFilters(it->second.fd);
+        if (it->second.owned)
+            ::close(it->second.fd); // a duplicate we made, never the caller's fd
         _registered.erase(it);
     }
     _registry.detach(token);

--- a/src/net/KqueueEventSource.cpp
+++ b/src/net/KqueueEventSource.cpp
@@ -207,11 +207,15 @@ WaitOutcome KqueueEventSource::wait(int timeoutMs)
     for (auto const& event: std::span { events.data(), static_cast<std::size_t>(ready) })
     {
         auto const token = FdToken { static_cast<std::uint64_t>(reinterpret_cast<uintptr_t>(event.udata)) };
-        // EV_EOF is reported as readable so a parked reader wakes and observes EOF,
-        // matching how poll(2)'s POLLHUP is routed.
-        if (event.filter == EVFILT_READ || (event.flags & EV_EOF) != 0)
+        // Route by the filter that fired, not by EV_EOF: a registration watches one
+        // direction, so reporting a write filter's EOF as readability would name a
+        // reader that does not exist. EV_EOF still wakes whoever is parked, because
+        // it arrives on that side's own filter — the peer closing makes the read
+        // filter fire (EOF is readable) and the write filter fire (the write can no
+        // longer block). That matches how poll(2)'s POLLHUP reaches both.
+        if (event.filter == EVFILT_READ)
             outcome.readyRead.push_back(token);
-        if (event.filter == EVFILT_WRITE)
+        else if (event.filter == EVFILT_WRITE)
             outcome.readyWrite.push_back(token);
     }
     return outcome;

--- a/src/net/KqueueEventSource.hpp
+++ b/src/net/KqueueEventSource.hpp
@@ -85,8 +85,8 @@ class KqueueEventSource: public EventSource
     /// Drops both filters for @p fd, ignoring a filter that was not armed.
     void dropFilters(NativeHandle fd) const noexcept;
 
-    FdRegistry _registry;                                   ///< Watched fds, in registration order.
-    int _kq = -1;                                           ///< The kqueue (owned).
+    FdRegistry _registry; ///< Watched fds, in registration order.
+    int _kq = -1;         ///< The kqueue (owned).
     /// The fd each live registration names, so detach can drop the kernel
     /// registration in O(1) without scanning the registry. Interest itself is
     /// fixed at attach — EventLoop only ever attaches and detaches — so there

--- a/src/net/KqueueEventSource.hpp
+++ b/src/net/KqueueEventSource.hpp
@@ -85,13 +85,30 @@ class KqueueEventSource: public EventSource
     /// Drops both filters for @p fd, ignoring a filter that was not armed.
     void dropFilters(NativeHandle fd) const noexcept;
 
+    /// The descriptor a registration is watched through, and whether this source
+    /// created it and must therefore close it.
+    struct Watched
+    {
+        NativeHandle fd = InvalidHandle; ///< The descriptor the filters are armed on.
+        bool owned = false;              ///< True if this is our dup(), false if the caller's fd.
+    };
+
     FdRegistry _registry; ///< Watched fds, in registration order.
     int _kq = -1;         ///< The kqueue (owned).
-    /// The fd each live registration names, so detach can drop the kernel
-    /// registration in O(1) without scanning the registry. Interest itself is
-    /// fixed at attach — EventLoop only ever attaches and detaches — so there
-    /// is nothing to reconcile per wait.
-    std::unordered_map<std::uint64_t, NativeHandle> _registered;
+    /// The descriptor each live registration is watched through, so detach can drop
+    /// the kernel registration in O(1) without scanning the registry. Interest itself
+    /// is fixed at attach — EventLoop only ever attaches and detaches — so there is
+    /// nothing to reconcile per wait.
+    ///
+    /// Normally this is the CALLER'S descriptor. A `dup()` would share the underlying
+    /// open file description, so the caller closing its copy would not release it —
+    /// no FIN would reach the peer, whose read would block forever rather than
+    /// observe EOF (poll(2), which holds no descriptor of its own, has no such
+    /// effect). A duplicate is made only for a genuine second registration of one
+    /// descriptor: a kqueue filter is keyed by (descriptor, filter), so a second
+    /// registration would REPLACE the first's filters rather than stand beside them,
+    /// and @c dropFilters — which deletes by descriptor — would then tear down both.
+    std::unordered_map<std::uint64_t, Watched> _registered;
 };
 
 } // namespace net

--- a/src/net/KqueueEventSource.hpp
+++ b/src/net/KqueueEventSource.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// The macOS/BSD @c EventSource: multiplexes the registered file descriptors with
+/// kqueue(2) instead of poll(2).
+///
+/// Same contract and same observable behaviour as @c PollEventSource — a drop-in
+/// alternative selected by @c makeDefaultEventSource(), differing only in cost: a
+/// wait is O(ready) rather than O(registered).
+///
+/// Interest is **level-triggered** (no `EV_CLEAR`), matching what @c PosixSocket and
+/// the accept loop assume.
+///
+/// Ported from the reactor in the fastcached project (Apache-2.0, same author),
+/// including the `EV_RECEIPT` handling described at @c applyInterest — without it,
+/// a write that parks while no read is outstanding never gets its filter armed.
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+
+    #include <unordered_map>
+
+    #include <net/EventSource.hpp>
+    #include <net/platform/NativeHandle.hpp>
+
+namespace net
+{
+
+/// An @c EventSource backed by a kqueue.
+///
+/// The kqueue filter set is kept in step with the @c FdRegistry: @c attach arms the
+/// requested filters, @c detach drops them, and a changed interest mask is pushed on
+/// the next @c wait. Registration failures surface as @c FdToken::invalid() so the
+/// awaiting flow fails rather than parking on a filter the kernel never armed.
+class KqueueEventSource: public EventSource
+{
+  public:
+    /// Creates the kqueue.
+    /// @note If `kqueue()` fails, @c good() reports false and every @c attach
+    ///       refuses, so @c makeDefaultEventSource() falls back to @c PollEventSource.
+    KqueueEventSource() noexcept;
+    ~KqueueEventSource() override;
+
+    KqueueEventSource(KqueueEventSource const&) = delete;
+    KqueueEventSource& operator=(KqueueEventSource const&) = delete;
+    KqueueEventSource(KqueueEventSource&&) = delete;
+    KqueueEventSource& operator=(KqueueEventSource&&) = delete;
+
+    [[nodiscard]] WaitOutcome wait(int timeoutMs) override;
+
+    [[nodiscard]] FdToken attach(NativeHandle fd, FdInterest interest) override;
+
+    void detach(FdToken token) override;
+
+    /// @return True if the kqueue was created successfully.
+    [[nodiscard]] bool good() const noexcept { return _kq >= 0; }
+
+    /// @return The number of fds currently attached.
+    [[nodiscard]] std::size_t attachedCount() const noexcept { return _registry.size(); }
+
+  private:
+    /// Arms or drops the read and write filters for @p fd to match @p interest.
+    ///
+    /// Submits both filter changes with `EV_RECEIPT`. That flag is load-bearing:
+    /// without an eventlist, `kevent()` stops at the FIRST failing change and the
+    /// remaining changes are silently never applied. Dropping a filter that was
+    /// never armed fails with `ENOENT`, so the routine "no read, yes write" case —
+    /// a write parking while no read is outstanding — would abort on the read
+    /// delete and never arm the write filter, parking that write forever.
+    /// @return True if every change applied (an `ENOENT` on a filter being dropped
+    ///         is the normal steady state, not a failure).
+    [[nodiscard]] bool applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept;
+
+    /// Drops both filters for @p fd, ignoring a filter that was not armed.
+    void dropFilters(NativeHandle fd) const noexcept;
+
+    FdRegistry _registry;                                   ///< Watched fds, in registration order.
+    int _kq = -1;                                           ///< The kqueue (owned).
+    std::unordered_map<std::uint64_t, FdInterest> _applied; ///< Interest last pushed, keyed by token.
+};
+
+} // namespace net
+
+#endif // kqueue platforms

--- a/src/net/KqueueEventSource.hpp
+++ b/src/net/KqueueEventSource.hpp
@@ -32,9 +32,11 @@ namespace net
 /// An @c EventSource backed by a kqueue.
 ///
 /// The kqueue filter set is kept in step with the @c FdRegistry: @c attach arms the
-/// requested filters, @c detach drops them, and a changed interest mask is pushed on
-/// the next @c wait. Registration failures surface as @c FdToken::invalid() so the
-/// awaiting flow fails rather than parking on a filter the kernel never armed.
+/// requested filters, @c detach drops them. Interest is fixed for a registration's
+/// lifetime — @c EventLoop only ever attaches and detaches — so a wait costs nothing
+/// beyond the kevent() itself. Registration failures surface as
+/// @c FdToken::invalid() so the awaiting flow fails rather than parking on a filter
+/// the kernel never armed.
 class KqueueEventSource: public EventSource
 {
   public:
@@ -70,6 +72,12 @@ class KqueueEventSource: public EventSource
     /// never armed fails with `ENOENT`, so the routine "no read, yes write" case —
     /// a write parking while no read is outstanding — would abort on the read
     /// delete and never arm the write filter, parking that write forever.
+    /// Returns `bool` rather than `std::expected` deliberately: this is a private
+    /// helper whose only caller turns a failure into @c FdToken::invalid(), which
+    /// is all the @c EventSource interface can express.
+    /// @param fd The descriptor whose filters to arm or drop.
+    /// @param interest The readiness bits to watch.
+    /// @param token The registration's identity, echoed back by @c wait.
     /// @return True if every change applied (an `ENOENT` on a filter being dropped
     ///         is the normal steady state, not a failure).
     [[nodiscard]] bool applyInterest(NativeHandle fd, FdInterest interest, FdToken token) const noexcept;
@@ -79,7 +87,11 @@ class KqueueEventSource: public EventSource
 
     FdRegistry _registry;                                   ///< Watched fds, in registration order.
     int _kq = -1;                                           ///< The kqueue (owned).
-    std::unordered_map<std::uint64_t, FdInterest> _applied; ///< Interest last pushed, keyed by token.
+    /// The fd each live registration names, so detach can drop the kernel
+    /// registration in O(1) without scanning the registry. Interest itself is
+    /// fixed at attach — EventLoop only ever attaches and detaches — so there
+    /// is nothing to reconcile per wait.
+    std::unordered_map<std::uint64_t, NativeHandle> _registered;
 };
 
 } // namespace net

--- a/src/net/PollEventSource.cpp
+++ b/src/net/PollEventSource.cpp
@@ -2,7 +2,9 @@
 #include <net/PollEventSource.hpp>
 
 #ifdef _WIN32
-    #include <crispy/LogStore.hpp>
+    #include <net/Diagnostics.hpp>
+
+    #include <format>
 
     #include <algorithm>
     #include <cstdint>
@@ -203,7 +205,7 @@ WaitOutcome PollEventSource::wait(int timeoutMs)
         // pure poll).
         if (verdict == WaitVerdict::Failed)
         {
-            errorLog()("WaitForMultipleObjects failed: {}", GetLastError());
+            reportDiagnostic(std::format("WaitForMultipleObjects failed: {}", GetLastError()));
             if (timeoutMs != 0)
                 Sleep(timeout < SweepSliceMs ? timeout : SweepSliceMs);
         }
@@ -234,7 +236,8 @@ WaitOutcome PollEventSource::wait(int timeoutMs)
                 WaitForMultipleObjects(chunkSize, handles.data() + chunk.offset, FALSE, 0), chunkSize);
             if (verdict == WaitVerdict::Failed && !failureLogged)
             {
-                errorLog()("WaitForMultipleObjects (chunk at {}) failed: {}", chunk.offset, GetLastError());
+                reportDiagnostic(std::format(
+                    "WaitForMultipleObjects (chunk at {}) failed: {}", chunk.offset, GetLastError()));
                 failureLogged = true; // log once per wait(), not once per sweep, to bound spam.
             }
             // Signalled OR Failed both hand off to collectSignalled below: a Failed chunk

--- a/src/net/PollEventSource.cpp
+++ b/src/net/PollEventSource.cpp
@@ -2,16 +2,14 @@
 #include <net/PollEventSource.hpp>
 
 #ifdef _WIN32
-    #include <net/Diagnostics.hpp>
-
-    #include <format>
-
     #include <algorithm>
     #include <cstdint>
+    #include <format>
     #include <ranges>
 
     #include <windows.h>
 
+    #include <net/Diagnostics.hpp>
     #include <net/WaitChunking.hpp>
 #else
     #include <poll.h>

--- a/src/net/README.md
+++ b/src/net/README.md
@@ -1,0 +1,45 @@
+# net — coroutine-native networking and event loop
+
+The reactor, socket layer and TLS transport that `src/vthost` and `src/contour/remote` are
+built on. Built on `src/coro`; depends on nothing above it in the tree.
+
+See [`../coro/README.md`](../coro/README.md) for provenance — **this copy is canonical** for
+Contour, Endo and fastcached alike, and changes flow outward from here.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `EventLoop.*` | Scheduling, timers, `post()`, spawned-flow reaping. Owns the ready queue. |
+| `EventSource.hpp` | The DI seam over "block until something happens". `FdRegistry`, `FdToken`, `FdInterest`, `WaitOutcome`. |
+| `PollEventSource.*` | The portable `EventSource`: `poll(2)` on POSIX, `WaitForMultipleObjects` on Windows. |
+| `EpollEventSource.*`, `KqueueEventSource.*` | Native `EventSource`s for Linux and macOS/BSD. Behaviourally identical to poll; a wait is O(ready) rather than O(registered). |
+| `DefaultEventSource.*` | `makeDefaultEventSource()` — picks the best backend, falling back to poll. Use this rather than naming a backend. |
+| `ISocket.hpp`, `IListener.hpp`, `IoResult.hpp` | Transport interfaces and the `std::expected` error vocabulary. |
+| `Sockets.hpp` | `listen`/`connect`/`listenUnix`/`connectUnix`/`adoptFd` free functions. |
+| `Tls.*` | TLS decorator behind `ITlsContext`; OpenSSL stays private to the `.cpp`. |
+| `AsyncBufferedReader.*`, `WriteQueue.*`, `SplitSocket.hpp`, `WithTimeout.hpp` | Composition helpers over `ISocket`. |
+| `platform/`, `posix/`, `windows/` | Per-OS implementation details. These directories do **not** introduce sub-namespaces. |
+| `testing/` | Test doubles: `ScriptedEventSource`, `ManualClock` (in `platform/Clock.hpp`), `makeSocketPair`, `TempDir`. |
+
+## Invariants worth not breaking
+
+- **`EventSource` is the extension point.** Adding a native reactor means adding an
+  implementation, not changing the interface — `EventLoop` already owns timers and the ready
+  queue, so a new source implements only the blocking wait plus fd registration. Every backend
+  must be behaviourally interchangeable; `EventSourceParity_test.cpp` runs the same scenarios
+  against each one to keep them so. IOCP is the exception that proves the rule — it is
+  completion-based rather than readiness-based, so it does not fit this interface at all (see
+  `DefaultEventSource.hpp`).
+- **A failed fd registration fails the awaitable; it never parks.** `EventLoop::registerFdWaiter`
+  returns `FdToken::invalid()` on failure and `WaitFdAwaiter::await_resume()` throws
+  `FdRegistrationFailed`. Suspending on an interest the kernel never registered is unresumable —
+  the connection would hang forever holding untransferred bytes. This is a real bug that has been
+  hit in a sibling copy of this code; preserve the invariant in any new `EventSource`.
+- **Readiness is level-triggered.** `PosixSocket` and the accept paths assume a still-ready fd is
+  reported again on the next wait. An edge-triggered source must either emulate that or come with
+  a socket layer that drains to `EAGAIN`.
+- **I/O errors are `std::expected`, not exceptions.** Exceptions are reserved for control flow:
+  `coro::OperationCancelled` and `net::FdRegistrationFailed`.
+- **No OpenSSL type crosses a `net` header.** `Tls.cpp` keeps it behind `ITlsContext`, which is
+  why `OpenSSL::SSL` is linked `PRIVATE`.

--- a/src/net/Socket_test.cpp
+++ b/src/net/Socket_test.cpp
@@ -21,14 +21,14 @@
 #include <net/EventLoop.hpp>
 #include <net/IListener.hpp>
 #include <net/ISocket.hpp>
-#include <net/PollEventSource.hpp>
 #include <net/Sockets.hpp>
+#include <net/testing/EventSourceBackends.hpp>
 #include <net/testing/InMemoryTransport.hpp>
 
 using coro::Task;
 using net::EventLoop;
 using net::ISocket;
-using net::PollEventSource;
+using net::testing::AllBackends;
 
 namespace
 {
@@ -131,49 +131,78 @@ Task<void> closeWhileParked(EventLoop* loop, ISocket* sock, bool* resumedWithErr
 
 TEST_CASE("InMemoryTransport round-trips bytes between connected endpoints", "[net]")
 {
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
 
-    auto wroteOk = false;
-    auto readOk = false;
-    loop.blockOn(pairRoundTrip(&loop, &wroteOk, &readOk));
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
 
-    REQUIRE(wroteOk);
-    REQUIRE(readOk);
+            auto wroteOk = false;
+            auto readOk = false;
+            loop.blockOn(pairRoundTrip(&loop, &wroteOk, &readOk));
+
+            REQUIRE(wroteOk);
+            REQUIRE(readOk);
+        }
+    }
 }
 
-TEST_CASE("closing a socket resumes a reader parked on it instead of hanging", "[net][poll]")
+TEST_CASE("closing a socket resumes a reader parked on it instead of hanging", "[net]")
 {
     // A reader parked on an idle socket that is then closed under it must resume with an error, not
-    // hang. On POSIX poll(2) reports POLLNVAL for the closed fd; on Windows the reactor must route the
-    // now-invalid WSAEVENT the same way. Regression guard: this deadlocked on Windows before the fix,
-    // taking the whole disconnect-while-parked path (attach clients, control clients) down with it.
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
-    auto pair = net::testing::makeSocketPair(loop);
-    REQUIRE(pair.has_value());
+    // hang. poll(2) reports POLLNVAL for the closed fd and Windows reports the now-invalid WSAEVENT
+    // as failed; epoll and kqueue can report neither, so they rely on EventLoop::notifyHandleClosing.
+    // Regression guard twice over: this deadlocked on Windows before the reactor routed the invalid
+    // handle, and it deadlocked on epoll/kqueue for as long as this case hardcoded PollEventSource —
+    // which is exactly why it now runs against every backend.
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
 
-    auto resumedWithError = false;
-    loop.blockOn(closeWhileParked(&loop, pair->second.get(), &resumedWithError));
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+            auto pair = net::testing::makeSocketPair(loop);
+            REQUIRE(pair.has_value());
 
-    CHECK(resumedWithError); // it resumed at all (no hang) AND saw the close as an error
+            auto resumedWithError = false;
+            loop.blockOn(closeWhileParked(&loop, pair->second.get(), &resumedWithError));
+
+            CHECK(resumedWithError); // it resumed at all (no hang) AND saw the close as an error
+        }
+    }
 }
 
-TEST_CASE("listen + connect + accept echo a request over loopback", "[net][poll]")
+TEST_CASE("listen + connect + accept echo a request over loopback", "[net]")
 {
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
 
-    auto listener = net::listen(loop, "127.0.0.1", 0);
-    REQUIRE(listener.has_value());
-    REQUIRE((*listener)->localPort() != 0);
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
 
-    auto served = false;
-    auto matched = false;
-    loop.blockOn(loopbackEcho(&loop, listener->get(), &served, &matched));
+            auto listener = net::listen(loop, "127.0.0.1", 0);
+            REQUIRE(listener.has_value());
+            REQUIRE((*listener)->localPort() != 0);
 
-    REQUIRE(served);
-    REQUIRE(matched);
+            auto served = false;
+            auto matched = false;
+            loop.blockOn(loopbackEcho(&loop, listener->get(), &served, &matched));
+
+            REQUIRE(served);
+            REQUIRE(matched);
+        }
+    }
 }
 
 namespace
@@ -259,61 +288,79 @@ Task<void> unixEcho(EventLoop* loop, net::IListener* listener, std::string path,
 // subset reports no skips: `windows-latest` is far past the 1803 that introduced AF_UNIX, so a
 // skip there means the daemon's transport silently stopped being tested, not that the platform
 // lacks it. Same reasoning as the [oracle] tag on the tmux interop tests.
-TEST_CASE("unix-domain listen + connect echo a request", "[net][poll][afunix]")
+TEST_CASE("unix-domain listen + connect echo a request", "[net][afunix]")
 {
     // Runtime-gated: on platforms without AF_UNIX support this documents the
     // Unsupported answer instead (never a crash). On Windows this is the
     // afunix.h path's coverage.
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
-
-    auto const path = (std::filesystem::temp_directory_path()
-                       / std::format("contour-net-{}", std::random_device {}()) / "echo.sock")
-                          .string();
-    auto listener = net::listenUnix(loop, path);
-    if (!listener.has_value())
+    for (auto const& backend: AllBackends)
     {
-        REQUIRE(listener.error().code == net::NetErrorCode::Unsupported);
-        SKIP("AF_UNIX not supported on this platform");
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+
+            auto const path = (std::filesystem::temp_directory_path()
+                               / std::format("contour-net-{}", std::random_device {}()) / "echo.sock")
+                                  .string();
+            auto listener = net::listenUnix(loop, path);
+            if (!listener.has_value())
+            {
+                REQUIRE(listener.error().code == net::NetErrorCode::Unsupported);
+                SKIP("AF_UNIX not supported on this platform");
+            }
+
+            auto served = false;
+            auto matched = false;
+            loop.blockOn(unixEcho(&loop, listener->get(), path, &served, &matched));
+            REQUIRE(served);
+            REQUIRE(matched);
+
+            auto ec = std::error_code {};
+            std::filesystem::remove_all(std::filesystem::path { path }.parent_path(), ec);
+        }
     }
-
-    auto served = false;
-    auto matched = false;
-    loop.blockOn(unixEcho(&loop, listener->get(), path, &served, &matched));
-    REQUIRE(served);
-    REQUIRE(matched);
-
-    auto ec = std::error_code {};
-    std::filesystem::remove_all(std::filesystem::path { path }.parent_path(), ec);
 }
 
-TEST_CASE("closing a unix listener removes its socket file", "[net][poll][afunix]")
+TEST_CASE("closing a unix listener removes its socket file", "[net][afunix]")
 {
     // The daemon's contract (docs/internals/vthost.md, "Daemon lifetime"): a closed listener
     // leaves no path behind, so the next start's liveness probe finds nothing and binds fresh
     // rather than reclaiming a corpse. Windows used to keep the file — WindowsListener held no
     // path at all — which is what this pins.
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
-
-    auto const dir = makeSocketDir();
-    auto const path = (dir / "closing.sock").string();
-    auto listener = net::listenUnix(loop, path);
-    if (!listener.has_value())
+    for (auto const& backend: AllBackends)
     {
-        REQUIRE(listener.error().code == net::NetErrorCode::Unsupported);
-        SKIP("AF_UNIX not supported on this platform");
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+
+            auto const dir = makeSocketDir();
+            auto const path = (dir / "closing.sock").string();
+            auto listener = net::listenUnix(loop, path);
+            if (!listener.has_value())
+            {
+                REQUIRE(listener.error().code == net::NetErrorCode::Unsupported);
+                SKIP("AF_UNIX not supported on this platform");
+            }
+            REQUIRE(socketFileExists(path));
+
+            (*listener)->close();
+            REQUIRE_FALSE(socketFileExists(path));
+
+            auto ec = std::error_code {};
+            std::filesystem::remove_all(dir, ec);
+        }
     }
-    REQUIRE(socketFileExists(path));
-
-    (*listener)->close();
-    REQUIRE_FALSE(socketFileExists(path));
-
-    auto ec = std::error_code {};
-    std::filesystem::remove_all(dir, ec);
 }
 
-TEST_CASE("a live server on the path is not hijacked", "[net][poll][afunix]")
+TEST_CASE("a live server on the path is not hijacked", "[net][afunix]")
 {
     // A second bind must be REFUSED rather than unlink the live socket out from under the
     // incumbent, which would keep all its sessions but become unreachable forever. The refusal
@@ -321,38 +368,48 @@ TEST_CASE("a live server on the path is not hijacked", "[net][poll][afunix]")
     //
     // Cross-platform on purpose: the POSIX twin in UnixSocket_test.cpp cannot run here, and the
     // Windows probe (WindowsListener::probeUnixSocketOwner) had no coverage at all.
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
-
-    auto const dir = makeSocketDir();
-    auto const path = (dir / "default").string();
-    auto first = net::listenUnix(loop, path);
-    if (!first.has_value())
+    for (auto const& backend: AllBackends)
     {
-        REQUIRE(first.error().code == net::NetErrorCode::Unsupported);
-        SKIP("AF_UNIX not supported on this platform");
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
+
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
+
+            auto const dir = makeSocketDir();
+            auto const path = (dir / "default").string();
+            auto first = net::listenUnix(loop, path);
+            if (!first.has_value())
+            {
+                REQUIRE(first.error().code == net::NetErrorCode::Unsupported);
+                SKIP("AF_UNIX not supported on this platform");
+            }
+
+            auto second = net::listenUnix(loop, path);
+            REQUIRE_FALSE(second.has_value());
+            REQUIRE(second.error().code == net::NetErrorCode::AddressInUse);
+            REQUIRE(socketFileExists(path)); // the incumbent's file, left intact
+
+            // The incumbent still serves: a client connects and gets its probe echoed back. The refused
+            // bind's own liveness probe left a dropped connection queued ahead of it, which is why the
+            // server flow here drains rather than treating the first accept as the request.
+            auto served = false;
+            auto matched = false;
+            auto run =
+                [](net::IListener* listener, EventLoop* lp, std::string p, bool* s, bool* m) -> Task<void> {
+                co_await coro::whenAll(echoOnceDraining(listener, s), unixProbe(lp, std::move(p), m));
+            };
+            loop.blockOn(run(first->get(), &loop, path, &served, &matched));
+
+            REQUIRE(served);
+            REQUIRE(matched);
+
+            auto ec = std::error_code {};
+            std::filesystem::remove_all(dir, ec);
+        }
     }
-
-    auto second = net::listenUnix(loop, path);
-    REQUIRE_FALSE(second.has_value());
-    REQUIRE(second.error().code == net::NetErrorCode::AddressInUse);
-    REQUIRE(socketFileExists(path)); // the incumbent's file, left intact
-
-    // The incumbent still serves: a client connects and gets its probe echoed back. The refused
-    // bind's own liveness probe left a dropped connection queued ahead of it, which is why the
-    // server flow here drains rather than treating the first accept as the request.
-    auto served = false;
-    auto matched = false;
-    auto run = [](net::IListener* listener, EventLoop* lp, std::string p, bool* s, bool* m) -> Task<void> {
-        co_await coro::whenAll(echoOnceDraining(listener, s), unixProbe(lp, std::move(p), m));
-    };
-    loop.blockOn(run(first->get(), &loop, path, &served, &matched));
-
-    REQUIRE(served);
-    REQUIRE(matched);
-
-    auto ec = std::error_code {};
-    std::filesystem::remove_all(dir, ec);
 }
 
 namespace
@@ -428,25 +485,34 @@ Task<void> duplexBulk(EventLoop* loop,
 //
 // A regression does not fail here — it HANGS, and the suite's per-test timeout reports it. That is
 // the nature of a lost wake-up, and matches how the TLS deadlock case is covered.
-TEST_CASE("a concurrent reader and writer on one socket both make progress", "[net][poll]")
+TEST_CASE("a concurrent reader and writer on one socket both make progress", "[net]")
 {
-    auto source = PollEventSource {};
-    auto loop = EventLoop { source };
+    for (auto const& backend: AllBackends)
+    {
+        auto source = net::makeEventSource(backend.kind);
+        if (!source)
+            continue; // not available on this platform
 
-    auto listener = net::listen(loop, "127.0.0.1", 0);
-    REQUIRE(listener.has_value());
+        DYNAMIC_SECTION("backend=" << backend.name)
+        {
+            auto loop = EventLoop { *source };
 
-    // Comfortably past any socket send buffer, so both directions really do block.
-    constexpr auto Payload = std::size_t { 4 } * 1024 * 1024;
-    auto serverGot = std::size_t { 0 };
-    auto clientGot = std::size_t { 0 };
-    auto serverSent = false;
-    auto clientSent = false;
-    loop.blockOn(
-        duplexBulk(&loop, listener->get(), Payload, &serverGot, &clientGot, &serverSent, &clientSent));
+            auto listener = net::listen(loop, "127.0.0.1", 0);
+            REQUIRE(listener.has_value());
 
-    CHECK(serverSent);
-    CHECK(clientSent);
-    CHECK(serverGot == Payload);
-    CHECK(clientGot == Payload);
+            // Comfortably past any socket send buffer, so both directions really do block.
+            constexpr auto Payload = std::size_t { 4 } * 1024 * 1024;
+            auto serverGot = std::size_t { 0 };
+            auto clientGot = std::size_t { 0 };
+            auto serverSent = false;
+            auto clientSent = false;
+            loop.blockOn(duplexBulk(
+                &loop, listener->get(), Payload, &serverGot, &clientGot, &serverSent, &clientSent));
+
+            CHECK(serverSent);
+            CHECK(clientSent);
+            CHECK(serverGot == Payload);
+            CHECK(clientGot == Payload);
+        }
+    }
 }

--- a/src/net/Tls.cpp
+++ b/src/net/Tls.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <net/Tls.hpp>
 
-#include <crispy/Utils.hpp>
-
 #include <algorithm>
 #include <array>
 #include <coroutine>
@@ -14,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include <net/detail/ScopeGuard.hpp>
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
@@ -229,7 +228,7 @@ namespace
 
             _handshaking = true;
             auto outcome = std::expected<void, NetError> {};
-            auto const openGate = crispy::Finally([this]() noexcept { openHandshakeGate(); });
+            auto const openGate = detail::ScopeGuard { [this]() noexcept { openHandshakeGate(); } };
             while (true)
             {
                 auto const result = SSL_do_handshake(_ssl);

--- a/src/net/detail/ScopeGuard.hpp
+++ b/src/net/detail/ScopeGuard.hpp
@@ -37,7 +37,9 @@ class ScopeGuard
     ScopeGuard(ScopeGuard&&) = delete;
     ScopeGuard& operator=(ScopeGuard&&) = delete;
 
-    ~ScopeGuard() { _callable(); }
+    /// Runs the action. Explicitly `noexcept` to state the intent the `requires`
+    /// clause enforces: a throwing action would terminate from here.
+    ~ScopeGuard() noexcept { _callable(); }
 
   private:
     Callable _callable; ///< The action run on scope exit.

--- a/src/net/detail/ScopeGuard.hpp
+++ b/src/net/detail/ScopeGuard.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// A minimal scope guard: run a callable when the enclosing scope exits.
+///
+/// `net` keeps its own rather than reaching for a utility library's, so the module
+/// stays dependency-free and can be consumed by other projects without dragging
+/// Contour's `crispy` along. Being a template, it also stores the callable inline —
+/// no `std::function` allocation on a path that runs per TLS handshake.
+
+#include <type_traits>
+#include <utility>
+
+namespace net::detail
+{
+
+/// Invokes a callable on destruction.
+///
+/// Deliberately immovable: a guard exists to fire exactly once, at the end of the
+/// scope that declared it. Construct it with a lambda and let it go out of scope.
+/// @tparam Callable The callable to invoke; must be nothrow-invocable, since it
+///         runs from a destructor and an escaping exception would terminate.
+template <typename Callable>
+    requires std::is_nothrow_invocable_v<Callable&>
+class ScopeGuard
+{
+  public:
+    /// @param callable The action to run when this guard is destroyed.
+    explicit ScopeGuard(Callable callable) noexcept(std::is_nothrow_move_constructible_v<Callable>):
+        _callable(std::move(callable))
+    {
+    }
+
+    ScopeGuard(ScopeGuard const&) = delete;
+    ScopeGuard& operator=(ScopeGuard const&) = delete;
+    ScopeGuard(ScopeGuard&&) = delete;
+    ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+    ~ScopeGuard() { _callable(); }
+
+  private:
+    Callable _callable; ///< The action run on scope exit.
+};
+
+} // namespace net::detail

--- a/src/net/posix/PosixListener.cpp
+++ b/src/net/posix/PosixListener.cpp
@@ -35,10 +35,6 @@ void PosixListener::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
-        // Resume a parked accept() before the descriptor goes away: a readiness
-        // poller cannot report a closed descriptor, so it would otherwise wait
-        // forever. See EventLoop::notifyHandleClosing.
-        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixListener.cpp
+++ b/src/net/posix/PosixListener.cpp
@@ -25,16 +25,28 @@ PosixListener::PosixListener(EventLoop& loop, int fd, std::uint16_t localPort) n
 
 PosixListener::~PosixListener()
 {
-    close();
+    // Cancel, not Resume: acceptOne holds `int const* fd` / `bool const* closed`
+    // into this object, which is about to stop existing. Unwinding via
+    // OperationCancelled returns without ever dereferencing them again.
+    close(FdWakePolicy::Cancel);
 }
 
 void PosixListener::close() noexcept
+{
+    close(FdWakePolicy::Resume);
+}
+
+void PosixListener::close(FdWakePolicy policy) noexcept
 {
     if (_closed)
         return;
     _closed = true;
     if (_fd >= 0)
     {
+        // Before the close, while the descriptor is still valid: epoll and kqueue
+        // cannot report a closed descriptor, so without this a parked accept would
+        // never be resumed.
+        _loop.notifyHandleClosing(_fd, policy);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixListener.cpp
+++ b/src/net/posix/PosixListener.cpp
@@ -35,6 +35,10 @@ void PosixListener::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
+        // Resume a parked accept() before the descriptor goes away: a readiness
+        // poller cannot report a closed descriptor, so it would otherwise wait
+        // forever. See EventLoop::notifyHandleClosing.
+        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixListener.hpp
+++ b/src/net/posix/PosixListener.hpp
@@ -47,6 +47,15 @@ class PosixListener final: public IListener
   private:
     PosixListener(EventLoop& loop, int fd, std::uint16_t localPort) noexcept;
 
+    /// Closes the listening fd, telling the loop first so a parked accept is
+    /// resumed rather than left waiting on a descriptor the poller can no longer
+    /// report.
+    /// @param policy How a parked accept observes the close. @c close() passes
+    ///        @c Resume — this listener is alive, so acceptOne may safely re-read
+    ///        the @c _fd / @c _closed it holds pointers to. The destructor passes
+    ///        @c Cancel, since those pointers are about to dangle.
+    void close(FdWakePolicy policy) noexcept;
+
     EventLoop& _loop;
     int _fd;
     std::uint16_t _localPort;

--- a/src/net/posix/PosixSocket.cpp
+++ b/src/net/posix/PosixSocket.cpp
@@ -72,12 +72,6 @@ void PosixSocket::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
-        // Resume anything parked on this descriptor BEFORE closing it. A readiness
-        // poller cannot report a closed descriptor -- epoll drops it from the set,
-        // kqueue drops its filters, both silently -- so a parked reader would hang
-        // forever. poll(2) reports POLLNVAL and resumes it, which is why closing
-        // under a parked reader worked before the native backends existed.
-        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixSocket.cpp
+++ b/src/net/posix/PosixSocket.cpp
@@ -62,16 +62,28 @@ PosixSocket::PosixSocket(EventLoop& loop, int fd, std::string peerAddress) noexc
 
 PosixSocket::~PosixSocket()
 {
-    close();
+    // Cancel, not Resume: read/write reach _fd and _closed through `this`, which is
+    // about to stop existing. A flow resumed on its normal path would read them from
+    // freed memory; unwinding via OperationCancelled never re-enters the body.
+    close(FdWakePolicy::Cancel);
 }
 
 void PosixSocket::close() noexcept
+{
+    close(FdWakePolicy::Resume);
+}
+
+void PosixSocket::close(FdWakePolicy policy) noexcept
 {
     if (_closed)
         return;
     _closed = true;
     if (_fd >= 0)
     {
+        // Before the close, while the descriptor is still valid: epoll and kqueue
+        // cannot report a closed descriptor, so without this a flow parked on it
+        // would never be resumed.
+        _loop.notifyHandleClosing(_fd, policy);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixSocket.cpp
+++ b/src/net/posix/PosixSocket.cpp
@@ -72,6 +72,12 @@ void PosixSocket::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
+        // Resume anything parked on this descriptor BEFORE closing it. A readiness
+        // poller cannot report a closed descriptor -- epoll drops it from the set,
+        // kqueue drops its filters, both silently -- so a parked reader would hang
+        // forever. poll(2) reports POLLNVAL and resumes it, which is why closing
+        // under a parked reader worked before the native backends existed.
+        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/PosixSocket.hpp
+++ b/src/net/posix/PosixSocket.hpp
@@ -48,6 +48,15 @@ class PosixSocket final: public ISocket
     [[nodiscard]] int native() const noexcept { return _fd; }
 
   private:
+    /// Closes the fd, telling the loop first so a flow parked on it is resumed
+    /// rather than left waiting for readiness the poller can no longer report.
+    /// @param policy How a parked flow observes the close. The public @c close()
+    ///        passes @c Resume — this object is still alive, so the flow may safely
+    ///        re-read @c _closed. The destructor passes @c Cancel, because by the
+    ///        time it resumes the flow would be reading `this` through a dangling
+    ///        pointer; unwinding via @c OperationCancelled never re-enters the body.
+    void close(FdWakePolicy policy) noexcept;
+
     EventLoop& _loop;
     int _fd;
     bool _plainFd = false; ///< Set on first ENOTSOCK: a PTY/pipe fd, served via read/write.

--- a/src/net/posix/SocketsPosix.cpp
+++ b/src/net/posix/SocketsPosix.cpp
@@ -24,6 +24,25 @@
 namespace net
 {
 
+namespace
+{
+    /// Closes a descriptor the connect path is abandoning, announcing it to the loop
+    /// first.
+    ///
+    /// Nothing is normally parked on it by this point — the awaiter detached in its
+    /// own await_resume — but the loop's contract is that a descriptor which may be
+    /// registered is announced BEFORE it closes, and honouring that unconditionally
+    /// is what keeps a second waiter on the same descriptor from being stranded on
+    /// epoll or kqueue, neither of which can report a closed one.
+    /// @param loop The loop the descriptor was registered with.
+    /// @param fd The descriptor to close.
+    void discardSocket(EventLoop* loop, int fd) noexcept
+    {
+        loop->notifyHandleClosing(fd, FdWakePolicy::Cancel);
+        ::close(fd);
+    }
+} // namespace
+
 std::expected<std::unique_ptr<IListener>, NetError> listen(EventLoop& loop,
                                                            std::string_view host,
                                                            std::uint16_t port,
@@ -79,7 +98,7 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connect(EventLoop*
             }
             catch (coro::OperationCancelled const&)
             {
-                ::close(fd);
+                discardSocket(loop, fd);
                 ::freeaddrinfo(resolved);
                 co_return std::unexpected(makeNetError(NetErrorCode::Cancelled, 0, "connect cancelled"));
             }
@@ -102,7 +121,7 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connect(EventLoop*
             lastError = makeNetError(
                 errno == ECONNREFUSED ? NetErrorCode::ConnRefused : NetErrorCode::Other, errno, "connect");
         }
-        ::close(fd);
+        discardSocket(loop, fd);
     }
     ::freeaddrinfo(resolved);
     co_return std::unexpected(lastError);
@@ -146,7 +165,7 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connectUnix(EventL
         }
         catch (coro::OperationCancelled const&)
         {
-            ::close(fd);
+            discardSocket(loop, fd);
             co_return std::unexpected(makeNetError(NetErrorCode::Cancelled, 0, "connect cancelled"));
         }
         int soError = 0;
@@ -154,13 +173,13 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connectUnix(EventL
         ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &soError, &soLen);
         if (soError == 0)
             co_return std::unique_ptr<ISocket>(new PosixSocket(*loop, fd));
-        ::close(fd);
+        discardSocket(loop, fd);
         co_return std::unexpected(makeNetError(
             soError == ECONNREFUSED ? NetErrorCode::ConnRefused : NetErrorCode::Other, soError, "connect"));
     }
 
     auto const err = errno;
-    ::close(fd);
+    discardSocket(loop, fd);
     co_return std::unexpected(
         makeNetError(err == ECONNREFUSED ? NetErrorCode::ConnRefused : NetErrorCode::Other, err, "connect"));
 }

--- a/src/net/posix/UnixListener.cpp
+++ b/src/net/posix/UnixListener.cpp
@@ -121,6 +121,10 @@ void UnixListener::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
+        // Resume a parked accept() before the descriptor goes away: a readiness
+        // poller cannot report a closed descriptor, so it would otherwise wait
+        // forever. See EventLoop::notifyHandleClosing.
+        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/UnixListener.cpp
+++ b/src/net/posix/UnixListener.cpp
@@ -111,16 +111,28 @@ UnixListener::UnixListener(EventLoop& loop, int fd, std::filesystem::path path) 
 
 UnixListener::~UnixListener()
 {
-    close();
+    // Cancel, not Resume: acceptOne holds `int const* fd` / `bool const* closed`
+    // into this object, which is about to stop existing. Unwinding via
+    // OperationCancelled returns without ever dereferencing them again.
+    close(FdWakePolicy::Cancel);
 }
 
 void UnixListener::close() noexcept
+{
+    close(FdWakePolicy::Resume);
+}
+
+void UnixListener::close(FdWakePolicy policy) noexcept
 {
     if (_closed)
         return;
     _closed = true;
     if (_fd >= 0)
     {
+        // Before the close, while the descriptor is still valid: epoll and kqueue
+        // cannot report a closed descriptor, so without this a parked accept would
+        // never be resumed.
+        _loop.notifyHandleClosing(_fd, policy);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/UnixListener.cpp
+++ b/src/net/posix/UnixListener.cpp
@@ -121,10 +121,6 @@ void UnixListener::close() noexcept
     _closed = true;
     if (_fd >= 0)
     {
-        // Resume a parked accept() before the descriptor goes away: a readiness
-        // poller cannot report a closed descriptor, so it would otherwise wait
-        // forever. See EventLoop::notifyHandleClosing.
-        _loop.notifyHandleClosing(_fd);
         ::close(_fd);
         _fd = -1;
     }

--- a/src/net/posix/UnixListener.hpp
+++ b/src/net/posix/UnixListener.hpp
@@ -69,6 +69,15 @@ class UnixListener final: public IListener
   private:
     UnixListener(EventLoop& loop, int fd, std::filesystem::path path) noexcept;
 
+    /// Closes the listening fd and unlinks the socket file, telling the loop first
+    /// so a parked accept is resumed rather than left waiting on a descriptor the
+    /// poller can no longer report.
+    /// @param policy How a parked accept observes the close. @c close() passes
+    ///        @c Resume — this listener is alive, so acceptOne may safely re-read
+    ///        the @c _fd / @c _closed it holds pointers to. The destructor passes
+    ///        @c Cancel, since those pointers are about to dangle.
+    void close(FdWakePolicy policy) noexcept;
+
     EventLoop& _loop;
     int _fd;
     std::filesystem::path _path;

--- a/src/net/test_main.cpp
+++ b/src/net/test_main.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <crispy/SuppressWindowsDialogs.hpp>
+#include <coro/testing/SuppressWindowsDialogs.hpp>
 
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch_session.hpp>
@@ -7,7 +7,7 @@
 
 int main(int argc, char const* argv[])
 {
-    crispy::suppressWindowsDialogs();
+    coro::testing::suppressWindowsDialogs();
 
     int const result = Catch::Session().run(argc, argv);
     return result;

--- a/src/net/testing/EventSourceBackends.hpp
+++ b/src/net/testing/EventSourceBackends.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// The table of @c EventSource backends a test should run against.
+///
+/// Shared rather than copied per test file for the reason the parity suite exists
+/// at all: `Socket_test` hardcoded @c PollEventSource in every case, so two
+/// native-backend defects — a registration holding the peer's connection open, and
+/// a parked flow never resuming after close — passed a green suite. One table
+/// means adding a backend enrols every suite that uses it, instead of enrolling
+/// whichever ones someone remembers.
+
+#include <array>
+#include <string_view>
+
+#include <net/DefaultEventSource.hpp>
+
+namespace net::testing
+{
+
+/// One backend to exercise, with a label so a failure names which one broke.
+struct Backend
+{
+    EventSourceKind kind;  ///< The backend to construct.
+    std::string_view name; ///< Its name, for the section label.
+};
+
+/// Every backend the interface defines. A test enumerates these, skips the ones
+/// @c makeEventSource reports unavailable on this platform, and runs the same
+/// scenario against the rest:
+///
+/// @code
+/// for (auto const& backend: net::testing::AllBackends)
+/// {
+///     auto source = net::makeEventSource(backend.kind);
+///     if (!source)
+///         continue; // not available on this platform
+///     DYNAMIC_SECTION("backend=" << backend.name) { ... }
+/// }
+/// @endcode
+constexpr auto AllBackends = std::array {
+    Backend { EventSourceKind::Poll, "poll" },
+    Backend { EventSourceKind::Epoll, "epoll" },
+    Backend { EventSourceKind::Kqueue, "kqueue" },
+};
+
+} // namespace net::testing

--- a/src/net/windows/SocketsWin32.cpp
+++ b/src/net/windows/SocketsWin32.cpp
@@ -27,6 +27,25 @@
 namespace net
 {
 
+namespace
+{
+    /// Closes a connect-readiness event the connect path is done with, announcing it
+    /// to the loop first.
+    ///
+    /// The EVENT, not the socket, is what a park registers with the loop, so it is
+    /// the handle the loop knows. Nothing is normally parked on it by this point —
+    /// the awaiter detached in its own await_resume — but the loop's contract is
+    /// that a handle which may be registered is announced BEFORE it closes, and
+    /// honouring that unconditionally keeps the behaviour identical to POSIX.
+    /// @param loop The loop the event may have been registered with.
+    /// @param event The event to close.
+    void discardEvent(EventLoop* loop, WSAEVENT event) noexcept
+    {
+        loop->notifyHandleClosing(static_cast<HANDLE>(event), FdWakePolicy::Cancel);
+        WSACloseEvent(event);
+    }
+} // namespace
+
 std::expected<std::unique_ptr<IListener>, NetError> listen(EventLoop& loop,
                                                            std::string_view host,
                                                            std::uint16_t port,
@@ -87,7 +106,7 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connect(EventLoop*
             }
             catch (coro::OperationCancelled const&)
             {
-                WSACloseEvent(event);
+                discardEvent(loop, event);
                 closesocket(sock);
                 freeaddrinfo(resolved);
                 co_return std::unexpected(makeNetError(NetErrorCode::Cancelled, 0, "connect cancelled"));
@@ -100,7 +119,7 @@ coro::Task<std::expected<std::unique_ptr<ISocket>, NetError>> connect(EventLoop*
         }
 
         // The WindowsSocket re-associates the event with its own interest set.
-        WSACloseEvent(event);
+        discardEvent(loop, event);
 
         if (connectErr == 0)
         {

--- a/src/net/windows/WindowsListener.cpp
+++ b/src/net/windows/WindowsListener.cpp
@@ -97,16 +97,28 @@ WindowsListener::WindowsListener(
 
 WindowsListener::~WindowsListener()
 {
-    close();
+    // Cancel, not Resume: the accept loop reaches _socket, _event and _closed
+    // through `this`, which is about to stop existing. Unwinding via
+    // OperationCancelled returns without dereferencing them again.
+    close(FdWakePolicy::Cancel);
 }
 
 void WindowsListener::close() noexcept
+{
+    close(FdWakePolicy::Resume);
+}
+
+void WindowsListener::close(FdWakePolicy policy) noexcept
 {
     if (_closed)
         return;
     _closed = true;
     if (_event != WSA_INVALID_EVENT)
     {
+        // Before the close, while the handle is still valid. The event -- not the
+        // socket -- is what accept() registers with the loop, so it is the handle a
+        // parked accept must be woken by.
+        _loop.notifyHandleClosing(static_cast<HANDLE>(_event), policy);
         WSACloseEvent(_event);
         _event = WSA_INVALID_EVENT;
     }

--- a/src/net/windows/WindowsListener.hpp
+++ b/src/net/windows/WindowsListener.hpp
@@ -70,6 +70,14 @@ class WindowsListener final: public IListener
     WindowsListener(
         EventLoop& loop, SOCKET socket, WSAEVENT event, std::uint16_t localPort, std::string path) noexcept;
 
+    /// Closes the listening socket and its event (and removes the socket file),
+    /// telling the loop first so a parked accept is resumed rather than left
+    /// waiting on a handle that can never signal again.
+    /// @param policy How a parked accept observes the close. @c close() passes
+    ///        @c Resume — this listener is alive. The destructor passes @c Cancel,
+    ///        since the accept loop reaches @c _socket / @c _event through `this`.
+    void close(FdWakePolicy policy) noexcept;
+
     EventLoop& _loop;
     SOCKET _socket;
     WSAEVENT _event;

--- a/src/net/windows/WindowsSocket.cpp
+++ b/src/net/windows/WindowsSocket.cpp
@@ -37,16 +37,28 @@ WindowsSocket::WindowsSocket(EventLoop& loop, SOCKET socket, std::string peerAdd
 
 WindowsSocket::~WindowsSocket()
 {
-    close();
+    // Cancel, not Resume: read/write and parkUntilReady reach _closed, _event and
+    // _socket through `this`, which is about to stop existing. Unwinding via
+    // OperationCancelled never re-enters the body.
+    close(FdWakePolicy::Cancel);
 }
 
 void WindowsSocket::close() noexcept
+{
+    close(FdWakePolicy::Resume);
+}
+
+void WindowsSocket::close(FdWakePolicy policy) noexcept
 {
     if (_closed)
         return;
     _closed = true;
     if (_event != WSA_INVALID_EVENT)
     {
+        // Before the close, while the handle is still valid. The event -- not the
+        // socket -- is what parkUntilReady registers with the loop, so it is the
+        // handle a parked flow must be woken by.
+        _loop.notifyHandleClosing(static_cast<HANDLE>(_event), policy);
         WSACloseEvent(_event);
         _event = WSA_INVALID_EVENT;
     }

--- a/src/net/windows/WindowsSocket.hpp
+++ b/src/net/windows/WindowsSocket.hpp
@@ -56,6 +56,15 @@ class WindowsSocket final: public ISocket
     [[nodiscard]] bool isClosed() const noexcept override { return _closed; }
 
   private:
+    /// Closes the socket and its event, telling the loop first so a flow parked on
+    /// the event is resumed rather than left waiting on a handle that can never
+    /// signal again.
+    /// @param policy How a parked flow observes the close. The public @c close()
+    ///        passes @c Resume — this object is still alive, so the flow may safely
+    ///        re-read @c _closed. The destructor passes @c Cancel, because by then
+    ///        the flow would be reading `this` through a dangling pointer.
+    void close(FdWakePolicy policy) noexcept;
+
     /// Which readiness a park waits for.
     enum class Ready
     {


### PR DESCRIPTION
The same coroutine and networking layer exists in three divergent copies — here, in
[Endo](https://github.com/contour-terminal/endo) (`src/coro`, `src/net`), and in fastcached
(`src/FastCache/Async`, `src/FastCache/Net`). Every fix has to be applied three times, and in
practice is not. This branch makes this copy the one that the others can consume, by folding in
what each of them had grown and removing what kept it Contour-specific.

The copy chain turns out to run fastcached → Endo → Contour, so this is the newest of the three
rather than the original. `src/coro/README.md` still described Endo as upstream and prescribed a
`sed`-based re-sync *from* it — a recipe that would now silently revert `UniqueCoroHandle`, the
`EventLoop`/`EventSource` split, TLS and Unix-domain sockets. That was the most urgent thing to fix.

Phases 4 and 5 of the plan — having Endo and fastcached consume this at CMake configure time, and
extracting it to a standalone repository — are **not** in this branch; they span the other repos.
This is the groundwork they depend on.

## Changes

- Record the real provenance and drop the destructive re-sync recipe; add the equivalent README for
  `net`, which carries the bulk of the code and had none.
- Give `AsyncBufferedReader` `readUntil` and `readExactly` alongside `readLine`, sharing one refill
  path. The delimiter scan resumes where a split match could still begin, so a delimiter straddling
  two reads is found without re-searching the prefix.
- Port Endo's async HTTP/1.1 server — the one thing this copy was missing — rebuilt on that reader.
  Fixes three defects it carried, none of which had a test: an empty reason phrase on every non-200
  status (`HTTP/1.1 404 \r\n`), a `Content-Length` that accepted trailing garbage, and a malformed
  request line being dispatched as if it had parsed.
- Add epoll and kqueue event sources behind the existing `EventSource` interface, ported from
  fastcached including its `EV_RECEIPT` fix — without which a reply larger than the socket send
  buffer parks forever on macOS. A wait becomes O(ready) rather than O(registered), which is what
  fastcached cannot give up. `makeDefaultEventSource()` picks the native backend and falls back to
  poll, so call sites carry no `#ifdef`s.
- Drop the last first-party dependencies: `crispy::Finally` becomes a local `ScopeGuard`,
  `crispy::LogStore` becomes an injectable diagnostics sink, and the test runners get a local
  dialog-suppression helper. `net` no longer links `crispy::core` at all, so both modules now depend
  on nothing above them in the tree.
- Fix the tmux oracle build, which is why `.github/` appears in the diff. tmux 3.7b's `configure`
  refuses to default utf8proc and exits 127, so the macOS job died before compiling anything —
  on `master` too. Passing `--disable-utf8proc` unblocks it, and on the Linux job as well, which
  had only escaped the error because utf8proc is absent from that image.

IOCP is deliberately **not** ported. It is a completion port rather than a readiness poller, so
fitting it behind `EventSource` would mean rewriting `WindowsSocket` and the `ISocket` contract
around completions — a socket-layer redesign, not another event source. Windows stays on
`PollEventSource`, and the reasoning is recorded at the `EventSourceKind` enum.

## Defects found while reviewing and building this branch

Reviewing the new code turned up two: `fill()` collapsed transport errors into EOF, reporting a
connection reset as a clean end-of-message; and both event sources reconciled interest across every
registration on every wait — exactly the O(registered) cost they exist to avoid, and unreachable
anyway, since interest is fixed at attach.

Two more came from getting this to build everywhere, both cross-platform divergences the parity
suite is meant to catch:

- **A descriptor could be registered twice under poll but not under epoll.** `FdRegistry` permits
  it and `poll(2)` takes two entries, but an epoll set is keyed by descriptor, so the second
  `EPOLL_CTL_ADD` returned `EEXIST`. Both native backends now register a private `dup()`, so each
  registration owns a distinct kernel object and detaching one leaves the other watching.
- **A parity test asserted a poll(2) detail as if it were the interface contract.** It required
  both tokens of a duplicated descriptor to appear in one wait — true on Linux, which fills in
  every matching `pollfd`, false on macOS, which reports the descriptor once. The test now asserts
  what `EventSource` actually promises, and `attach()` documents the difference.

The second of those was only reachable once the tmux fix let macOS build this branch at all.
