### PR TITLE
Fix a silently-disabled stack-trace demangler and clear the CMake configure warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,9 +273,9 @@ if(CONTOUR_USE_CPM)
     # download CPM.cmake
     file(
         DOWNLOAD
-        https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.3/CPM.cmake
+        https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.43.1/CPM.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
-        EXPECTED_HASH SHA256=cc155ce02e7945e7b8967ddfaff0b050e958a723ef7aad3766d368940cb15494
+        EXPECTED_HASH SHA256=1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934
     )
     include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
 endif()

--- a/_typos.toml
+++ b/_typos.toml
@@ -78,6 +78,15 @@ rin = "rin"   # Scroll back n lines.
 Fo = "Fo"     # Function key 15.
 FO = "FO"     # Function key 41.
 
+# MSVC requires its flags be written attached to their argument, so the compile-cache probe's
+# `/Fo${_dir}/probe.obj` reads as the word "Fo". Branch 2 does not apply: the spelling is
+# Microsoft's, not ours to rename. Scoped to the one file that shells out to a compiler this way.
+[type.msvc-flags]
+extend-glob = ["CompileCache.cmake"]
+
+[type.msvc-flags.extend-words]
+Fo = "Fo" # Names the object file to write.
+
 # The spell-checking documentation has to quote misspellings to explain itself -- it cites the
 # words the old allow-list had absorbed. Its code spans are therefore exempt; its prose is not.
 [type.spelling-docs]

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -97,6 +97,27 @@ if(CONTOUR_FRONTEND_GUI)
 endif()
 # }}}
 
+# {{{ Optional: Qt's WaylandClient, for blur-behind and the window shadow
+# Looked up here rather than in platform/, which is the only directory that consumes it, because
+# imported targets are directory scoped: a find_package() down there leaves Qt6::WaylandClient
+# undeclared in *this* scope, where the deferred qt6_finalize_target(contour) walks
+# contour_platform's dependencies -- and Qt then warns, four times, that the linking might be
+# incomplete. Found here, the targets are visible to platform/ (a child scope) as well.
+#
+# QUIET and degrading rather than REQUIRED, for the same reason as TextToSpeech above: two
+# decorations must not make every Linux packager carry Qt's Wayland module. Shadowing the
+# CONTOUR_WAYLAND cache option with a normal variable is how that reaches the consumer -- the guard
+# in platform/CMakeLists.txt reads the shadow, because a child scope sees it in place of the cache
+# entry, and the C++ side is already guarded on the matching compile definition.
+if(CONTOUR_FRONTEND_GUI AND LINUX AND CONTOUR_WAYLAND)
+    find_package(Qt6 COMPONENTS WaylandClient WaylandClientPrivate QUIET)
+    if(NOT Qt6WaylandClient_FOUND)
+        set(CONTOUR_WAYLAND OFF)
+        contour_note_excluded_feature("Wayland blur & shadow" "Qt6::WaylandClient not found")
+    endif()
+endif()
+# }}}
+
 # The imported-target name differs between a vendored yaml-cpp and a system one, so
 # resolve it once here -- before add_subdirectory(config), which puts it in contour_config's
 # PUBLIC interface (Config.hpp exposes yaml-cpp's headers).

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -43,11 +43,11 @@ NumberToHex(${PROJECT_VERSION_PATCH} HEX_PATCH)
 #     is not to render -- and on a platform where Qt6 does not exist, in the way of building at all.
 if(CONTOUR_FRONTEND_GUI)
     # Qt warns, once per private module and on every configure, that a project using private headers
-    # is tied to the exact Qt build it compiled against. That is true and it is deliberate: we take
-    # rhi/qrhi.h from GuiPrivate for the display's RHI resource model, and QWaylandWindow from
-    # WaylandClientPrivate to reach the wl_surface that blur-behind and the window shadow attach to.
-    # Neither has a public equivalent. So the statement is recorded here, where it is read once,
-    # rather than reprinted as ~20 lines of configure output that teach the reader to skim warnings.
+    # is tied to the exact Qt build it compiled against. That is true and it is deliberate: rhi/qrhi.h
+    # comes from GuiPrivate (see the NB above), and QWaylandWindow from WaylandClientPrivate, to reach
+    # the wl_surface that blur-behind and the window shadow attach to. Neither has a public
+    # equivalent. So the statement is recorded here, where it is read once, rather than reprinted as
+    # ~20 lines of configure output that teach the reader to skim warnings.
     #
     # The consequence is real and belongs to packaging, not to the build: a Contour binary must be
     # run against the Qt minor release it was built against. That is why CONTOUR_QT_VALIDATED_VERSION

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -42,6 +42,18 @@ NumberToHex(${PROJECT_VERSION_PATCH} HEX_PATCH)
 #     Qt for that build would put a Qt that renders in the way of the very configuration whose point
 #     is not to render -- and on a platform where Qt6 does not exist, in the way of building at all.
 if(CONTOUR_FRONTEND_GUI)
