### PR TITLE
contour(remote): clear the geometry anchor when its pane unbinds

### DIFF
--- a/src/contour/remote/NativeController.cpp
+++ b/src/contour/remote/NativeController.cpp
@@ -389,21 +389,14 @@ std::optional<vtpty::PageSize> NativeController::composedClientArea() const
         return std::nullopt;
     };
 
-    // The anchor test is a plain tree walk, so it gates the (more expensive) composition rather
-    // than the other way round; only the first otherwise-usable tab is composed as a fallback.
-    auto fallback = std::optional<vtpty::PageSize> {};
-    for (auto const& layout: _layouts | std::views::values)
-        for (auto const& tab: layout.tabs)
-        {
-            if (_geometryAnchor.has_value() && vthost::client::paneTreeHosts(tab.root, *_geometryAnchor))
-            {
-                if (auto const composed = vthost::client::composeClientArea(tab.root, resolve))
-                    return composed;
-            }
-            else if (!fallback.has_value())
-                fallback = vthost::client::composeClientArea(tab.root, resolve);
-        }
-    return fallback;
+    // Every mirrored tab, in window-id then tab order — `_layouts` is ordered, so the fallback the
+    // composer picks is deterministic rather than a hash-order accident.
+    auto const roots =
+        _layouts | std::views::values
+        | std::views::transform([](auto const& layout) -> auto const& { return layout.tabs; })
+        | std::views::join
+        | std::views::transform([](auto const& tab) -> vthost::proto::WirePane const& { return tab.root; });
+    return vthost::client::composeAnchoredClientArea(roots, _geometryAnchor, resolve);
 }
 
 void NativeController::primeBinding(uint64_t session)
@@ -481,6 +474,13 @@ void NativeController::unbind(uint64_t session)
         auto const geometryLock = std::lock_guard { _geometryMutex };
         _paneSizes.erase(session);
         _lastReportedPaneSizes.erase(session);
+        // The anchor is the third thing this pane owned: it selects WHICH tab the client area is
+        // composed from, and a session id is never reused, so once the pane is gone the anchor can
+        // only ever miss. Left set, a flush already queued when this ran would compose the fallback
+        // tab while still believing it had anchored — reporting a client area for a window the user
+        // never touched, which the daemon answers by re-projecting every pane of every window.
+        if (_geometryAnchor == session)
+            _geometryAnchor.reset();
     }
     // Tombstone while the connection lives, so a remote session that outlives its local pane cannot
     // resurrect it through a later delta. Whether that session should also be ENDED on the daemon is

--- a/src/contour/remote/NativeController.hpp
+++ b/src/contour/remote/NativeController.hpp
@@ -372,7 +372,10 @@ class NativeController final: public QObject, public contour::session::SessionFa
     /// snapshot per followed session.
     std::optional<vtpty::PageSize> _lastReportedArea;
     std::unordered_map<uint64_t, vtpty::PageSize> _lastReportedPaneSizes;
-    /// The session whose report is pending; anchors which tab the client area is composed from.
+    /// The session whose pane last reported a grid; anchors which tab the client area is composed
+    /// from, @see vthost::client::composeAnchoredClientArea. Outlives the individual flush it was
+    /// set for — a report is not "consumed" — but never its pane: `unbind` clears it, so it either
+    /// names a live pane or nothing.
     std::optional<uint64_t> _geometryAnchor;
     bool _geometryFlushScheduled = false;            ///< A coalesced flush is already queued.
     vthost::client::NativeClient* _client = nullptr; ///< Reactor-owned; valid while serving.

--- a/src/vthost/client/LayoutReconstruction.hpp
+++ b/src/vthost/client/LayoutReconstruction.hpp
@@ -15,7 +15,9 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <ranges>
 #include <unordered_map>
+#include <utility>
 
 #include <vthost/proto/Pdu.hpp>
 #include <vtworkspace/LayoutTree.hpp>
