### PR TITLE
build: enable libc++'s gated <stop_token> where it is switched off

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,7 +427,11 @@ jobs:
   freebsd:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    name: FreeBSD 13
+    # Unversioned deliberately: the VM's release is whatever vmactions/freebsd-vm defaults to, which
+    # has moved on to 15.1-RELEASE. This job was named "FreeBSD 13" long after that stopped being
+    # true, and a name that states a version nothing pins is worse than none -- it invites reading
+    # a failure as an old-toolchain problem when the VM is in fact running a current one.
+    name: FreeBSD
     # env:
     #   MYTOKEN: "value1"
     #   MYTOKEN2: "value2"

--- a/src/coro/CMakeLists.txt
+++ b/src/coro/CMakeLists.txt
@@ -12,6 +12,40 @@ target_include_directories(coro INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
 )
 
+# Cancellation.hpp is built on C++20 <stop_token>, and refuses to compile without it (#error). One
+# standard library we target does ship it but keeps it switched off: libc++ guards stop_token and
+# jthread with _LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN, defined unless _LIBCPP_ENABLE_EXPERIMENTAL is
+# -- which is what -fexperimental-library sets. libc++ 20 dropped the guard, so this affects
+# libc++ 18 and 19 only; FreeBSD 15's base toolchain (Clang 19.1.7) is the one CI meets it on.
+#
+# Probed, not version-tested: what matters is the standard library the compiler actually uses, which
+# its version number does not name -- and a probe stops adding the flag by itself once a platform
+# moves on to libc++ 20, instead of pinning a workaround to a version range that has to be curated.
+include(CheckCXXSourceCompiles)
+set(_coro_stop_token_probe "
+#include <version>
+#if !defined(__cpp_lib_jthread) || __cpp_lib_jthread < 201911L
+#error stop_token unavailable
+#endif
+int main() { return 0; }
+")
+check_cxx_source_compiles("${_coro_stop_token_probe}" CORO_HAS_STOP_TOKEN)
+if(NOT CORO_HAS_STOP_TOKEN)
+    set(CMAKE_REQUIRED_FLAGS "-fexperimental-library")
+    check_cxx_source_compiles("${_coro_stop_token_probe}" CORO_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(NOT CORO_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
+        message(FATAL_ERROR
+            "coro requires C++20 <stop_token> (__cpp_lib_jthread), which this standard library does "
+            "not provide even with -fexperimental-library. Use libstdc++ 11+, libc++ 18+, or MSVC "
+            "STL -- or add the minimal fallback that src/coro/Cancellation.hpp describes.")
+    endif()
+    # Compile AND link: -fexperimental-library also selects the matching libc++experimental.
+    target_compile_options(coro INTERFACE -fexperimental-library)
+    target_link_options(coro INTERFACE -fexperimental-library)
+    message(STATUS "[coro] <stop_token>: enabling -fexperimental-library (libc++ keeps it gated)")
+endif()
+
 option(CORO_TESTING "Enables building of unittests for coro [default: ON]" ${CONTOUR_TESTING})
 if(CORO_TESTING)
     enable_testing()


### PR DESCRIPTION
The **FreeBSD** job has failed to compile `src/coro` and `src/net` since they landed:

```
src/coro/Cancellation.hpp:38:6: error: "coro cancellation requires C++20 <stop_token>
    (__cpp_lib_jthread). Add a minimal fallback in Cancellation.hpp if a target platform lacks it."
src/coro/Cancellation.hpp:60:5: error: unknown type name 'StopToken'
... 20 errors generated.
```

## Why

The platform does not lack `<stop_token>` — libc++ ships it **switched off**. From libc++ 19's `__config`:

```cpp
#if !defined(_LIBCPP_ENABLE_EXPERIMENTAL) && !defined(_LIBCPP_BUILDING_LIBRARY)
#  define _LIBCPP_HAS_NO_INCOMPLETE_PSTL
#  define _LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN
```

and `<version>`:

```cpp
# if !defined(_LIBCPP_HAS_NO_THREADS) && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN) && _LIBCPP_AVAILABILITY_HAS_SYNC
#   define __cpp_lib_jthread                            201911L
# endif
```

`-fexperimental-library` is what defines `_LIBCPP_ENABLE_EXPERIMENTAL`. libc++ 20 dropped the guard, so this reaches **libc++ 18 and 19 only**.

Worth stressing: the CI VM is **not** an old system. It runs FreeBSD **15.1-RELEASE-p1** with base **Clang 19.1.7** — so this equally hits any FreeBSD user building Contour with the base toolchain. It is not only a CI fix.

## The fix

`src/coro/CMakeLists.txt` probes for the feature and adds `-fexperimental-library` only when that is what unlocks it:

1. compile `<version>` and require `__cpp_lib_jthread >= 201911L` → if it works, nothing is added;
2. else retry with `-fexperimental-library` → if that works, apply it to `coro`'s INTERFACE (compile **and** link, since the flag also selects `libc++experimental`);
3. else fail at configure time with a message naming the supported libraries and the fallback `Cancellation.hpp` itself describes.

Probed rather than version-tested: the answer is a property of the standard library the compiler actually uses, which its version number does not name — and a probe stops adding the flag by itself once a platform moves to libc++ 20, instead of pinning a workaround to a version range someone has to curate.

## Also

Drops the version from the FreeBSD job's name. It said "FreeBSD 13" while the VM has long run whatever `vmactions/freebsd-vm` defaults to — 15.1 today. A version nothing pins is worse than none: it cost me a wrong first diagnosis (old toolchain) before `freebsd-version` in the log said otherwise. Not a required status check, so renaming is safe.

## Verification

Both probe branches were exercised locally:

| path | result |
|---|---|
| feature present (normal) | probe succeeds, **no flag added**, configure unchanged |
| feature gated (forced via `-D CORO_HAS_STOP_TOKEN:INTERNAL=FALSE`) | second probe succeeds, flag applied, `-- [coro] <stop_token>: enabling -fexperimental-library` |

With the flag applied, both consumers build and pass:

- `coro_test` — all tests passed (63 assertions in 17 test cases)
- `net_test` — all tests passed (633 assertions in 121 test cases)

`actionlint` passes. The FreeBSD job itself runs only on master (`if: github.ref == 'refs/heads/master'`), so it cannot be exercised by this PR — but the mechanism it depends on is verified above, and the failure mode if the premise were wrong is now an explicit configure-time message rather than a bare `#error`.

## Risk

Low. Where the standard library already provides `<stop_token>` — every current Linux, macOS and Windows job — the probe succeeds and nothing changes at all.