### PR TITLE
sixel: clamp raster aspect ratio to stop a wraparound OOB write

### DIFF
--- a/src/vtbackend/SixelParser.cpp
+++ b/src/vtbackend/SixelParser.cpp
@@ -416,8 +416,15 @@ void SixelImageBuilder::newline()
 void SixelImageBuilder::setRaster(unsigned int pan, unsigned int pad, optional<ImageSize> imageSize)
 {
     if (pad != 0)
-        _aspectRatio =
-            max(1u, static_cast<unsigned int>(std::ceil(static_cast<float>(pan) / static_cast<float>(pad))));
+        // Clamped to keep every y0 + bit*_aspectRatio computation below (render(), bandRows()) well
+        // inside unsigned range: an attacker-supplied Pan close to UINT_MAX with Pad=1 would otherwise
+        // let (y + _aspectRatio) wrap around to a small value in the bounds check while y itself stays
+        // huge, producing a heap write far past _buffer. Real encoders never need more than single-digit
+        // ratios; 255 leaves generous headroom without reopening the overflow.
+        _aspectRatio = clamp(
+            max(1u, static_cast<unsigned int>(std::ceil(static_cast<float>(pan) / static_cast<float>(pad)))),
+            1u,
+            255u);
     _sixelBandHeight = 6 * _aspectRatio;
     if (imageSize)
     {
@@ -460,7 +467,10 @@ void SixelImageBuilder::render(int8_t sixel)
     // A bit that would overhang the bottom paints nothing and so cannot grow the image either --
     // taking the highest SET bit instead would grow it by the very rows that get clipped.
     auto const topBit = static_cast<unsigned>(std::bit_width(bits)) - 1;
-    auto lastRowExclusive = y0 + ((topBit + 1) * _aspectRatio);
+    // 64-bit throughout: with _aspectRatio now clamped this can no longer wrap in practice, but doing
+    // the arithmetic in a width the values can never fill is a second, independent guard against the
+    // same overflow class regardless of what future callers of setRaster() pass in.
+    auto lastRowExclusive = static_cast<uint64_t>(y0) + (static_cast<uint64_t>(topBit + 1) * _aspectRatio);
     if (lastRowExclusive > canvasHeight)
     {
         // Only when the sixel overhangs is it worth hunting for the highest bit that still fits.
@@ -469,7 +479,8 @@ void SixelImageBuilder::render(int8_t sixel)
         {
             if ((bits & (1u << bit)) == 0)
                 continue;
-            if (auto const y = y0 + (bit * _aspectRatio); y + _aspectRatio <= canvasHeight)
+            auto const y = static_cast<uint64_t>(y0) + (static_cast<uint64_t>(bit) * _aspectRatio);
+            if (y + _aspectRatio <= canvasHeight)
             {
                 lastRowExclusive = y + _aspectRatio;
                 break;
@@ -483,14 +494,18 @@ void SixelImageBuilder::render(int8_t sixel)
         return;
     }
 
+    // Narrowed back down deliberately: every path above leaves lastRowExclusive <= canvasHeight (an
+    // unsigned), so this is lossless -- the 64-bit width above exists only to keep the intermediate
+    // additions from wrapping, not because the final row count can legitimately exceed 32 bits.
+    auto const lastRow = static_cast<unsigned>(lastRowExclusive);
     if (!_explicitSize)
     {
-        if (lastRowExclusive > unbox<unsigned>(_size.height))
-            _size.height = Height::cast_from(lastRowExclusive);
+        if (lastRow > unbox<unsigned>(_size.height))
+            _size.height = Height::cast_from(lastRow);
         if (x >= unbox<unsigned>(_size.width))
             _size.width = Width::cast_from(x + 1);
     }
-    reserve(x + 1, lastRowExclusive);
+    reserve(x + 1, lastRow);
 
     auto const color = currentColor();
     auto const rowBytes = static_cast<size_t>(_stride) * 4;
@@ -499,7 +514,7 @@ void SixelImageBuilder::render(int8_t sixel)
     for (auto remaining = bits; remaining != 0; remaining &= remaining - 1)
     {
         auto const bit = static_cast<unsigned>(std::countr_zero(remaining));
-        auto const y = y0 + (bit * _aspectRatio);
+        auto const y = static_cast<uint64_t>(y0) + (static_cast<uint64_t>(bit) * _aspectRatio);
         if (y + _aspectRatio > canvasHeight)
             break; // bits only climb, so nothing above this fits either
 
@@ -583,7 +598,7 @@ SixelImageBuilder::BandRows SixelImageBuilder::bandRows() const noexcept
 
     for (auto const bit: std::views::iota(0u, SixelBitCount))
     {
-        auto const y = y0 + (bit * _aspectRatio);
+        auto const y = static_cast<uint64_t>(y0) + (static_cast<uint64_t>(bit) * _aspectRatio);
         if (y + _aspectRatio > canvasHeight)
             break; // bits only climb, so nothing above this fits either
         result.fittingBits |= 1u << bit;

--- a/src/vtbackend/SixelParser_test.cpp
+++ b/src/vtbackend/SixelParser_test.cpp
@@ -572,6 +572,42 @@ TEST_CASE("SixelParser.explicit_raster_vertical_overflow", "[sixel]")
     CHECK(ib.sixelCursor() == CellLocation { LineOffset(0), ColumnOffset(1) });
 }
 
+TEST_CASE("SixelParser.raster_aspect_ratio_wraparound_is_clamped", "[sixel]")
+{
+    // A raster Pan close to UINT_MAX with Pad=1 used to set _aspectRatio to ~2^31 unclamped. The
+    // render()/bandRows() bounds check (y + _aspectRatio > canvasHeight) is unsigned arithmetic,
+    // so that huge aspect ratio made the check wrap around and pass while the write offset itself
+    // (y, still ~2^31) stayed enormous -- a heap write far past the pixel buffer. setRaster() now
+    // clamps the ratio to a sane maximum, so this must no longer reach anywhere near that scale.
+    auto constexpr DefaultColor = RGBAColor { 0, 0, 0, 0xFF };
+    auto constexpr PinColor = RGBColor { 0x10, 0x20, 0x40 };
+
+    // Canvas height must clear 512: with Pan=2147483904, (topBit+1)*_aspectRatio wraps mod 2^32 to
+    // exactly 512, and the pre-write bounds check only reaches the vulnerable line when that wrapped
+    // value is <= canvasHeight -- a too-small canvas makes render() bail out via its own early
+    // return before ever touching the write path this test exists to cover.
+    auto ib = SixelImageBuilder(
+        { Width(4), Height(600) }, 1, 1, DefaultColor, std::make_shared<SixelColorPalette>(16, 256));
+    ib.setRaster(2147483904u, 1, std::nullopt);
+
+    // The clamp is the actual regression guard: any value near 2^31 here means the wraparound
+    // window this test exists to close is open again.
+    REQUIRE(ib.aspectRatio() <= 255u);
+
+    auto sp = SixelParser { ib };
+    ib.setColor(0, PinColor);
+
+    // Bit 1 set ('A' = 63+2): with an unclamped aspect ratio this alone used to be enough to
+    // compute a pointer offset gigabytes past the buffer -- the wrapped bounds check above passes,
+    // y stays ~2^31, and paintBit() writes there. It must now just clip against the 600-row canvas
+    // like any other out-of-range sixel, painting nothing.
+    sp.parseFragment("A");
+    sp.done();
+
+    // Storage stays bounded by the declared canvas -- not by whatever `Pan` claimed.
+    CHECK(ib.data().size() <= static_cast<std::size_t>(4u * 600u * 4u));
+}
+
 TEST_CASE("SixelParser.finalize_is_idempotent", "[sixel]")
 {
     // finalize() must be safe to run twice. On the implicit-raster path it compacts rows from the


### PR DESCRIPTION

While reading through the Sixel parser I noticed `setRaster()` takes the
`Pan`/`Pad` values straight off the wire and turns them into `_aspectRatio`
with no upper bound. That value later drives `y = y0 + bit*_aspectRatio` in
`render()`/`bandRows()`, and the bounds check right after it
(`y + _aspectRatio > canvasHeight`) is 32-bit arithmetic, so a large enough
`_aspectRatio` makes that addition wrap around to something small while `y`
itself stays a huge (but perfectly valid) `unsigned`. The check passes, and
`y` goes straight into a pointer offset in `paintBit()` -- a write far past
the actual pixel buffer.

Concretely: `ESC P q "2147483904;1 A ESC \` sets `Pan=2147483904, Pad=1`
(aspect ratio ~2^31), then a single sixel character with bit 1 set walks
straight off the end of `_buffer`.

Fix is two parts:
- Clamp `_aspectRatio` to 255 in `setRaster()` -- real encoders use single-digit
  ratios, so this doesn't change behavior for any legitimate stream.
- Do the `y`/`lastRowExclusive` bounds-check arithmetic in 64 bits in both
  `render()` and `bandRows()`, so the same overflow class can't reopen if a
  future caller of `setRaster()` skips the clamp.

Added a regression test (`SixelParser.raster_aspect_ratio_wraparound_is_clamped`)
covering the exact PoC above.

Full disclosure: I used Claude to help audit this code and work through the fix
with me, not just my own eyes on it. Verified the overflow and the resulting
diff by hand and built/tested it locally under ASan before opening this.