@@ -75,5 +77,45 @@ using LeafCellSize = std::function<std::optional<vtpty::PageSize>(uint64_t sessi
 /// @return The composed area, or nullopt if any leaf is unresolved (nothing meaningful to report).
 [[nodiscard]] std::optional<vtpty::PageSize> composeClientArea(proto::WirePane const& root,
                                                                LeafCellSize const& leafSize);
+
+/// Picks WHICH tab @ref composeClientArea is applied to, across every window a client mirrors.
+///
+/// The wire carries one client area per CLIENT (`proto::ResizeRequest`), while a client may mirror
+/// several daemon windows — so one tab has to speak for all of them. The anchor names the session
+/// whose pane just resized, and the tab hosting it is the one whose extent actually changed; any
+/// other tab would report an area no one asked about. When the anchor resolves to nothing — no pane
+/// has reported yet, or the anchoring pane has since been unbound — the first tab that composes
+/// stands in, which is the right answer for the single-window case (every tab of a window fills the
+/// same content area) and a stable guess otherwise.
+///
+/// @param roots     Every mirrored tab's wire pane tree, in a deterministic order.
+/// @param anchor    The session whose pane last reported a grid, if any.
+/// @param leafSize  Resolves one leaf's rendered extent, @see LeafCellSize.
+/// @return The composed area, or nullopt when no tab composes.
+template <std::ranges::input_range Roots>
+    requires std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<Roots>>, proto::WirePane>
+[[nodiscard]] std::optional<vtpty::PageSize> composeAnchoredClientArea(Roots&& roots,
+                                                                       std::optional<uint64_t> anchor,
+                                                                       LeafCellSize const& leafSize)
+{
+    // The anchor test is a plain tree walk, so it gates the (more expensive) composition rather
+    // than the other way round; only the first otherwise-usable tab is composed as a fallback.
+    auto fallback = std::optional<vtpty::PageSize> {};
+    // Forwarded rather than iterated directly: `Roots` is a forwarding reference, and the call site
+    // passes a range adaptor pipeline whose const-iterability is not guaranteed in general -- a
+    // `views::filter` inserted into that pipeline later would have no const `begin()`. Forwarding
+    // preserves the caller's value category, which is what makes such a view iterable here.
+    for (proto::WirePane const& root: std::forward<Roots>(roots))
+    {
+        if (anchor.has_value() && paneTreeHosts(root, *anchor))
+        {
+            if (auto const composed = composeClientArea(root, leafSize))
+                return composed;
+        }
+        else if (!fallback.has_value())
+            fallback = composeClientArea(root, leafSize);
+    }
+    return fallback;
+}
 
 } // namespace vthost::client

--- a/src/vthost/client/LayoutReconstruction_test.cpp
+++ b/src/vthost/client/LayoutReconstruction_test.cpp
@@ -17,6 +17,7 @@
 #include <vtworkspace/SessionModel.hpp>
 #include <vtworkspace/Tab.hpp>
 
+using vthost::client::composeAnchoredClientArea;
 using vthost::client::composeClientArea;
 using vthost::client::WireLayout;
 using vthost::client::wireToLayout;
