### PR TITLE
ci: let the docs deploy be triggered by hand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,14 @@ name: Docs
 
 on:
   merge_group:
+  # Redeploying the docs is sometimes necessary after a commit that touches no documentation at all:
+  # this job builds `contour` to generate half the site, so anything that breaks or fixes the build
+  # decides whether the site can be published, while the paths filter below -- rightly -- does not
+  # fire for it. That is not hypothetical; it is exactly the situation this was added in, with the
+  # last run red from a compile error whose fix touched only src/net. Re-running the old run is no
+  # answer either, since it replays the commit that failed. Without a manual trigger the only way to
+  # redeploy was to invent a commit under docs/.
+  workflow_dispatch:
   push:
     paths:
       - 'docs/**'


### PR DESCRIPTION
The Docs job builds `contour` to generate half the site — the VT sequence reference, the configuration pages and the key-mapping table all come out of the built binary. So anything that breaks or fixes *the build* decides whether the site can be published, while the `paths` filter (rightly) only fires for `docs/`, `metainfo.xml` and this workflow.

That gap is not hypothetical — it is the situation right now:

- the last Docs run is **red**, from `-Werror=logical-op` in `src/net/platform/SystemPipe.cpp`
- the fix (#2062, merged) touches only `src/net`, so **nothing will schedule another run**
- re-running the old run is no answer: it replays the very commit that failed

Short of inventing a commit under `docs/`, a red site build stays red and the published site stays stale — which is how it went unnoticed for six weeks in the first place.

`workflow_dispatch` closes that. As a side effect, merging this trips the `paths` filter too, so the `logical-op` fix gets its verification run either way.

## Verification

`actionlint` passes (`scripts/check-workflows.py`). The change adds a trigger and alters no step.

## Risk

None to the build. It only makes an existing job startable by hand.