### PR TITLE
ci: build the docs with the GCC it installs, not the default one

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,10 @@ jobs:
       - name: "update APT database"
         run: sudo apt -q update
       - name: "Install GCC"
-        run: sudo apt -y install g++-14
+        # gcc-14 as well as g++-14: the compiler is named explicitly at configure time below, so the
+        # C driver has to exist under that name too (g++-14 does depend on it, but the build should
+        # not lean on a transitive dependency for a tool it invokes by name).
+        run: sudo apt -y install gcc-14 g++-14
       - name: "install dependencies"
         run: sudo env QTVER=6 SYSDEP_ASSUME_YES=ON ./scripts/install-deps.sh
       - name: "Post-fix embedded dependency permissions."
@@ -53,11 +56,20 @@ jobs:
       # instead. CMAKE_DISABLE_FIND_PACKAGE_Qt6 makes every find_package(Qt6 ...) fail, so the build
       # cannot merely happen to pick up whichever Qt is lying around -- same assertion as the
       # "Ubuntu Linux (no GUI frontend)" job in build.yml.
+      #
+      # The compiler is named rather than left to the default: this job installs g++-14, but that
+      # does not make it the default -- Ubuntu 24.04's `g++` is 13.3, whose libstdc++ has no
+      # std::ranges::to (C++23, and GCC 14 is where it arrived), so vtbackend/Color.cpp fails with
+      # "'to' is not a member of 'std::ranges'". This job takes the gcc-debug preset's
+      # PEDANTIC_COMPILER_WERROR=ON, which the build matrix passes OFF, so it is the strictest GCC
+      # build in the tree and the only one that has to be told which GCC to be.
       - name: "Install-contour"
         run: |
           cmake --preset gcc-debug \
                 -B build \
                 -G Ninja \
+                -D CMAKE_C_COMPILER=gcc-14 \
+                -D CMAKE_CXX_COMPILER=g++-14 \
                 -D CONTOUR_WAYLAND=OFF \
                 -D CONTOUR_FRONTEND_GUI=OFF \
                 -D CMAKE_DISABLE_FIND_PACKAGE_Qt6=ON


### PR DESCRIPTION
The Docs run triggered by #2065 got past the `-Werror=logical-op` failure (#2062 fixed that) and stopped on the next one:

```
src/vtbackend/Color.cpp:159:44: error: 'to' is not a member of 'std::ranges'
```

## Why

The job does this:

```yaml
- name: "Install GCC"
  run: sudo apt -y install g++-14
```

…and then builds with `g++`, which on Ubuntu 24.04 is **13.3**. Installing a compiler does not make it the default, so the preset picked up the distro one and the install step was decoration:

```
-- The CXX compiler identification is GNU 13.3.0
```

`std::ranges::to` is C++23 and arrived in GCC 14, hence the error.

## Why nothing caught it

This job could not reach its compile step *at all* until today, and it is the only GCC build in the tree that would notice: it takes the `gcc-debug` preset's `PEDANTIC_COMPILER_WERROR=ON`, which the build matrix passes `OFF`.

The **same mistake, same symptom, same file** was in the static build image and was fixed there in #2060 — this is its twin, in the one other place that builds by hand rather than through `install-deps.sh`.

## The fix

Name the compiler at configure time, and install `gcc-14` alongside `g++-14` — the C driver is now invoked by name, and while `g++-14` does depend on it, a build should not lean on a transitive dependency for a tool it names.

## Verification

`actionlint` passes. Merging this trips the `paths` filter (it edits `docs.yml`), so the run that proves it starts automatically — and #2065 also added `workflow_dispatch` if it needs re-running by hand.

## Note

This is the third layer of a docs build that had not compiled since 2026-07-06: distro Qt → `logical-op` → GCC 13. The job stops at the first error, so I cannot promise it is the last; what I can say is that each layer so far has been a real, pre-existing defect that nothing else in CI was positioned to see.