### PR TITLE
ci: pin Qt to 6.11.1 (corrupt AARCH64 archive), and repair the static build image

### DIFF
--- a/.github/static/DockerUbuntu
+++ b/.github/static/DockerUbuntu
@@ -4,6 +4,18 @@ FROM yaraslaut/static_qt:$VERSION
 #FROM qt_static:$VERSION
 ARG ARCH="x86_64"
 
+# Two additions over the plain build-dependency list, each answering a failure this job hit:
+#
+# libssl-dev -- src/net does find_package(OpenSSL REQUIRED) for the TLS decorator behind its
+# ITlsContext seam, so its absence fails the configure step outright rather than at link time. This
+# image installs its packages by hand instead of through scripts/install-deps.sh, whose Ubuntu list
+# does carry libssl-dev, so the two lists have to be kept in step and were not.
+#
+# g++-14 -- Ubuntu 24.04's default g++ is 13.3, whose libstdc++ has no std::ranges::to; that is C++23
+# and arrived in GCC 14. Every other Linux job already builds with GCC 14 or Clang, so this image was
+# the one place still on 13.3, and vtbackend/Color.cpp failed there with "'to' is not a member of
+# 'std::ranges'". The compiler is then named explicitly at configure time below, because installing
+# it does not make it the default.
 RUN apt-get update && apt-get install -y \
     lsb-release software-properties-common gnupg \
     wget gcc g++ \
@@ -11,7 +23,8 @@ RUN apt-get update && apt-get install -y \
     g++ libc6-dev make ninja-build git zlib1g-dev libx11-xcb-dev \
     build-essential pkg-config libxcb-render-util0-dev libfontconfig1-dev \
     libxcb-*-dev libglib2.0-dev libgl1-mesa-dev libxkbcommon-x11-dev \
-    libdouble-conversion-dev libb2-dev libharfbuzz-dev libcairo2-dev
+    libdouble-conversion-dev libb2-dev libharfbuzz-dev libcairo2-dev \
+    libssl-dev gcc-14 g++-14
 
 WORKDIR /
 COPY . /contour
@@ -19,6 +32,8 @@ RUN LD_LIBRARY_PATH=/usr/local/lib sh /contour/scripts/install-static.sh
 
 WORKDIR /contour
 RUN LD_LIBRARY_PATH=/usr/local/lib cmake -S . -B build -G Ninja \
+    -D CMAKE_C_COMPILER=gcc-14 \
+    -D CMAKE_CXX_COMPILER=g++-14 \
     -D CONTOUR_BUILD_STATIC=ON \
     -D CONTOUR_USE_CPM=ON \
     -D CONTOUR_WITH_UTEMPTER=OFF \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,33 @@ jobs:
       run: sudo find _deps/sources -exec chown $UID {} \;
     # Ubuntu 24.04's distro Qt (6.4.2) lacks the Qt6::GuiPrivate CMake package the RHI renderer needs;
     # install a modern Qt6 over it (see the build matrix job for the same rationale).
+    #
+    # Pinned to 6.11.1 rather than tracking 6.11.*: 6.11.2's Linux AARCH64 qttools archive is
+    # corrupt where it is published, so unpacking it dies with
+    # `zipfile.BadZipFile: Bad offset for central directory` and takes the whole install with it.
+    # Every arm64 job started failing the moment 6.11.2 appeared, while yesterday's runs on 6.11.1
+    # were green and today's x86_64 runs on 6.11.2 still are -- only the AARCH64 archive is bad.
+    # Raise this once a later 6.11 publishes an archive that unpacks. See the retry below for why
+    # re-running does not help here.
+    #
+    # Attempted twice all the same: aqtinstall pulls each archive from whichever mirror
+    # download.qt.io redirects it to, so a mirror that serves a truncated file is a verdict on the
+    # mirror, not on the commit under test, and re-resolving the redirect usually lands elsewhere.
+    # It buys nothing against a corrupt *upstream* archive -- both attempts fetched the bad qttools
+    # from two different mirrors -- which is what the pin above is for. Only a repeated failure
+    # fails the job.
     - name: "Install Qt (GuiPrivate-capable)"
