### PR TITLE
ci: drop the temporary FreeBSD gate that reached master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,13 +448,7 @@ jobs:
   # }}}
   # {{{ FreeBSD
   freebsd:
-    # TEMPORARY, REVERTED BEFORE MERGE: also run on this branch. The FreeBSD build has not compiled
-    # since src/coro landed and is being repaired one layer at a time (<stop_token>, then environ,
-    # now the threading library); with the job gated on master, each layer costs a merge and a full
-    # master run to discover the next. Restore this line to
-    #     if: github.ref == 'refs/heads/master'
-    # once the job is green here.
-    if: github.ref == 'refs/heads/master' || github.head_ref == 'fix/freebsd-link-threads'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     # Unversioned deliberately: the VM's release is whatever vmactions/freebsd-vm defaults to, which
     # has moved on to 15.1-RELEASE. This job was named "FreeBSD 13" long after that stopped being


### PR DESCRIPTION
#2067 carried a commit that additionally ran the FreeBSD job on its own branch, so a build that had not compiled since 2026-07-29 could be repaired without paying a merge and a full master run per layer. It found two layers that way, and its comment says plainly:

```
# TEMPORARY, REVERTED BEFORE MERGE: also run on this branch.
```

That revert did not happen. Auto-merge had been armed on the PR *before* that commit was added, so the branch merged the moment its checks passed and took the gate with it — my mistake, not a process one.

## Impact

None functionally: the extra condition names `fix/freebsd-link-threads`, a branch that merging deleted, so it can never match again. But a workflow that describes itself as temporary and already reverted has no business sitting on master, and the next person to read it would reasonably wonder what else is half-done.

## The fix

```yaml
    if: github.ref == 'refs/heads/master'
```

byte-for-byte what it was before #2067. `actionlint` passes.

## Lesson worth recording

Arm auto-merge *after* the last commit a PR is meant to carry, not before — otherwise a scaffolding commit can ride in on a green check the scaffolding itself produced.