### PR TITLE
build: link the threading library where the headers demand it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,7 +448,13 @@ jobs:
   # }}}
   # {{{ FreeBSD
   freebsd:
-    if: github.ref == 'refs/heads/master'
+    # TEMPORARY, REVERTED BEFORE MERGE: also run on this branch. The FreeBSD build has not compiled
+    # since src/coro landed and is being repaired one layer at a time (<stop_token>, then environ,
+    # now the threading library); with the job gated on master, each layer costs a merge and a full
+    # master run to discover the next. Restore this line to
+    #     if: github.ref == 'refs/heads/master'
+    # once the job is green here.
+    if: github.ref == 'refs/heads/master' || github.head_ref == 'fix/freebsd-link-threads'
     runs-on: ubuntu-latest
     # Unversioned deliberately: the VM's release is whatever vmactions/freebsd-vm defaults to, which
     # has moved on to 15.1-RELEASE. This job was named "FreeBSD 13" long after that stopped being

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,48 @@ if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
 endif()
 
+# src/coro/Cancellation.hpp is built on C++20 <stop_token> and refuses to compile without it. One
+# standard library we target ships it switched off: libc++ guards stop_token and jthread with
+# _LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN, which __config defines unless _LIBCPP_ENABLE_EXPERIMENTAL
+# is -- and that is what -fexperimental-library sets. libc++ 20 dropped the guard, so this reaches
+# libc++ 18 and 19 only; FreeBSD 15's base Clang 19 is where CI meets it, and so does anyone
+# building there with the base toolchain.
+#
+# Global rather than a property of the `coro` target, which is what this was first written as: coro
+# is header-only, and its headers are pulled in through several layers of other headers -- contour's
+# ReactorThread.hpp reaches Cancellation.hpp, so contour_gui_test compiled it while linking no coro
+# target and got none of its INTERFACE flags. Whether the standard library needs this switch is a
+# property of the toolchain, not of any one target, so every translation unit gets the same answer.
+#
+# Probed, not version-tested: what matters is the standard library the compiler actually uses, which
+# its version number does not name -- and a probe stops adding the flag by itself once a platform
+# moves on to libc++ 20, instead of pinning a workaround to a version range someone must curate.
+include(CheckCXXSourceCompiles)
+set(_stop_token_probe "
+#include <version>
+#if !defined(__cpp_lib_jthread) || __cpp_lib_jthread < 201911L
+#error stop_token unavailable
+#endif
+int main() { return 0; }
+")
+check_cxx_source_compiles("${_stop_token_probe}" CONTOUR_HAS_STOP_TOKEN)
+if(NOT CONTOUR_HAS_STOP_TOKEN)
+    set(CMAKE_REQUIRED_FLAGS "-fexperimental-library")
+    check_cxx_source_compiles("${_stop_token_probe}" CONTOUR_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(NOT CONTOUR_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
+        message(FATAL_ERROR
+            "coro requires C++20 <stop_token> (__cpp_lib_jthread), which this standard library does "
+            "not provide even with -fexperimental-library. Use libstdc++ 11+, libc++ 18+, or MSVC "
+            "STL -- or add the minimal fallback that src/coro/Cancellation.hpp describes.")
+    endif()
+    # Compile AND link: -fexperimental-library also selects the matching libc++experimental.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fexperimental-library")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fexperimental-library")
+    message(STATUS "<stop_token>: enabling -fexperimental-library (libc++ keeps it gated)")
+endif()
+
 if (CONTOUR_BUILD_WITH_MIMALLOC)
     add_definitions(-DCONTOUR_BUILD_WITH_MIMALLOC)
 endif()

--- a/src/coro/CMakeLists.txt
+++ b/src/coro/CMakeLists.txt
@@ -12,40 +12,6 @@ target_include_directories(coro INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
 )
 
-# Cancellation.hpp is built on C++20 <stop_token>, and refuses to compile without it (#error). One
-# standard library we target does ship it but keeps it switched off: libc++ guards stop_token and
-# jthread with _LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN, defined unless _LIBCPP_ENABLE_EXPERIMENTAL is
-# -- which is what -fexperimental-library sets. libc++ 20 dropped the guard, so this affects
-# libc++ 18 and 19 only; FreeBSD 15's base toolchain (Clang 19.1.7) is the one CI meets it on.
-#
-# Probed, not version-tested: what matters is the standard library the compiler actually uses, which
-# its version number does not name -- and a probe stops adding the flag by itself once a platform
-# moves on to libc++ 20, instead of pinning a workaround to a version range that has to be curated.
-include(CheckCXXSourceCompiles)
-set(_coro_stop_token_probe "
-#include <version>
-#if !defined(__cpp_lib_jthread) || __cpp_lib_jthread < 201911L
-#error stop_token unavailable
-#endif
-int main() { return 0; }
-")
-check_cxx_source_compiles("${_coro_stop_token_probe}" CORO_HAS_STOP_TOKEN)
-if(NOT CORO_HAS_STOP_TOKEN)
-    set(CMAKE_REQUIRED_FLAGS "-fexperimental-library")
-    check_cxx_source_compiles("${_coro_stop_token_probe}" CORO_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
-    unset(CMAKE_REQUIRED_FLAGS)
-    if(NOT CORO_HAS_STOP_TOKEN_WHEN_EXPERIMENTAL)
-        message(FATAL_ERROR
-            "coro requires C++20 <stop_token> (__cpp_lib_jthread), which this standard library does "
-            "not provide even with -fexperimental-library. Use libstdc++ 11+, libc++ 18+, or MSVC "
-            "STL -- or add the minimal fallback that src/coro/Cancellation.hpp describes.")
-    endif()
-    # Compile AND link: -fexperimental-library also selects the matching libc++experimental.
-    target_compile_options(coro INTERFACE -fexperimental-library)
-    target_link_options(coro INTERFACE -fexperimental-library)
-    message(STATUS "[coro] <stop_token>: enabling -fexperimental-library (libc++ keeps it gated)")
-endif()
-
 option(CORO_TESTING "Enables building of unittests for coro [default: ON]" ${CONTOUR_TESTING})
 if(CORO_TESTING)
     enable_testing()

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -66,7 +66,17 @@ if(NOT MSVC)
 endif()
 
 target_compile_features(crispy-core PUBLIC cxx_std_17)
-target_link_libraries(crispy-core PUBLIC ${CRISPY_CORE_LIBS})
+# Threads::Threads is PUBLIC because threading is part of crispy-core's INTERFACE and not merely its
+# implementation: BufferObject.hpp, LogSink.hpp, ReadSelector.hpp, FileDescriptor.hpp and
+# Environment.hpp all expose std::mutex / std::condition_variable / std::thread, so every consumer
+# instantiates them and every consumer needs the threading library on its link line.
+#
+# On glibc that link is free -- pthread_create has lived in libc since glibc 2.34 -- so no Linux job
+# ever noticed it missing. FreeBSD keeps those symbols in libthr, where the omission is fatal:
+# `ld: error: undefined symbol: pthread_create`, linking crispy_test. Declaring it here rather than
+# on each test target also carries it to vtpty, vthost and vtrasterizer, which reach threading
+# through this same header set.
+target_link_libraries(crispy-core PUBLIC ${CRISPY_CORE_LIBS} Threads::Threads)
 target_include_directories(crispy-core PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -68,7 +68,11 @@ add_library(net STATIC ${net_SOURCES})
 # OpenSSL backs the TLS ISocket decorator (net/Tls.*). It stays behind the
 # ITlsContext DI seam, so it is PRIVATE: no OpenSSL type crosses net's headers.
 find_package(OpenSSL REQUIRED)
-target_link_libraries(net PUBLIC coro)
+# Threads::Threads, and PUBLIC for the same reason crispy-core declares it: net's own headers
+# (EventLoop.hpp above all) expose std::mutex and std::thread, so consumers instantiate them too.
+# net deliberately does not depend on crispy, so it cannot inherit the declaration from there and
+# has to make it itself. Free on glibc, fatal on FreeBSD, where the symbols live in libthr.
+target_link_libraries(net PUBLIC coro Threads::Threads)
 target_link_libraries(net PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 if(WIN32)
     target_link_libraries(net PUBLIC ws2_32)


### PR DESCRIPTION
With #2063 in, the FreeBSD build compiled for the first time since 2026-07-29 — and reached the link step, where it stopped:

```
[ 34%] Linking CXX executable crispy_test
ld: error: undefined symbol: pthread_create
```

## Why

`crispy-core`'s **public** headers — `BufferObject.hpp`, `LogSink.hpp`, `ReadSelector.hpp`, `FileDescriptor.hpp`, `Environment.hpp` — expose `std::mutex`, `std::condition_variable` and `std::thread`. Threading is part of that library's INTERFACE, so every consumer instantiates it and needs the threading library on its link line.

Neither `crispy-core` nor `net` declared `Threads::Threads` at all. Of the ten first-party modules, only `vtbackend` did:

| module | uses threading | linked `Threads::Threads` |
|---|---|---|
| crispy | 6 files | ✗ |
| vtpty | 6 files | ✗ |
| net | 3 files | ✗ |
| vthost | 3 files | ✗ |
| vtrasterizer | 2 files | ✗ |
| vtbackend | 4 files | ✓ |

**No Linux job could notice**: glibc has carried `pthread_create` in libc since 2.34, so the omission is free there. FreeBSD keeps those symbols in `libthr`, where a missing `-pthread` is a link error — and this is the first time in seven weeks a FreeBSD build got far enough to link anything.

## The fix

Declared PUBLIC on `crispy-core`, which carries it to `vtpty`, `vthost` and `vtrasterizer` — all of them reach threading through that same header set, so one declaration covers them correctly rather than four copies.

`net` gets its own, because it deliberately does not depend on crispy (per its README, so the module stays consumable without dragging `crispy` along) and therefore cannot inherit it.

## Verification

- `crispy_test`: **1613 assertions in 109 test cases** — pass
- `net_test`: **633 assertions in 121 test cases** — pass
- configures and links clean

## Note

This is the fourth layer of the FreeBSD build: `<stop_token>` → `environ` → this. Each was a real, pre-existing defect that no other platform was positioned to catch. The job stops at the first error, so I cannot promise it is the last — but the failures have moved from configure, through compile, to link, which is the right direction.