### PR TITLE
build: cap concurrent link steps, which were killing the CI runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,24 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Ninja starts as many link steps as there are cores, and the tail of this build is a dozen test
+# executables that each pull the whole tree in with debug info. Four of those linking at once
+# exhausted the 16 GB x86_64 GitHub runner: the kernel took the runner agent with it, and the job
+# reported "The runner has received a shutdown signal" and exit 143 -- a message that reads like
+# infrastructure and is not. It struck four times out of five, always between ninja steps 608 and
+# 610 of 623, i.e. always in the concurrent-link phase, while the arm64 GCC and x86_64 Clang jobs
+# of the very same runs passed (Clang's debug info is smaller, and it never tipped over).
+#
+# The cap is on LINK steps only, which is where the memory goes; compiling still uses every core,
+# and that is where the build actually spends its time. CONTOUR_LINK_JOBS raises or lowers it for
+# a machine that wants something else.
+set(CONTOUR_LINK_JOBS "2" CACHE STRING "Maximum number of concurrent link steps (Ninja generators)")
+if(CMAKE_GENERATOR MATCHES "Ninja")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS contour_link_pool=${CONTOUR_LINK_JOBS})
+    # Read when each target is created, so it must be set before any add_subdirectory() below.
+    set(CMAKE_JOB_POOL_LINK contour_link_pool)
+endif()
+
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
     set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")
 endif()


### PR DESCRIPTION
The `ubuntu-24.04 (GCC 14, C++23, Qt6)` job has been failing with a message that reads like infrastructure but is not:

```
##[error]The runner has received a shutdown signal. This can happen when the runner
service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143.
```

## Evidence it is us, not GitHub

| run | where it died |
|---|---|
| master `31942619005` | `[610/623] Linking CXX executable src/vthost/vthost_test` |
| #2059 `31942650992` | `[610/623] Linking CXX executable src/vtrasterizer/vtrasterizer_test` |
| master `31948271799` | `[610/623] Linking CXX executable src/vthost/vthost_test` |
| master `31949938166` | `[610/623] Linking CXX executable src/vthost/vthost_test` |

Four times out of five today, **always** between ninja steps 608 and 610 of 623 — always in the phase where the test executables link concurrently. On those same runs, `ubuntu-24.04-arm (GCC 14)` and `ubuntu-24.04 (Clang 22)` passed every time.

Two things rule out random VM reclamation:

- reclamation does not pick the same ninja step four times
- the job *does* still pass occasionally (#2061's run) — which is what **grazing a memory ceiling** looks like, rather than a deterministic bug

Ninja starts as many link steps as there are cores, and the tail of this build is a dozen test executables that each pull the whole tree in with debug info. Four of those at once exhaust the 16 GB x86_64 runner; the kernel takes the runner agent with them, which is exactly how a job reports "shutdown signal". Clang survives because its debug info is smaller.

## The fix

A Ninja job pool capping **link** steps to 2 — that is where the memory goes. Compiling still uses every core, and that is where the build actually spends its time; the linking tail is a small fraction of it. `CONTOUR_LINK_JOBS` raises or lowers the cap for a machine that wants something else.

## Verification

In the generated build:

```
$ grep -A1 '^pool contour_link_pool' CMakeFiles/rules.ninja
pool contour_link_pool
  depth = 2
$ grep -c 'pool = contour_link_pool' build.ninja
40
```

so the pool is declared and 40 link statements bind to it. A target built under it links and runs normally (`vtparser_test`: 30 assertions in 12 test cases).

## Risk

Low. It constrains scheduling only — no flags, no toolchain change, nothing about how anything is compiled or linked. Non-Ninja generators are unaffected. The worst case is a slightly longer link tail on a machine with many cores and plenty of RAM, and `-D CONTOUR_LINK_JOBS=<n>` opts out.