### PR TITLE
Update libunicode to 0.9.3, restoring combining marks on ASCII bases

### DIFF
--- a/cmake/ContourThirdParties.cmake
+++ b/cmake/ContourThirdParties.cmake
@@ -90,7 +90,7 @@ endmacro()
 message(STATUS "==============================================================================")
 message(STATUS "    Contour ThirdParties: ${ContourThirdParties}")
 
-set(LIBUNICODE_MINIMAL_VERSION "0.9.2")
+set(LIBUNICODE_MINIMAL_VERSION "0.9.3")
 set(BOXED_CPP_MINIMAL_VERSION "1.4.3")
 set(TERMBENCH_PRO_COMMIT_HASH "f6c37988e6481b48a8b8acaf1575495e018e9747")
 set(CATCH_VERSION "3.4.0")

--- a/scripts/check-common.sh
+++ b/scripts/check-common.sh
@@ -2,19 +2,44 @@
 
 set -e
 
+# A check that silently checks nothing is worse than no check, and relative paths are how that
+# happens -- so resolve the repo root rather than trusting $PWD.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null)"
+
+if [[ -z "$repo_root" ]]; then
+    echo 1>&2 "Error: ${script_dir} is not inside a git repository."
+    exit 1
+fi
+
 ErrorCount=0
 
-## libunicode version match
+## libunicode version
 
-LIBUNICODE_SHA_PS=$(awk 'match ($0, /libunicode_git_sha="[0-9a-f]+/) { print(substr($0, RSTART+20, RLENGTH-20)); }' scripts/install-deps.ps1)
-LIBUNICODE_SHA_SH=$(awk 'match ($0, /libunicode_git_sha="[0-9a-f]+/) { print(substr($0, RSTART+20, RLENGTH-20)); }' scripts/install-deps.sh)
+# Neither install-deps script pins libunicode's version: both read it out of the single
+# LIBUNICODE_MINIMAL_VERSION line in cmake/ContourThirdParties.cmake, so there is no pair of literals
+# left to compare -- and restating their patterns here would only compare this file against itself.
+# Each script now rejects an unreadable version where it reads it, which covers every platform rather
+# than just CI. What is left worth doing here is failing fast, in the cheap lint job, on the two ways
+# that arrangement breaks: the line stops being parseable, or a script stops consulting it.
 
-if [[ "${LIBUNICODE_SHA_SH}" != "${LIBUNICODE_SHA_PS}" ]]; then
-    echo 1>&2 "Error: libunicode version seems to mismatch between the two install-deps scripts."
-    echo 1>&2 "libunicode sha (PowerShell) : ${LIBUNICODE_SHA_SH}"
-    echo 1>&2 "libunicode sha (bash)       : ${LIBUNICODE_SHA_PS}"
-    ErrorCount=$[ErrorCount + 1]
+ThirdPartiesCMakeFile="${repo_root}/cmake/ContourThirdParties.cmake"
+
+LibUnicodeVersion=$(sed -n 's/^set(LIBUNICODE_MINIMAL_VERSION "\([0-9.]*\)".*/\1/p' "${ThirdPartiesCMakeFile}")
+
+if [[ -z "${LibUnicodeVersion}" ]]; then
+    echo 1>&2 "Error: cannot read LIBUNICODE_MINIMAL_VERSION from cmake/ContourThirdParties.cmake."
+    echo 1>&2 "Expected a line of the form: set(LIBUNICODE_MINIMAL_VERSION \"<version>\")"
+    ErrorCount=$((ErrorCount + 1))
 fi
