### PR TITLE
ci: build the docs generator without the GUI frontend

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,10 +36,25 @@ jobs:
         run: sudo find _deps/sources -exec chown $UID {} \;
       - name: "create build directory"
         run: mkdir build
+      # Every `contour documentation ...` verb below is registered by ContourApp and reads only
+      # Qt-free sources (vtbackend's function table, contour::actions, contour::config), so docs
+      # generation has no use for the GUI frontend -- and building it here is what broke this
+      # workflow: Ubuntu 24.04's distro Qt is 6.4.2, whose Qt6::QmlPrivate names an include path it
+      # does not ship, which fails the configure step outright. The build matrix works around that
+      # by installing a modern Qt over the distro one; this job needs no Qt at all, so it opts out
+      # instead. CMAKE_DISABLE_FIND_PACKAGE_Qt6 makes every find_package(Qt6 ...) fail, so the build
+      # cannot merely happen to pick up whichever Qt is lying around -- same assertion as the
+      # "Ubuntu Linux (no GUI frontend)" job in build.yml.
       - name: "Install-contour"
-        run: cmake --preset gcc-debug -B build -G Ninja -D CONTOUR_WAYLAND=OFF
+        run: |
+          cmake --preset gcc-debug \
+                -B build \
+                -G Ninja \
+                -D CONTOUR_WAYLAND=OFF \
+                -D CONTOUR_FRONTEND_GUI=OFF \
+                -D CMAKE_DISABLE_FIND_PACKAGE_Qt6=ON
       - name: "build"
-        run: cmake --build build
+        run: cmake --build build --target contour
       - name: "create vt-sequence directory"
         run: mkdir docs/vt-sequence
       - name: "Generate documentation for global config"

--- a/src/contour/test/e2e/CliVerbs.cmake
+++ b/src/contour/test/e2e/CliVerbs.cmake
@@ -23,8 +23,11 @@ if(NOT FRONTEND STREQUAL "gui" AND NOT FRONTEND STREQUAL "headless")
 endif()
 
 # Verbs that must be present in EVERY configuration: the crispy::App base plus everything
-# ContourApp registers. `daemon` is the one that makes this test worth running.
-set(ALWAYS_PRESENT version license help capture cat daemon list-debug-tags)
+# ContourApp registers. `daemon` is the one that makes this test worth running; `documentation` is
+# the one the Docs workflow runs, and it runs it against a CONTOUR_FRONTEND_GUI=OFF build -- so a
+# guard slipping around that verb would not fail a build, it would silently stop the website from
+# updating.
+set(ALWAYS_PRESENT version license help capture cat daemon list-debug-tags documentation)
 # Verbs ContourGuiApp registers, which exist only when the GUI frontend is built.
 set(GUI_ONLY client font-locator)
 


### PR DESCRIPTION
## Problem

The **Docs** workflow has failed at its CMake configure step on **every run since 2026-07-06** — the website has not been redeployed in six weeks.

Ubuntu 24.04's distro Qt is 6.4.2, which cannot support the GUI frontend:

- initially: `Failed to find required Qt component "GuiPrivate"`
- currently: `Imported target "Qt6::QmlPrivate" includes non-existent path "/usr/include/x86_64-linux-gnu/qt6/QtQml/6.4.2"`

Same root cause both times, and the same one `build.yml` documents for its own jobs.

## Fix

The build matrix works around this by installing a modern Qt over the distro one. This job has no reason to: every `contour documentation ...` verb it runs is registered by `ContourApp` and reads only Qt-free sources — vtbackend's function table, `contour::actions`, `contour::config`. So it builds `CONTOUR_FRONTEND_GUI=OFF` and reaches for no Qt at all.

- `CMAKE_DISABLE_FIND_PACKAGE_Qt6=ON` makes "no Qt" a build-time fact rather than an intention — the same assertion the *Ubuntu Linux (no GUI frontend)* job makes.
- The build is narrowed to the `contour` target the job actually runs.

## Verification

All four generated documents are **byte-identical** between a Qt-linked GUI build and the Qt-free headless build of the same tree:

| document | lines | result |
|---|---|---|
| `documentation vt` | 258 | identical |
| `documentation keys` | 205 | identical |
| `documentation configuration global` | 219 | identical |
| `documentation configuration profile` | 585 | identical |

The headless binary links no Qt (`otool -L` shows zero Qt entries); the GUI one does. `actionlint` passes on the workflow set, and `CliVerbs.cmake` passes against the headless binary.

Nothing in `src/` is gated on `CONTOUR_FRONTEND_GUI` except `main.cpp`'s choice of entry point, so the documentation output cannot differ by configuration.

## Regression guard

`documentation` joins the verbs `CliVerbs.cmake` requires of *every* configuration. The workflow now runs it against a GUI-less build, where a guard slipping around that verb would not fail a build — it would silently stop the website from updating, which is exactly how this went unnoticed for six weeks.

## Risk

Low, and confined to CI. No production code changes; the only source-tree edit is a test assertion. Worst case is the docs job failing as it already does today.