@@ -259,6 +260,51 @@ TEST_CASE("composeClientArea sums a split's axis and spans the other", "[vthost]
     {
         auto const root = split(2, 5000, leaf(100), leaf(101));
         CHECK_FALSE(composeClientArea(root, sizesOf({ { 100, cells(50, 30) } })).has_value());
+    }
+}
+
+TEST_CASE("composeAnchoredClientArea reports the anchoring tab's area", "[vthost][layout]")
+{
+    // Two mirrored windows, each one tab: window A is 80x24, window B is 100x30. The wire carries
+    // ONE client area per client, so exactly one of them has to speak for both.
+    auto const roots = std::vector { leaf(100), leaf(200) };
+    auto const sizes = sizesOf({ { 100, cells(80, 24) }, { 200, cells(100, 30) } });
+
+    SECTION("the anchor selects its own tab, not the first one")
+    {
+        CHECK(composeAnchoredClientArea(roots, 200, sizes) == cells(100, 30));
+        CHECK(composeAnchoredClientArea(roots, 100, sizes) == cells(80, 24));
+    }
+
+    SECTION("no anchor falls back to the first tab that composes")
+    {
+        CHECK(composeAnchoredClientArea(roots, std::nullopt, sizes) == cells(80, 24));
+    }
+
+    SECTION("an anchor naming no mirrored pane falls back rather than reporting nothing")
+    {
+        // Regression: `NativeController::unbind` clears `_geometryAnchor` when the anchoring pane
+        // goes away, so this state is transient — but a flush queued before the unbind still
+        // observes it, and it must degrade to the fallback instead of dropping the report.
+        CHECK(composeAnchoredClientArea(roots, 999, sizes) == cells(80, 24));
+    }
+
+    SECTION("an anchored tab that cannot compose yields to a tab that can")
+    {
+        // The anchoring pane was unbound (its extent is gone) while its leaf is still on the wire:
+        // the layout push that removes it has not arrived yet.
+        auto const partial = sizesOf({ { 100, cells(80, 24) } });
+        CHECK(composeAnchoredClientArea(roots, 200, partial) == cells(80, 24));
+    }
+
+    SECTION("no tab composing at all is no report")
+    {
+        CHECK_FALSE(composeAnchoredClientArea(roots, 100, sizesOf({})).has_value());
+    }
+
+    SECTION("an empty layout set is no report")
+    {
+        CHECK_FALSE(composeAnchoredClientArea(std::vector<proto::WirePane> {}, 100, sizes).has_value());
     }
 }
 


### PR DESCRIPTION
## What

`NativeController::_geometryAnchor` names the session whose pane last reported a grid, and `composedClientArea()` uses it to pick **which** tab the client area is composed from. The wire carries one client area per client (`proto::ResizeRequest`) while a client may mirror several daemon windows, so one tab has to speak for all of them.

`unbind()` cleared the two sibling members right next to it — `_paneSizes` and `_lastReportedPaneSizes` — but left the anchor naming the pane that had just gone away.

## Why it matters

A session id is never reused, so a stale anchor can only ever miss: every tab fails `paneTreeHosts`, and the composition silently degrades to "first tab that composes". With more than one mirrored window that reports a client area for a window the user never touched — which the daemon answers by re-projecting every pane of every window.

**Exposure is narrow.** Nothing calls `flushGeometry()` between the `unbind()` and the next geometry report, so it takes a flush already queued across the unbind, and the next report re-anchors. Single-window is unaffected entirely: every tab of a window fills the same content area, so anchor and fallback agree. This is hygiene, not a bug fix for a reported symptom — but the asymmetry with its two siblings was plainly unintended, and the member's doc comment described a "pending" report that nothing ever consumed.

## How

- `unbind()` resets `_geometryAnchor` when it names the departing session.
- Extracted the tab-selection decision into `vthost::client::composeAnchoredClientArea`. `composedClientArea()` is private and the behaviour is otherwise only reachable through a multi-window E2E race, so without this the fix is untestable. The extraction is behaviour-preserving and lands beside `composeClientArea` / `paneTreeHosts`, which it is built from and which already have unit tests.
- Corrected the `_geometryAnchor` doc comment.

## Tests

New `composeAnchoredClientArea reports the anchoring tab's area` in `LayoutReconstruction_test.cpp`, covering anchor selection across two windows, the no-anchor fallback, an anchor naming no mirrored pane, an anchored tab that cannot compose, and both empty cases.

- Full suite green: **26/26** (`ctest --preset=clang-debug`)
- Clean build under `-Werror`

## Risk

Low. One behavioural change, on a path that previously produced a wrong-but-plausible area; the rest is a behaviour-preserving extraction covered by the existing `attach sizes remote panes to the panes the GUI renders` regression test. No performance impact — the composition runs per coalesced geometry flush and does the same work, now over a lazy view instead of a nested loop.