+
+for script in scripts/install-deps.sh scripts/install-deps.ps1; do
+    if ! grep -q 'LIBUNICODE_MINIMAL_VERSION' "${repo_root}/${script}"; then
+        echo 1>&2 "Error: ${script} no longer derives libunicode's version from"
+        echo 1>&2 "cmake/ContourThirdParties.cmake, so the two can drift apart again."
+        ErrorCount=$((ErrorCount + 1))
+    fi
+done
 
 if [[ $ErrorCount -ne 0 ]]; then
     exit 1

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -15,8 +15,16 @@ class ThirdParty {
 # the vendored source drift below the CMake requirement, which then fails to configure -- and it did:
 # raising the floor updated every platform except Windows, which kept unpacking the older archive.
 $ThirdPartiesCMakeFile = Join-Path (Join-Path $PSScriptRoot "..") "cmake/ContourThirdParties.cmake"
-$libunicode_version = (Select-String -Path $ThirdPartiesCMakeFile `
-    -Pattern '^set\(LIBUNICODE_MINIMAL_VERSION "([0-9.]+)"').Matches[0].Groups[1].Value
+$libunicode_match = Select-String -Path $ThirdPartiesCMakeFile `
+    -Pattern '^set\(LIBUNICODE_MINIMAL_VERSION "([0-9.]+)"'
+# Say what went wrong here rather than 404 on ".../tags/v.zip" further down: no match means that line
+# changed shape, and the download error names neither the file nor the reason. Without this, the
+# missing match surfaces as a null-reference on .Matches[0] at best, and as an empty version at worst.
+if (-not $libunicode_match) {
+    Write-Error "Cannot read LIBUNICODE_MINIMAL_VERSION from ${ThirdPartiesCMakeFile}.`nExpected a line of the form: set(LIBUNICODE_MINIMAL_VERSION `"<version>`")"
+    exit 1
+}
+$libunicode_version = $libunicode_match.Matches[0].Groups[1].Value
 $reflection_cpp_version="0.4.0"
 
 # Take care, order matters, at least as much as dependencies are of concern.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -108,8 +108,17 @@ fetch_and_unpack_libunicode() {
         # (LIBUNICODE_MINIMAL_VERSION). Hard-coding it here too would let the vendored source drift
         # below the CMake requirement, which then fails to configure.
         local libunicode_version
+        local thirdparties_cmake="$SYSDEPS_BASE_DIR/../cmake/ContourThirdParties.cmake"
         libunicode_version=$(sed -n 's/^set(LIBUNICODE_MINIMAL_VERSION "\([0-9.]*\)".*/\1/p' \
-            "$SYSDEPS_BASE_DIR/../cmake/ContourThirdParties.cmake")
+            "$thirdparties_cmake")
+        # Say what went wrong here rather than 404 on ".../tags/v.tar.gz" further down: an empty
+        # version means that line changed shape, and the download error names neither the file nor
+        # the reason.
+        if test x$libunicode_version = x; then
+            echo 1>&2 "Cannot read LIBUNICODE_MINIMAL_VERSION from $thirdparties_cmake."
+            echo 1>&2 "Expected a line of the form: set(LIBUNICODE_MINIMAL_VERSION \"<version>\")"
+            exit 1
+        fi
         fetch_and_unpack \
             libunicode-$libunicode_version \
             libunicode-$libunicode_version.tar.gz \

--- a/src/vtbackend/Screen_test.cpp
+++ b/src/vtbackend/Screen_test.cpp
@@ -470,6 +470,45 @@ TEST_CASE("AppendChar.VS15_is_inert_without_a_defined_variation_sequence", "[scr
     CHECK(c0.width() == 2);
 }
 
+TEST_CASE("AppendChar.a_zero_width_codepoint_after_an_ASCII_base_joins_its_cell", "[screen]")
+{
+    // The cell-level half of Parser.BulkText_ZeroWidthAfterAsciiBase. scan_text() splits a run at the
+    // ASCII/non-ASCII boundary, so a mark on an ASCII base is handed to Screen separately from its
+    // base and has to find that cell again through the grapheme-state reconstruction in writeText --
+    // which deliberately does NOT reuse the parser's state. Every other cluster test here uses a
+    // non-ASCII base, which never crosses that seam, so this is the case that reached the screen as a
+    // bare "e" while libunicode measured the handover in columns rather than bytes (< 0.9.3).
+    //
+    // Bytes, not codepoints: the defect lives in the UTF-8 bulk scanner, so it has to be fed UTF-8.
+    auto mock = MockTerm { PageSize { LineCount(1), ColumnCount(10) } };
+    auto& screen = mock.terminal.primaryScreen();
+
+    SECTION("the base alone in the buffer")
+    {
+        mock.writeToScreen("e\xCC\x81"); // "é" decomposed: 'e' + U+0301 COMBINING ACUTE ACCENT
+
+        CHECK(*screen.logicalCursorPosition().column == 1);
+        auto const& c0 = screen.at(LineOffset(0), ColumnOffset(0));
+        CHECK(c0.codepoints() == U"é");
+        CHECK(c0.width() == 1);
+    }
+
+    SECTION("the base mid-run, so the scan hands over and then returns to ASCII")
+    {
+        mock.writeToScreen("abcde\xCC\x81"
+                           "fgh");
+
+        CHECK(*screen.logicalCursorPosition().column == 8);
+        // The mark joined 'e' at column 4 rather than opening a cell of its own...
+        auto const& c4 = screen.at(LineOffset(0), ColumnOffset(4));
+        CHECK(c4.codepoints() == U"é");
+        CHECK(c4.width() == 1);
+        // ... so what follows it is still 'f', not a column further along.
+        CHECK(screen.at(LineOffset(0), ColumnOffset(5)).codepoints() == U"f");
+        CHECK(screen.renderMainPageText() == "abcdéfgh  \n");
+    }
+}
+
 TEST_CASE("AppendChar.a_wide_char_at_the_second_to_last_column_claims_the_last_one", "[screen]")
 {
     // The room a character has is its own column PLUS the writable columns to its right. Counting

--- a/src/vtparser/Parser_test.cpp
+++ b/src/vtparser/Parser_test.cpp
@@ -5,6 +5,7 @@
 #include <libunicode/convert.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 using namespace std;
 
@@ -170,6 +171,51 @@ TEST_CASE("Parser.BulkText_MultipleIncompleteUtf8Splits", "[Parser]")
           == "A\xE2\x94\x82"
              "B\xE2\x94\x9C"
              "C");
+}
+
+TEST_CASE("Parser.BulkText_ZeroWidthAfterAsciiBase", "[Parser]")
+{
+    // Zero COLUMNS is not zero BYTES. scan_text() splits a run at the ASCII/non-ASCII boundary, and a
+    // zero-width codepoint that follows an ASCII base arrives in the non-ASCII half on its own,
+    // joining the cluster the ASCII half left open without widening it. libunicode < 0.9.3 measured
+    // that half's progress in columns: state.next moved past those bytes while the reported end did
+    // not, so parseBulkText -- which prints [subStart, subEnd) and resumes at _scanState.next --
+    // printed the base, consumed the rest, and never rendered it. Decomposed "é" arrived as "e".
+    //
+    // Every byte handed in must come back out, whatever the cluster measures.
+    auto const input = GENERATE(values<std::string_view>({
+        "e\xCC\x81"sv, // U+0301 COMBINING ACUTE on a lone ASCII base, at end of buffer
+        "abcde\xCC\x81"
+        "fgh"sv,           // ... mid-buffer, so the scan hands over and then returns to ASCII
+        "a\xEF\xB8\x8E"sv, // U+FE0E VARIATION SELECTOR-15, three bytes, on a base with no
+                           // variation sequence to select -- so it too adds no column
+        "a\xE2\x80\x8D"sv, // U+200D ZERO WIDTH JOINER, which opens no cluster of its own
+    }));
+
+    INFO("input: " << input);
+    MockParserEvents listener;
+    auto p = vtparser::Parser<vtparser::ParserEvents>(listener);
+
+    p.parseFragment(input);
+
+    CHECK(listener.text == input);
+}
+
+TEST_CASE("Parser.BulkText_CombiningMarkSplitAcrossCalls", "[Parser]")
+{
+    // The base and its mark arriving in separate reads, as a PTY delivers them. The second fragment
+    // opens with the mark, so the scan enters its non-ASCII half immediately rather than through the
+    // ASCII handoff -- the arm that was always correct. Pinned so both routes to the same cluster
+    // stay in agreement.
+
+    MockParserEvents listener;
+    auto p = vtparser::Parser<vtparser::ParserEvents>(listener);
+
+    p.parseFragment("e"sv);
+    CHECK(listener.text == "e");
+
+    p.parseFragment("\xCC\x81"sv);
+    CHECK(listener.text == "e\xCC\x81");
 }
 
 TEST_CASE("Parser.precedingGraphicCharacter.ascii", "[Parser]")


### PR DESCRIPTION
libunicode 0.9.3 fixes a scanner bug Contour sits directly downstream of, so the bump is a
user-visible rendering fix rather than routine maintenance.

`scan_text()` splits a run at the ASCII/non-ASCII boundary, and a zero-width codepoint that follows
an ASCII base arrives in the non-ASCII half alone, joining the cluster the ASCII half left open
without widening it. That half reported its progress in columns, so `state.next` moved past those
bytes while the reported end did not. `parseBulkText()` prints `[subStart, subEnd)` and resumes at
`_scanState.next`, which makes those exactly the bytes it consumed but never rendered: decomposed
`e` + U+0301 reached the screen as a bare `e`, as did any variation selector or ZWJ on an ASCII
base. `abcdéfgh` rendered as `abcdefgh`.

The suite passed unchanged across the bump, because nothing covered the ASCII-handoff path — every
pre-existing cluster test uses a non-ASCII base, which never crosses that seam. Two tests now cover
it at the layers that see it differently: the parser's own contract (every byte handed in is handed
back, over four zero-width inputs) and what the user actually sees (the mark lands in its base's
cell). Both fail against 0.9.2.

## Changes

- Require libunicode 0.9.3. Only `LIBUNICODE_MINIMAL_VERSION` moves — both install-deps scripts and
  the CPM `GIT_TAG` derive from that one line.
- Cover the ASCII-handoff path in `vtparser` and `vtbackend`.
- Fail where libunicode's version is read, not at the download. `check-common.sh` had compared a
  `libunicode_git_sha="..."` literal that stopped existing when 7691c86d centralised the version, so
  both sides matched empty against empty and the gate passed unconditionally — including across the
  0.9.2 and 0.9.3 bumps. Each install-deps script now rejects an unreadable version at its own
  extraction site, covering every platform rather than only CI, and the lint job fails fast on the
  two ways that arrangement breaks.