### PR TITLE
net: test EAGAIN/EWOULDBLOCK through one shared helper

### DIFF
--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -18,6 +18,7 @@ set(net_SOURCES
     KqueueEventSource.cpp
     KqueueEventSource.hpp
     detail/ScopeGuard.hpp
+    detail/WouldBlock.hpp
     WriteQueue.cpp
     WriteQueue.hpp
     PollEventSource.cpp

--- a/src/net/detail/WouldBlock.hpp
+++ b/src/net/detail/WouldBlock.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// One spelling of the non-blocking "would have blocked" errno test, shared by net's call sites.
+///
+/// POSIX permits EAGAIN and EWOULDBLOCK to name the same value, and on Linux with glibc they do.
+/// Testing both in a single `||` is therefore a tautology there, which GCC diagnoses as
+/// `-Wlogical-op` ("logical 'or' of equal expressions") and this tree's pedantic builds turn into
+/// an error. Every call site had written that `||` out by hand; they now share this one, which
+/// selects the comparison with the preprocessor. The preprocessor rather than `if constexpr`
+/// deliberately: a discarded `if constexpr` branch in a non-template function is still parsed and
+/// still warned about, so only `#if` actually removes the offending expression.
+
+#include <cerrno>
+
+namespace net::detail
+{
+
+/// Tests whether @p err is the errno a non-blocking socket or pipe reports when the operation
+/// would have blocked and should be retried once the descriptor is ready.
+/// @param err An errno value.
+/// @return True if @p err means "would block; retry when ready".
+[[nodiscard]] constexpr bool isWouldBlock(int err) noexcept
+{
+#if EAGAIN == EWOULDBLOCK
+    return err == EAGAIN;
+#else
+    return err == EAGAIN || err == EWOULDBLOCK;
+#endif
+}
+
+} // namespace net::detail

--- a/src/net/platform/SystemPipe.cpp
+++ b/src/net/platform/SystemPipe.cpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <cerrno>
 
+#include <net/detail/WouldBlock.hpp>
 #include <net/platform/WindowsLoopback.hpp>
 #include <net/platform/WinsockInit.hpp>
 
@@ -63,7 +64,7 @@ namespace
         [[nodiscard]] IoResult write(void const* data, std::size_t size) override
         {
             auto const n = ::send(_writeFd, data, size, MSG_NOSIGNAL);
-            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            if (n < 0 && net::detail::isWouldBlock(errno))
                 // The pair is non-blocking: a full buffer means a wakeup is already
                 // pending, which is all this byte would have signaled. Report the
                 // write as done so a busy loop never stalls a producer thread.

--- a/src/net/posix/AcceptLoop.cpp
+++ b/src/net/posix/AcceptLoop.cpp
@@ -12,6 +12,7 @@
 
     #include <coro/Cancellation.hpp>
     #include <net/EventLoop.hpp>
+    #include <net/detail/WouldBlock.hpp>
     #include <net/platform/PeerAddress.hpp>
     #include <net/posix/PosixSocket.hpp>
 
@@ -46,7 +47,7 @@ coro::Task<AcceptResult> acceptOne(EventLoop* loop, int const* fd, bool const* c
         }
 
         auto const err = errno;
-        if (err == EAGAIN || err == EWOULDBLOCK)
+        if (net::detail::isWouldBlock(err))
         {
             // Park until the listener fd is readable (a connection is pending). A
             // cancelled wait (listener closed / stop requested) throws

--- a/src/net/posix/PosixSocket.cpp
+++ b/src/net/posix/PosixSocket.cpp
@@ -12,6 +12,7 @@
     #include <fcntl.h>
     #include <unistd.h>
 
+    #include <net/detail/WouldBlock.hpp>
     #include <net/posix/FdUtils.hpp> // MSG_NOSIGNAL fallback, makeNonBlockingCloexec
 
     // macOS / BSD also lack MSG_CMSG_CLOEXEC (atomic close-on-exec for received
@@ -25,14 +26,10 @@
 namespace net
 {
 
+using detail::isWouldBlock;
+
 namespace
 {
-    /// @return True if @p err is the transient "retry when ready" errno.
-    [[nodiscard]] bool isWouldBlock(int err) noexcept
-    {
-        return err == EAGAIN || err == EWOULDBLOCK;
-    }
-
     /// Maps an errno from a socket call to a NetError category.
     [[nodiscard]] NetError fromErrno(int err, std::string context)
     {

--- a/src/net/posix/UnixListener.cpp
+++ b/src/net/posix/UnixListener.cpp
@@ -12,6 +12,7 @@
 
     #include <unistd.h>
 
+    #include <net/detail/WouldBlock.hpp>
     #include <net/posix/AcceptLoop.hpp>
     #include <net/posix/FdUtils.hpp>
 
@@ -65,7 +66,7 @@ namespace
 
         auto const rc = ::connect(fd.get(), reinterpret_cast<sockaddr const*>(&address), sizeof(address));
         auto const err = errno;
-        if (rc == 0 || err == EINPROGRESS || err == EAGAIN || err == EWOULDBLOCK)
+        if (rc == 0 || err == EINPROGRESS || net::detail::isWouldBlock(err))
             // Connected, or a connect pending against a live listener: it is alive.
             return std::unexpected(
                 makeNetError(NetErrorCode::AddressInUse, EADDRINUSE, "a daemon is already serving " + path));


### PR DESCRIPTION
Fixing the Docs workflow (#2059) got its build past the configure step for the first time since 2026-07-06 — and the compile step immediately found this:

```
src/net/platform/SystemPipe.cpp:66:43: error: logical 'or' of equal expressions [-Werror=logical-op]
```

## Why it was never caught

POSIX permits `EAGAIN` and `EWOULDBLOCK` to name the same value, and on Linux with glibc they do — so `err == EAGAIN || err == EWOULDBLOCK` is a tautology there.

No CI job compiled these files with GCC *and* `-Werror` at the same time:

- the build matrix passes `-DPEDANTIC_COMPILER_WERROR=OFF`
- the **Docs** job takes the `gcc-debug` preset's `ON` — and had not reached the compile step in six weeks

So this was latent on master, not introduced by anything recent.

## The fix

Four sites wrote the `||` out by hand:

| file | |
|---|---|
| `net/platform/SystemPipe.cpp` | the one that failed |
| `net/posix/AcceptLoop.cpp` | |
| `net/posix/PosixSocket.cpp` | already had a local `isWouldBlock()` helper |
| `net/posix/UnixListener.cpp` | |

They now share `net::detail::isWouldBlock`, which selects the comparison with **the preprocessor** rather than `if constexpr` — a discarded `if constexpr` branch in a non-template function is still parsed and still warned about, so only `#if` actually removes the offending expression. Platforms where the two values genuinely differ keep both comparisons.

The existing local helper in `PosixSocket.cpp` is replaced by the shared one rather than left as a second spelling.

## Verification

macOS also defines `EAGAIN == EWOULDBLOCK`, so a local build takes the *same* preprocessor branch Linux does — this is not an untested path.

- `net_test`: **all tests passed (633 assertions in 121 test cases)**
- builds clean with no new warnings

## Note

Ninja stops at the first error, so this is the first error the Docs build hit, not necessarily the last. If more `-Werror` findings are hiding behind it, they will surface on the next Docs run — which this PR's merge triggers.