### PR TITLE
Release 0.7.0

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -104,7 +104,7 @@
 
     -->
 
-    <release version="0.7.0" urgency="medium" type="development">
+    <release version="0.7.0" urgency="medium" date="2026-08-17">
       <description>
         <p>
           Contour 0.7.0 makes the window a workspace: native GUI tabs in the title bar, split panes,


### PR DESCRIPTION
Cuts the 0.7.0 release: stamps `metainfo.xml`'s topmost `<release>` with today's date and drops `type="development"`.

CI builds the draft release from this branch. Note the same-day constraint: the date written is `2026-08-17`, and the build validates it against the day it runs.