+    # Qt warns, once per private module and on every configure, that a project using private headers
+    # is tied to the exact Qt build it compiled against. That is true and it is deliberate: we take
+    # rhi/qrhi.h from GuiPrivate for the display's RHI resource model, and QWaylandWindow from
+    # WaylandClientPrivate to reach the wl_surface that blur-behind and the window shadow attach to.
+    # Neither has a public equivalent. So the statement is recorded here, where it is read once,
+    # rather than reprinted as ~20 lines of configure output that teach the reader to skim warnings.
+    #
+    # The consequence is real and belongs to packaging, not to the build: a Contour binary must be
+    # run against the Qt minor release it was built against. That is why CONTOUR_QT_VALIDATED_VERSION
+    # below exists and why the bundles ship their own Qt.
+    set(QT_NO_PRIVATE_MODULE_WARNING ON)
+
     # Gating GuiPrivate needs Qt6_VERSION, which nothing but find_package(Qt6) sets -- hence this
     # lookup, one line ahead of the gate that reads it.
     find_package(Qt6 COMPONENTS Core REQUIRED)

--- a/src/contour/platform/CMakeLists.txt
+++ b/src/contour/platform/CMakeLists.txt
@@ -94,8 +94,10 @@ elseif(NOT WIN32 AND NOT APPLE)
     target_link_libraries(contour_platform PUBLIC xcb)
 endif()
 
+# Qt6::WaylandClient{,Private} are found one directory up, in src/contour/CMakeLists.txt, so that
+# they are declared in the scope that finalizes the contour executable; that gate also clears
+# CONTOUR_WAYLAND when the module is absent, so reaching this block means the targets exist.
 if(LINUX AND CONTOUR_WAYLAND)
-    find_package(Qt6 COMPONENTS WaylandClient WaylandClientPrivate)
     target_compile_definitions(contour_platform PUBLIC CONTOUR_WAYLAND)
     target_link_libraries(contour_platform PUBLIC Qt6::WaylandClient Qt6::WaylandClientPrivate)
     qt6_generate_wayland_protocol_client_sources(contour_platform

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -103,7 +103,11 @@ if(UNIX)
     check_function_exists(dladdr HAVE_DLADDR)
     check_function_exists(dlsym HAVE_DLSYM)
     check_include_files(dlfcn.h HAVE_DLFCN_H)
-    check_include_files(cxxabi.h HAVE_CXXABI_H)
+    # cxxabi.h is a C++ header (libstdc++ ships it under /usr/include/c++/<ver>/), so it must be
+    # probed with the C++ compiler. check_include_files() compiles a C translation unit and would
+    # never find it -- and the failure is silent: StackTrace::demangleSymbol() compiles out and
+    # every frame prints its mangled name instead.
+    check_include_file_cxx(cxxabi.h HAVE_CXXABI_H)
     check_include_files(execinfo.h HAVE_EXECINFO_H)
     check_include_files(sys/select.h HAVE_SYS_SELECT_H)
     check_include_files(unwind.h HAVE_UNWIND_H)


### PR DESCRIPTION
A fresh `cmake --preset clang-release` succeeded but printed 12 `CMake Warning` blocks, which is
enough noise to read like a failure and enough to train a reader to skim past the next real one.
Two of them turned out to be actual defects rather than noise, and the lint gate had been red on
master since the compile-cache probe landed. Configure is now warning-free.

## Changes

- **The stack-trace demangler was never compiled in.** `cxxabi.h` was probed with
  `check_include_files()`, which compiles a *C* translation unit, so the C++ header was never
  found on any Linux build. `HAVE_CXXABI_H` stayed undefined and `StackTrace::demangleSymbol()`
  returned its argument unchanged — every crash dump printed mangled frames. Probed with the C++
  compiler now, which is what the already-present `include(CheckIncludeFileCXX)` intended.

- **Qt's Wayland modules are found in the scope that links them.** `find_package()` declares
  imported targets in the calling directory only, so looking them up in `platform/` left
  `Qt6::WaylandClient` undeclared where `qt6_finalize_target(contour)` walks the dependency graph.
  The same lesson is already recorded a few lines up for `GuiPrivate`. The lookup was also
  non-`REQUIRED` while the link below it was unconditional, so a machine without Qt's Wayland
  module failed at generate time with a target-does-not-exist error; it now degrades and reports
  itself through `contour_note_excluded_feature()`, like `TextToSpeech`.

- **Qt's private-module warning is acknowledged rather than reprinted.** We use `rhi/qrhi.h` and
  `QWaylandWindow` deliberately and neither has a public equivalent, so the statement is recorded
  in a comment where it is read once instead of as ~20 lines every configure. Nothing about the
  compiled result changes.

- **CPM bumped to v0.43.1**, which stops calling the deprecated single-argument
  `FetchContent_Populate()` on CMake 3.30.3 and newer.

- **`check_spelling` fixed** — `typos` reads MSVC's `/Fo<path>` flag as the word "Fo". Scoped to
  the one file that shells out to a compiler that way.

The twelfth warning needed no code change: `Qt6::TextToSpeech not found` was a genuinely missing
optional package, and the excluded-features gate reported it exactly as designed. Installing
`qt6-qtspeech-devel` silences it.