+      id: install_qt
+      continue-on-error: true
       uses: jurplel/install-qt-action@v4
       with:
-        version: "6.11.*"
+        version: "6.11.1"
+        modules: qtmultimedia qt5compat qtshadertools qtspeech
+    - name: "Install Qt (GuiPrivate-capable) -- retry past a bad mirror"
+      if: steps.install_qt.outcome == 'failure'
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: "6.11.1"
         modules: qtmultimedia qt5compat qtshadertools qtspeech
     - name: Install clang
       run: |
@@ -608,9 +631,22 @@ jobs:
         # splits Qt across ~40 per-module prefixes and macdeployqt only follows one of
         # them, so a brew-Qt bundle ships missing frameworks and unresolvable @rpath
         # references. That is the defect this job used to hand to users as a .dmg.
+        #
+        # Version pinned and the install attempted twice, both for the reasons documented at the
+        # clang-tidy job's copy of this step. Pinned here too so every platform is measured against
+        # one Qt, even though the corrupt archive is Linux AARCH64 only.
+        id: install_qt
+        continue-on-error: true
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.11.*
+          version: 6.11.1
+          modules: qtmultimedia qt5compat qtshadertools qtspeech
+          cache: true
+      - name: Install Qt -- retry past a bad mirror
+        if: steps.install_qt.outcome == 'failure'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.11.1
           modules: qtmultimedia qt5compat qtshadertools qtspeech
           cache: true
       - name: "Install dependencies"
@@ -853,6 +889,10 @@ jobs:
           ./scripts/install-deps.ps1 --skip-vcpkg
           type ./_deps/sources/CMakeLists.txt
       - name: Install Qt
+        # Attempted twice, for the bad-mirror failure documented at the clang-tidy job's copy of
+        # this step; only a repeated failure fails the job.
+        id: install_qt
+        continue-on-error: true
         uses: jurplel/install-qt-action@v4
         with:
           # 6.10, not the 6.11 the other platforms pin: Qt restructured its Windows package
@@ -868,6 +908,12 @@ jobs:
           # this to "6.11.*" once aqtinstall learns the new layout.
           version: "6.10.*"
           #version: "5.15.*"
+          modules: qtmultimedia qt5compat qtshadertools qtspeech
+      - name: Install Qt -- retry past a bad mirror
+        if: steps.install_qt.outcome == 'failure'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.10.*"
           modules: qtmultimedia qt5compat qtshadertools qtspeech
       - name: "Setup NuGet for vcpkg caching"
         shell: bash
@@ -1081,10 +1127,22 @@ jobs:
       # the RHI renderer needs (rhi/qrhi.h). Install a modern Qt6 over it; install-qt-action prepends
       # its Qt to CMAKE_PREFIX_PATH via the Qt6_DIR/QT_ROOT_DIR env vars it exports, so find_package
       # resolves this one ahead of the distro package.
+      #
+      # Version pinned and the install attempted twice, both for the reasons documented at the
+      # clang-tidy job's copy of this step. These are the jobs that forced it: both ubuntu-24.04-arm
+      # matrix entries are exactly the AARCH64 install that 6.11.2's corrupt qttools archive breaks.
       - name: "Install Qt (GuiPrivate-capable)"
+        id: install_qt
+        continue-on-error: true
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.11.*"
+          version: "6.11.1"
+          modules: qtmultimedia qt5compat qtshadertools qtspeech
+      - name: "Install Qt (GuiPrivate-capable) -- retry past a bad mirror"
+        if: steps.install_qt.outcome == 'failure'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.11.1"
           modules: qtmultimedia qt5compat qtshadertools qtspeech
       - name: Install GCC
         if: ${{ startsWith(matrix.compiler, 'GCC') }}


