### PR TITLE
vtpty: declare `environ` on the BSDs, where no header does

### DIFF
--- a/src/vtpty/Process_unix.cpp
+++ b/src/vtpty/Process_unix.cpp
@@ -44,11 +44,20 @@
 
 #include <unistd.h>
 
-// A shared library on macOS cannot link against `environ` directly; everywhere else <unistd.h>
-// already declares it.
+// POSIX requires no header to declare `environ`; each platform is left to differ, and all three we
+// build on do.
+//
+// macOS: a shared library cannot link against the symbol directly, so it goes through
+// _NSGetEnviron(). Linux: glibc's <unistd.h> declares it, so nothing is needed. FreeBSD: its
+// <unistd.h> does NOT declare it in the configuration this tree builds with, which is why the
+// FreeBSD job failed with "use of undeclared identifier 'environ'" -- so the declaration is
+// supplied here, as POSIX intends. `extern "C"` rather than a bare `extern`: the symbol has C
+// linkage, and declaring it with C++ linkage would name a different entity and fail to link.
 #ifdef __APPLE__
     #include <crt_externs.h>
     #define environ (*_NSGetEnviron())
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+extern "C" char** environ;
 #endif
 
 using namespace std;


### PR DESCRIPTION
The FreeBSD job's next layer. #2061 fixed the `<stop_token>` failure that stopped the build in `src/coro`; with that out of the way the build reached `src/vtpty` and hit this:

```
src/vtpty/Process_unix.cpp:135:29: error: use of undeclared identifier 'environ'
src/vtpty/Process_unix.cpp:356:17: error: use of undeclared identifier 'environ'
```

## Why

POSIX requires **no header** to declare `environ` — each platform differs, and all three this tree builds on do:

| platform | |
|---|---|
| macOS | already handled: a shared library cannot link the symbol directly, so it goes through `_NSGetEnviron()` |
| Linux | needs nothing — glibc's `<unistd.h>` declares it |
| FreeBSD | leaves it **undeclared** in the configuration this tree builds with |

The existing comment claimed macOS was the exception and `<unistd.h>` "already declares it" everywhere else. That was true of the platforms CI could actually reach at the time.

## The fix

Supply the declaration on the BSDs, which is what POSIX intends the application to do.

`extern "C"` rather than a bare `extern` deliberately: the symbol has C linkage, and declaring it with C++ linkage would name a *different entity* and fail at link time — a subtler failure than the compile error it replaces.

## Verification

- macOS still takes the `_NSGetEnviron()` path, untouched — `vtpty_test` passes there: **517 assertions in 16 test cases**
- Linux is untouched (neither branch of the `#if` applies)
- The FreeBSD job runs only on master (`if: github.ref == 'refs/heads/master'`), so it cannot be exercised from this PR — it will be proven on the run this merge triggers

## Note

This is the second layer of a build that had not compiled since `src/coro` landed on 2026-07-29. Each fix reveals the next, so there may be more behind it; the FreeBSD job stops at the first error.