### PR TITLE
ci: retry the two macOS steps that fail on things outside this repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -735,10 +735,26 @@ jobs:
           # bundled dylibs demand anything newer, the package step fails rather than
           # shipping a .dmg that cannot launch. Configuring also triggers the vcpkg
           # manifest install, which builds those dylibs against that same target.
-          cmake --preset macos-package \
-                -DCODE_SIGN_CERTIFICATE_ID="${{ steps.set_vars.outputs.CODE_SIGN_CERTIFICATE_ID }}" \
-                -DCONTOUR_MACOS_NOTARIZE="${{ steps.set_vars.outputs.NOTARIZE }}" \
-                -DCONTOUR_MACOS_STAPLE_APP="${{ steps.set_vars.outputs.STAPLE_APP }}"
+          #
+          # Attempted twice. Configuring is where the vcpkg manifest install runs, and that builds
+          # its dependencies from source, so this step's success depends on hosts nobody here
+          # controls being up: it has failed repeatedly on 502/503/504 from
+          # gitlab.freedesktop.org (cairo, fontconfig) and once on a 404 from ftpmirror.gnu.org.
+          # vcpkg already retries an individual download three times; what it cannot retry is the
+          # whole install once a port has given up. None of it is a verdict on the commit under
+          # test, and this job is a required check, so a single bad minute upstream otherwise
+          # blocks every pull request. Only a repeated failure fails the job.
+          configure() {
+            cmake --preset macos-package \
+                  -DCODE_SIGN_CERTIFICATE_ID="${{ steps.set_vars.outputs.CODE_SIGN_CERTIFICATE_ID }}" \
+                  -DCONTOUR_MACOS_NOTARIZE="${{ steps.set_vars.outputs.NOTARIZE }}" \
+                  -DCONTOUR_MACOS_STAPLE_APP="${{ steps.set_vars.outputs.STAPLE_APP }}"
+          }
+          configure || {
+            echo "::warning::configure failed (typically an upstream source download); retrying once"
+            sleep 30
+            configure
+          }
       - name: "Build"
         run: cmake --build --preset macos-package
       - name: "tests"
@@ -776,7 +792,27 @@ jobs:
           set -ex
           echo killing...; sudo pkill -9 XProtect >/dev/null || true; # see https://github.com/actions/runner-images/issues/7522
           echo waiting...; while pgrep XProtect; do sleep 3; done;
-          cpack --preset macos-package --verbose
+          # Attempted twice. CPack's DragNDrop generator mounts a temporary image and detaches it
+          # again, and the detach loses a race against whatever is still walking the volume --
+          # Spotlight's indexer, or XProtect rescanning the freshly written bundle. CPack reports it
+          # as:
+          #     CPack Error: Error executing: /usr/bin/hdiutil detach "/Volumes/Contour"
+          #     CPack Error: Error detaching temporary disk image.
+          # which has cost this job several runs. The killing of XProtect above is the same class of
+          # workaround and does not cover it, because the rescan can start after that wait.
+          #
+          # Before retrying, force-detach anything still mounted: a leftover /Volumes/Contour would
+          # otherwise make the second attempt fail for a different reason, mounting as
+          # "Contour 1" and defeating the fixed path the mv below expects.
+          package() { cpack --preset macos-package --verbose; }
+          package || {
+            echo "::warning::cpack failed (typically the hdiutil detach race); retrying once"
+            hdiutil detach "/Volumes/Contour" -force || true
+            sudo pkill -9 XProtect >/dev/null || true
+            while pgrep XProtect; do sleep 3; done
+            sleep 10
+            package
+          }
           BASENAME="contour-${{ steps.set_vars.outputs.VERSION_STRING }}-macOS-arm"
           mv -vf "out/macos-package/Contour-${{ steps.set_vars.outputs.VERSION_STRING }}-Darwin.dmg" "${BASENAME}.dmg"
           echo "DMG=${BASENAME}.dmg" >> "$GITHUB_ENV"


### PR DESCRIPTION
`macOSArm` is a **required check**, so a bad minute on a host nobody here controls blocks every pull request. Both of its fragile steps failed repeatedly today, neither for a reason having anything to do with the commit under test.

## 1. Configure → vcpkg builds dependencies from source

```
error: curl operation failed with response code 504.
error: Reached maximum number of attempts, won't retry download from
       https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/2.17.1/fontconfig-2.17.1.tar.gz
error: building fontconfig:arm64-osx-contour failed with: BUILD_FAILED
```

Seen today against `gitlab.freedesktop.org` for both cairo and fontconfig (502/503/504), and once as a **404** from `ftpmirror.gnu.org` for gperf. vcpkg already retries an individual download three times; what it cannot retry is the whole install once a port has given up.

## 2. Packaging → `hdiutil detach` race

```
CPack Error: Error executing: /usr/bin/hdiutil detach "/Volumes/Contour"
CPack Error: Error detaching temporary disk image.
```

CPack's DragNDrop generator mounts a temporary image and detaches it again; the detach loses a race against whatever is still walking the volume — Spotlight's indexer, or XProtect rescanning the freshly written bundle. The `pkill XProtect` already in that step is the same class of workaround and doesn't cover this, because the rescan can begin *after* its wait.

## The fix

Each step attempts its command twice.

The packaging retry **force-detaches any leftover volume first** — a still-mounted `/Volumes/Contour` would otherwise make the second attempt mount as `Contour 1`, failing on the fixed path the following `mv` expects, which would look like a different bug.

Only a repeated failure fails the job, so a genuine breakage still stops CI — twice, and slower.

## Verification

- `actionlint` passes on the workflow set
- both modified step bodies pass `bash -n` (with GitHub expressions stubbed), since the change introduces shell functions and `||` blocks into steps running under `set -e`
- the retry pattern matches the one already accepted for the Qt install

## Risk

Low, and confined to CI. A step that succeeds first time takes exactly the path it does today.