### PR DESCRIPTION
Two independent CI failures. The first is why **every arm64 job is red right now**, on every branch.

## 1. Qt 6.11.2 ships a corrupt Linux AARCH64 archive

`6.11.*` started resolving to **6.11.2** today, and its Linux AARCH64 `qttools` archive is corrupt where it is published:

```
INFO    : Downloading qttools...
INFO    : Finished installation of qtdeclarative-Linux-Ubuntu_24_04-GCC-Linux-Ubuntu_24_04-AARCH64.7z
WARNING : Caught BadZipFile, terminating installer workers
ERROR   : Bad offset for central directory
zipfile.BadZipFile: Bad offset for central directory
```

The evidence that it is the archive and not a flaky mirror:

| observation | |
|---|---|
| yesterday's arm64 runs, resolving to **6.11.1** | green |
| today's **x86_64** runs, resolving to 6.11.2 | green |
| today's **arm64** runs, resolving to 6.11.2 | fail, every one |
| two attempts in one job, served by two *different* mirrors (`mirror.accum.se`, `qt.mirror.constant.com`) | both got the same truncated file |

So: pin to **6.11.1**, on every platform rather than arm64 alone so one Qt is what all of them are measured against. Raise it once a later 6.11 publishes an AARCH64 archive that unpacks.

Each of the four `install-qt-action` call sites also **attempts the install twice** now. That is deliberately *not* the fix for the above and does not help there — it is worth having for the case it does cover, a single mirror serving a truncated file, which is a verdict on the mirror rather than on the commit under test. Only a repeated failure fails the job. Inlined at each site rather than factored into a composite action: `continue-on-error` inside a composite action has [documented edge cases](https://github.com/actions/runner/issues/2418) when the step also takes inputs — exactly this shape.

## 2. Static build image: no OpenSSL, and GCC 13

The **Static build** job has been red for weeks, on two counts that surface one after the other.

**Configure fails first** — `find_package(OpenSSL REQUIRED)` in `src/net/CMakeLists.txt` backs the TLS decorator behind net's `ITlsContext` seam, and the image had no OpenSSL development package:

```
Could NOT find OpenSSL ... (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR)
  src/net/CMakeLists.txt:69 (find_package)
```

The image installs its packages by hand instead of through `scripts/install-deps.sh`, whose Ubuntu list has carried `libssl-dev` all along — the two lists have to be kept in step, and were not.

**Behind it waits the older failure**: Ubuntu 24.04's default `g++` is 13.3, whose libstdc++ has no `std::ranges::to` (C++23, arrived in GCC 14):

```
/contour/src/vtbackend/Color.cpp:159:44: error: 'to' is not a member of 'std::ranges'
```

Every other Linux job already builds with GCC 14 or Clang; this image was the last one on 13.3. Installing `g++-14` does not make it the default, so the compiler is named at configure time.

## Verification

- `actionlint` passes on the workflow set (`scripts/check-workflows.py`).
- The retry shape is the ordinary `id` + `continue-on-error` + `if: outcome == 'failure'` pair, and it was **observed working** in this PR's own first run — it ran the second attempt, which is how the corrupt-archive diagnosis was confirmed rather than assumed.
- **The static image fixes cannot be exercised before merging**: that job carries `if: github.ref == 'refs/heads/master'`, so pull requests skip it, and no Docker daemon was available locally to dry-run the image. Both changes are derived from the exact errors in the master run logs. If a third failure waits behind these two, it will only show up once this is on master.

## Merge order

Everything with an arm64 job is blocked on the pin, so **this wants to go in first**; #2055 and #2059 then need a rebase or merge from master to pick it up.

## Risk

Low. The pin returns arm64 to the Qt every job used yesterday. The retry can only turn a failing install into a second attempt — a job that installed Qt successfully takes the identical path it does today. The image changes add two packages and pin the compiler that every other Linux job already uses.