### PR TITLE
Fix desktop notifications never appearing in the Flatpak build

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,7 +107,8 @@
     <release version="0.7.1" urgency="medium" type="development">
       <description>
         <ul>
-
+          <li>Fixes desktop notifications never appearing in the Flatpak build. Contour asked org.freedesktop.Notifications for them directly, which a sandbox does not permit and which Flathub declines to grant a permission for; a sandboxed Contour now speaks the org.freedesktop.portal.Notification portal instead, which needs no permission at all. Outside a sandbox nothing changes — the session bus is still used, and still reports a dismissal exactly as before</li>
+          <li>Adds notification_close_timeout, for the one thing the notification portal cannot do: tell an application that its notification was dismissed. Where a close cannot be observed, Contour now assumes one after this long (10 seconds by default) and reports it back over OSC 99 marked `untracked`, so an application that asked for close events with `c=1` is answered instead of waiting forever, and can still tell a guess from an observation. A notification that states its own lifetime with `w=` is answered on that instead, and 0 disables the assumption entirely</li>
         </ul>
       </description>
     </release>

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -613,6 +613,8 @@ if(CONTOUR_FRONTEND_GUI)
             window/MultiWindow_test.cpp
             platform/FreeDesktopNotifier_test.cpp
             platform/NotificationRouter_test.cpp
+            platform/Notifier_test.cpp
+            platform/PortalNotificationTransport_test.cpp
             platform/TaskbarProgressRouter_test.cpp
             platform/NativeWindowFrame_test.cpp
             platform/PopupShadow_test.cpp

--- a/src/contour/config/Config.cpp
+++ b/src/contour/config/Config.cpp
@@ -645,6 +645,7 @@ static void mergeGuiManagedSideFiles(Config& config, YAMLConfigReader& reader)
             overrides.loadFromEntry("accessibility_caret_reporting", config.accessibilityCaretReporting);
             overrides.loadFromEntry("hyperlink_hover_tooltip", config.hyperlinkHoverTooltip);
             overrides.loadFromEntry("progress_timeout", config.progressTimeout);
+            overrides.loadFromEntry("notification_close_timeout", config.notificationCloseTimeout);
             overrides.loadFromEntry("tab_bar_position", config.tabBarPosition);
             overrides.loadFromEntry("tab_bar_visibility", config.tabBarVisibility);
             overrides.loadFromEntry("theme", config.theme);
@@ -853,6 +854,7 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("accessibility_caret_reporting", c.accessibilityCaretReporting);
         loadFromEntry("hyperlink_hover_tooltip", c.hyperlinkHoverTooltip);
         loadFromEntry("progress_timeout", c.progressTimeout);
+        loadFromEntry("notification_close_timeout", c.notificationCloseTimeout);
         loadFromEntry("tab_bar_position", c.tabBarPosition);
         loadFromEntry("tab_bar_visibility", c.tabBarVisibility);
         loadFromEntry("text_scaling_method", c.textScalingMethod);

--- a/src/contour/config/Config.hpp
+++ b/src/contour/config/Config.hpp
@@ -1140,6 +1140,14 @@ struct Config
     ConfigEntry<std::chrono::milliseconds, documentation::ProgressTimeout> progressTimeout {
         std::chrono::milliseconds { 0 }
     };
+
+    /// How long after showing a desktop notification the terminal assumes it was closed, where the
+    /// desktop cannot say. Only the portal backend a sandboxed Contour must use is in that
+    /// position; on the session bus a close is observed and this is never consulted. A
+    /// notification's own OSC 99 `w=` wins where it states one, and zero reports nothing at all.
+    ConfigEntry<std::chrono::milliseconds, documentation::NotificationCloseTimeout> notificationCloseTimeout {
+        std::chrono::milliseconds { 10000 }
+    };
     ConfigEntry<bool, documentation::AccessibilityAnnouncements> accessibilityAnnouncements { true };
     ConfigEntry<bool, documentation::AccessibilityCaretReporting> accessibilityCaretReporting { true };
     // The tab bar belongs to the WINDOW, not to the profile a pane happens to run: a window shows one

--- a/src/contour/config/ConfigDocumentation.hpp
+++ b/src/contour/config/ConfigDocumentation.hpp
@@ -230,6 +230,14 @@ constexpr StringLiteral ProgressTimeoutConfig {
     "\n"
 };
 
+constexpr StringLiteral NotificationCloseTimeoutConfig {
+    "{comment} How long after showing a desktop notification the terminal assumes it was closed,\n"
+    "{comment} in milliseconds, on desktops that cannot report a close. A notification that states\n"
+    "{comment} its own lifetime (OSC 99 `w=`) wins; 0 disables the assumption, reporting nothing.\n"
+    "notification_close_timeout: {}\n"
+    "\n"
+};
+
 constexpr StringLiteral TabBarPositionConfig {
     "{comment} Where the GUI tab strip (tab bar) is placed within the window (ignore-case):\n"
     "{comment}   Top    = above the terminal content (default).\n"
@@ -1755,6 +1763,33 @@ constexpr StringLiteral ProgressTimeoutWeb {
     "\n"
 };
 
+constexpr StringLiteral NotificationCloseTimeoutWeb {
+    "\n"
+    "How long after showing a desktop notification the terminal waits before assuming the desktop "
+    "closed it, in milliseconds.\n"
+    "\n"
+    "This only applies where a close cannot be observed. Contour normally learns that a notification "
+    "was dismissed or expired from the desktop itself and reports it back to the application as the "
+    "OSC 99 `p=close` event. Inside a Flatpak sandbox that is impossible: the only reachable service "
+    "is the `org.freedesktop.portal.Notification` portal, which has no close signal of any kind, so "
+    "an application that asked for close events (`c=1`) would otherwise wait forever.\n"
+    "\n"
+    "A notification that states its own lifetime through `w=` is answered after that instead -- the "
+    "application already said what it wanted. Only `w=-1`, \"whatever the desktop does\", falls back "
+    "to this value.\n"
+    "\n"
+    "Two cases are deliberately never answered, because there is no moment at which an answer would "
+    "be true: `0` here, which disables the assumption outright, and `w=0` on the notification, which "
+    "asks for a popup that never expires on its own. An application that requested close events in "
+    "either case is not told.\n"
+    "\n"
+    "Read once per terminal session, so a changed value reaches sessions opened after the reload.\n"
+    "\n"
+    "Because the report is a timer rather than an observation, it is marked `untracked` on the wire, "
+    "so an application can tell the two apart.\n"
+    "\n"
+};
+
 constexpr StringLiteral TabBarPositionWeb {
     "\n"
     "Selects where the GUI tab strip (tab bar) is placed within the window. Valid values (ignore-case):\n"
@@ -2394,6 +2429,8 @@ using AccessibilityCaretReporting =
     DocumentationEntry<AccessibilityCaretReportingConfig, AccessibilityCaretReportingWeb>;
 using HyperlinkHoverTooltip = DocumentationEntry<HyperlinkHoverTooltipConfig, HyperlinkHoverTooltipWeb>;
 using ProgressTimeout = DocumentationEntry<ProgressTimeoutConfig, ProgressTimeoutWeb>;
+using NotificationCloseTimeout =
+    DocumentationEntry<NotificationCloseTimeoutConfig, NotificationCloseTimeoutWeb>;
 using TabBarPosition = DocumentationEntry<TabBarPositionConfig, TabBarPositionWeb>;
 using TabBarVisibility = DocumentationEntry<TabBarVisibilityConfig, TabBarVisibilityWeb>;
 using UiStyle = DocumentationEntry<UiStyleConfig, UiStyleWeb>;

--- a/src/contour/config/Config_test.cpp
+++ b/src/contour/config/Config_test.cpp
@@ -78,6 +78,7 @@ default_profile: main
 early_exit_threshold: 11
 live_config: true
 reflow_on_resize: false
+notification_close_timeout: 2500
 profiles:
     main:
         shell: /bin/sh
@@ -87,6 +88,22 @@ profiles:
     CHECK(config.earlyExitThreshold.value() == 11);
     CHECK(config.live.value() == true);
     CHECK(config.reflowOnResize.value() == false);
+    CHECK(config.notificationCloseTimeout.value() == std::chrono::milliseconds { 2500 });
+}
+
+TEST_CASE("Config: the desktop-notification close timeout defaults to ten seconds", "[config]")
+{
+    // Only consulted where a close cannot be observed -- today the portal backend a sandboxed
+    // Contour must use. Comfortably past a typical desktop's own expiry, so the assumed close lands
+    // after the popup is realistically gone rather than while it is still on screen.
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+
+    CHECK(config.notificationCloseTimeout.value() == std::chrono::milliseconds { 10000 });
 }
 
 TEST_CASE("Config: grapheme clustering defaults on and can be turned off", "[config]")

--- a/src/contour/platform/CMakeLists.txt
+++ b/src/contour/platform/CMakeLists.txt
@@ -20,10 +20,12 @@ add_library(contour_platform STATIC
     Clipboard.cpp Clipboard.hpp
     ColorConversion.hpp
     ExternalLauncher.hpp
-    # Both translation units are wholly inside `#ifdef __linux__`, so they compile to nothing
+    # These translation units are wholly inside `#ifdef __linux__`, so they compile to nothing
     # elsewhere. Listed unconditionally all the same: AUTOMOC must still see the Q_OBJECT.
     DBusNotificationTransport.cpp DBusNotificationTransport.hpp
+    DBusSignalSubscription.hpp
     FreeDesktopNotifier.cpp FreeDesktopNotifier.hpp
+    PortalNotificationTransport.cpp PortalNotificationTransport.hpp
     GuiTheme.hpp
     NotificationRouter.hpp
     NotificationTransport.hpp

--- a/src/contour/platform/CMakeLists.txt
+++ b/src/contour/platform/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(contour_platform STATIC
     FreeDesktopNotifier.cpp FreeDesktopNotifier.hpp
     PortalNotificationTransport.cpp PortalNotificationTransport.hpp
     GuiTheme.hpp
+    NotificationIdMap.hpp
     NotificationRouter.hpp
     NotificationTransport.hpp
     Notifier.cpp Notifier.hpp

--- a/src/contour/platform/DBusNotificationTransport.cpp
+++ b/src/contour/platform/DBusNotificationTransport.cpp
@@ -66,7 +66,7 @@ QVariantList buildFreedesktopNotifyArguments(vtbackend::DesktopNotification cons
                              : QString::fromStdString(notification.applicationName);
 
     auto hints = QVariantMap {};
-    hints["urgency"] = QVariant::fromValue(NotificationRouter::toFreedesktopUrgency(notification.urgency));
+    hints["urgency"] = QVariant::fromValue(toFreedesktopUrgency(notification.urgency));
 
     // The default action is what a click on the popup triggers.
     auto const actions = QStringList { QStringLiteral("default"), QStringLiteral("Activate") };

--- a/src/contour/platform/DBusNotificationTransport.cpp
+++ b/src/contour/platform/DBusNotificationTransport.cpp
@@ -3,7 +3,10 @@
 
     #include <contour/Logging.hpp>
     #include <contour/platform/DBusNotificationTransport.hpp>
+    #include <contour/platform/DBusSignalSubscription.hpp>
 
+    #include <QtCore/QStringList>
+    #include <QtCore/QVariantMap>
     #include <QtDBus/QDBusMessage>
     #include <QtDBus/QDBusPendingCallWatcher>
     #include <QtDBus/QDBusPendingReply>
@@ -17,48 +20,33 @@ namespace contour::platform
 namespace
 {
     // The one string trio every call and every match rule is addressed with.
-    constexpr auto NotificationsService = QLatin1StringView("org.freedesktop.Notifications");
-    constexpr auto NotificationsPath = QLatin1StringView("/org/freedesktop/Notifications");
-    constexpr auto NotificationsInterface = QLatin1StringView("org.freedesktop.Notifications");
-
-    /// How long a call may stay outstanding before D-Bus reports NoReply.
-    ///
-    /// Qt's default is 25 seconds, which is a long time to hold a watcher open against a desktop
-    /// that is not answering. Nothing here needs its reply urgently: losing a Notify reply costs
-    /// only the replace-in-place bookkeeping for that one notification, and CloseNotification's
-    /// reply is not read at all.
-    constexpr auto CallTimeoutMilliseconds = 5000;
-
-    /// A server signal, and the slot it is delivered to.
-    struct SignalSubscription
-    {
-        QLatin1StringView name;
-        char const* slot = nullptr;
+    constexpr auto NotificationsSource = DBusSignalSource {
+        .service = QLatin1StringView("org.freedesktop.Notifications"),
+        .path = QLatin1StringView("/org/freedesktop/Notifications"),
+        .interface = QLatin1StringView("org.freedesktop.Notifications"),
     };
 
-    /// The signals this transport listens for.
-    ///
-    /// A table rather than four hand-written calls, because subscribe() and the destructor must pass
-    /// D-Bus byte-for-byte identical arguments or the match rule is added in one shape and looked for
-    /// in another -- which fails silently and leaks the rule for the life of the process. Walking one
-    /// table makes that structural instead of something two code blocks have to agree about.
-    ///
-    /// A function rather than a constant, because SLOT() expands to a qFlagLocation() call: it is
-    /// neither constexpr nor safe to run before main().
-    [[nodiscard]] std::array<SignalSubscription, 2> signalSubscriptions()
+    // Deliberately below Qt's 25-second default: losing a Notify reply costs only the
+    // replace-in-place bookkeeping for that one notification, and CloseNotification's reply is not
+    // read at all. A desktop that is not answering must not be able to hold anything of ours open.
+    constexpr auto CallTimeoutMilliseconds = 5000;
+
+    // A function rather than a constant because SLOT() expands to qFlagLocation(), which is neither
+    // constexpr nor safe to run before main().
+    [[nodiscard]] std::array<DBusSignalSubscription, 2> signalSubscriptions()
     {
         return {
-            SignalSubscription { QLatin1StringView("NotificationClosed"),
-                                 SLOT(onNotificationClosed(uint, uint)) },
-            SignalSubscription { QLatin1StringView("ActionInvoked"), SLOT(onActionInvoked(uint, QString)) },
+            DBusSignalSubscription { QLatin1StringView("NotificationClosed"),
+                                     SLOT(onNotificationClosed(uint, uint)) },
+            DBusSignalSubscription { QLatin1StringView("ActionInvoked"),
+                                     SLOT(onActionInvoked(uint, QString)) },
         };
     }
 
-    /// The one method-call shape: same service, same object, same interface, every time.
     [[nodiscard]] QDBusMessage notificationCall(QLatin1StringView method)
     {
         return QDBusMessage::createMethodCall(
-            NotificationsService, NotificationsPath, NotificationsInterface, method);
+            NotificationsSource.service, NotificationsSource.path, NotificationsSource.interface, method);
     }
 } // namespace
 
@@ -72,20 +60,46 @@ DBusNotificationTransport::~DBusNotificationTransport()
     if (!_onClosed)
         return;
 
-    // Mirror image of subscribe(). @see the declaration for why this cannot be defaulted.
-    for (auto const& subscription: signalSubscriptions())
-        _bus.disconnect(NotificationsService,
-                        NotificationsPath,
-                        NotificationsInterface,
-                        subscription.name,
-                        this,
-                        subscription.slot);
+    unsubscribeFromDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
 }
 
-void DBusNotificationTransport::notify(QVariantList arguments, SentHandler onSent)
+QVariantList buildFreedesktopNotifyArguments(vtbackend::DesktopNotification const& notification,
+                                             NotificationTransport::ServerId replacesId)
+{
+    auto const appName = notification.applicationName.empty()
+                             ? QStringLiteral("contour")
+                             : QString::fromStdString(notification.applicationName);
+
+    auto hints = QVariantMap {};
+    hints["urgency"] = QVariant::fromValue(NotificationRouter::toFreedesktopUrgency(notification.urgency));
+
+    // The default action is what a click on the popup triggers.
+    auto const actions = QStringList { QStringLiteral("default"), QStringLiteral("Activate") };
+
+    // org.freedesktop.Notifications.Notify, signature susssasa{sv}i:
+    // STRING app_name, UINT32 replaces_id, STRING app_icon, STRING summary,
+    // STRING body, ARRAY actions, DICT hints, INT32 expire_timeout.
+    // The casts are load-bearing: QDBusInterface::call used to deduce the wire types from the C++
+    // argument types, and a QVariant built from the wrong integer type marshals as the wrong D-Bus
+    // type, which the notification server rejects outright.
+    return QVariantList {
+        appName,
+        QVariant::fromValue(static_cast<quint32>(replacesId)),
+        QStringLiteral(""), // app_icon (empty)
+        QString::fromStdString(notification.title),
+        QString::fromStdString(notification.body),
+        actions,
+        hints,
+        QVariant::fromValue(static_cast<int>(notification.timeout)),
+    };
+}
+
+void DBusNotificationTransport::notify(vtbackend::DesktopNotification const& notification,
+                                       ServerId replacesId,
+                                       SentHandler onSent)
 {
     auto message = notificationCall(QLatin1StringView("Notify"));
-    message.setArguments(arguments);
+    message.setArguments(buildFreedesktopNotifyArguments(notification, replacesId));
 
     // Parented to this, so a transport destroyed with a call in flight takes its watcher with it and
     // the handler -- which reaches back into the notifier that owns us -- is simply never run.
@@ -122,22 +136,15 @@ void DBusNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandl
     _onClosed = std::move(onClosed);
     _onActivated = std::move(onActivated);
 
-    // Registering a match rule does not wait for the bus: Qt hands AddMatch a null error pointer,
-    // making it fire-and-forget. Installed unconditionally, with no check that anyone is listening
-    // for us to talk to -- the notification daemon may well start after this session did.
-    for (auto const& subscription: signalSubscriptions())
-        _bus.connect(NotificationsService,
-                     NotificationsPath,
-                     NotificationsInterface,
-                     subscription.name,
-                     this,
-                     subscription.slot);
+    subscribeToDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
 }
 
 void DBusNotificationTransport::onNotificationClosed(uint id, uint reason)
 {
+    // Observed: the notification daemon is telling us this happened, so the close report Contour
+    // sends back over the PTY is a fact rather than an assumption.
     if (_onClosed)
-        _onClosed(id, reason);
+        _onClosed(id, reason, vtbackend::CloseReport::Observed);
 }
 
 void DBusNotificationTransport::onActionInvoked(uint id, QString const& actionKey)

--- a/src/contour/platform/DBusNotificationTransport.cpp
+++ b/src/contour/platform/DBusNotificationTransport.cpp
@@ -57,7 +57,7 @@ DBusNotificationTransport::DBusNotificationTransport(QObject* parent):
 
 DBusNotificationTransport::~DBusNotificationTransport()
 {
-    if (!_onClosed)
+    if (_subscription == DBusSubscriptionState::NotSubscribed)
         return;
 
     unsubscribeFromDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
@@ -137,6 +137,7 @@ void DBusNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandl
     _onActivated = std::move(onActivated);
 
     subscribeToDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
+    _subscription = DBusSubscriptionState::Subscribed;
 }
 
 void DBusNotificationTransport::onNotificationClosed(uint id, uint reason)

--- a/src/contour/platform/DBusNotificationTransport.cpp
+++ b/src/contour/platform/DBusNotificationTransport.cpp
@@ -50,14 +50,6 @@ DBusNotificationTransport::DBusNotificationTransport(QObject* parent):
 {
 }
 
-DBusNotificationTransport::~DBusNotificationTransport()
-{
-    if (_subscription == DBusSubscriptionState::NotSubscribed)
-        return;
-
-    unsubscribeFromDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
-}
-
 QVariantList buildFreedesktopNotifyArguments(vtbackend::DesktopNotification const& notification,
                                              NotificationTransport::ServerId replacesId)
 {
@@ -132,8 +124,7 @@ void DBusNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandl
     _onClosed = std::move(onClosed);
     _onActivated = std::move(onActivated);
 
-    subscribeToDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
-    _subscription = DBusSubscriptionState::Subscribed;
+    _subscription = subscribeToDBusSignals(_bus, NotificationsSource, this, signalSubscriptions());
 }
 
 void DBusNotificationTransport::onNotificationClosed(uint id, uint reason)

--- a/src/contour/platform/DBusNotificationTransport.cpp
+++ b/src/contour/platform/DBusNotificationTransport.cpp
@@ -26,11 +26,6 @@ namespace
         .interface = QLatin1StringView("org.freedesktop.Notifications"),
     };
 
-    // Deliberately below Qt's 25-second default: losing a Notify reply costs only the
-    // replace-in-place bookkeeping for that one notification, and CloseNotification's reply is not
-    // read at all. A desktop that is not answering must not be able to hold anything of ours open.
-    constexpr auto CallTimeoutMilliseconds = 5000;
-
     // A function rather than a constant because SLOT() expands to qFlagLocation(), which is neither
     // constexpr nor safe to run before main().
     [[nodiscard]] std::array<DBusSignalSubscription, 2> signalSubscriptions()
@@ -103,7 +98,8 @@ void DBusNotificationTransport::notify(vtbackend::DesktopNotification const& not
 
     // Parented to this, so a transport destroyed with a call in flight takes its watcher with it and
     // the handler -- which reaches back into the notifier that owns us -- is simply never run.
-    auto* const watcher = new QDBusPendingCallWatcher(_bus.asyncCall(message, CallTimeoutMilliseconds), this);
+    auto* const watcher =
+        new QDBusPendingCallWatcher(_bus.asyncCall(message, DBusCallTimeoutMilliseconds), this);
 
     QObject::connect(
         watcher, &QDBusPendingCallWatcher::finished, this, [onSent = std::move(onSent)](auto* self) {
@@ -128,7 +124,7 @@ void DBusNotificationTransport::close(ServerId serverId)
 
     // Sent and forgotten: there is nothing in the reply the caller acts on, and waiting for it was
     // what made closing a notification able to stall the terminal thread.
-    _bus.asyncCall(message, CallTimeoutMilliseconds);
+    _bus.asyncCall(message, DBusCallTimeoutMilliseconds);
 }
 
 void DBusNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandler onActivated)

--- a/src/contour/platform/DBusNotificationTransport.hpp
+++ b/src/contour/platform/DBusNotificationTransport.hpp
@@ -58,15 +58,6 @@ class DBusNotificationTransport final: public QObject, public NotificationTransp
   public:
     explicit DBusNotificationTransport(QObject* parent = nullptr);
 
-    /// Removes the session-bus signal subscriptions that subscribe() installed.
-    ///
-    /// Not defaulted: QDBusConnection::connect() registers a match rule on the process-wide session
-    /// bus, and there is one transport per terminal session. Without the matching disconnect the
-    /// rules accumulate for the life of the process, and the bus keeps delivering those signals
-    /// towards an object that is being destroyed -- the bus runs its own thread, so that is a
-    /// teardown race and not merely a leak.
-    ~DBusNotificationTransport() override;
-
     void notify(vtbackend::DesktopNotification const& notification,
                 ServerId replacesId,
                 SentHandler onSent) override;
@@ -85,8 +76,8 @@ class DBusNotificationTransport final: public QObject, public NotificationTransp
     /// obtaining it costs a Hello round-trip to the bus daemon, which always answers at once.
     QDBusConnection _bus;
 
-    /// Whether subscribe() has installed the match rules, so the destructor knows to remove them.
-    DBusSubscriptionState _subscription = DBusSubscriptionState::NotSubscribed;
+    /// The installed match rules, removed when this dies. @see DBusSignalSubscriptionGuard.
+    DBusSignalSubscriptionGuard _subscription;
 
     /// The subscription handlers.
     ClosedHandler _onClosed;

--- a/src/contour/platform/DBusNotificationTransport.hpp
+++ b/src/contour/platform/DBusNotificationTransport.hpp
@@ -13,6 +13,20 @@
 namespace contour::platform
 {
 
+/// Maps a notification urgency onto the freedesktop.org urgency byte (0=low, 1=normal, 2=critical).
+/// @param urgency The backend urgency level.
+/// @return The freedesktop urgency byte; Normal (1) for any unrecognized value.
+[[nodiscard]] constexpr uint8_t toFreedesktopUrgency(vtbackend::NotificationUrgency urgency) noexcept
+{
+    switch (urgency)
+    {
+        case vtbackend::NotificationUrgency::Low: return 0;
+        case vtbackend::NotificationUrgency::Normal: return 1;
+        case vtbackend::NotificationUrgency::Critical: return 2;
+    }
+    return 1;
+}
+
 /// Builds the positional argument tuple for org.freedesktop.Notifications.Notify.
 ///
 /// A free function rather than a member, because it is the one part of this transport a headless

--- a/src/contour/platform/DBusNotificationTransport.hpp
+++ b/src/contour/platform/DBusNotificationTransport.hpp
@@ -3,6 +3,7 @@
 
 #ifdef __linux__
 
+    #include <contour/platform/DBusSignalSubscription.hpp>
     #include <contour/platform/NotificationTransport.hpp>
 
     #include <QtCore/QObject>
@@ -70,8 +71,10 @@ class DBusNotificationTransport final: public QObject, public NotificationTransp
     /// obtaining it costs a Hello round-trip to the bus daemon, which always answers at once.
     QDBusConnection _bus;
 
-    /// The subscription handlers. Their emptiness IS the "not subscribed yet" state, which is why
-    /// there is no separate flag: the destructor removes the match rules only when one is set.
+    /// Whether subscribe() has installed the match rules, so the destructor knows to remove them.
+    DBusSubscriptionState _subscription = DBusSubscriptionState::NotSubscribed;
+
+    /// The subscription handlers.
     ClosedHandler _onClosed;
     ActivatedHandler _onActivated;
 };

--- a/src/contour/platform/DBusNotificationTransport.hpp
+++ b/src/contour/platform/DBusNotificationTransport.hpp
@@ -6,10 +6,23 @@
     #include <contour/platform/NotificationTransport.hpp>
 
     #include <QtCore/QObject>
+    #include <QtCore/QVariantList>
     #include <QtDBus/QDBusConnection>
 
 namespace contour::platform
 {
+
+/// Builds the positional argument tuple for org.freedesktop.Notifications.Notify.
+///
+/// A free function rather than a member, because it is the one part of this transport a headless
+/// test can check head-on: no bus, no daemon, no waiting -- just the notification in and the wire
+/// tuple out.
+///
+/// @param notification The notification to send.
+/// @param replacesId A live server id this supersedes, or 0 for a fresh notification.
+/// @return The eight Notify arguments, in wire order.
+[[nodiscard]] QVariantList buildFreedesktopNotifyArguments(vtbackend::DesktopNotification const& notification,
+                                                           NotificationTransport::ServerId replacesId);
 
 /// Speaks org.freedesktop.Notifications over the session bus, asynchronously.
 ///
@@ -39,7 +52,9 @@ class DBusNotificationTransport final: public QObject, public NotificationTransp
     /// teardown race and not merely a leak.
     ~DBusNotificationTransport() override;
 
-    void notify(QVariantList arguments, SentHandler onSent) override;
+    void notify(vtbackend::DesktopNotification const& notification,
+                ServerId replacesId,
+                SentHandler onSent) override;
     void close(ServerId serverId) override;
     void subscribe(ClosedHandler onClosed, ActivatedHandler onActivated) override;
 

--- a/src/contour/platform/DBusSignalSubscription.hpp
+++ b/src/contour/platform/DBusSignalSubscription.hpp
@@ -7,8 +7,9 @@
     #include <QtCore/QObject>
     #include <QtDBus/QDBusConnection>
 
-    #include <cstdint>
     #include <span>
+    #include <utility>
+    #include <vector>
 
 namespace contour::platform
 {
@@ -37,19 +38,6 @@ struct DBusSignalSubscription
 /// both transports to it.
 constexpr auto DBusCallTimeoutMilliseconds = 5000;
 
-/// Whether a client has installed its match rules yet.
-///
-/// A state of its own rather than something inferred from a handler being non-empty: those are two
-/// different questions, and answering the second in place of the first leaves the match rule
-/// installed whenever a client subscribes with only the handlers it has a use for -- the portal
-/// transport, for one, has no close signal to hand a handler to. A rule that outlives its receiver
-/// is a teardown race, not merely a leak. @see unsubscribeFromDBusSignals().
-enum class DBusSubscriptionState : uint8_t
-{
-    NotSubscribed = 0,
-    Subscribed = 1,
-};
-
 /// The one service, path and interface a set of subscriptions is addressed with.
 struct DBusSignalSource
 {
@@ -58,7 +46,95 @@ struct DBusSignalSource
     QLatin1StringView interface;
 };
 
-/// Registers a match rule on @p bus for each of @p subscriptions.
+/// Owns a set of installed match rules and removes them when it dies.
+///
+/// The pairing is the whole point. A match rule is removed by naming it again, argument for
+/// argument, and one that does not match the rule registered fails SILENTLY -- leaving the rule in
+/// place for the life of the process while the bus, which runs its own thread, keeps delivering
+/// towards an object being destroyed. That is a teardown race, not merely a leak.
+///
+/// Holding the arguments rather than asking each client to remember them is what makes the two
+/// sides unable to drift apart: previously every backend had to declare a non-defaulted destructor,
+/// track for itself whether it had subscribed, and repeat the identical source and subscription
+/// array -- three chances per backend to get a silent race wrong. A default-constructed guard owns
+/// nothing and does nothing, so "not subscribed yet" needs no separate flag.
+///
+/// The subscriptions are COPIED rather than referenced: they name the slots to disconnect, and a
+/// caller building them in a temporary (as both backends do -- SLOT() is not constexpr, so the
+/// array cannot be static) would otherwise leave the guard pointing at a dead one.
+class DBusSignalSubscriptionGuard
+{
+  public:
+    DBusSignalSubscriptionGuard() = default;
+
+    /// @param bus The bus the rules are installed on.
+    /// @param source Where the signals come from.
+    /// @param receiver The object they are delivered to.
+    /// @param subscriptions What was subscribed to.
+    DBusSignalSubscriptionGuard(QDBusConnection bus,
+                                DBusSignalSource const& source,
+                                QObject* receiver,
+                                std::span<DBusSignalSubscription const> subscriptions):
+        _bus { std::move(bus) },
+        _source { source },
+        _receiver { receiver },
+        _subscriptions { subscriptions.begin(), subscriptions.end() }
+    {
+    }
+
+    DBusSignalSubscriptionGuard(DBusSignalSubscriptionGuard const&) = delete;
+    DBusSignalSubscriptionGuard& operator=(DBusSignalSubscriptionGuard const&) = delete;
+
+    DBusSignalSubscriptionGuard(DBusSignalSubscriptionGuard&& other) noexcept { swap(other); }
+
+    DBusSignalSubscriptionGuard& operator=(DBusSignalSubscriptionGuard&& other) noexcept
+    {
+        if (this != &other)
+        {
+            auto discarded = DBusSignalSubscriptionGuard {};
+            discarded.swap(*this);
+            swap(other);
+        }
+        return *this;
+    }
+
+    ~DBusSignalSubscriptionGuard() { unsubscribe(); }
+
+  private:
+    void swap(DBusSignalSubscriptionGuard& other) noexcept
+    {
+        std::swap(_bus, other._bus);
+        std::swap(_source, other._source);
+        std::swap(_receiver, other._receiver);
+        _subscriptions.swap(other._subscriptions);
+    }
+
+    void unsubscribe() noexcept
+    {
+        if (_receiver == nullptr)
+            return;
+
+        for (auto const& subscription: _subscriptions)
+            _bus.disconnect(_source.service,
+                            _source.path,
+                            _source.interface,
+                            subscription.name,
+                            _receiver,
+                            subscription.slot);
+        _receiver = nullptr;
+    }
+
+    QDBusConnection _bus = QDBusConnection { QString {} };
+    DBusSignalSource _source {};
+
+    /// Null in a guard that owns nothing -- which is what a default-constructed one is.
+    QObject* _receiver = nullptr;
+
+    /// Copied, so the guard does not depend on the caller's array outliving it.
+    std::vector<DBusSignalSubscription> _subscriptions;
+};
+
+/// Registers a match rule on @p bus for each of @p subscriptions, and hands back what removes them.
 ///
 /// Registering does not wait for the bus: Qt hands AddMatch a null error pointer, making it
 /// fire-and-forget. So this is installed unconditionally, with no check that there is anyone to
@@ -67,37 +143,19 @@ struct DBusSignalSource
 /// @param bus The bus to register on.
 /// @param source Where the signals come from.
 /// @param receiver The object whose slots they are delivered to.
-/// @param subscriptions What to subscribe to.
-inline void subscribeToDBusSignals(QDBusConnection& bus,
-                                   DBusSignalSource const& source,
-                                   QObject* receiver,
-                                   std::span<DBusSignalSubscription const> subscriptions)
+/// @param subscriptions What to subscribe to; copied into the guard.
+/// @return The guard that removes them again. Discarding it unsubscribes immediately.
+[[nodiscard]] inline DBusSignalSubscriptionGuard subscribeToDBusSignals(
+    QDBusConnection& bus,
+    DBusSignalSource const& source,
+    QObject* receiver,
+    std::span<DBusSignalSubscription const> subscriptions)
 {
     for (auto const& subscription: subscriptions)
         bus.connect(
             source.service, source.path, source.interface, subscription.name, receiver, subscription.slot);
-}
 
-/// Removes the match rules subscribeToDBusSignals() registered.
-///
-/// Pairing the two here is the point: a match rule is removed by naming it again, argument for
-/// argument, and one that does not match the rule registered fails SILENTLY -- leaving the rule in
-/// place for the life of the process while the bus keeps delivering towards an object that is being
-/// destroyed. The bus runs its own thread, so that is a teardown race and not merely a leak. Going
-/// through one function with one @p source is what makes the two sides unable to drift apart.
-///
-/// @param bus The bus to remove them from.
-/// @param source Where the signals come from; must equal what was subscribed with.
-/// @param receiver The object they were delivered to.
-/// @param subscriptions What was subscribed to.
-inline void unsubscribeFromDBusSignals(QDBusConnection& bus,
-                                       DBusSignalSource const& source,
-                                       QObject* receiver,
-                                       std::span<DBusSignalSubscription const> subscriptions)
-{
-    for (auto const& subscription: subscriptions)
-        bus.disconnect(
-            source.service, source.path, source.interface, subscription.name, receiver, subscription.slot);
+    return DBusSignalSubscriptionGuard { bus, source, receiver, subscriptions };
 }
 
 } // namespace contour::platform

--- a/src/contour/platform/DBusSignalSubscription.hpp
+++ b/src/contour/platform/DBusSignalSubscription.hpp
@@ -28,6 +28,15 @@ struct DBusSignalSubscription
     char const* slot = nullptr;
 };
 
+/// How long a D-Bus method call to a notification service may stay outstanding, in milliseconds.
+///
+/// Deliberately below Qt's 25-second default: losing a reply costs only the replace-in-place
+/// bookkeeping for that one notification, and several of these calls do not read their reply at
+/// all. A desktop that is not answering must not be able to hold anything of ours open. @see
+/// issue #2051, and the wedged-bus harness at test/e2e/notification-nonblocking.sh that holds
+/// both transports to it.
+constexpr auto DBusCallTimeoutMilliseconds = 5000;
+
 /// Whether a client has installed its match rules yet.
 ///
 /// A state of its own rather than something inferred from a handler being non-empty: those are two

--- a/src/contour/platform/DBusSignalSubscription.hpp
+++ b/src/contour/platform/DBusSignalSubscription.hpp
@@ -7,6 +7,7 @@
     #include <QtCore/QObject>
     #include <QtDBus/QDBusConnection>
 
+    #include <cstdint>
     #include <span>
 
 namespace contour::platform
@@ -25,6 +26,19 @@ struct DBusSignalSubscription
     /// reconstructs from the slot's parameters, so a slot taking fewer arguments does not fail
     /// loudly -- it is simply never called.
     char const* slot = nullptr;
+};
+
+/// Whether a client has installed its match rules yet.
+///
+/// A state of its own rather than something inferred from a handler being non-empty: those are two
+/// different questions, and answering the second in place of the first leaves the match rule
+/// installed whenever a client subscribes with only the handlers it has a use for -- the portal
+/// transport, for one, has no close signal to hand a handler to. A rule that outlives its receiver
+/// is a teardown race, not merely a leak. @see unsubscribeFromDBusSignals().
+enum class DBusSubscriptionState : uint8_t
+{
+    NotSubscribed = 0,
+    Subscribed = 1,
 };
 
 /// The one service, path and interface a set of subscriptions is addressed with.

--- a/src/contour/platform/DBusSignalSubscription.hpp
+++ b/src/contour/platform/DBusSignalSubscription.hpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#ifdef __linux__
+
+    #include <QtCore/QLatin1StringView>
+    #include <QtCore/QObject>
+    #include <QtDBus/QDBusConnection>
+
+    #include <span>
+
+namespace contour::platform
+{
+
+/// One signal a D-Bus client subscribes to, and the slot it is delivered into.
+struct DBusSignalSubscription
+{
+    /// The signal's name on the interface.
+    QLatin1StringView name;
+
+    /// The receiving slot, as SLOT() expands it.
+    ///
+    /// Note that the slot must declare EVERY parameter the signal carries. QtDBus matches an
+    /// incoming signal to a subscription by comparing the message's signature against the one it
+    /// reconstructs from the slot's parameters, so a slot taking fewer arguments does not fail
+    /// loudly -- it is simply never called.
+    char const* slot = nullptr;
+};
+
+/// The one service, path and interface a set of subscriptions is addressed with.
+struct DBusSignalSource
+{
+    QLatin1StringView service;
+    QLatin1StringView path;
+    QLatin1StringView interface;
+};
+
+/// Registers a match rule on @p bus for each of @p subscriptions.
+///
+/// Registering does not wait for the bus: Qt hands AddMatch a null error pointer, making it
+/// fire-and-forget. So this is installed unconditionally, with no check that there is anyone to
+/// listen to -- the service may well start after this process did.
+///
+/// @param bus The bus to register on.
+/// @param source Where the signals come from.
+/// @param receiver The object whose slots they are delivered to.
+/// @param subscriptions What to subscribe to.
+inline void subscribeToDBusSignals(QDBusConnection& bus,
+                                   DBusSignalSource const& source,
+                                   QObject* receiver,
+                                   std::span<DBusSignalSubscription const> subscriptions)
+{
+    for (auto const& subscription: subscriptions)
+        bus.connect(
+            source.service, source.path, source.interface, subscription.name, receiver, subscription.slot);
+}
+
+/// Removes the match rules subscribeToDBusSignals() registered.
+///
+/// Pairing the two here is the point: a match rule is removed by naming it again, argument for
+/// argument, and one that does not match the rule registered fails SILENTLY -- leaving the rule in
+/// place for the life of the process while the bus keeps delivering towards an object that is being
+/// destroyed. The bus runs its own thread, so that is a teardown race and not merely a leak. Going
+/// through one function with one @p source is what makes the two sides unable to drift apart.
+///
+/// @param bus The bus to remove them from.
+/// @param source Where the signals come from; must equal what was subscribed with.
+/// @param receiver The object they were delivered to.
+/// @param subscriptions What was subscribed to.
+inline void unsubscribeFromDBusSignals(QDBusConnection& bus,
+                                       DBusSignalSource const& source,
+                                       QObject* receiver,
+                                       std::span<DBusSignalSubscription const> subscriptions)
+{
+    for (auto const& subscription: subscriptions)
+        bus.disconnect(
+            source.service, source.path, source.interface, subscription.name, receiver, subscription.slot);
+}
+
+} // namespace contour::platform
+
+#endif // defined(__linux__)

--- a/src/contour/platform/FreeDesktopNotifier.cpp
+++ b/src/contour/platform/FreeDesktopNotifier.cpp
@@ -26,7 +26,7 @@ FreeDesktopNotifier::FreeDesktopNotifier(std::unique_ptr<NotificationTransport> 
             notifierLog()("Notification closed: id={} reason={} report={}",
                           serverId,
                           reason,
-                          report == vtbackend::CloseReport::Observed ? "observed" : "untracked");
+                          vtbackend::closeReportName(report));
             emit notificationClosed(QString::fromStdString(*oscIdentifier), reason, report);
         },
         [this](NotificationTransport::ServerId serverId) {

--- a/src/contour/platform/FreeDesktopNotifier.cpp
+++ b/src/contour/platform/FreeDesktopNotifier.cpp
@@ -5,9 +5,6 @@
     #include <contour/platform/FreeDesktopNotifier.hpp>
     #include <contour/platform/QtInvoke.hpp>
 
-    #include <QtCore/QStringList>
-    #include <QtCore/QVariantMap>
-
     #include <utility>
 
 namespace contour::platform
@@ -21,20 +18,23 @@ FreeDesktopNotifier::FreeDesktopNotifier(std::unique_ptr<NotificationTransport> 
     // old code probed the service synchronously and, when that probe failed, left the session unable
     // to notify for the rest of the process's life.
     _transport->subscribe(
-        [this](NotificationTransport::ServerId serverId, uint32_t reason) {
+        [this](NotificationTransport::ServerId serverId, uint32_t reason, vtbackend::CloseReport report) {
             auto const oscIdentifier = _router.takeForServerEvent(serverId);
             if (!oscIdentifier.has_value())
                 return;
 
-            notifierLog()("Notification closed: dbus_id={} reason={}", serverId, reason);
-            emit notificationClosed(QString::fromStdString(*oscIdentifier), reason);
+            notifierLog()("Notification closed: id={} reason={} report={}",
+                          serverId,
+                          reason,
+                          report == vtbackend::CloseReport::Observed ? "observed" : "untracked");
+            emit notificationClosed(QString::fromStdString(*oscIdentifier), reason, report);
         },
         [this](NotificationTransport::ServerId serverId) {
             auto const oscIdentifier = _router.takeForServerEvent(serverId);
             if (!oscIdentifier.has_value())
                 return;
 
-            notifierLog()("Notification activated: dbus_id={}", serverId);
+            notifierLog()("Notification activated: id={}", serverId);
             emit actionInvoked(QString::fromStdString(*oscIdentifier));
         });
 }
@@ -55,43 +55,19 @@ void FreeDesktopNotifier::close(std::string const& identifier)
 
 void FreeDesktopNotifier::sendNotification(vtbackend::DesktopNotification const& notification)
 {
-    auto const appName = notification.applicationName.empty()
-                             ? QStringLiteral("contour")
-                             : QString::fromStdString(notification.applicationName);
-
-    auto hints = QVariantMap {};
-    hints["urgency"] = QVariant::fromValue(NotificationRouter::toFreedesktopUrgency(notification.urgency));
-
-    // The default action is what a click on the popup triggers.
-    auto const actions = QStringList { QStringLiteral("default"), QStringLiteral("Activate") };
-
-    // Whether this replaces a notification of ours that is still on screen.
+    // Whether this replaces a notification of ours that is still on screen. What that means on the
+    // wire is the transport's business: freedesktop's Notify carries it as replaces_id, while the
+    // portal gets replacement for free from reusing the notification's id.
     auto const replacesId = _router.replacementFor(notification.identifier);
 
-    // org.freedesktop.Notifications.Notify, signature susssasa{sv}i:
-    // STRING app_name, UINT32 replaces_id, STRING app_icon, STRING summary,
-    // STRING body, ARRAY actions, DICT hints, INT32 expire_timeout.
-    // The casts are load-bearing: QDBusInterface::call used to deduce the wire types from the C++
-    // argument types, and a QVariant built from the wrong integer type marshals as the wrong D-Bus
-    // type, which the notification server rejects outright.
-    auto arguments = QVariantList {
-        appName,
-        QVariant::fromValue(static_cast<quint32>(replacesId)),
-        QStringLiteral(""), // app_icon (empty)
-        QString::fromStdString(notification.title),
-        QString::fromStdString(notification.body),
-        actions,
-        hints,
-        QVariant::fromValue(static_cast<int>(notification.timeout)),
-    };
-
     auto const identifier = notification.identifier;
-    _transport->notify(std::move(arguments),
+    _transport->notify(notification,
+                       replacesId,
                        [this, identifier, replacesId](std::optional<NotificationRouter::ServerId> serverId) {
                            if (!serverId.has_value())
                                return;
 
-                           notifierLog()("Notification sent: id='{}' -> dbus_id={}", identifier, *serverId);
+                           notifierLog()("Notification sent: id='{}' -> {}", identifier, *serverId);
                            _router.onSent(identifier, *serverId, replacesId);
                        });
 }

--- a/src/contour/platform/FreeDesktopNotifier.hpp
+++ b/src/contour/platform/FreeDesktopNotifier.hpp
@@ -44,10 +44,11 @@ class FreeDesktopNotifier final: public Notifier
     void close(std::string const& identifier) override;
 
   private:
-    /// Builds and dispatches the freedesktop Notify call. Runs on this object's own thread.
+    /// Resolves what this notification replaces and hands it to the transport, which decides what
+    /// that means on the wire. Runs on this object's own thread.
     void sendNotification(vtbackend::DesktopNotification const& notification);
 
-    /// Resolves @p identifier to a live server id and dispatches CloseNotification for it, if any.
+    /// Resolves @p identifier to a live server id and asks the transport to withdraw it, if any.
     void sendClose(std::string const& identifier);
 
     /// The transport-independent OSC-id <-> server-id bookkeeping and urgency policy. Only ever

--- a/src/contour/platform/FreeDesktopNotifier.hpp
+++ b/src/contour/platform/FreeDesktopNotifier.hpp
@@ -15,16 +15,22 @@
 namespace contour::platform
 {
 
-/// Backend for the Kitty OSC 99 desktop notification protocol on Linux, speaking the
-/// org.freedesktop.Notifications vocabulary:
-/// - Sending notifications (Notify)
-/// - Closing notifications (CloseNotification)
-/// - Receiving close events (NotificationClosed signal)
-/// - Receiving activation events (ActionInvoked signal)
+/// Backend for the Kitty OSC 99 desktop notification protocol on Linux, in the four verbs every
+/// freedesktop notification service offers:
+/// - Sending a notification, replacing one still on screen where the identifier repeats
+/// - Withdrawing a notification
+/// - Receiving close events
+/// - Receiving activation events
 ///
 /// Holds no transport of its own: what it does is decide, and the sending is a NotificationTransport
 /// it is handed. That is what keeps the OSC-identifier bookkeeping testable without a D-Bus session,
 /// and what lets the class guarantee it never blocks -- @see NotificationTransport.
+///
+/// It is deliberately ignorant of WHICH service it is talking to. org.freedesktop.Notifications and
+/// org.freedesktop.portal.Notification differ in argument shape, in who assigns the notification id,
+/// and in whether a close can be observed at all -- and none of those three reach this class. The
+/// last of them arrives as the CloseReport on a close event rather than as a question this class
+/// has to ask. @see https://github.com/contour-terminal/contour/issues/2074
 class FreeDesktopNotifier final: public Notifier
 {
     Q_OBJECT

--- a/src/contour/platform/FreeDesktopNotifier_test.cpp
+++ b/src/contour/platform/FreeDesktopNotifier_test.cpp
@@ -12,6 +12,7 @@
 
 #ifdef __linux__
 
+    #include <contour/platform/DBusNotificationTransport.hpp>
     #include <contour/platform/FreeDesktopNotifier.hpp>
 
     #include <QtCore/QCoreApplication>
@@ -27,6 +28,7 @@
 
 using contour::platform::FreeDesktopNotifier;
 using contour::platform::NotificationTransport;
+using vtbackend::CloseReport;
 
 namespace
 {
@@ -34,20 +36,23 @@ namespace
 /// A NotificationTransport that sends nothing and remembers everything.
 ///
 /// Deliberately not a mock framework: the recorded vectors ARE the assertions. It also never replies
-/// on its own — @c completeLast() is what delivers a reply — which is how a test can observe that
+/// on its own — @c completeNotify() is what delivers a reply — which is how a test can observe that
 /// notify() returned before any reply existed.
 class RecordingNotificationTransport final: public NotificationTransport
 {
   public:
     struct NotifyCall
     {
-        QVariantList arguments;
+        vtbackend::DesktopNotification notification;
+        ServerId replacesId;
         SentHandler onSent;
     };
 
-    void notify(QVariantList arguments, SentHandler onSent) override
+    void notify(vtbackend::DesktopNotification const& notification,
+                ServerId replacesId,
+                SentHandler onSent) override
     {
-        notifyCalls.emplace_back(NotifyCall { std::move(arguments), std::move(onSent) });
+        notifyCalls.emplace_back(NotifyCall { notification, replacesId, std::move(onSent) });
     }
 
     void close(ServerId serverId) override { closedServerIds.push_back(serverId); }
@@ -66,7 +71,10 @@ class RecordingNotificationTransport final: public NotificationTransport
     }
 
     /// Drives the server-side signals the transport would otherwise receive over the bus.
-    void emitClosed(ServerId serverId, uint32_t reason) { _onClosed(serverId, reason); }
+    void emitClosed(ServerId serverId, uint32_t reason, CloseReport report = CloseReport::Observed)
+    {
+        _onClosed(serverId, reason, report);
+    }
     void emitActivated(ServerId serverId) { _onActivated(serverId); }
 
     std::vector<NotifyCall> notifyCalls;
@@ -137,21 +145,18 @@ TEST_CASE("FreeDesktopNotifier does not wait for a reply", "[contour][notificati
     pump();
     REQUIRE(transport->notifyCalls.size() == 2);
     // Still 0 == "a fresh notification": without a reply there is no server id to replace.
-    CHECK(transport->notifyCalls[1].arguments[1].value<quint32>() == 0);
+    CHECK(transport->notifyCalls[1].replacesId == 0);
 }
 
-TEST_CASE("FreeDesktopNotifier builds the freedesktop Notify argument tuple", "[contour][notification]")
+TEST_CASE("buildFreedesktopNotifyArguments builds the Notify tuple", "[contour][notification]")
 {
-    auto const [notifier, transport] = makeNotifier();
-
+    // Checked head-on rather than through the notifier: the tuple is what the D-Bus transport puts
+    // on the wire, and nothing about building it needs a bus, a daemon or an event loop.
     auto notification = aNotification("osc-1");
     notification.urgency = vtbackend::NotificationUrgency::Critical;
     notification.timeout = 4200;
-    notifier->notify(notification);
-    pump();
 
-    REQUIRE(transport->notifyCalls.size() == 1);
-    auto const& arguments = transport->notifyCalls[0].arguments;
+    auto const arguments = contour::platform::buildFreedesktopNotifyArguments(notification, /*replacesId*/ 0);
 
     // Signature susssasa{sv}i, in wire order. The types matter as much as the values: a QVariant
     // built from the wrong integer type marshals as the wrong D-Bus type and the server rejects it.
@@ -170,14 +175,35 @@ TEST_CASE("FreeDesktopNotifier builds the freedesktop Notify argument tuple", "[
 
     SECTION("an explicit application name wins over the default")
     {
-        auto named = aNotification("osc-2");
-        named.applicationName = "my-app";
-        notifier->notify(named);
-        pump();
-
-        REQUIRE(transport->notifyCalls.size() == 2);
-        CHECK(transport->notifyCalls[1].arguments[0].toString() == QStringLiteral("my-app"));
+        notification.applicationName = "my-app";
+        auto const named = contour::platform::buildFreedesktopNotifyArguments(notification, 0);
+        CHECK(named[0].toString() == QStringLiteral("my-app"));
     }
+
+    SECTION("the replaced id is carried as replaces_id")
+    {
+        auto const replacing = contour::platform::buildFreedesktopNotifyArguments(notification, 77);
+        CHECK(replacing[1].value<quint32>() == 77);
+    }
+}
+
+TEST_CASE("FreeDesktopNotifier hands the transport the notification, not a wire tuple",
+          "[contour][notification]")
+{
+    // The seam is stated in the domain type, so the portal transport never has to read a shape it
+    // does not speak. @see issue #2074.
+    auto const [notifier, transport] = makeNotifier();
+
+    auto notification = aNotification("osc-1");
+    notification.urgency = vtbackend::NotificationUrgency::Critical;
+    notifier->notify(notification);
+    pump();
+
+    REQUIRE(transport->notifyCalls.size() == 1);
+    CHECK(transport->notifyCalls[0].notification.identifier == "osc-1");
+    CHECK(transport->notifyCalls[0].notification.title == "Title");
+    CHECK(transport->notifyCalls[0].notification.urgency == vtbackend::NotificationUrgency::Critical);
+    CHECK(transport->notifyCalls[0].replacesId == 0);
 }
 
 TEST_CASE("FreeDesktopNotifier replaces in place once the reply arrives", "[contour][notification]")
@@ -195,7 +221,7 @@ TEST_CASE("FreeDesktopNotifier replaces in place once the reply arrives", "[cont
     notifier->notify(aNotification("osc-1"));
     pump();
     REQUIRE(transport->notifyCalls.size() == 2);
-    CHECK(transport->notifyCalls[1].arguments[1].value<quint32>() == 77);
+    CHECK(transport->notifyCalls[1].replacesId == 77);
 
     SECTION("a failed send records nothing, so the next one is fresh again")
     {
@@ -205,7 +231,7 @@ TEST_CASE("FreeDesktopNotifier replaces in place once the reply arrives", "[cont
         pump();
         REQUIRE(transport->notifyCalls.size() == 3);
         // Still 77: the failed call did not overwrite the live mapping.
-        CHECK(transport->notifyCalls[2].arguments[1].value<quint32>() == 77);
+        CHECK(transport->notifyCalls[2].replacesId == 77);
     }
 }
 
@@ -245,7 +271,7 @@ TEST_CASE("FreeDesktopNotifier drives the real D-Bus transport without waiting",
     // its notification daemon disabled looks like, and what used to cost 25 seconds per session.
     auto const startedAt = std::chrono::steady_clock::now();
 
-    auto notifier = contour::platform::makeDesktopNotifier();
+    auto notifier = contour::platform::makeDesktopNotifier(std::chrono::milliseconds { 10000 });
     REQUIRE(notifier != nullptr);
 
     // Actually sending is gated, so that a run on a developer's own desktop does not pop a
@@ -267,12 +293,19 @@ TEST_CASE("FreeDesktopNotifier reports server-side close and activation", "[cont
 {
     auto const [notifier, transport] = makeNotifier();
 
-    auto closed = std::vector<std::pair<QString, uint>> {};
+    struct ClosedEvent
+    {
+        QString identifier;
+        uint reason;
+        CloseReport report;
+    };
+    auto closed = std::vector<ClosedEvent> {};
     auto activated = std::vector<QString> {};
-    QObject::connect(
-        notifier.get(),
-        &contour::platform::Notifier::notificationClosed,
-        [&](QString const& identifier, uint reason) { closed.emplace_back(identifier, reason); });
+    QObject::connect(notifier.get(),
+                     &contour::platform::Notifier::notificationClosed,
+                     [&](QString const& identifier, uint reason, CloseReport report) {
+                         closed.emplace_back(ClosedEvent { identifier, reason, report });
+                     });
     QObject::connect(notifier.get(),
                      &contour::platform::Notifier::actionInvoked,
                      [&](QString const& identifier) { activated.push_back(identifier); });
@@ -286,12 +319,24 @@ TEST_CASE("FreeDesktopNotifier reports server-side close and activation", "[cont
         transport->emitClosed(12, /*reason*/ 2);
 
         REQUIRE(closed.size() == 1);
-        CHECK(closed[0].first == QStringLiteral("osc-1"));
-        CHECK(closed[0].second == 2);
+        CHECK(closed[0].identifier == QStringLiteral("osc-1"));
+        CHECK(closed[0].reason == 2);
+        CHECK(closed[0].report == CloseReport::Observed);
 
         // The notification is retired, so a repeat of the same server id says nothing.
         transport->emitClosed(12, 2);
         CHECK(closed.size() == 1);
+    }
+
+    SECTION("a close the backend only assumed is forwarded as such")
+    {
+        // What the portal backend produces: nothing observed the close, a timer expired. The
+        // provenance travels with the event, so the session can report it honestly.
+        transport->emitClosed(12, /*reason*/ 1, CloseReport::Untracked);
+
+        REQUIRE(closed.size() == 1);
+        CHECK(closed[0].identifier == QStringLiteral("osc-1"));
+        CHECK(closed[0].report == CloseReport::Untracked);
     }
 
     SECTION("an activation carries the OSC identifier")

--- a/src/contour/platform/FreeDesktopNotifier_test.cpp
+++ b/src/contour/platform/FreeDesktopNotifier_test.cpp
@@ -269,10 +269,7 @@ TEST_CASE("FreeDesktopNotifier drives the real D-Bus transport without waiting",
     auto notifier = contour::platform::makeDesktopNotifier(std::chrono::milliseconds { 10000 });
     REQUIRE(notifier != nullptr);
 
-    contour::test::checkReturnsWithoutWaiting([&](bool maySend) {
-        if (!maySend)
-            return;
-
+    contour::test::checkReturnsWithoutWaiting([&] {
         notifier->notify(aNotification("osc-real"));
         notifier->close("osc-real");
     });

--- a/src/contour/platform/FreeDesktopNotifier_test.cpp
+++ b/src/contour/platform/FreeDesktopNotifier_test.cpp
@@ -14,6 +14,7 @@
 
     #include <contour/platform/DBusNotificationTransport.hpp>
     #include <contour/platform/FreeDesktopNotifier.hpp>
+    #include <contour/test/NotificationFixtures.hpp>
 
     #include <QtCore/QCoreApplication>
     #include <QtCore/QStringList>
@@ -28,6 +29,7 @@
 
 using contour::platform::FreeDesktopNotifier;
 using contour::platform::NotificationTransport;
+using contour::test::aNotification;
 using vtbackend::CloseReport;
 
 namespace
@@ -102,15 +104,6 @@ class RecordingNotificationTransport final: public NotificationTransport
 void pump()
 {
     QCoreApplication::processEvents();
-}
-
-[[nodiscard]] vtbackend::DesktopNotification aNotification(std::string identifier)
-{
-    auto notification = vtbackend::DesktopNotification {};
-    notification.identifier = std::move(identifier);
-    notification.title = "Title";
-    notification.body = "Body";
-    return notification;
 }
 
 } // namespace
@@ -262,31 +255,19 @@ TEST_CASE("FreeDesktopNotifier closes only what is live", "[contour][notificatio
 TEST_CASE("FreeDesktopNotifier drives the real D-Bus transport without waiting",
           "[contour][notification][dbus]")
 {
-    // Everything above talks to a recorder, which cannot catch the bug this file exists for: that
-    // was in the D-Bus adapter, and specifically in it waiting. So this one case builds the notifier
-    // exactly as production does, against whatever session bus the machine running it has.
-    //
-    // test/e2e/notification-nonblocking.sh is what makes that bus interesting: there
-    // org.freedesktop.Notifications is activatable and never answers, which is what a desktop with
-    // its notification daemon disabled looks like, and what used to cost 25 seconds per session.
-    auto const startedAt = std::chrono::steady_clock::now();
-
+    // Built exactly as production does, against whatever session bus is there. @see
+    // contour::test::checkReturnsWithoutWaiting for what this is guarding and why the bound is what
+    // it is.
     auto notifier = contour::platform::makeDesktopNotifier(std::chrono::milliseconds { 10000 });
     REQUIRE(notifier != nullptr);
 
-    // Actually sending is gated, so that a run on a developer's own desktop does not pop a
-    // notification up at them and leave it there. The wedged-bus harness, where by construction
-    // nothing can be displayed, sets this and so covers the send path too.
-    if (qEnvironmentVariableIsSet("CONTOUR_TEST_NOTIFICATION_SEND"))
-    {
+    contour::test::checkReturnsWithoutWaiting([&](bool maySend) {
+        if (!maySend)
+            return;
+
         notifier->notify(aNotification("osc-real"));
         notifier->close("osc-real");
-    }
-    QCoreApplication::processEvents();
-
-    // Deliberately generous: this separates "returned promptly" from "waited out a 25-second D-Bus
-    // reply timeout", and is not trying to measure anything finer than that.
-    CHECK(std::chrono::steady_clock::now() - startedAt < std::chrono::seconds { 5 });
+    });
 }
 
 TEST_CASE("FreeDesktopNotifier reports server-side close and activation", "[contour][notification]")

--- a/src/contour/platform/FreeDesktopNotifier_test.cpp
+++ b/src/contour/platform/FreeDesktopNotifier_test.cpp
@@ -29,6 +29,7 @@
 
 using contour::platform::FreeDesktopNotifier;
 using contour::platform::NotificationTransport;
+using contour::platform::toFreedesktopUrgency;
 using contour::test::aNotification;
 using vtbackend::CloseReport;
 
@@ -107,6 +108,13 @@ void pump()
 }
 
 } // namespace
+
+TEST_CASE("buildFreedesktopNotifyArguments maps urgency onto the freedesktop byte", "[contour][notification]")
+{
+    STATIC_CHECK(toFreedesktopUrgency(vtbackend::NotificationUrgency::Low) == 0);
+    STATIC_CHECK(toFreedesktopUrgency(vtbackend::NotificationUrgency::Normal) == 1);
+    STATIC_CHECK(toFreedesktopUrgency(vtbackend::NotificationUrgency::Critical) == 2);
+}
 
 TEST_CASE("FreeDesktopNotifier sends nothing while being constructed", "[contour][notification]")
 {

--- a/src/contour/platform/NotificationIdMap.hpp
+++ b/src/contour/platform/NotificationIdMap.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace contour::platform
+{
+
+/// The identifier ⇄ server-id bookkeeping a desktop-notification backend needs, and the one place
+/// its invariant lives.
+///
+/// The relation has to be answerable from both ends: an outgoing notification asks "is one already
+/// live under this identifier, to replace?", while an incoming close or activation arrives naming
+/// only the numeric id. So it is held twice, in opposite directions, as exact mutual inverses --
+/// every entry in one direction has its counterpart in the other, and retiring a notification drops
+/// both.
+///
+/// It is a type of its own because it was written twice: NotificationRouter maps the OSC 99
+/// identifier to the id the notification server assigned, PortalNotificationTransport maps the
+/// portal's application-chosen id to the one it mints itself. Two copies of one invariant is two
+/// places to break it -- as both were, in the same way, by the same missing retirement.
+class NotificationIdMap
+{
+  public:
+    /// A notification's numeric id. Zero is freedesktop's "this is a new notification" sentinel, so
+    /// it never names a live notification and is safe as the "nothing is live" answer.
+    using ServerId = uint32_t;
+
+    /// The id live under @p identifier, if any.
+    /// @param identifier The identifier to look up.
+    /// @return The live id, or 0 when nothing is live under it.
+    [[nodiscard]] ServerId serverIdFor(std::string const& identifier) const noexcept
+    {
+        auto const it = _byIdentifier.find(identifier);
+        return it != _byIdentifier.end() ? it->second : ServerId { 0 };
+    }
+
+    /// Whether @p serverId names a live notification.
+    /// @param serverId The id to test.
+    /// @return Whether it is live.
+    [[nodiscard]] bool contains(ServerId serverId) const noexcept { return _byServerId.contains(serverId); }
+
+    /// Records @p serverId as the notification live under @p identifier, retiring whatever was live
+    /// under either name before.
+    ///
+    /// @p replacedId is retired as well as -- not instead of -- whatever @p identifier already
+    /// resolved to, because the caller cannot always name it: a notification sent under an
+    /// identifier whose previous send has not been answered yet has no id to name. Left behind,
+    /// that earlier entry answers its own close by retiring the LIVE notification, which can then
+    /// be neither closed nor replaced.
+    ///
+    /// @param identifier The identifier the notification was sent under.
+    /// @param serverId The id now live under it.
+    /// @param replacedId An id this notification supersedes, or 0 for none.
+    void record(std::string const& identifier, ServerId serverId, ServerId replacedId)
+    {
+        forget(replacedId);
+        forget(serverIdFor(identifier));
+
+        // A notification server is free to reissue an id once the notification wearing it is gone,
+        // so the incoming id is cleared of any stale identifier too.
+        forget(serverId);
+
+        _byServerId[serverId] = identifier;
+        _byIdentifier[identifier] = serverId;
+    }
+
+    /// Resolves @p identifier to its live id and retires it.
+    /// @param identifier The identifier to resolve.
+    /// @return The id, or nullopt when nothing is live under it.
+    [[nodiscard]] std::optional<ServerId> takeByIdentifier(std::string const& identifier)
+    {
+        auto const it = _byIdentifier.find(identifier);
+        if (it == _byIdentifier.end())
+            return std::nullopt;
+
+        auto const serverId = it->second;
+        _byServerId.erase(serverId);
+        _byIdentifier.erase(it);
+        return serverId;
+    }
+
+    /// Resolves @p serverId to its identifier and retires it.
+    /// @param serverId The id to resolve.
+    /// @return The identifier, or nullopt when the id names nothing of ours.
+    [[nodiscard]] std::optional<std::string> takeByServerId(ServerId serverId)
+    {
+        auto const it = _byServerId.find(serverId);
+        if (it == _byServerId.end())
+            return std::nullopt;
+
+        auto identifier = it->second;
+        _byIdentifier.erase(identifier);
+        _byServerId.erase(it);
+        return identifier;
+    }
+
+    /// Retires @p serverId in both directions; a no-op where it names nothing live.
+    /// @param serverId The id to forget.
+    void forget(ServerId serverId)
+    {
+        auto const it = _byServerId.find(serverId);
+        if (it == _byServerId.end())
+            return;
+
+        _byIdentifier.erase(it->second);
+        _byServerId.erase(it);
+    }
+
+  private:
+    std::unordered_map<ServerId, std::string> _byServerId;
+    std::unordered_map<std::string, ServerId> _byIdentifier;
+};
+
+} // namespace contour::platform

--- a/src/contour/platform/NotificationIdMap.hpp
+++ b/src/contour/platform/NotificationIdMap.hpp
@@ -38,11 +38,6 @@ class NotificationIdMap
         return it != _byIdentifier.end() ? it->second : ServerId { 0 };
     }
 
-    /// Whether @p serverId names a live notification.
-    /// @param serverId The id to test.
-    /// @return Whether it is live.
-    [[nodiscard]] bool contains(ServerId serverId) const noexcept { return _byServerId.contains(serverId); }
-
     /// Records @p serverId as the notification live under @p identifier, retiring whatever was live
     /// under either name before.
     ///
@@ -98,6 +93,7 @@ class NotificationIdMap
         return identifier;
     }
 
+  private:
     /// Retires @p serverId in both directions; a no-op where it names nothing live.
     /// @param serverId The id to forget.
     void forget(ServerId serverId)
@@ -110,7 +106,6 @@ class NotificationIdMap
         _byServerId.erase(it);
     }
 
-  private:
     std::unordered_map<ServerId, std::string> _byServerId;
     std::unordered_map<std::string, ServerId> _byIdentifier;
 };

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <contour/platform/NotificationIdMap.hpp>
+
 #include <vtbackend/DesktopNotification.hpp>
 
 #include <algorithm>
@@ -9,21 +11,21 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 namespace contour::platform
 {
 
-/// The dependency-free identifier-mapping and urgency policy shared by the desktop-notification
-/// backends. It owns the bidirectional OSC-id ⇄ server-id bookkeeping the D-Bus transport would
-/// otherwise tangle with the wire calls, so the routing logic (replace-in-place, close cleanup,
-/// server-close/activation dispatch) is unit-testable without a D-Bus session.
+/// The dependency-free routing policy the desktop-notification backends share: it says what the
+/// OSC 99 identifiers MEAN -- which notification an outgoing one replaces, which one a close or an
+/// activation is about, and how long to wait before assuming a close nobody reported. The
+/// bookkeeping underneath is NotificationIdMap; this names it in the protocol's own vocabulary, so
+/// the routing logic is unit-testable without a D-Bus session.
 ///
 /// The transport-specific numeric id type is @p ServerId (a D-Bus notification id is a uint32).
 class NotificationRouter
 {
   public:
-    using ServerId = uint32_t;
+    using ServerId = NotificationIdMap::ServerId;
 
     /// Maps a notification urgency onto the freedesktop.org urgency byte (0=low, 1=normal, 2=critical).
     /// @param urgency The backend urgency level.
@@ -87,8 +89,7 @@ class NotificationRouter
     /// @return The live server id to replace, or 0 for a fresh notification.
     [[nodiscard]] ServerId replacementFor(std::string const& oscIdentifier) const noexcept
     {
-        auto const it = _oscToServer.find(oscIdentifier);
-        return it != _oscToServer.end() ? it->second : ServerId { 0 };
+        return _ids.serverIdFor(oscIdentifier);
     }
 
     /// Records the server id the transport returned for a sent notification, updating the
@@ -98,20 +99,7 @@ class NotificationRouter
     /// @param replacedId The server id this notification replaced (0 if it was new).
     void onSent(std::string const& oscIdentifier, ServerId serverId, ServerId replacedId)
     {
-        if (replacedId != 0)
-            _serverToOsc.erase(replacedId);
-
-        // Whatever this identifier last resolved to goes too, even where the caller did not know to
-        // name it: a second notification sent under the same identifier before the first reply
-        // arrived carries replacedId 0, and would otherwise leave the earlier server id mapped to an
-        // identifier that no longer points back at it. That stale entry answers the earlier
-        // notification's close by retiring the LIVE one -- which can then neither be closed nor
-        // replaced, and whose close is reported against an instance that is already gone.
-        if (auto const previous = _oscToServer.find(oscIdentifier); previous != _oscToServer.end())
-            _serverToOsc.erase(previous->second);
-
-        _serverToOsc[serverId] = oscIdentifier;
-        _oscToServer[oscIdentifier] = serverId;
+        _ids.record(oscIdentifier, serverId, replacedId);
     }
 
     /// Resolves the server id to close for an OSC identifier and forgets the mapping. The caller
@@ -120,13 +108,7 @@ class NotificationRouter
     /// @return The server id to close, or nullopt if the identifier is not live.
     [[nodiscard]] std::optional<ServerId> takeForClose(std::string const& oscIdentifier)
     {
-        auto const it = _oscToServer.find(oscIdentifier);
-        if (it == _oscToServer.end())
-            return std::nullopt;
-        auto const serverId = it->second;
-        _serverToOsc.erase(serverId);
-        _oscToServer.erase(it);
-        return serverId;
+        return _ids.takeByIdentifier(oscIdentifier);
     }
 
     /// Resolves a server-side close/activation event back to its OSC identifier and forgets the
@@ -136,18 +118,12 @@ class NotificationRouter
     /// @return The OSC identifier, or nullopt if the server id is unknown (a foreign notification).
     [[nodiscard]] std::optional<std::string> takeForServerEvent(ServerId serverId)
     {
-        auto const it = _serverToOsc.find(serverId);
-        if (it == _serverToOsc.end())
-            return std::nullopt;
-        auto oscIdentifier = it->second;
-        _oscToServer.erase(oscIdentifier);
-        _serverToOsc.erase(it);
-        return oscIdentifier;
+        return _ids.takeByServerId(serverId);
     }
 
   private:
-    std::unordered_map<ServerId, std::string> _serverToOsc;
-    std::unordered_map<std::string, ServerId> _oscToServer;
+    /// The OSC 99 identifier ⇄ server id bookkeeping. @see NotificationIdMap.
+    NotificationIdMap _ids;
 };
 
 } // namespace contour::platform

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -3,6 +3,7 @@
 
 #include <vtbackend/DesktopNotification.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -65,8 +66,8 @@ class NotificationRouter
     ///
     /// @param timeout The notification's `w=` in milliseconds: >0 an explicit lifetime, 0 "never
     ///                auto-close" (kitty's meaning), <0 "the desktop's default".
-    /// @param configured The configured fallback; zero disables the assumption entirely.
-    /// @return How long to wait, or zero for "never assume it closed".
+    /// @param configured The configured fallback; zero or less disables the assumption entirely.
+    /// @return How long to wait, never negative; zero means "never assume it closed".
     [[nodiscard]] static constexpr std::chrono::milliseconds resolveCloseDelay(
         int timeout, std::chrono::milliseconds configured) noexcept
     {
@@ -74,7 +75,10 @@ class NotificationRouter
             return std::chrono::milliseconds { timeout };
         if (timeout == 0)
             return std::chrono::milliseconds { 0 };
-        return configured;
+
+        // A negative configuration value reads as "disabled" rather than travelling on to become a
+        // negative timer interval, which Qt refuses to start and complains about instead.
+        return std::max(configured, std::chrono::milliseconds { 0 });
     }
 
     /// The server id an outgoing notification should REPLACE, if one with the same OSC identifier is

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -63,8 +63,10 @@ class NotificationRouter
         return _ids.serverIdFor(oscIdentifier);
     }
 
-    /// Records the server id the transport returned for a sent notification, updating the
-    /// bidirectional mapping and dropping the stale reverse entry when this replaced @p replacedId.
+    /// Records the server id the transport returned for a sent notification.
+    ///
+    /// What that entails -- which stale entries go, and why the caller cannot always name them --
+    /// is stated once, at NotificationIdMap::record().
     /// @param oscIdentifier The OSC 99 identifier that was sent.
     /// @param serverId The id the notification server assigned.
     /// @param replacedId The server id this notification replaced (0 if it was new).

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -100,6 +100,16 @@ class NotificationRouter
     {
         if (replacedId != 0)
             _serverToOsc.erase(replacedId);
+
+        // Whatever this identifier last resolved to goes too, even where the caller did not know to
+        // name it: a second notification sent under the same identifier before the first reply
+        // arrived carries replacedId 0, and would otherwise leave the earlier server id mapped to an
+        // identifier that no longer points back at it. That stale entry answers the earlier
+        // notification's close by retiring the LIVE one -- which can then neither be closed nor
+        // replaced, and whose close is reported against an instance that is already gone.
+        if (auto const previous = _oscToServer.find(oscIdentifier); previous != _oscToServer.end())
+            _serverToOsc.erase(previous->second);
+
         _serverToOsc[serverId] = oscIdentifier;
         _oscToServer[oscIdentifier] = serverId;
     }

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <string_view>
 
 namespace contour::platform
 {
@@ -21,44 +20,16 @@ namespace contour::platform
 /// bookkeeping underneath is NotificationIdMap; this names it in the protocol's own vocabulary, so
 /// the routing logic is unit-testable without a D-Bus session.
 ///
+/// It speaks NEITHER wire format. How an urgency is spelled is the sending transport's business and
+/// lives beside the call that carries it -- @see buildFreedesktopNotifyArguments() and
+/// buildPortalNotificationOptions() -- so a third backend adds its table to its own header rather
+/// than to this one.
+///
 /// The transport-specific numeric id type is @p ServerId (a D-Bus notification id is a uint32).
 class NotificationRouter
 {
   public:
     using ServerId = NotificationIdMap::ServerId;
-
-    /// Maps a notification urgency onto the freedesktop.org urgency byte (0=low, 1=normal, 2=critical).
-    /// @param urgency The backend urgency level.
-    /// @return The freedesktop urgency byte; Normal (1) for any unrecognized value.
-    [[nodiscard]] static constexpr uint8_t toFreedesktopUrgency(
-        vtbackend::NotificationUrgency urgency) noexcept
-    {
-        switch (urgency)
-        {
-            case vtbackend::NotificationUrgency::Low: return 0;
-            case vtbackend::NotificationUrgency::Normal: return 1;
-            case vtbackend::NotificationUrgency::Critical: return 2;
-        }
-        return 1;
-    }
-
-    /// Maps a notification urgency onto the xdg-desktop-portal `priority` string.
-    ///
-    /// The portal names four levels where freedesktop has three, so its `high` has no counterpart
-    /// here and stays unused; Critical maps to `urgent`, the level that survives Do-Not-Disturb.
-    /// @param urgency The backend urgency level.
-    /// @return The portal priority string; `normal` for any unrecognized value.
-    [[nodiscard]] static constexpr std::string_view toPortalPriority(
-        vtbackend::NotificationUrgency urgency) noexcept
-    {
-        switch (urgency)
-        {
-            case vtbackend::NotificationUrgency::Low: return "low";
-            case vtbackend::NotificationUrgency::Normal: return "normal";
-            case vtbackend::NotificationUrgency::Critical: return "urgent";
-        }
-        return "normal";
-    }
 
     /// How long to wait before ASSUMING a notification was closed, where the desktop cannot say so.
     ///

--- a/src/contour/platform/NotificationRouter.hpp
+++ b/src/contour/platform/NotificationRouter.hpp
@@ -3,9 +3,11 @@
 
 #include <vtbackend/DesktopNotification.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace contour::platform
@@ -35,6 +37,44 @@ class NotificationRouter
             case vtbackend::NotificationUrgency::Critical: return 2;
         }
         return 1;
+    }
+
+    /// Maps a notification urgency onto the xdg-desktop-portal `priority` string.
+    ///
+    /// The portal names four levels where freedesktop has three, so its `high` has no counterpart
+    /// here and stays unused; Critical maps to `urgent`, the level that survives Do-Not-Disturb.
+    /// @param urgency The backend urgency level.
+    /// @return The portal priority string; `normal` for any unrecognized value.
+    [[nodiscard]] static constexpr std::string_view toPortalPriority(
+        vtbackend::NotificationUrgency urgency) noexcept
+    {
+        switch (urgency)
+        {
+            case vtbackend::NotificationUrgency::Low: return "low";
+            case vtbackend::NotificationUrgency::Normal: return "normal";
+            case vtbackend::NotificationUrgency::Critical: return "urgent";
+        }
+        return "normal";
+    }
+
+    /// How long to wait before ASSUMING a notification was closed, where the desktop cannot say so.
+    ///
+    /// A notification states its own lifetime through OSC 99's `w=`, and that always wins: the
+    /// application knows what it asked for. Only `w=-1` -- "use whatever the desktop does" -- has
+    /// nothing to go on, and falls back to the configured guess.
+    ///
+    /// @param timeout The notification's `w=` in milliseconds: >0 an explicit lifetime, 0 "never
+    ///                auto-close" (kitty's meaning), <0 "the desktop's default".
+    /// @param configured The configured fallback; zero disables the assumption entirely.
+    /// @return How long to wait, or zero for "never assume it closed".
+    [[nodiscard]] static constexpr std::chrono::milliseconds resolveCloseDelay(
+        int timeout, std::chrono::milliseconds configured) noexcept
+    {
+        if (timeout > 0)
+            return std::chrono::milliseconds { timeout };
+        if (timeout == 0)
+            return std::chrono::milliseconds { 0 };
+        return configured;
     }
 
     /// The server id an outgoing notification should REPLACE, if one with the same OSC identifier is

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -50,6 +50,10 @@ TEST_CASE("NotificationRouter resolves how long before a close is assumed", "[no
 
     // ... but an explicit `w=` still wins over a disabled fallback.
     STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/500, 0ms) == 500ms);
+
+    // A configuration file is free to say -1. That must read as "disabled" rather than travel on to
+    // become a negative timer interval, which Qt refuses to start and complains about instead.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/-1, -1ms) == 0ms);
 }
 
 TEST_CASE("NotificationRouter tracks a fresh notification and resolves its server event", "[notification]")

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -11,13 +11,45 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
+
 using contour::platform::NotificationRouter;
+using namespace std::chrono_literals;
 
 TEST_CASE("NotificationRouter maps urgency onto the freedesktop byte", "[notification]")
 {
     STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Low) == 0);
     STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Normal) == 1);
     STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Critical) == 2);
+}
+
+TEST_CASE("NotificationRouter maps urgency onto the portal priority string", "[notification]")
+{
+    // The portal names four levels to freedesktop's three, so Critical lands on `urgent` -- the one
+    // that survives Do-Not-Disturb -- and the portal's `high` has no source to come from.
+    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Low) == "low");
+    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Normal) == "normal");
+    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Critical) == "urgent");
+}
+
+TEST_CASE("NotificationRouter resolves how long before a close is assumed", "[notification]")
+{
+    // A notification that stated its own lifetime is answered on that, whatever the configuration
+    // says: the application already told us what it wanted.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/4200, 10000ms) == 4200ms);
+
+    // OSC 99 `w=0` means "never auto-close", so there is nothing to assume, ever.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/0, 10000ms) == 0ms);
+
+    // `w=-1` is "whatever the desktop does" -- the only case with nothing to go on, and so the only
+    // one the configured fallback answers.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/-1, 10000ms) == 10000ms);
+
+    // A zero fallback disables the assumption rather than making it instant.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/-1, 0ms) == 0ms);
+
+    // ... but an explicit `w=` still wins over a disabled fallback.
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/500, 0ms) == 500ms);
 }
 
 TEST_CASE("NotificationRouter tracks a fresh notification and resolves its server event", "[notification]")

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -90,6 +90,26 @@ TEST_CASE("NotificationRouter replaces a live notification in place", "[notifica
     CHECK(*oscId == "osc-a");
 }
 
+TEST_CASE("NotificationRouter drops the stale reverse entry of a re-sent identifier", "[notification]")
+{
+    // A transport does not wait for a reply, so a second notification carrying the same identifier
+    // can be sent while the first is still in flight -- and it is recorded with replacedId 0,
+    // because there was no server id to name when it was sent. Were the earlier server id left
+    // mapped, its close event would retire the LIVE notification: the popup still on screen could
+    // then be neither closed nor replaced, and its close would be reported for an instance that is
+    // already gone.
+    NotificationRouter router;
+    router.onSent("osc-a", 100, /*replacedId*/ 0);
+    router.onSent("osc-a", 200, /*replacedId*/ 0);
+
+    CHECK_FALSE(router.takeForServerEvent(100).has_value());
+    CHECK(router.replacementFor("osc-a") == 200);
+
+    auto const oscId = router.takeForServerEvent(200);
+    REQUIRE(oscId.has_value());
+    CHECK(*oscId == "osc-a");
+}
+
 TEST_CASE("NotificationRouter close resolves and forgets the mapping", "[notification]")
 {
     NotificationRouter router;

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -36,20 +36,20 @@ TEST_CASE("NotificationRouter resolves how long before a close is assumed", "[no
 {
     // A notification that stated its own lifetime is answered on that, whatever the configuration
     // says: the application already told us what it wanted.
-    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/4200, 10000ms) == 4200ms);
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/4200, 10000ms) == 4200ms);
 
     // OSC 99 `w=0` means "never auto-close", so there is nothing to assume, ever.
-    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/0, 10000ms) == 0ms);
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/0, 10000ms) == 0ms);
 
     // `w=-1` is "whatever the desktop does" -- the only case with nothing to go on, and so the only
     // one the configured fallback answers.
-    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/-1, 10000ms) == 10000ms);
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/-1, 10000ms) == 10000ms);
 
     // A zero fallback disables the assumption rather than making it instant.
-    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/-1, 0ms) == 0ms);
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/-1, 0ms) == 0ms);
 
     // ... but an explicit `w=` still wins over a disabled fallback.
-    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*w=*/500, 0ms) == 500ms);
+    STATIC_CHECK(NotificationRouter::resolveCloseDelay(/*timeout=*/500, 0ms) == 500ms);
 }
 
 TEST_CASE("NotificationRouter tracks a fresh notification and resolves its server event", "[notification]")

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -110,6 +110,24 @@ TEST_CASE("NotificationRouter drops the stale reverse entry of a re-sent identif
     CHECK(*oscId == "osc-a");
 }
 
+TEST_CASE("NotificationRouter accepts a server id reissued under a new identifier", "[notification]")
+{
+    // A notification server is free to hand out an id again once the notification wearing it is
+    // gone, and nothing obliges it to tell us the first one closed -- an assumed close retires our
+    // side only. The incoming id must therefore arrive cleared of whatever it used to name, or the
+    // two directions disagree about who owns it.
+    NotificationRouter router;
+    router.onSent("osc-a", 100, /*replacedId*/ 0);
+    router.onSent("osc-b", 100, /*replacedId*/ 0);
+
+    CHECK(router.replacementFor("osc-a") == 0);
+    CHECK(router.replacementFor("osc-b") == 100);
+
+    auto const oscId = router.takeForServerEvent(100);
+    REQUIRE(oscId.has_value());
+    CHECK(*oscId == "osc-b");
+}
+
 TEST_CASE("NotificationRouter close resolves and forgets the mapping", "[notification]")
 {
     NotificationRouter router;

--- a/src/contour/platform/NotificationRouter_test.cpp
+++ b/src/contour/platform/NotificationRouter_test.cpp
@@ -16,22 +16,6 @@
 using contour::platform::NotificationRouter;
 using namespace std::chrono_literals;
 
-TEST_CASE("NotificationRouter maps urgency onto the freedesktop byte", "[notification]")
-{
-    STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Low) == 0);
-    STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Normal) == 1);
-    STATIC_CHECK(NotificationRouter::toFreedesktopUrgency(vtbackend::NotificationUrgency::Critical) == 2);
-}
-
-TEST_CASE("NotificationRouter maps urgency onto the portal priority string", "[notification]")
-{
-    // The portal names four levels to freedesktop's three, so Critical lands on `urgent` -- the one
-    // that survives Do-Not-Disturb -- and the portal's `high` has no source to come from.
-    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Low) == "low");
-    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Normal) == "normal");
-    STATIC_CHECK(NotificationRouter::toPortalPriority(vtbackend::NotificationUrgency::Critical) == "urgent");
-}
-
 TEST_CASE("NotificationRouter resolves how long before a close is assumed", "[notification]")
 {
     // A notification that stated its own lifetime is answered on that, whatever the configuration

--- a/src/contour/platform/NotificationTransport.hpp
+++ b/src/contour/platform/NotificationTransport.hpp
@@ -3,8 +3,6 @@
 
 #include <contour/platform/NotificationRouter.hpp>
 
-#include <QtCore/QVariantList>
-
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -12,11 +10,17 @@
 namespace contour::platform
 {
 
-/// The org.freedesktop.Notifications method-call transport a FreeDesktopNotifier speaks.
+/// The desktop-notification method-call transport a FreeDesktopNotifier speaks.
 ///
 /// An interface for the reason Announcer gives: the DECISIONS -- which method is sent with which
 /// arguments, and how a reply feeds the identifier bookkeeping -- are the part worth testing, and a
 /// headless test has no notification daemon to observe the delivery through.
+///
+/// Two implementations exist and they do NOT speak the same protocol: DBusNotificationTransport
+/// talks to org.freedesktop.Notifications on the session bus, PortalNotificationTransport to
+/// org.freedesktop.portal.Notification (the only one a Flatpak sandbox can reach). This interface
+/// is therefore stated in the DOMAIN type, not in either wire format -- each implementation builds
+/// its own arguments, and neither has to read a shape it does not speak. @see issue #2074.
 ///
 /// It also pins down the property this seam exists to protect: **no implementation may wait for a
 /// reply**. A desktop that is not answering must cost nothing, because these calls are made while a
@@ -26,12 +30,14 @@ class NotificationTransport
   public:
     using ServerId = NotificationRouter::ServerId;
 
-    /// Invoked with the server-assigned notification id, or nullopt if the call failed.
+    /// Invoked with the notification id assigned to the sent notification, or nullopt if the call
+    /// failed. The id is the notification server's where the server assigns one, and the
+    /// transport's own where it does not.
     using SentHandler = std::function<void(std::optional<ServerId>)>;
 
-    /// Invoked when the desktop closed a notification. @param reason 1=expired, 2=dismissed,
-    /// 3=closed on request, 4=undefined.
-    using ClosedHandler = std::function<void(ServerId, uint32_t reason)>;
+    /// Invoked when a notification was closed. @param reason 1=expired, 2=dismissed, 3=closed on
+    /// request, 4=undefined. @param report Whether the close was observed or merely assumed.
+    using ClosedHandler = std::function<void(ServerId, uint32_t reason, vtbackend::CloseReport report)>;
 
     /// Invoked when the user activated a notification.
     using ActivatedHandler = std::function<void(ServerId)>;
@@ -43,18 +49,21 @@ class NotificationTransport
     NotificationTransport& operator=(NotificationTransport&&) = delete;
     virtual ~NotificationTransport() = default;
 
-    /// Sends `Notify`, returning WITHOUT waiting for its reply.
+    /// Sends the notification, returning WITHOUT waiting for its reply.
     ///
-    /// @param arguments The freedesktop Notify arguments, in wire order.
-    /// @param onSent    Called later, on the caller's thread, with the assigned id.
-    virtual void notify(QVariantList arguments, SentHandler onSent) = 0;
+    /// @param notification What to show.
+    /// @param replacesId   A live id this notification supersedes, or 0 when it is a fresh one.
+    /// @param onSent       Called later, on the caller's thread, with the assigned id.
+    virtual void notify(vtbackend::DesktopNotification const& notification,
+                        ServerId replacesId,
+                        SentHandler onSent) = 0;
 
-    /// Sends `CloseNotification`, returning WITHOUT waiting for its reply.
-    /// @param serverId The id the notification server assigned.
+    /// Withdraws a notification, returning WITHOUT waiting for its reply.
+    /// @param serverId The id this notification was sent under.
     virtual void close(ServerId serverId) = 0;
 
-    /// Subscribes to the server's NotificationClosed and ActionInvoked signals. Called once, by the
-    /// notifier's constructor, and undone when the transport is destroyed.
+    /// Subscribes to the backend's close and activation events. Called once, by the notifier's
+    /// constructor, and undone when the transport is destroyed.
     virtual void subscribe(ClosedHandler onClosed, ActivatedHandler onActivated) = 0;
 };
 
@@ -65,7 +74,11 @@ class NotificationTransport
 class NullNotificationTransport final: public NotificationTransport
 {
   public:
-    void notify(QVariantList /*arguments*/, SentHandler /*onSent*/) override {}
+    void notify(vtbackend::DesktopNotification const& /*notification*/,
+                ServerId /*replacesId*/,
+                SentHandler /*onSent*/) override
+    {
+    }
     void close(ServerId /*serverId*/) override {}
     void subscribe(ClosedHandler /*onClosed*/, ActivatedHandler /*onActivated*/) override {}
 };

--- a/src/contour/platform/Notifier.cpp
+++ b/src/contour/platform/Notifier.cpp
@@ -2,9 +2,6 @@
 #include <contour/platform/NotificationTransport.hpp>
 #include <contour/platform/Notifier.hpp>
 
-#include <QtCore/QUuid>
-
-#include <atomic>
 #include <format>
 
 #ifdef __linux__
@@ -33,23 +30,6 @@ namespace
 
 } // namespace
 #endif
-
-std::string makePortalIdPrefix()
-{
-    // A random per-process component rather than the process id, because the process id is exactly
-    // what a sandbox takes away: Flatpak runs every instance in its own PID namespace, so two
-    // Contour instances -- the only case where a collision between processes is possible at all --
-    // both report a small, identical pid. A UUID is unique wherever a pid is, and stays unique
-    // where a pid stops being.
-    static auto const processNamespace = QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString();
-
-    // A plain counter rather than anything meaningful: the only requirement is that no two
-    // transports in this process share a namespace. Atomic because sessions are created from more
-    // than one thread.
-    static auto nextNamespace = std::atomic<uint64_t> { 0 };
-
-    return std::format("contour-{}-{}", processNamespace, ++nextNamespace);
-}
 
 std::unique_ptr<NotificationTransport> makeNotificationTransport(
     [[maybe_unused]] NotificationBackend backend, [[maybe_unused]] std::chrono::milliseconds closeDelay)

--- a/src/contour/platform/Notifier.cpp
+++ b/src/contour/platform/Notifier.cpp
@@ -1,18 +1,69 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <contour/platform/NotificationTransport.hpp>
 #include <contour/platform/Notifier.hpp>
+
+#include <QtCore/QCoreApplication>
+
+#include <atomic>
+#include <format>
 
 #ifdef __linux__
     #include <contour/platform/DBusNotificationTransport.hpp>
     #include <contour/platform/FreeDesktopNotifier.hpp>
+    #include <contour/platform/PortalNotificationTransport.hpp>
+
+    #include <vtpty/Process.hpp>
 #endif
 
 namespace contour::platform
 {
 
-std::unique_ptr<Notifier> makeDesktopNotifier()
+#ifdef __linux__
+namespace
+{
+    /// Where this process is running.
+    ///
+    /// vtpty::Process::isFlatpak() answers with a bool -- a signature this layer does not own -- so
+    /// the conversion into the named state happens here, at the boundary, and nothing below deals
+    /// in the anonymous form.
+    [[nodiscard]] SandboxState currentSandboxState() noexcept
+    {
+        return vtpty::Process::isFlatpak() ? SandboxState::Flatpak : SandboxState::Host;
+    }
+
+} // namespace
+#endif
+
+std::string makePortalIdPrefix()
+{
+    // A plain counter rather than anything meaningful: the only requirement is that no two
+    // transports in this process share a namespace. Atomic because sessions are created from more
+    // than one thread.
+    static auto nextNamespace = std::atomic<uint64_t> { 0 };
+
+    return std::format("contour-{}-{}", QCoreApplication::applicationPid(), ++nextNamespace);
+}
+
+std::unique_ptr<NotificationTransport> makeNotificationTransport(
+    [[maybe_unused]] NotificationBackend backend, [[maybe_unused]] std::chrono::milliseconds closeDelay)
 {
 #ifdef __linux__
-    return std::make_unique<FreeDesktopNotifier>(std::make_unique<DBusNotificationTransport>());
+    switch (backend)
+    {
+        case NotificationBackend::FreeDesktop: return std::make_unique<DBusNotificationTransport>();
+        case NotificationBackend::Portal:
+            return std::make_unique<PortalNotificationTransport>(
+                closeDelay, makePortalIdPrefix(), qtDelayScheduler(), qtPortalCaller());
+    }
+#endif
+    return std::make_unique<NullNotificationTransport>();
+}
+
+std::unique_ptr<Notifier> makeDesktopNotifier([[maybe_unused]] std::chrono::milliseconds closeDelay)
+{
+#ifdef __linux__
+    auto const backend = selectNotificationBackend(currentSandboxState());
+    return std::make_unique<FreeDesktopNotifier>(makeNotificationTransport(backend, closeDelay));
 #else
     return std::make_unique<NullNotifier>();
 #endif

--- a/src/contour/platform/Notifier.cpp
+++ b/src/contour/platform/Notifier.cpp
@@ -2,7 +2,7 @@
 #include <contour/platform/NotificationTransport.hpp>
 #include <contour/platform/Notifier.hpp>
 
-#include <QtCore/QCoreApplication>
+#include <QtCore/QUuid>
 
 #include <atomic>
 #include <format>
@@ -36,12 +36,19 @@ namespace
 
 std::string makePortalIdPrefix()
 {
+    // A random per-process component rather than the process id, because the process id is exactly
+    // what a sandbox takes away: Flatpak runs every instance in its own PID namespace, so two
+    // Contour instances -- the only case where a collision between processes is possible at all --
+    // both report a small, identical pid. A UUID is unique wherever a pid is, and stays unique
+    // where a pid stops being.
+    static auto const processNamespace = QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString();
+
     // A plain counter rather than anything meaningful: the only requirement is that no two
     // transports in this process share a namespace. Atomic because sessions are created from more
     // than one thread.
     static auto nextNamespace = std::atomic<uint64_t> { 0 };
 
-    return std::format("contour-{}-{}", QCoreApplication::applicationPid(), ++nextNamespace);
+    return std::format("contour-{}-{}", processNamespace, ++nextNamespace);
 }
 
 std::unique_ptr<NotificationTransport> makeNotificationTransport(

--- a/src/contour/platform/Notifier.hpp
+++ b/src/contour/platform/Notifier.hpp
@@ -112,7 +112,11 @@ enum class NotificationBackend : uint8_t
 /// same OSC 99 identifier -- so a per-process prefix alone would have them collide, replacing each
 /// other's popups and each answering the other's activation. Hence unique per call, not per process.
 ///
-/// @return The prefix, of the shape `contour-<pid>-<n>`.
+/// The per-process half is random rather than the process id, because a sandbox is precisely where
+/// a process id stops identifying anything: Flatpak gives every instance its own PID namespace, so
+/// two sandboxed Contours both see a small, identical pid.
+///
+/// @return The prefix, of the shape `contour-<uuid>-<n>`.
 [[nodiscard]] std::string makePortalIdPrefix();
 
 /// The transport for a given backend.

--- a/src/contour/platform/Notifier.hpp
+++ b/src/contour/platform/Notifier.hpp
@@ -103,22 +103,6 @@ enum class NotificationBackend : uint8_t
     return NotificationBackend::FreeDesktop;
 }
 
-/// A fresh portal-notification id namespace, unique within this process and across calls.
-///
-/// Portal notification ids are chosen by the application, and two things make a namespace
-/// necessary. Between processes: the portal's ActionInvoked signal is broadcast and carries no app
-/// id, so another sandboxed application's notification "1" would be indistinguishable from ours.
-/// WITHIN one process: a transport is built per terminal session, and two panes are free to use the
-/// same OSC 99 identifier -- so a per-process prefix alone would have them collide, replacing each
-/// other's popups and each answering the other's activation. Hence unique per call, not per process.
-///
-/// The per-process half is random rather than the process id, because a sandbox is precisely where
-/// a process id stops identifying anything: Flatpak gives every instance its own PID namespace, so
-/// two sandboxed Contours both see a small, identical pid.
-///
-/// @return The prefix, of the shape `contour-<uuid>-<n>`.
-[[nodiscard]] std::string makePortalIdPrefix();
-
 /// The transport for a given backend.
 ///
 /// Separate from makeDesktopNotifier() so the dispatch is reachable without the sandbox that would

--- a/src/contour/platform/Notifier.hpp
+++ b/src/contour/platform/Notifier.hpp
@@ -6,11 +6,15 @@
 #include <QtCore/QObject>
 #include <QtCore/QString>
 
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 
 namespace contour::platform
 {
+
+class NotificationTransport;
 
 /// The desktop-notification capability a terminal session reaches for.
 ///
@@ -43,7 +47,8 @@ class Notifier: public QObject
     ///
     /// @param identifier the OSC 99 identifier of the closed notification.
     /// @param reason the D-Bus close reason code (1=expired, 2=dismissed, 3=closed, 4=undefined).
-    void notificationClosed(QString identifier, uint reason);
+    /// @param report whether the desktop reported the close, or a timer merely assumed it.
+    void notificationClosed(QString identifier, uint reason, vtbackend::CloseReport report);
 
     /// Emitted when the user interacts with a notification.
     ///
@@ -65,11 +70,76 @@ class NullNotifier final: public Notifier
     void close(std::string const& /*identifier*/) override {}
 };
 
+/// Whether this process runs inside an application sandbox, and which.
+enum class SandboxState : uint8_t
+{
+    Host = 0,    ///< No sandbox: the session bus is reachable by name.
+    Flatpak = 1, ///< A Flatpak sandbox: only the portals are reachable without a static permission.
+};
+
+/// Which service a notifier should talk to.
+enum class NotificationBackend : uint8_t
+{
+    FreeDesktop = 0, ///< org.freedesktop.Notifications on the session bus.
+    Portal = 1,      ///< org.freedesktop.portal.Notification.
+};
+
+/// The notification service a given sandbox state can reach.
+///
+/// The portal is chosen ONLY when sandboxed, not wherever it happens to exist. On the host,
+/// org.freedesktop.Notifications is strictly the more capable of the two: it reports that a
+/// notification was dismissed, which the portal cannot, so preferring the portal everywhere would
+/// trade away a working OSC 99 `c=1` close report for uniformity.
+///
+/// @param sandbox Where this process is running.
+/// @return The backend to construct.
+[[nodiscard]] constexpr NotificationBackend selectNotificationBackend(SandboxState sandbox) noexcept
+{
+    switch (sandbox)
+    {
+        case SandboxState::Host: return NotificationBackend::FreeDesktop;
+        case SandboxState::Flatpak: return NotificationBackend::Portal;
+    }
+    return NotificationBackend::FreeDesktop;
+}
+
+/// A fresh portal-notification id namespace, unique within this process and across calls.
+///
+/// Portal notification ids are chosen by the application, and two things make a namespace
+/// necessary. Between processes: the portal's ActionInvoked signal is broadcast and carries no app
+/// id, so another sandboxed application's notification "1" would be indistinguishable from ours.
+/// WITHIN one process: a transport is built per terminal session, and two panes are free to use the
+/// same OSC 99 identifier -- so a per-process prefix alone would have them collide, replacing each
+/// other's popups and each answering the other's activation. Hence unique per call, not per process.
+///
+/// @return The prefix, of the shape `contour-<pid>-<n>`.
+[[nodiscard]] std::string makePortalIdPrefix();
+
+/// The transport for a given backend.
+///
+/// Separate from makeDesktopNotifier() so the dispatch is reachable without the sandbox that would
+/// otherwise be the only way to select the portal: on Linux every branch is constructible here, and
+/// on other platforms this is always the null transport.
+///
+/// @param backend Which service to talk to.
+/// @param closeDelay Passed to a backend that cannot observe a close; ignored by one that can.
+/// @return The transport; never null.
+[[nodiscard]] std::unique_ptr<NotificationTransport> makeNotificationTransport(
+    NotificationBackend backend, std::chrono::milliseconds closeDelay);
+
 /// The notifier this platform can offer.
 ///
-/// A FreeDesktopNotifier over D-Bus on Linux, a NullNotifier everywhere else. Mirrors
-/// makeSpeechSynthesizer(): the platform split lives here, so nothing above this layer needs an
-/// #ifdef to hold a notifier.
-[[nodiscard]] std::unique_ptr<Notifier> makeDesktopNotifier();
+/// A FreeDesktopNotifier on Linux -- over the session bus or over the portal, depending on whether
+/// this process is sandboxed -- and a NullNotifier everywhere else. Mirrors makeSpeechSynthesizer():
+/// the platform split lives here, so nothing above this layer needs an #ifdef to hold a notifier.
+///
+/// @param closeDelay How long a backend that cannot observe a close should wait before assuming
+///                   one. Zero never assumes. Ignored by backends that can observe it.
+/// @return The notifier; never null.
+[[nodiscard]] std::unique_ptr<Notifier> makeDesktopNotifier(std::chrono::milliseconds closeDelay);
 
 } // namespace contour::platform
+
+// So the notificationClosed signal survives a queued connection, where Qt must copy its arguments
+// through the metatype system rather than pass them on the stack.
+Q_DECLARE_METATYPE(vtbackend::CloseReport)

--- a/src/contour/platform/Notifier_test.cpp
+++ b/src/contour/platform/Notifier_test.cpp
@@ -12,7 +12,6 @@
 #include <chrono>
 
 using contour::platform::makeNotificationTransport;
-using contour::platform::makePortalIdPrefix;
 using contour::platform::NotificationBackend;
 using contour::platform::SandboxState;
 using contour::platform::selectNotificationBackend;
@@ -42,17 +41,4 @@ TEST_CASE("makeNotificationTransport builds every backend it names", "[contour][
 
     CHECK(makeNotificationTransport(NotificationBackend::FreeDesktop, 10000ms) != nullptr);
     CHECK(makeNotificationTransport(NotificationBackend::Portal, 10000ms) != nullptr);
-}
-
-TEST_CASE("makePortalIdPrefix hands out a fresh namespace every time", "[contour][notification]")
-{
-    // A transport is built per terminal session, and two panes are free to pick the same OSC 99
-    // identifier. Were the namespace merely per-process, their portal ids would be equal: the portal
-    // would replace one pane's popup with the other's, and because ActionInvoked is broadcast, a
-    // click on either would be reported back by BOTH sessions.
-    auto const first = makePortalIdPrefix();
-    auto const second = makePortalIdPrefix();
-
-    CHECK(first != second);
-    CHECK(first.starts_with("contour-"));
 }

--- a/src/contour/platform/Notifier_test.cpp
+++ b/src/contour/platform/Notifier_test.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the notification backend selection — which desktop-notification service a given
+// sandbox state can actually reach. Pure and constexpr, so the choice is pinned without needing a
+// Flatpak sandbox to run inside of. @see issue #2074.
+
+#include <contour/platform/NotificationTransport.hpp>
+#include <contour/platform/Notifier.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+
+using contour::platform::makeNotificationTransport;
+using contour::platform::makePortalIdPrefix;
+using contour::platform::NotificationBackend;
+using contour::platform::SandboxState;
+using contour::platform::selectNotificationBackend;
+
+TEST_CASE("selectNotificationBackend prefers the session bus off the sandbox", "[contour][notification]")
+{
+    // org.freedesktop.Notifications is strictly the more capable of the two: it reports that a
+    // notification was dismissed, which the portal cannot. Preferring the portal everywhere would
+    // trade a working OSC 99 `c=1` close report away for uniformity.
+    STATIC_CHECK(selectNotificationBackend(SandboxState::Host) == NotificationBackend::FreeDesktop);
+}
+
+TEST_CASE("selectNotificationBackend uses the portal inside a sandbox", "[contour][notification]")
+{
+    // Inside Flatpak the session-bus name is unreachable without --talk-name, which Flathub
+    // declines to grant; the portal needs no static permission at all.
+    STATIC_CHECK(selectNotificationBackend(SandboxState::Flatpak) == NotificationBackend::Portal);
+}
+
+TEST_CASE("makeNotificationTransport builds every backend it names", "[contour][notification]")
+{
+    // Reachable here without the sandbox that would otherwise be the only way to select the portal,
+    // so the enumerator is a tested row rather than a branch nobody off Flatpak ever compiles into
+    // existence. Nothing is sent: constructing a transport costs no round-trip, which is the
+    // property the whole seam exists to protect (issue #2051).
+    using namespace std::chrono_literals;
+
+    CHECK(makeNotificationTransport(NotificationBackend::FreeDesktop, 10000ms) != nullptr);
+    CHECK(makeNotificationTransport(NotificationBackend::Portal, 10000ms) != nullptr);
+}
+
+TEST_CASE("makePortalIdPrefix hands out a fresh namespace every time", "[contour][notification]")
+{
+    // A transport is built per terminal session, and two panes are free to pick the same OSC 99
+    // identifier. Were the namespace merely per-process, their portal ids would be equal: the portal
+    // would replace one pane's popup with the other's, and because ActionInvoked is broadcast, a
+    // click on either would be reported back by BOTH sessions.
+    auto const first = makePortalIdPrefix();
+    auto const second = makePortalIdPrefix();
+
+    CHECK(first != second);
+    CHECK(first.starts_with("contour-"));
+}

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -160,6 +160,15 @@ void PortalNotificationTransport::notify(vtbackend::DesktopNotification const& n
             // Recorded only now, and only on success -- exactly when NotificationRouter records
             // its own mapping, so a failed send leaves the previous notification still live and
             // still replaceable.
+            //
+            // Retired by PORTAL ID rather than by replacesId alone, because the two maps must stay
+            // exact mutual inverses and the caller cannot always see the collision: a second send
+            // of the same OSC identifier issued before the first AddNotification was answered
+            // carries replacesId 0, yet lands on the very same portal id. Keying on the id the
+            // portal itself replaces by is what makes "one portal id, one live server id"
+            // structural instead of something the caller has to get right.
+            if (auto const previous = _serverIds.find(portalId); previous != _serverIds.end())
+                retire(previous->second);
             if (replacesId != 0)
                 retire(replacesId);
             _portalIds[serverId] = portalId;

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -140,14 +140,6 @@ PortalNotificationTransport::PortalNotificationTransport(std::chrono::millisecon
 {
 }
 
-PortalNotificationTransport::~PortalNotificationTransport()
-{
-    if (_subscription == DBusSubscriptionState::NotSubscribed)
-        return;
-
-    unsubscribeFromDBusSignals(_bus, PortalSource, this, signalSubscriptions());
-}
-
 std::string PortalNotificationTransport::portalIdFor(std::string const& identifier) const
 {
     return std::format("{}/{}", _idPrefix, identifier);
@@ -215,8 +207,7 @@ void PortalNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHan
 
     // Only the activation signal exists to subscribe to; the portal has no close signal at all, so
     // _onClosed is driven by the timer instead.
-    subscribeToDBusSignals(_bus, PortalSource, this, signalSubscriptions());
-    _subscription = DBusSubscriptionState::Subscribed;
+    _subscription = subscribeToDBusSignals(_bus, PortalSource, this, signalSubscriptions());
 }
 
 void PortalNotificationTransport::onActionInvoked(QString const& identifier,

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -111,11 +111,8 @@ PortalCaller qtPortalCaller()
 
 std::string makePortalIdPrefix()
 {
-    // A random per-process component rather than the process id, because the process id is exactly
-    // what a sandbox takes away: Flatpak runs every instance in its own PID namespace, so two
-    // Contour instances -- the only case where a collision between processes is possible at all --
-    // both report a small, identical pid. A UUID is unique wherever a pid is, and stays unique
-    // where a pid stops being.
+    // Random rather than the process id, for the reason the declaration gives: a sandbox is
+    // exactly where a pid stops identifying anything.
     static auto const processNamespace = QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString();
 
     // A plain counter rather than anything meaningful: the only requirement is that no two

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -6,11 +6,13 @@
     #include <contour/platform/PortalNotificationTransport.hpp>
 
     #include <QtCore/QTimer>
+    #include <QtCore/QUuid>
     #include <QtDBus/QDBusMessage>
     #include <QtDBus/QDBusPendingCallWatcher>
     #include <QtDBus/QDBusPendingReply>
 
     #include <array>
+    #include <atomic>
     #include <format>
     #include <utility>
 
@@ -53,7 +55,7 @@ namespace
 
 QVariantMap buildPortalNotificationOptions(vtbackend::DesktopNotification const& notification)
 {
-    auto const priority = NotificationRouter::toPortalPriority(notification.urgency);
+    auto const priority = toPortalPriority(notification.urgency);
 
     auto options = QVariantMap {};
 
@@ -105,6 +107,23 @@ PortalCaller qtPortalCaller()
                 onReply(reply.isError() ? CallOutcome::Failed : CallOutcome::Accepted);
             });
     };
+}
+
+std::string makePortalIdPrefix()
+{
+    // A random per-process component rather than the process id, because the process id is exactly
+    // what a sandbox takes away: Flatpak runs every instance in its own PID namespace, so two
+    // Contour instances -- the only case where a collision between processes is possible at all --
+    // both report a small, identical pid. A UUID is unique wherever a pid is, and stays unique
+    // where a pid stops being.
+    static auto const processNamespace = QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString();
+
+    // A plain counter rather than anything meaningful: the only requirement is that no two
+    // transports in this process share a namespace. Atomic because sessions are created from more
+    // than one thread.
+    static auto nextNamespace = std::atomic<uint64_t> { 0 };
+
+    return std::format("contour-{}-{}", processNamespace, ++nextNamespace);
 }
 
 PortalNotificationTransport::PortalNotificationTransport(std::chrono::milliseconds closeDelay,

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -82,11 +82,11 @@ PortalCaller qtPortalCaller()
 {
     return [bus = QDBusConnection::sessionBus()](QObject* context,
                                                  QLatin1StringView method,
-                                                 QVariantList arguments,
+                                                 QVariantList const& arguments,
                                                  std::function<void(CallOutcome)> onReply) {
         auto message = QDBusMessage::createMethodCall(
             PortalSource.service, PortalSource.path, PortalSource.interface, method);
-        message.setArguments(std::move(arguments));
+        message.setArguments(arguments);
 
         auto pending = bus.asyncCall(message, CallTimeoutMilliseconds);
         if (!onReply)

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -27,10 +27,6 @@ namespace
         .interface = QLatin1StringView("org.freedesktop.portal.Notification"),
     };
 
-    // Below Qt's 25-second default, for the reason DBusNotificationTransport gives: losing an
-    // AddNotification reply costs only this notification's bookkeeping.
-    constexpr auto CallTimeoutMilliseconds = 5000;
-
     // The freedesktop close reason reported for an assumed close. There is no "we guessed" reason
     // in that enumeration, and "expired" is the closest true statement: the time we waited is up.
     // What actually distinguishes it is the CloseReport carried alongside.
@@ -88,7 +84,7 @@ PortalCaller qtPortalCaller()
             PortalSource.service, PortalSource.path, PortalSource.interface, method);
         message.setArguments(arguments);
 
-        auto pending = bus.asyncCall(message, CallTimeoutMilliseconds);
+        auto pending = bus.asyncCall(message, DBusCallTimeoutMilliseconds);
         if (!onReply)
             return; // Sent and forgotten: nothing in this reply is acted on.
 

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -127,7 +127,7 @@ PortalNotificationTransport::PortalNotificationTransport(std::chrono::millisecon
 
 PortalNotificationTransport::~PortalNotificationTransport()
 {
-    if (!_onActivated)
+    if (_subscription == DBusSubscriptionState::NotSubscribed)
         return;
 
     unsubscribeFromDBusSignals(_bus, PortalSource, this, signalSubscriptions());
@@ -205,6 +205,7 @@ void PortalNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHan
     // Only the activation signal exists to subscribe to; the portal has no close signal at all, so
     // _onClosed is driven by the timer instead.
     subscribeToDBusSignals(_bus, PortalSource, this, signalSubscriptions());
+    _subscription = DBusSubscriptionState::Subscribed;
 }
 
 void PortalNotificationTransport::onActionInvoked(QString const& identifier,

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifdef __linux__
+
+    #include <contour/Logging.hpp>
+    #include <contour/platform/DBusSignalSubscription.hpp>
+    #include <contour/platform/PortalNotificationTransport.hpp>
+
+    #include <QtCore/QTimer>
+    #include <QtDBus/QDBusMessage>
+    #include <QtDBus/QDBusPendingCallWatcher>
+    #include <QtDBus/QDBusPendingReply>
+
+    #include <array>
+    #include <format>
+    #include <utility>
+
+namespace contour::platform
+{
+
+namespace
+{
+    // The portal is always at this one name, path and interface -- it is the sandbox's single
+    // entry point, so there is nothing to discover.
+    constexpr auto PortalSource = DBusSignalSource {
+        .service = QLatin1StringView("org.freedesktop.portal.Desktop"),
+        .path = QLatin1StringView("/org/freedesktop/portal/desktop"),
+        .interface = QLatin1StringView("org.freedesktop.portal.Notification"),
+    };
+
+    // Below Qt's 25-second default, for the reason DBusNotificationTransport gives: losing an
+    // AddNotification reply costs only this notification's bookkeeping.
+    constexpr auto CallTimeoutMilliseconds = 5000;
+
+    // The freedesktop close reason reported for an assumed close. There is no "we guessed" reason
+    // in that enumeration, and "expired" is the closest true statement: the time we waited is up.
+    // What actually distinguishes it is the CloseReport carried alongside.
+    constexpr auto ExpiredReason = uint32_t { 1 };
+
+    // The action name registered as the notification's default -- what a click on the popup
+    // triggers. The absence of an "app." prefix is the whole mechanism and NOT an oversight: the
+    // portal treats an "app."-prefixed action as exported and D-Bus-activates it via
+    // org.freedesktop.Application.ActivateAction, delivering nothing to us, while any other name
+    // takes the branch that emits ActionInvoked. @see xdg-desktop-portal-gtk's activate_action().
+    constexpr auto DefaultActionName = "default";
+
+    // A function rather than a constant because SLOT() expands to qFlagLocation(), which is neither
+    // constexpr nor safe to run before main().
+    [[nodiscard]] std::array<DBusSignalSubscription, 1> signalSubscriptions()
+    {
+        return {
+            DBusSignalSubscription { QLatin1StringView("ActionInvoked"),
+                                     SLOT(onActionInvoked(QString, QString, QVariantList)) },
+        };
+    }
+
+} // namespace
+
+QVariantMap buildPortalNotificationOptions(vtbackend::DesktopNotification const& notification)
+{
+    auto const priority = NotificationRouter::toPortalPriority(notification.urgency);
+
+    auto options = QVariantMap {};
+
+    options["title"] = QString::fromStdString(notification.title);
+    options["body"] = QString::fromStdString(notification.body);
+    options["priority"] = QString::fromLatin1(priority.data(), static_cast<qsizetype>(priority.size()));
+    options["default-action"] = QString::fromLatin1(DefaultActionName);
+
+    return options;
+}
+
+DelayScheduler qtDelayScheduler()
+{
+    return [](QObject* context, std::chrono::milliseconds delay, std::function<void()> action) {
+        // Bound to the context object, so a transport destroyed with a timer pending takes the
+        // timer with it and the action -- which reaches back into that transport -- never runs.
+        QTimer::singleShot(delay, context, std::move(action));
+    };
+}
+
+PortalCaller qtPortalCaller()
+{
+    return [bus = QDBusConnection::sessionBus()](QObject* context,
+                                                 QLatin1StringView method,
+                                                 QVariantList arguments,
+                                                 std::function<void(CallOutcome)> onReply) {
+        auto message = QDBusMessage::createMethodCall(
+            PortalSource.service, PortalSource.path, PortalSource.interface, method);
+        message.setArguments(std::move(arguments));
+
+        auto pending = bus.asyncCall(message, CallTimeoutMilliseconds);
+        if (!onReply)
+            return; // Sent and forgotten: nothing in this reply is acted on.
+
+        // Parented to the context, so a transport destroyed with a call in flight takes its watcher
+        // with it and the handler -- which reaches back into that transport -- is never run.
+        auto* const watcher = new QDBusPendingCallWatcher(pending, context);
+        QObject::connect(
+            watcher, &QDBusPendingCallWatcher::finished, context, [onReply = std::move(onReply)](auto* self) {
+                // AddNotification returns nothing, so there is no value to read -- only whether it
+                // arrived at all.
+                auto const reply = QDBusPendingReply<>(*self);
+                self->deleteLater();
+
+                if (reply.isError())
+                    notifierLog()("Portal notification call failed: {}",
+                                  reply.error().message().toStdString());
+
+                onReply(reply.isError() ? CallOutcome::Failed : CallOutcome::Accepted);
+            });
+    };
+}
+
+PortalNotificationTransport::PortalNotificationTransport(std::chrono::milliseconds closeDelay,
+                                                         std::string idPrefix,
+                                                         DelayScheduler scheduler,
+                                                         PortalCaller caller,
+                                                         QObject* parent):
+    QObject(parent),
+    _bus { QDBusConnection::sessionBus() },
+    _closeDelay { closeDelay },
+    _idPrefix { std::move(idPrefix) },
+    _schedule { std::move(scheduler) },
+    _call { std::move(caller) }
+{
+}
+
+PortalNotificationTransport::~PortalNotificationTransport()
+{
+    if (!_onActivated)
+        return;
+
+    unsubscribeFromDBusSignals(_bus, PortalSource, this, signalSubscriptions());
+}
+
+std::string PortalNotificationTransport::portalIdFor(std::string const& identifier) const
+{
+    return std::format("{}/{}", _idPrefix, identifier);
+}
+
+void PortalNotificationTransport::notify(vtbackend::DesktopNotification const& notification,
+                                         ServerId replacesId,
+                                         SentHandler onSent)
+{
+    auto const portalId = portalIdFor(notification.identifier);
+    auto const serverId = ++_lastServerId;
+    auto const closeDelay = NotificationRouter::resolveCloseDelay(notification.timeout, _closeDelay);
+
+    _call(
+        this,
+        QLatin1StringView("AddNotification"),
+        { QString::fromStdString(portalId), buildPortalNotificationOptions(notification) },
+        [this, portalId, serverId, replacesId, closeDelay, onSent = std::move(onSent)](CallOutcome outcome) {
+            if (outcome != CallOutcome::Accepted)
+            {
+                onSent(std::nullopt);
+                return;
+            }
+
+            // Recorded only now, and only on success -- exactly when NotificationRouter records
+            // its own mapping, so a failed send leaves the previous notification still live and
+            // still replaceable.
+            if (replacesId != 0)
+                retire(replacesId);
+            _portalIds[serverId] = portalId;
+            _serverIds[portalId] = serverId;
+
+            notifierLog()("Notification sent: portal_id='{}' -> id={}", portalId, serverId);
+            onSent(serverId);
+
+            if (closeDelay == std::chrono::milliseconds { 0 })
+                return;
+
+            _schedule(this, closeDelay, [this, serverId] {
+                // The notification may have been withdrawn, superseded or activated while the
+                // timer ran; all three retire it, so finding it gone is how the timer cancels.
+                if (!_portalIds.contains(serverId))
+                    return;
+
+                retire(serverId);
+                if (_onClosed)
+                    _onClosed(serverId, ExpiredReason, vtbackend::CloseReport::Untracked);
+            });
+        });
+}
+
+void PortalNotificationTransport::close(ServerId serverId)
+{
+    auto const it = _portalIds.find(serverId);
+    if (it == _portalIds.end())
+        return; // Never sent, or already retired: nothing to withdraw and no traffic to make.
+
+    auto const portalId = it->second;
+    retire(serverId);
+
+    // No reply handler: nothing in RemoveNotification's reply is acted on.
+    _call(this, QLatin1StringView("RemoveNotification"), { QString::fromStdString(portalId) }, {});
+}
+
+void PortalNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandler onActivated)
+{
+    _onClosed = std::move(onClosed);
+    _onActivated = std::move(onActivated);
+
+    // Only the activation signal exists to subscribe to; the portal has no close signal at all, so
+    // _onClosed is driven by the timer instead.
+    subscribeToDBusSignals(_bus, PortalSource, this, signalSubscriptions());
+}
+
+void PortalNotificationTransport::onActionInvoked(QString const& identifier,
+                                                  QString const& action,
+                                                  QVariantList const& parameters)
+{
+    (void) action;     // We only register the "default" action.
+    (void) parameters; // Carries the action target and the activation token; neither is used.
+
+    auto const it = _serverIds.find(identifier.toStdString());
+    if (it == _serverIds.end())
+        return; // Another application's notification: this signal is broadcast.
+
+    auto const serverId = it->second;
+    retire(serverId);
+
+    if (_onActivated)
+        _onActivated(serverId);
+}
+
+void PortalNotificationTransport::retire(ServerId serverId)
+{
+    auto const it = _portalIds.find(serverId);
+    if (it == _portalIds.end())
+        return;
+
+    _serverIds.erase(it->second);
+    _portalIds.erase(it);
+}
+
+} // namespace contour::platform
+
+#endif // defined(__linux__)

--- a/src/contour/platform/PortalNotificationTransport.cpp
+++ b/src/contour/platform/PortalNotificationTransport.cpp
@@ -159,20 +159,11 @@ void PortalNotificationTransport::notify(vtbackend::DesktopNotification const& n
 
             // Recorded only now, and only on success -- exactly when NotificationRouter records
             // its own mapping, so a failed send leaves the previous notification still live and
-            // still replaceable.
-            //
-            // Retired by PORTAL ID rather than by replacesId alone, because the two maps must stay
-            // exact mutual inverses and the caller cannot always see the collision: a second send
-            // of the same OSC identifier issued before the first AddNotification was answered
-            // carries replacesId 0, yet lands on the very same portal id. Keying on the id the
-            // portal itself replaces by is what makes "one portal id, one live server id"
-            // structural instead of something the caller has to get right.
-            if (auto const previous = _serverIds.find(portalId); previous != _serverIds.end())
-                retire(previous->second);
-            if (replacesId != 0)
-                retire(replacesId);
-            _portalIds[serverId] = portalId;
-            _serverIds[portalId] = serverId;
+            // still replaceable. record() retires by portal id as well as by replacesId, which is
+            // what makes "one portal id, one live server id" hold even for a second send issued
+            // before the first was answered: that one carries replacesId 0 and lands on the very
+            // same portal id.
+            _ids.record(portalId, serverId, replacesId);
 
             notifierLog()("Notification sent: portal_id='{}' -> id={}", portalId, serverId);
             onSent(serverId);
@@ -183,10 +174,9 @@ void PortalNotificationTransport::notify(vtbackend::DesktopNotification const& n
             _schedule(this, closeDelay, [this, serverId] {
                 // The notification may have been withdrawn, superseded or activated while the
                 // timer ran; all three retire it, so finding it gone is how the timer cancels.
-                if (!_portalIds.contains(serverId))
+                if (!_ids.takeByServerId(serverId).has_value())
                     return;
 
-                retire(serverId);
                 if (_onClosed)
                     _onClosed(serverId, ExpiredReason, vtbackend::CloseReport::Untracked);
             });
@@ -195,15 +185,12 @@ void PortalNotificationTransport::notify(vtbackend::DesktopNotification const& n
 
 void PortalNotificationTransport::close(ServerId serverId)
 {
-    auto const it = _portalIds.find(serverId);
-    if (it == _portalIds.end())
+    auto const portalId = _ids.takeByServerId(serverId);
+    if (!portalId.has_value())
         return; // Never sent, or already retired: nothing to withdraw and no traffic to make.
 
-    auto const portalId = it->second;
-    retire(serverId);
-
     // No reply handler: nothing in RemoveNotification's reply is acted on.
-    _call(this, QLatin1StringView("RemoveNotification"), { QString::fromStdString(portalId) }, {});
+    _call(this, QLatin1StringView("RemoveNotification"), { QString::fromStdString(*portalId) }, {});
 }
 
 void PortalNotificationTransport::subscribe(ClosedHandler onClosed, ActivatedHandler onActivated)
@@ -224,25 +211,12 @@ void PortalNotificationTransport::onActionInvoked(QString const& identifier,
     (void) action;     // We only register the "default" action.
     (void) parameters; // Carries the action target and the activation token; neither is used.
 
-    auto const it = _serverIds.find(identifier.toStdString());
-    if (it == _serverIds.end())
+    auto const serverId = _ids.takeByIdentifier(identifier.toStdString());
+    if (!serverId.has_value())
         return; // Another application's notification: this signal is broadcast.
 
-    auto const serverId = it->second;
-    retire(serverId);
-
     if (_onActivated)
-        _onActivated(serverId);
-}
-
-void PortalNotificationTransport::retire(ServerId serverId)
-{
-    auto const it = _portalIds.find(serverId);
-    if (it == _portalIds.end())
-        return;
-
-    _serverIds.erase(it->second);
-    _portalIds.erase(it);
+        _onActivated(*serverId);
 }
 
 } // namespace contour::platform

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#ifdef __linux__
+
+    #include <contour/platform/NotificationTransport.hpp>
+
+    #include <QtCore/QLatin1StringView>
+    #include <QtCore/QObject>
+    #include <QtCore/QVariantList>
+    #include <QtCore/QVariantMap>
+    #include <QtDBus/QDBusConnection>
+
+    #include <chrono>
+    #include <cstdint>
+    #include <functional>
+    #include <optional>
+    #include <string>
+    #include <unordered_map>
+
+namespace contour::platform
+{
+
+/// Builds the options dictionary for org.freedesktop.portal.Notification.AddNotification.
+///
+/// A free function rather than a member, for the same reason buildFreedesktopNotifyArguments() is:
+/// it is the part a headless test can check head-on, without a bus or a portal.
+///
+/// Only interface version 1 keys are produced (title, body, priority, default-action), so no
+/// runtime version probe is needed -- the portal shipped on current desktops still advertises
+/// version 1. The portal has no counterpart for freedesktop's app_name, app_icon or
+/// expire_timeout: it derives the application from the sandbox's own app id, and it never expires
+/// a notification on the caller's instruction.
+///
+/// @param notification The notification to send.
+/// @return The AddNotification options dictionary.
+[[nodiscard]] QVariantMap buildPortalNotificationOptions(vtbackend::DesktopNotification const& notification);
+
+/// Runs @p action after @p delay, keeping it bound to the lifetime of @p context.
+///
+/// Injected rather than called directly so a test can drive the timer by hand instead of waiting:
+/// the recording scheduler stores the action and the test decides when it fires, which is the same
+/// "stored, not invoked" shape RecordingNotificationTransport uses for replies.
+using DelayScheduler =
+    std::function<void(QObject* context, std::chrono::milliseconds delay, std::function<void()> action)>;
+
+/// The production DelayScheduler: a single-shot QTimer owned by the context object, so a transport
+/// destroyed with a timer pending takes the timer with it.
+[[nodiscard]] DelayScheduler qtDelayScheduler();
+
+/// Whether a portal method call was accepted.
+///
+/// An enum rather than a bool because at the call site `true` says nothing about which way round the
+/// question was asked, and the two states have real names. The reason for a failure is not carried:
+/// nothing acts on it beyond the log line the caller already writes.
+enum class CallOutcome : uint8_t
+{
+    Failed = 0,
+    Accepted = 1,
+};
+
+/// Issues one org.freedesktop.portal.Notification method call, returning WITHOUT waiting for it.
+///
+/// Injected because the D-Bus call is the one ambient resource this class is built out of. Behind a
+/// seam, a headless test drives the whole transport -- the id bookkeeping, replace-in-place, the
+/// assumed close -- with no portal to send to; without one, the only way to reach the code that
+/// runs when a call is ACCEPTED would be to send real notifications at whoever runs the suite.
+///
+/// @param context Whose lifetime the pending call is bound to.
+/// @param method The interface method to call.
+/// @param arguments Its arguments, in wire order.
+/// @param onReply Called if and when a reply arrives, with whether the call was accepted. Empty
+///                where the caller does not read the reply at all.
+using PortalCaller = std::function<void(QObject* context,
+                                        QLatin1StringView method,
+                                        QVariantList arguments,
+                                        std::function<void(CallOutcome)> onReply)>;
+
+/// The production PortalCaller: an asynchronous session-bus call to the portal, whose reply watcher
+/// is owned by the context object.
+[[nodiscard]] PortalCaller qtPortalCaller();
+
+/// Speaks org.freedesktop.portal.Notification, asynchronously.
+///
+/// The transport a sandboxed Contour must use. Inside a Flatpak sandbox the session-bus name
+/// org.freedesktop.Notifications is unreachable without --talk-name, and Flathub declines to grant
+/// it ("Your app should not need direct access to org.freedesktop.Notifications. There's a
+/// notifications portal."); the portal needs no static permission at all.
+/// @see https://github.com/contour-terminal/contour/issues/2074
+///
+/// Three ways it is NOT a drop-in for org.freedesktop.Notifications, and what is done about each:
+///
+///  1. **It assigns no id.** AddNotification takes an application-chosen string and returns
+///     nothing, so the ServerId every layer above deals in is minted HERE, as a counter, and mapped
+///     to the portal's string. That keeps NotificationRouter and the notifier unchanged.
+///  2. **It has no NotificationClosed signal.** Nothing can report that the desktop retired a
+///     popup, so a close is ASSUMED once the resolved delay elapses and reported as
+///     CloseReport::Untracked -- never as an observation. A delay of zero reports nothing at all.
+///  3. **Its ActionInvoked is broadcast**, and carries only (id, action, parameter) -- the app id
+///     the portal matched on is dropped before the signal reaches us. A bare "1" would therefore
+///     collide with another sandboxed application's notification, so portal ids are namespaced with
+///     a per-process prefix.
+class PortalNotificationTransport final: public QObject, public NotificationTransport
+{
+    Q_OBJECT
+
+  public:
+    /// @param closeDelay How long to wait before assuming a notification closed, where the
+    ///                   notification itself does not say (OSC 99 `w=`). Zero never assumes.
+    /// @param idPrefix   Namespace for this process's portal ids. @see the class doc, point 3.
+    /// @param scheduler  How a delayed action is run; required, so a test can drive it by hand.
+    /// @param caller     How a portal method call is issued; required, for the same reason.
+    /// @param parent     Qt ownership, or nullptr.
+    explicit PortalNotificationTransport(std::chrono::milliseconds closeDelay,
+                                         std::string idPrefix,
+                                         DelayScheduler scheduler,
+                                         PortalCaller caller,
+                                         QObject* parent = nullptr);
+
+    /// Removes the session-bus signal subscription that subscribe() installed. Not defaulted, for
+    /// the reason DBusNotificationTransport's destructor gives: one match rule per terminal session
+    /// on a process-wide bus that runs its own thread.
+    ~PortalNotificationTransport() override;
+
+    void notify(vtbackend::DesktopNotification const& notification,
+                ServerId replacesId,
+                SentHandler onSent) override;
+    void close(ServerId serverId) override;
+    void subscribe(ClosedHandler onClosed, ActivatedHandler onActivated) override;
+
+    /// The portal id a notification is sent under: the prefix, then the OSC identifier.
+    ///
+    /// Deriving it from the OSC identifier rather than from the minted ServerId is what gives
+    /// replace-in-place for free: re-sending the same OSC identifier reuses the same portal id, and
+    /// the portal's own rule is that reusing an id updates the notification already showing.
+    /// @param identifier The OSC 99 notification identifier.
+    /// @return The portal id.
+    [[nodiscard]] std::string portalIdFor(std::string const& identifier) const;
+
+  private slots:
+    /// Handles the portal's ActionInvoked signal.
+    ///
+    /// All three parameters are declared even though only the id is used, because QtDBus matches a
+    /// hook to an incoming signal by comparing the signature it reconstructs from the SLOT's
+    /// parameters against the message's own. A slot taking fewer arguments does not fail loudly --
+    /// it is simply never called.
+    void onActionInvoked(QString const& identifier, QString const& action, QVariantList const& parameters);
+
+  private:
+    /// Forgets a notification, in both directions.
+    /// @param serverId The id to forget.
+    void retire(ServerId serverId);
+
+    /// The session bus, held rather than fetched per call. @see DBusNotificationTransport.
+    QDBusConnection _bus;
+
+    /// How long before a close is assumed, where the notification itself does not say.
+    std::chrono::milliseconds _closeDelay;
+
+    /// This process's portal id namespace.
+    std::string _idPrefix;
+
+    /// How a delayed close is scheduled.
+    DelayScheduler _schedule;
+
+    /// How a portal method call is issued.
+    PortalCaller _call;
+
+    /// The last minted ServerId. Zero is never handed out: it is freedesktop's "this is a new
+    /// notification" sentinel, and NotificationRouter::replacementFor() returns it to mean exactly
+    /// that -- so a real notification must never wear it.
+    ServerId _lastServerId = 0;
+
+    /// The minted-id ⇄ portal-id mapping, kept as exact mutual inverses.
+    std::unordered_map<ServerId, std::string> _portalIds;
+    std::unordered_map<std::string, ServerId> _serverIds;
+
+    /// The subscription handlers; their emptiness IS the "not subscribed yet" state.
+    ClosedHandler _onClosed;
+    ActivatedHandler _onActivated;
+};
+
+} // namespace contour::platform
+
+#endif // defined(__linux__)

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -170,10 +170,8 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
   private slots:
     /// Handles the portal's ActionInvoked signal.
     ///
-    /// All three parameters are declared even though only the id is used, because QtDBus matches a
-    /// hook to an incoming signal by comparing the signature it reconstructs from the SLOT's
-    /// parameters against the message's own. A slot taking fewer arguments does not fail loudly --
-    /// it is simply never called.
+    /// All three parameters are declared even though only the id is used. @see
+    /// DBusSignalSubscription::slot for why a slot declaring fewer is simply never called.
     void onActionInvoked(QString const& identifier, QString const& action, QVariantList const& parameters);
 
   private:

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -152,11 +152,6 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
                                          PortalCaller caller,
                                          QObject* parent = nullptr);
 
-    /// Removes the session-bus signal subscription that subscribe() installed. Not defaulted, for
-    /// the reason DBusNotificationTransport's destructor gives: one match rule per terminal session
-    /// on a process-wide bus that runs its own thread.
-    ~PortalNotificationTransport() override;
-
     void notify(vtbackend::DesktopNotification const& notification,
                 ServerId replacesId,
                 SentHandler onSent) override;
@@ -207,8 +202,8 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
     /// NotificationIdMap.
     NotificationIdMap _ids;
 
-    /// Whether subscribe() has installed the match rule, so the destructor knows to remove it.
-    DBusSubscriptionState _subscription = DBusSubscriptionState::NotSubscribed;
+    /// The installed match rule, removed when this dies. @see DBusSignalSubscriptionGuard.
+    DBusSignalSubscriptionGuard _subscription;
 
     /// The subscription handlers.
     ClosedHandler _onClosed;

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -3,6 +3,7 @@
 
 #ifdef __linux__
 
+    #include <contour/platform/DBusSignalSubscription.hpp>
     #include <contour/platform/NotificationTransport.hpp>
 
     #include <QtCore/QLatin1StringView>
@@ -175,7 +176,10 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
     std::unordered_map<ServerId, std::string> _portalIds;
     std::unordered_map<std::string, ServerId> _serverIds;
 
-    /// The subscription handlers; their emptiness IS the "not subscribed yet" state.
+    /// Whether subscribe() has installed the match rule, so the destructor knows to remove it.
+    DBusSubscriptionState _subscription = DBusSubscriptionState::NotSubscribed;
+
+    /// The subscription handlers.
     ClosedHandler _onClosed;
     ActivatedHandler _onActivated;
 };

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -4,6 +4,7 @@
 #ifdef __linux__
 
     #include <contour/platform/DBusSignalSubscription.hpp>
+    #include <contour/platform/NotificationIdMap.hpp>
     #include <contour/platform/NotificationTransport.hpp>
 
     #include <QtCore/QLatin1StringView>
@@ -17,7 +18,6 @@
     #include <functional>
     #include <optional>
     #include <string>
-    #include <unordered_map>
 
 namespace contour::platform
 {
@@ -148,10 +148,6 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
     void onActionInvoked(QString const& identifier, QString const& action, QVariantList const& parameters);
 
   private:
-    /// Forgets a notification, in both directions.
-    /// @param serverId The id to forget.
-    void retire(ServerId serverId);
-
     /// The session bus, held rather than fetched per call. @see DBusNotificationTransport.
     QDBusConnection _bus;
 
@@ -172,9 +168,10 @@ class PortalNotificationTransport final: public QObject, public NotificationTran
     /// that -- so a real notification must never wear it.
     ServerId _lastServerId = 0;
 
-    /// The minted-id ⇄ portal-id mapping, kept as exact mutual inverses.
-    std::unordered_map<ServerId, std::string> _portalIds;
-    std::unordered_map<std::string, ServerId> _serverIds;
+    /// The minted-id ⇄ portal-id bookkeeping. The same relation NotificationRouter keeps one layer
+    /// up between the OSC identifier and the id a server assigns, so it is the same type. @see
+    /// NotificationIdMap.
+    NotificationIdMap _ids;
 
     /// Whether subscribe() has installed the match rule, so the destructor knows to remove it.
     DBusSubscriptionState _subscription = DBusSubscriptionState::NotSubscribed;

--- a/src/contour/platform/PortalNotificationTransport.hpp
+++ b/src/contour/platform/PortalNotificationTransport.hpp
@@ -18,9 +18,43 @@
     #include <functional>
     #include <optional>
     #include <string>
+    #include <string_view>
 
 namespace contour::platform
 {
+
+/// A fresh portal-notification id namespace, unique within this process and across calls.
+///
+/// Portal notification ids are chosen by the application, and two things make a namespace
+/// necessary. Between processes: the portal's ActionInvoked signal is broadcast and carries no app
+/// id, so another sandboxed application's notification "1" would be indistinguishable from ours.
+/// WITHIN one process: a transport is built per terminal session, and two panes are free to use the
+/// same OSC 99 identifier -- so a per-process prefix alone would have them collide, replacing each
+/// other's popups and each answering the other's activation. Hence unique per call, not per process.
+///
+/// The per-process half is random rather than the process id, because a sandbox is precisely where
+/// a process id stops identifying anything: Flatpak gives every instance its own PID namespace, so
+/// two sandboxed Contours both see a small, identical pid.
+///
+/// @return The prefix, of the shape `contour-<uuid>-<n>`.
+[[nodiscard]] std::string makePortalIdPrefix();
+
+/// Maps a notification urgency onto the xdg-desktop-portal `priority` string.
+///
+/// The portal names four levels where freedesktop has three, so its `high` has no counterpart
+/// here and stays unused; Critical maps to `urgent`, the level that survives Do-Not-Disturb.
+/// @param urgency The backend urgency level.
+/// @return The portal priority string; `normal` for any unrecognized value.
+[[nodiscard]] constexpr std::string_view toPortalPriority(vtbackend::NotificationUrgency urgency) noexcept
+{
+    switch (urgency)
+    {
+        case vtbackend::NotificationUrgency::Low: return "low";
+        case vtbackend::NotificationUrgency::Normal: return "normal";
+        case vtbackend::NotificationUrgency::Critical: return "urgent";
+    }
+    return "normal";
+}
 
 /// Builds the options dictionary for org.freedesktop.portal.Notification.AddNotification.
 ///

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -17,14 +17,12 @@
     #include <contour/platform/PortalNotificationTransport.hpp>
     #include <contour/test/NotificationFixtures.hpp>
 
-    #include <QtCore/QCoreApplication>
     #include <QtCore/QMetaObject>
 
     #include <catch2/catch_test_macros.hpp>
 
     #include <chrono>
     #include <optional>
-    #include <string>
     #include <utility>
     #include <vector>
 
@@ -116,12 +114,19 @@ struct Fixture
             [this](auto serverId) { activated.push_back(serverId); });
     }
 
+    /// Sends @p notification, leaving the portal's reply outstanding.
+    void send(vtbackend::DesktopNotification const& notification,
+              NotificationTransport::ServerId replacesId = 0)
+    {
+        transport.notify(notification, replacesId, [this](auto serverId) { sent.push_back(serverId); });
+    }
+
     /// Sends @p notification and lets the portal accept it, returning the id it was recorded under.
     [[nodiscard]] NotificationTransport::ServerId sendAccepted(
         vtbackend::DesktopNotification const& notification, NotificationTransport::ServerId replacesId = 0)
     {
         auto const index = recorder.calls.size();
-        transport.notify(notification, replacesId, [this](auto serverId) { sent.push_back(serverId); });
+        send(notification, replacesId);
         recorder.completeCall(index, CallOutcome::Accepted);
         return sent.back().value();
     }
@@ -214,8 +219,7 @@ TEST_CASE("PortalNotificationTransport sends AddNotification with the id and opt
 {
     auto fixture = Fixture {};
 
-    fixture.transport.notify(
-        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+    fixture.send(aNotification("osc-1"));
 
     REQUIRE(fixture.recorder.calls.size() == 1);
     CHECK(fixture.recorder.calls[0].method == QStringLiteral("AddNotification"));
@@ -233,8 +237,7 @@ TEST_CASE("PortalNotificationTransport records nothing when the portal refuses",
 {
     auto fixture = Fixture {};
 
-    fixture.transport.notify(
-        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+    fixture.send(aNotification("osc-1"));
     fixture.recorder.completeCall(0, CallOutcome::Failed);
 
     REQUIRE(fixture.sent.size() == 1);
@@ -329,15 +332,13 @@ TEST_CASE("PortalNotificationTransport survives a second send before the first w
     // notify() returns without waiting, so a second notification carrying the same OSC identifier
     // can be issued while the first AddNotification is still outstanding -- and it arrives with
     // replacesId 0, because nothing upstream has a server id to name yet. Both land on the SAME
-    // portal id all the same, so the two maps must not be left believing two server ids are live
+    // portal id all the same, so the id map must not be left believing two server ids are live
     // under it: the stale one's timer would otherwise retire the live one, dropping its activation
     // on the floor and reporting a close for a popup still on screen.
     auto fixture = Fixture {};
 
-    fixture.transport.notify(
-        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
-    fixture.transport.notify(
-        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+    fixture.send(aNotification("osc-1"));
+    fixture.send(aNotification("osc-1"));
 
     fixture.recorder.completeCall(0, CallOutcome::Accepted);
     fixture.recorder.completeCall(1, CallOutcome::Accepted);

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -29,8 +29,10 @@
     #include <vector>
 
 using contour::platform::CallOutcome;
+using contour::platform::makePortalIdPrefix;
 using contour::platform::NotificationTransport;
 using contour::platform::PortalNotificationTransport;
+using contour::platform::toPortalPriority;
 using contour::test::aNotification;
 using vtbackend::CloseReport;
 using namespace std::chrono_literals;
@@ -143,6 +145,28 @@ void fireActionInvoked(PortalNotificationTransport& transport, QString const& id
 }
 
 } // namespace
+
+TEST_CASE("makePortalIdPrefix hands out a fresh namespace every time", "[contour][notification]")
+{
+    // A transport is built per terminal session, and two panes are free to pick the same OSC 99
+    // identifier. Were the namespace merely per-process, their portal ids would be equal: the portal
+    // would replace one pane's popup with the other's, and because ActionInvoked is broadcast, a
+    // click on either would be reported back by BOTH sessions.
+    auto const first = makePortalIdPrefix();
+    auto const second = makePortalIdPrefix();
+
+    CHECK(first != second);
+    CHECK(first.starts_with("contour-"));
+}
+TEST_CASE("buildPortalNotificationOptions maps urgency onto the portal priority string",
+          "[contour][notification]")
+{
+    // The portal names four levels to freedesktop's three, so Critical lands on `urgent` -- the one
+    // that survives Do-Not-Disturb -- and the portal's `high` has no source to come from.
+    STATIC_CHECK(toPortalPriority(vtbackend::NotificationUrgency::Low) == "low");
+    STATIC_CHECK(toPortalPriority(vtbackend::NotificationUrgency::Normal) == "normal");
+    STATIC_CHECK(toPortalPriority(vtbackend::NotificationUrgency::Critical) == "urgent");
+}
 
 TEST_CASE("buildPortalNotificationOptions builds the AddNotification dictionary", "[contour][notification]")
 {

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -438,10 +438,7 @@ TEST_CASE("PortalNotificationTransport drives the real portal without waiting",
     };
     transport.subscribe([](auto, auto, auto) {}, [](auto) {});
 
-    contour::test::checkReturnsWithoutWaiting([&](bool maySend) {
-        if (!maySend)
-            return;
-
+    contour::test::checkReturnsWithoutWaiting([&] {
         transport.notify(aNotification("osc-real"), 0, [](auto) {});
 
         // close() short-circuits on an id it holds no mapping for, and on a bus that never answers

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -130,11 +130,14 @@ struct Fixture
 /// surface of one of them.
 void fireActionInvoked(PortalNotificationTransport& transport, QString const& identifier)
 {
-    QMetaObject::invokeMethod(&transport,
-                              "onActionInvoked",
-                              Q_ARG(QString, identifier),
-                              Q_ARG(QString, QStringLiteral("default")),
-                              Q_ARG(QVariantList, QVariantList {}));
+    // Checked, because a name resolved at run time can stop resolving: were the slot renamed, every
+    // "and nothing was reported" case below would keep passing while reporting nothing at all.
+    auto const invoked = QMetaObject::invokeMethod(&transport,
+                                                   "onActionInvoked",
+                                                   Q_ARG(QString, identifier),
+                                                   Q_ARG(QString, QStringLiteral("default")),
+                                                   Q_ARG(QVariantList, QVariantList {}));
+    REQUIRE(invoked);
 }
 
 [[nodiscard]] vtbackend::DesktopNotification aNotification(std::string identifier)
@@ -431,7 +434,14 @@ TEST_CASE("PortalNotificationTransport drives the real portal without waiting",
     if (qEnvironmentVariableIsSet("CONTOUR_TEST_NOTIFICATION_SEND"))
     {
         transport.notify(aNotification("osc-real"), 0, [](auto) {});
-        transport.close(1);
+
+        // close() short-circuits on an id it holds no mapping for, and on a bus that never answers
+        // no mapping is ever recorded -- so the withdraw path is put on the wire through the caller
+        // itself. Sending it, not skipping it, is what this case is here to time.
+        contour::platform::qtPortalCaller()(&transport,
+                                            QLatin1StringView("RemoveNotification"),
+                                            { QStringLiteral("contour-test/osc-real") },
+                                            {});
     }
     QCoreApplication::processEvents();
 

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for PortalNotificationTransport — the org.freedesktop.portal.Notification backend a
+// sandboxed Contour must use, because Flatpak cannot reach org.freedesktop.Notifications and
+// Flathub declines to grant the permission that would. @see issue #2074.
+//
+// The portal differs from the session-bus service in three ways that all land here: it assigns no
+// notification id, it has no close signal of any kind, and its ActionInvoked is broadcast. So the
+// cases below are about the id bookkeeping, the close this transport has to ASSUME rather than
+// observe, and not mistaking another application's notification for one of ours.
+//
+// Both the portal call and the delay are injected, so none of this needs a portal to talk to — and
+// running the suite never pops a real notification up at whoever is running it.
+
+#ifdef __linux__
+
+    #include <contour/platform/PortalNotificationTransport.hpp>
+
+    #include <QtCore/QCoreApplication>
+    #include <QtCore/QMetaObject>
+
+    #include <catch2/catch_test_macros.hpp>
+
+    #include <chrono>
+    #include <optional>
+    #include <string>
+    #include <utility>
+    #include <vector>
+
+using contour::platform::CallOutcome;
+using contour::platform::NotificationTransport;
+using contour::platform::PortalNotificationTransport;
+using vtbackend::CloseReport;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+/// One recorded portal method call, with the reply the test has yet to deliver.
+struct PortalCall
+{
+    QString method;
+    QVariantList arguments;
+    std::function<void(CallOutcome)> onReply;
+};
+
+/// One scheduled delayed action, with the timer the test has yet to fire.
+struct ScheduledAction
+{
+    std::chrono::milliseconds delay;
+    std::function<void()> action;
+};
+
+/// Everything the transport reached for, and nothing it was given back unasked.
+///
+/// Deliberately not a mock framework: the recorded vectors ARE the assertions. Nothing replies or
+/// fires on its own, which is how a test observes that the transport records a notification only
+/// once the portal ACCEPTED it, and assumes a close only once the delay actually elapsed.
+struct Recorder
+{
+    std::vector<PortalCall> calls;
+    std::vector<ScheduledAction> scheduled;
+
+    [[nodiscard]] contour::platform::PortalCaller caller()
+    {
+        return [this](QObject*,
+                      QLatin1StringView method,
+                      QVariantList arguments,
+                      std::function<void(CallOutcome)> onReply) {
+            calls.emplace_back(PortalCall { QString(method), std::move(arguments), std::move(onReply) });
+        };
+    }
+
+    [[nodiscard]] contour::platform::DelayScheduler scheduler()
+    {
+        return [this](QObject*, std::chrono::milliseconds delay, std::function<void()> action) {
+            scheduled.emplace_back(ScheduledAction { delay, std::move(action) });
+        };
+    }
+
+    /// Delivers the portal's reply for the call at @p index.
+    void completeCall(size_t index, CallOutcome outcome) { calls.at(index).onReply(outcome); }
+
+    /// Fires the timer at @p index, as the event loop would once the delay elapsed.
+    void fireScheduled(size_t index) { scheduled.at(index).action(); }
+};
+
+/// One close event as the transport reported it.
+struct ClosedEvent
+{
+    NotificationTransport::ServerId serverId;
+    uint32_t reason;
+    CloseReport report;
+};
+
+/// A transport over a recorder, already subscribed, with the events it reports collected.
+struct Fixture
+{
+    Recorder recorder;
+    std::vector<ClosedEvent> closed;
+    std::vector<NotificationTransport::ServerId> activated;
+    std::vector<std::optional<NotificationTransport::ServerId>> sent;
+    PortalNotificationTransport transport;
+
+    explicit Fixture(std::chrono::milliseconds closeDelay = 10000ms):
+        transport { closeDelay, "contour-test", recorder.scheduler(), recorder.caller() }
+    {
+        transport.subscribe(
+            [this](auto serverId, auto reason, auto report) {
+                closed.emplace_back(ClosedEvent { serverId, reason, report });
+            },
+            [this](auto serverId) { activated.push_back(serverId); });
+    }
+
+    /// Sends @p notification and lets the portal accept it, returning the id it was recorded under.
+    [[nodiscard]] NotificationTransport::ServerId sendAccepted(
+        vtbackend::DesktopNotification const& notification, NotificationTransport::ServerId replacesId = 0)
+    {
+        auto const index = recorder.calls.size();
+        transport.notify(notification, replacesId, [this](auto serverId) { sent.push_back(serverId); });
+        recorder.completeCall(index, CallOutcome::Accepted);
+        return sent.back().value();
+    }
+};
+
+/// Plays back the portal's ActionInvoked signal, the way the bus would deliver it.
+///
+/// Through the meta-object rather than as a direct call, because the slot is private -- which is how
+/// the sibling D-Bus transport keeps its own, and there is no reason for a test to widen the public
+/// surface of one of them.
+void fireActionInvoked(PortalNotificationTransport& transport, QString const& identifier)
+{
+    QMetaObject::invokeMethod(&transport,
+                              "onActionInvoked",
+                              Q_ARG(QString, identifier),
+                              Q_ARG(QString, QStringLiteral("default")),
+                              Q_ARG(QVariantList, QVariantList {}));
+}
+
+[[nodiscard]] vtbackend::DesktopNotification aNotification(std::string identifier)
+{
+    auto notification = vtbackend::DesktopNotification {};
+    notification.identifier = std::move(identifier);
+    notification.title = "Title";
+    notification.body = "Body";
+    return notification;
+}
+
+} // namespace
+
+TEST_CASE("buildPortalNotificationOptions builds the AddNotification dictionary", "[contour][notification]")
+{
+    auto notification = aNotification("osc-1");
+    notification.urgency = vtbackend::NotificationUrgency::Critical;
+
+    auto const options = contour::platform::buildPortalNotificationOptions(notification);
+
+    CHECK(options["title"].toString() == QStringLiteral("Title"));
+    CHECK(options["body"].toString() == QStringLiteral("Body"));
+    CHECK(options["priority"].toString() == QStringLiteral("urgent"));
+
+    // The portal has no counterpart for freedesktop's app_name, app_icon or expire_timeout: it
+    // takes the application from the sandbox's own app id and never expires on our instruction.
+    // Sending them anyway would be sending keys the interface does not define.
+    CHECK_FALSE(options.contains("app_name"));
+    CHECK_FALSE(options.contains("expire_timeout"));
+}
+
+TEST_CASE("buildPortalNotificationOptions does not export the default action", "[contour][notification]")
+{
+    // The absence of an "app." prefix is the whole mechanism, and reads like an oversight: the
+    // portal D-Bus-activates an "app."-prefixed action through org.freedesktop.Application and
+    // delivers nothing back to us, while any other name takes the branch that emits ActionInvoked.
+    // Prefix this and OSC 99's a=report and a=focus both go silent.
+    auto const options = contour::platform::buildPortalNotificationOptions(aNotification("osc-1"));
+
+    auto const defaultAction = options["default-action"].toString();
+    REQUIRE_FALSE(defaultAction.isEmpty());
+    CHECK_FALSE(defaultAction.startsWith(QStringLiteral("app.")));
+}
+
+TEST_CASE("PortalNotificationTransport namespaces its portal ids", "[contour][notification]")
+{
+    // The portal's ActionInvoked is broadcast and drops the app id it matched on, so a bare "1"
+    // would be indistinguishable from another sandboxed application's notification "1".
+    auto fixture = Fixture {};
+
+    auto const portalId = fixture.transport.portalIdFor("osc-1");
+    CHECK(portalId == "contour-test/osc-1");
+}
+
+TEST_CASE("PortalNotificationTransport sends AddNotification with the id and options",
+          "[contour][notification]")
+{
+    auto fixture = Fixture {};
+
+    fixture.transport.notify(
+        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+
+    REQUIRE(fixture.recorder.calls.size() == 1);
+    CHECK(fixture.recorder.calls[0].method == QStringLiteral("AddNotification"));
+    REQUIRE(fixture.recorder.calls[0].arguments.size() == 2);
+    CHECK(fixture.recorder.calls[0].arguments[0].toString() == QStringLiteral("contour-test/osc-1"));
+    CHECK(fixture.recorder.calls[0].arguments[1].toMap()["title"].toString() == QStringLiteral("Title"));
+
+    // The call is outstanding: notify() returned with no reply in existence, and nothing was
+    // assumed about a notification the portal has not yet accepted.
+    CHECK(fixture.sent.empty());
+    CHECK(fixture.recorder.scheduled.empty());
+}
+
+TEST_CASE("PortalNotificationTransport records nothing when the portal refuses", "[contour][notification]")
+{
+    auto fixture = Fixture {};
+
+    fixture.transport.notify(
+        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+    fixture.recorder.completeCall(0, CallOutcome::Failed);
+
+    REQUIRE(fixture.sent.size() == 1);
+    CHECK_FALSE(fixture.sent[0].has_value());
+
+    // Nothing to close and nothing to assume: a notification that was never shown must not be
+    // reported as having closed later.
+    CHECK(fixture.recorder.scheduled.empty());
+    fixture.transport.close(1);
+    CHECK(fixture.recorder.calls.size() == 1);
+}
+
+TEST_CASE("PortalNotificationTransport assumes a close once the delay elapses", "[contour][notification]")
+{
+    auto fixture = Fixture { 10000ms };
+
+    auto const serverId = fixture.sendAccepted(aNotification("osc-1"));
+
+    REQUIRE(fixture.recorder.scheduled.size() == 1);
+    CHECK(fixture.recorder.scheduled[0].delay == 10000ms);
+    CHECK(fixture.closed.empty()); // Nothing until the timer actually fires.
+
+    fixture.recorder.fireScheduled(0);
+
+    REQUIRE(fixture.closed.size() == 1);
+    CHECK(fixture.closed[0].serverId == serverId);
+    // Marked for what it is. The portal has no close signal, so this was never observed -- and
+    // reporting it as though it had been is what would make the OSC 99 close report a lie.
+    CHECK(fixture.closed[0].report == CloseReport::Untracked);
+}
+
+TEST_CASE("PortalNotificationTransport honours the notification's own lifetime", "[contour][notification]")
+{
+    SECTION("an explicit w= wins over the configured delay")
+    {
+        auto fixture = Fixture { 10000ms };
+        auto notification = aNotification("osc-1");
+        notification.timeout = 4200;
+
+        (void) fixture.sendAccepted(notification);
+
+        REQUIRE(fixture.recorder.scheduled.size() == 1);
+        CHECK(fixture.recorder.scheduled[0].delay == 4200ms);
+    }
+
+    SECTION("w=0 means never auto-close, so nothing is ever assumed")
+    {
+        auto fixture = Fixture { 10000ms };
+        auto notification = aNotification("osc-1");
+        notification.timeout = 0;
+
+        (void) fixture.sendAccepted(notification);
+
+        CHECK(fixture.recorder.scheduled.empty());
+    }
+
+    SECTION("a zero configured delay disables the assumption entirely")
+    {
+        auto fixture = Fixture { 0ms };
+
+        (void) fixture.sendAccepted(aNotification("osc-1"));
+
+        CHECK(fixture.recorder.scheduled.empty());
+    }
+}
+
+TEST_CASE("PortalNotificationTransport reuses the portal id to replace in place", "[contour][notification]")
+{
+    auto fixture = Fixture {};
+
+    auto const first = fixture.sendAccepted(aNotification("osc-1"));
+    auto const second = fixture.sendAccepted(aNotification("osc-1"), /*replacesId*/ first);
+
+    // Same portal id both times: the portal's own rule is that reusing an id updates the
+    // notification already showing, so replacement needs no replaces_id equivalent.
+    REQUIRE(fixture.recorder.calls.size() == 2);
+    CHECK(fixture.recorder.calls[1].arguments[0].toString()
+          == fixture.recorder.calls[0].arguments[0].toString());
+
+    // The superseded id is forgotten, so closing it is not closing the live notification.
+    fixture.transport.close(first);
+    CHECK(fixture.recorder.calls.size() == 2);
+
+    fixture.transport.close(second);
+    REQUIRE(fixture.recorder.calls.size() == 3);
+    CHECK(fixture.recorder.calls[2].method == QStringLiteral("RemoveNotification"));
+}
+
+TEST_CASE("PortalNotificationTransport withdraws only what is live", "[contour][notification]")
+{
+    auto fixture = Fixture {};
+
+    // An id that was never sent produces no traffic at all.
+    fixture.transport.close(42);
+    CHECK(fixture.recorder.calls.empty());
+
+    auto const serverId = fixture.sendAccepted(aNotification("osc-1"));
+
+    fixture.transport.close(serverId);
+    REQUIRE(fixture.recorder.calls.size() == 2);
+    CHECK(fixture.recorder.calls[1].method == QStringLiteral("RemoveNotification"));
+    CHECK(fixture.recorder.calls[1].arguments[0].toString() == QStringLiteral("contour-test/osc-1"));
+
+    // Closing twice is not closing someone else's notification the second time.
+    fixture.transport.close(serverId);
+    CHECK(fixture.recorder.calls.size() == 2);
+
+    SECTION("and a withdrawn notification is never assumed to have closed")
+    {
+        // The timer is not cancelled; it finds the notification gone and says nothing. Reporting a
+        // close here would answer a withdrawal the application itself asked for.
+        REQUIRE(fixture.recorder.scheduled.size() == 1);
+        fixture.recorder.fireScheduled(0);
+
+        CHECK(fixture.closed.empty());
+    }
+}
+
+TEST_CASE("PortalNotificationTransport reports an activation and retires it", "[contour][notification]")
+{
+    auto fixture = Fixture {};
+
+    auto const serverId = fixture.sendAccepted(aNotification("osc-1"));
+
+    fireActionInvoked(fixture.transport, QStringLiteral("contour-test/osc-1"));
+
+    REQUIRE(fixture.activated.size() == 1);
+    CHECK(fixture.activated[0] == serverId);
+
+    SECTION("an activated notification is not then also assumed to have closed")
+    {
+        REQUIRE(fixture.recorder.scheduled.size() == 1);
+        fixture.recorder.fireScheduled(0);
+
+        CHECK(fixture.closed.empty());
+    }
+
+    SECTION("and the same activation twice is still one activation")
+    {
+        fireActionInvoked(fixture.transport, QStringLiteral("contour-test/osc-1"));
+
+        CHECK(fixture.activated.size() == 1);
+    }
+}
+
+TEST_CASE("PortalNotificationTransport ignores another application's notification", "[contour][notification]")
+{
+    // ActionInvoked is broadcast to every subscriber and carries no app id, so foreign ids arrive
+    // constantly. The prefix is what tells them apart.
+    auto fixture = Fixture {};
+
+    (void) fixture.sendAccepted(aNotification("osc-1"));
+
+    fireActionInvoked(fixture.transport, QStringLiteral("some-other-app/1"));
+    fireActionInvoked(fixture.transport, QStringLiteral("osc-1"));
+
+    CHECK(fixture.activated.empty());
+}
+
+TEST_CASE("PortalNotificationTransport drives the real portal without waiting",
+          "[contour][notification][dbus]")
+{
+    // Everything above talks to a recorder, which by construction cannot catch a transport that
+    // WAITS -- and waiting is the regression the whole seam exists to prevent (issue #2051). So
+    // this one case builds the transport exactly as production does, against whatever session bus
+    // the machine running it has.
+    //
+    // test/e2e/notification-nonblocking.sh is what makes that bus interesting: there
+    // org.freedesktop.portal.Desktop is activatable and never answers, which is what a desktop with
+    // no working portal looks like.
+    auto const startedAt = std::chrono::steady_clock::now();
+
+    auto transport = PortalNotificationTransport {
+        10000ms, "contour-test", contour::platform::qtDelayScheduler(), contour::platform::qtPortalCaller()
+    };
+    transport.subscribe([](auto, auto, auto) {}, [](auto) {});
+
+    // Actually sending is gated, so a run on a developer's own desktop does not pop a notification
+    // up at them and leave it there. The wedged-bus harness, where by construction nothing can be
+    // displayed, sets this and so covers the send path too.
+    if (qEnvironmentVariableIsSet("CONTOUR_TEST_NOTIFICATION_SEND"))
+    {
+        transport.notify(aNotification("osc-real"), 0, [](auto) {});
+        transport.close(1);
+    }
+    QCoreApplication::processEvents();
+
+    // Deliberately generous: this separates "returned promptly" from "waited out a 25-second D-Bus
+    // reply timeout", and is not trying to measure anything finer than that.
+    CHECK(std::chrono::steady_clock::now() - startedAt < std::chrono::seconds { 5 });
+}
+
+#endif // defined(__linux__)

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -303,6 +303,39 @@ TEST_CASE("PortalNotificationTransport reuses the portal id to replace in place"
     CHECK(fixture.recorder.calls[2].method == QStringLiteral("RemoveNotification"));
 }
 
+TEST_CASE("PortalNotificationTransport survives a second send before the first was answered",
+          "[contour][notification]")
+{
+    // notify() returns without waiting, so a second notification carrying the same OSC identifier
+    // can be issued while the first AddNotification is still outstanding -- and it arrives with
+    // replacesId 0, because nothing upstream has a server id to name yet. Both land on the SAME
+    // portal id all the same, so the two maps must not be left believing two server ids are live
+    // under it: the stale one's timer would otherwise retire the live one, dropping its activation
+    // on the floor and reporting a close for a popup still on screen.
+    auto fixture = Fixture {};
+
+    fixture.transport.notify(
+        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+    fixture.transport.notify(
+        aNotification("osc-1"), 0, [&](auto serverId) { fixture.sent.push_back(serverId); });
+
+    fixture.recorder.completeCall(0, CallOutcome::Accepted);
+    fixture.recorder.completeCall(1, CallOutcome::Accepted);
+
+    REQUIRE(fixture.sent.size() == 2);
+    auto const live = fixture.sent[1].value();
+
+    // The superseded notification says nothing when its timer comes up.
+    REQUIRE(fixture.recorder.scheduled.size() == 2);
+    fixture.recorder.fireScheduled(0);
+    CHECK(fixture.closed.empty());
+
+    // ... and the live one is still reachable, in both directions.
+    fireActionInvoked(fixture.transport, QStringLiteral("contour-test/osc-1"));
+    REQUIRE(fixture.activated.size() == 1);
+    CHECK(fixture.activated[0] == live);
+}
+
 TEST_CASE("PortalNotificationTransport withdraws only what is live", "[contour][notification]")
 {
     auto fixture = Fixture {};

--- a/src/contour/platform/PortalNotificationTransport_test.cpp
+++ b/src/contour/platform/PortalNotificationTransport_test.cpp
@@ -15,6 +15,7 @@
 #ifdef __linux__
 
     #include <contour/platform/PortalNotificationTransport.hpp>
+    #include <contour/test/NotificationFixtures.hpp>
 
     #include <QtCore/QCoreApplication>
     #include <QtCore/QMetaObject>
@@ -30,6 +31,7 @@
 using contour::platform::CallOutcome;
 using contour::platform::NotificationTransport;
 using contour::platform::PortalNotificationTransport;
+using contour::test::aNotification;
 using vtbackend::CloseReport;
 using namespace std::chrono_literals;
 
@@ -138,15 +140,6 @@ void fireActionInvoked(PortalNotificationTransport& transport, QString const& id
                                                    Q_ARG(QString, QStringLiteral("default")),
                                                    Q_ARG(QVariantList, QVariantList {}));
     REQUIRE(invoked);
-}
-
-[[nodiscard]] vtbackend::DesktopNotification aNotification(std::string identifier)
-{
-    auto notification = vtbackend::DesktopNotification {};
-    notification.identifier = std::move(identifier);
-    notification.title = "Title";
-    notification.body = "Body";
-    return notification;
 }
 
 } // namespace
@@ -413,26 +406,18 @@ TEST_CASE("PortalNotificationTransport ignores another application's notificatio
 TEST_CASE("PortalNotificationTransport drives the real portal without waiting",
           "[contour][notification][dbus]")
 {
-    // Everything above talks to a recorder, which by construction cannot catch a transport that
-    // WAITS -- and waiting is the regression the whole seam exists to prevent (issue #2051). So
-    // this one case builds the transport exactly as production does, against whatever session bus
-    // the machine running it has.
-    //
-    // test/e2e/notification-nonblocking.sh is what makes that bus interesting: there
-    // org.freedesktop.portal.Desktop is activatable and never answers, which is what a desktop with
-    // no working portal looks like.
-    auto const startedAt = std::chrono::steady_clock::now();
-
+    // Built exactly as production does, against whatever session bus is there. @see
+    // contour::test::checkReturnsWithoutWaiting for what this is guarding and why the bound is what
+    // it is.
     auto transport = PortalNotificationTransport {
         10000ms, "contour-test", contour::platform::qtDelayScheduler(), contour::platform::qtPortalCaller()
     };
     transport.subscribe([](auto, auto, auto) {}, [](auto) {});
 
-    // Actually sending is gated, so a run on a developer's own desktop does not pop a notification
-    // up at them and leave it there. The wedged-bus harness, where by construction nothing can be
-    // displayed, sets this and so covers the send path too.
-    if (qEnvironmentVariableIsSet("CONTOUR_TEST_NOTIFICATION_SEND"))
-    {
+    contour::test::checkReturnsWithoutWaiting([&](bool maySend) {
+        if (!maySend)
+            return;
+
         transport.notify(aNotification("osc-real"), 0, [](auto) {});
 
         // close() short-circuits on an id it holds no mapping for, and on a bus that never answers
@@ -442,12 +427,7 @@ TEST_CASE("PortalNotificationTransport drives the real portal without waiting",
                                             QLatin1StringView("RemoveNotification"),
                                             { QStringLiteral("contour-test/osc-real") },
                                             {});
-    }
-    QCoreApplication::processEvents();
-
-    // Deliberately generous: this separates "returned promptly" from "waited out a 25-second D-Bus
-    // reply timeout", and is not trying to measure anything finer than that.
-    CHECK(std::chrono::steady_clock::now() - startedAt < std::chrono::seconds { 5 });
+    });
 }
 
 #endif // defined(__linux__)

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -992,52 +992,63 @@ void TerminalSession::showDesktopNotification(vtbackend::DesktopNotification con
 #ifdef __linux__
     _desktopNotifier->notify(notification);
 
+    // Deliberately NOT Qt::SingleShotConnection. That breaks the connection on the first EMISSION of
+    // the signal, whichever notification it was about -- so with two notifications outstanding, the
+    // one that closes (or is clicked) first silently retires the OTHER one's handler, and the report
+    // it was waiting for is never sent. Several notifications are live at once routinely: OSC 99
+    // identifies them precisely so an application can have more than one. So the connection is
+    // broken by the handler that matched, and only once it has matched.
+    auto const identifier = notification.identifier;
+
     // Connect close event reporting if requested.
     if (notification.closeEventRequested)
     {
-        auto const identifier = notification.identifier;
-        QObject::connect(
+        auto const connection = std::make_shared<QMetaObject::Connection>();
+        *connection = QObject::connect(
             _desktopNotifier.get(),
             &platform::Notifier::notificationClosed,
             this,
-            [this, identifier](QString const& closedId, uint /*reason*/, vtbackend::CloseReport report) {
-                if (closedId.toStdString() == identifier)
-                {
-                    _terminal.reply("\033]{}\033\\", vtbackend::buildOSC99CloseResponse(identifier, report));
-                    _terminal.desktopNotificationManager().removeActiveNotification(identifier);
-                }
-            },
-            Qt::SingleShotConnection);
-    }
+            [this, identifier, connection](
+                QString const& closedId, uint /*reason*/, vtbackend::CloseReport report) {
+                if (closedId.toStdString() != identifier)
+                    return;
 
-    auto const identifier = notification.identifier;
+                QObject::disconnect(*connection);
+                _terminal.reply("\033]{}\033\\", vtbackend::buildOSC99CloseResponse(identifier, report));
+                _terminal.desktopNotificationManager().removeActiveNotification(identifier);
+            });
+    }
 
     // Connect activation reporting if requested.
     if (notification.reportOnActivation)
     {
-        QObject::connect(
-            _desktopNotifier.get(),
-            &platform::Notifier::actionInvoked,
-            this,
-            [this, identifier](QString const& activatedId) {
-                if (activatedId.toStdString() == identifier)
-                    _terminal.reply("\033]99;i={}:p=activated;\033\\", identifier);
-            },
-            Qt::SingleShotConnection);
+        auto const connection = std::make_shared<QMetaObject::Connection>();
+        *connection = QObject::connect(_desktopNotifier.get(),
+                                       &platform::Notifier::actionInvoked,
+                                       this,
+                                       [this, identifier, connection](QString const& activatedId) {
+                                           if (activatedId.toStdString() != identifier)
+                                               return;
+
+                                           QObject::disconnect(*connection);
+                                           _terminal.reply("\033]99;i={}:p=activated;\033\\", identifier);
+                                       });
     }
 
     // Focus terminal on activation if requested.
     if (notification.focusOnActivation)
     {
-        QObject::connect(
-            _desktopNotifier.get(),
-            &platform::Notifier::actionInvoked,
-            this,
-            [this, identifier](QString const& activatedId) {
-                if (activatedId.toStdString() == identifier)
-                    focusTerminalWindow();
-            },
-            Qt::SingleShotConnection);
+        auto const connection = std::make_shared<QMetaObject::Connection>();
+        *connection = QObject::connect(_desktopNotifier.get(),
+                                       &platform::Notifier::actionInvoked,
+                                       this,
+                                       [this, identifier, connection](QString const& activatedId) {
+                                           if (activatedId.toStdString() != identifier)
+                                               return;
+
+                                           QObject::disconnect(*connection);
+                                           focusTerminalWindow();
+                                       });
     }
 #else
     // On non-Linux platforms, fall back to the simple notification mechanism.

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -97,6 +97,45 @@ namespace
 #endif
     }
 
+#ifdef __linux__
+    /// Connects @p action to @p signal, running it on the first emission naming @p identifier and
+    /// breaking the connection there.
+    ///
+    /// Deliberately NOT Qt::SingleShotConnection: that breaks the connection on the first EMISSION
+    /// of the signal, whichever notification it was about -- so with two notifications outstanding,
+    /// the one that closes (or is clicked) first silently retires the OTHER one's handler, and the
+    /// report it was waiting for is never sent. Several notifications are live at once routinely:
+    /// OSC 99 identifies them precisely so an application can have more than one.
+    ///
+    /// @param notifier   Whose signal to connect to.
+    /// @param context    Whose lifetime the connection is bound to.
+    /// @param signal     The signal, whose first parameter is the identifier emitted.
+    /// @param identifier The notification identifier this connection is about.
+    /// @param action     What to run, taking the signal's remaining parameters.
+    template <typename... Args, typename Action>
+    void connectOnceMatching(platform::Notifier* notifier,
+                             TerminalSession* context,
+                             void (platform::Notifier::*signal)(QString, Args...),
+                             std::string identifier,
+                             Action action)
+    {
+        // Held indirectly because the handler must be able to break its own connection, which does
+        // not exist yet when the handler is built.
+        auto const connection = std::make_shared<QMetaObject::Connection>();
+        *connection = QObject::connect(
+            notifier,
+            signal,
+            context,
+            [identifier = std::move(identifier), connection, action](QString const& emitted, Args... args) {
+                if (emitted.toStdString() != identifier)
+                    return;
+
+                QObject::disconnect(*connection);
+                action(args...);
+            });
+    }
+#endif
+
     ColorPalette const* preferredColorPalette(config::ColorConfig const& config,
                                               vtbackend::ColorPreference preference)
     {
@@ -992,64 +1031,33 @@ void TerminalSession::showDesktopNotification(vtbackend::DesktopNotification con
 #ifdef __linux__
     _desktopNotifier->notify(notification);
 
-    // Deliberately NOT Qt::SingleShotConnection. That breaks the connection on the first EMISSION of
-    // the signal, whichever notification it was about -- so with two notifications outstanding, the
-    // one that closes (or is clicked) first silently retires the OTHER one's handler, and the report
-    // it was waiting for is never sent. Several notifications are live at once routinely: OSC 99
-    // identifies them precisely so an application can have more than one. So the connection is
-    // broken by the handler that matched, and only once it has matched.
     auto const identifier = notification.identifier;
 
     // Connect close event reporting if requested.
     if (notification.closeEventRequested)
-    {
-        auto const connection = std::make_shared<QMetaObject::Connection>();
-        *connection = QObject::connect(
-            _desktopNotifier.get(),
-            &platform::Notifier::notificationClosed,
-            this,
-            [this, identifier, connection](
-                QString const& closedId, uint /*reason*/, vtbackend::CloseReport report) {
-                if (closedId.toStdString() != identifier)
-                    return;
-
-                QObject::disconnect(*connection);
-                _terminal.reply("\033]{}\033\\", vtbackend::buildOSC99CloseResponse(identifier, report));
-                _terminal.desktopNotificationManager().removeActiveNotification(identifier);
-            });
-    }
+        connectOnceMatching(_desktopNotifier.get(),
+                            this,
+                            &platform::Notifier::notificationClosed,
+                            identifier,
+                            [this, identifier](uint /*reason*/, vtbackend::CloseReport report) {
+                                _terminal.reply("\033]{}\033\\",
+                                                vtbackend::buildOSC99CloseResponse(identifier, report));
+                                _terminal.desktopNotificationManager().removeActiveNotification(identifier);
+                            });
 
     // Connect activation reporting if requested.
     if (notification.reportOnActivation)
-    {
-        auto const connection = std::make_shared<QMetaObject::Connection>();
-        *connection = QObject::connect(_desktopNotifier.get(),
-                                       &platform::Notifier::actionInvoked,
-                                       this,
-                                       [this, identifier, connection](QString const& activatedId) {
-                                           if (activatedId.toStdString() != identifier)
-                                               return;
-
-                                           QObject::disconnect(*connection);
-                                           _terminal.reply("\033]99;i={}:p=activated;\033\\", identifier);
-                                       });
-    }
+        connectOnceMatching(
+            _desktopNotifier.get(), this, &platform::Notifier::actionInvoked, identifier, [this, identifier] {
+                _terminal.reply("\033]99;i={}:p=activated;\033\\", identifier);
+            });
 
     // Focus terminal on activation if requested.
     if (notification.focusOnActivation)
-    {
-        auto const connection = std::make_shared<QMetaObject::Connection>();
-        *connection = QObject::connect(_desktopNotifier.get(),
-                                       &platform::Notifier::actionInvoked,
-                                       this,
-                                       [this, identifier, connection](QString const& activatedId) {
-                                           if (activatedId.toStdString() != identifier)
-                                               return;
-
-                                           QObject::disconnect(*connection);
-                                           focusTerminalWindow();
-                                       });
-    }
+        connectOnceMatching(
+            _desktopNotifier.get(), this, &platform::Notifier::actionInvoked, identifier, [this] {
+                focusTerminalWindow();
+            });
 #else
     // On non-Linux platforms, fall back to the simple notification mechanism.
     emit showNotification(QString::fromStdString(notification.title),

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -122,17 +122,18 @@ namespace
         // Held indirectly because the handler must be able to break its own connection, which does
         // not exist yet when the handler is built.
         auto const connection = std::make_shared<QMetaObject::Connection>();
-        *connection = QObject::connect(
-            notifier,
-            signal,
-            context,
-            [identifier = std::move(identifier), connection, action](QString const& emitted, Args... args) {
-                if (emitted.toStdString() != identifier)
-                    return;
+        *connection =
+            QObject::connect(notifier,
+                             signal,
+                             context,
+                             [identifier = std::move(identifier), connection, action = std::move(action)](
+                                 QString const& emitted, Args... args) {
+                                 if (emitted.toStdString() != identifier)
+                                     return;
 
-                QObject::disconnect(*connection);
-                action(args...);
-            });
+                                 QObject::disconnect(*connection);
+                                 action(args...);
+                             });
     }
 #endif
 

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -1034,7 +1034,6 @@ void TerminalSession::showDesktopNotification(vtbackend::DesktopNotification con
 
     auto const identifier = notification.identifier;
 
-    // Connect close event reporting if requested.
     if (notification.closeEventRequested)
         connectOnceMatching(_desktopNotifier.get(),
                             this,
@@ -1046,14 +1045,12 @@ void TerminalSession::showDesktopNotification(vtbackend::DesktopNotification con
                                 _terminal.desktopNotificationManager().removeActiveNotification(identifier);
                             });
 
-    // Connect activation reporting if requested.
     if (notification.reportOnActivation)
         connectOnceMatching(
             _desktopNotifier.get(), this, &platform::Notifier::actionInvoked, identifier, [this, identifier] {
                 _terminal.reply("\033]99;i={}:p=activated;\033\\", identifier);
             });
 
-    // Focus terminal on activation if requested.
     if (notification.focusOnActivation)
         connectOnceMatching(
             _desktopNotifier.get(), this, &platform::Notifier::actionInvoked, identifier, [this] {

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -299,7 +299,11 @@ TerminalSession::TerminalSession(TerminalSessionManager* manager,
                 createSettingsFromConfig(_config, _profile, _currentColorPreference, initialPageSize),
                 std::chrono::steady_clock::now() },
     _exitWatcherThread { std::make_unique<ExitWatcherThread>(*this) },
-    _desktopNotifier { notifier ? std::move(notifier) : platform::makeDesktopNotifier() }
+    // _config is declared before _desktopNotifier, so reading it here is well-defined. The delay is
+    // fixed for the notifier's life: it decides how a backend that cannot observe a close behaves,
+    // which is configuration, not state.
+    _desktopNotifier { notifier ? std::move(notifier)
+                                : platform::makeDesktopNotifier(_config.notificationCloseTimeout.value()) }
 {
     if (app.liveConfig())
     {
@@ -996,10 +1000,10 @@ void TerminalSession::showDesktopNotification(vtbackend::DesktopNotification con
             _desktopNotifier.get(),
             &platform::Notifier::notificationClosed,
             this,
-            [this, identifier](QString const& closedId, uint /*reason*/) {
+            [this, identifier](QString const& closedId, uint /*reason*/, vtbackend::CloseReport report) {
                 if (closedId.toStdString() == identifier)
                 {
-                    _terminal.reply("\033]99;i={}:p=close;\033\\", identifier);
+                    _terminal.reply("\033]{}\033\\", vtbackend::buildOSC99CloseResponse(identifier, report));
                     _terminal.desktopNotificationManager().removeActiveNotification(identifier);
                 }
             },

--- a/src/contour/session/TerminalSession_test.cpp
+++ b/src/contour/session/TerminalSession_test.cpp
@@ -101,9 +101,13 @@ class RecordingNotifier final: public contour::platform::Notifier
     void close(std::string const& identifier) override { closed.push_back(identifier); }
 
     /// Plays back what the desktop would report once the user (or a timeout) retired a notification.
-    void fireClosed(std::string const& identifier, uint reason)
+    /// @param report Whether the backend observed the close or a timer merely assumed it; the
+    ///               portal backend can only ever produce the latter.
+    void fireClosed(std::string const& identifier,
+                    uint reason,
+                    vtbackend::CloseReport report = vtbackend::CloseReport::Observed)
     {
-        emit notificationClosed(QString::fromStdString(identifier), reason);
+        emit notificationClosed(QString::fromStdString(identifier), reason, report);
     }
 
     /// Plays back what the desktop would report when the user clicked a notification.
@@ -1387,7 +1391,19 @@ TEST_CASE("TerminalSession: desktop notification wiring is display-safe and repo
     {
         auto const written = writtenAfter([&] { raised->fireClosed("n2", /*reason*/ 2); });
 
-        CHECK(written.contains("\033]99;i=n2:p=close;"));
+        CHECK(written.contains("\033]99;i=n2:p=close;\033\\"));
+    }
+
+    SECTION("a close the backend only assumed is reported back as untracked")
+    {
+        // What a sandboxed Contour produces: org.freedesktop.portal.Notification has no close
+        // signal at all, so the close is a timer expiring rather than something observed. Saying
+        // so is the difference between an honest report and claiming to have watched it happen.
+        // @see issue #2074.
+        auto const written =
+            writtenAfter([&] { raised->fireClosed("n2", /*reason*/ 1, vtbackend::CloseReport::Untracked); });
+
+        CHECK(written.contains("\033]99;i=n2:p=close;untracked\033\\"));
     }
 
     SECTION("an activation is reported back as p=activated")

--- a/src/contour/session/TerminalSession_test.cpp
+++ b/src/contour/session/TerminalSession_test.cpp
@@ -1423,6 +1423,39 @@ TEST_CASE("TerminalSession: desktop notification wiring is display-safe and repo
         CHECK_FALSE(written.contains(":p=close;"));
         CHECK_FALSE(written.contains(":p=activated;"));
     }
+
+    SECTION("another notification's events do not retire this one's reporting")
+    {
+        // Several notifications are live at once routinely -- OSC 99 identifies them precisely so
+        // an application can have more than one. A handler wired with Qt::SingleShotConnection
+        // would be broken by the FIRST emission whatever it was about, so the events below would
+        // silently swallow n2's, and an application waiting on `c=1` would wait forever.
+        (void) writtenAfter([&] {
+            raised->fireClosed("n1", 2);
+            raised->fireActivated("n1");
+        });
+
+        auto const written = writtenAfter([&] {
+            raised->fireClosed("n2", 2);
+            raised->fireActivated("n2");
+        });
+
+        CHECK(written.contains("\033]99;i=n2:p=close;\033\\"));
+        CHECK(written.contains("\033]99;i=n2:p=activated;"));
+    }
+
+    SECTION("a notification is reported on once, not once per event")
+    {
+        auto const written = writtenAfter([&] {
+            raised->fireClosed("n2", 2);
+            raised->fireClosed("n2", 2);
+            raised->fireActivated("n2");
+            raised->fireActivated("n2");
+        });
+
+        CHECK(written.find("p=close;") == written.rfind("p=close;"));
+        CHECK(written.find("p=activated;") == written.rfind("p=activated;"));
+    }
 #endif
 }
 

--- a/src/contour/test/NotificationFixtures.hpp
+++ b/src/contour/test/NotificationFixtures.hpp
@@ -51,13 +51,19 @@ namespace contour::test
 /// The bound is deliberately generous: it separates "returned promptly" from "waited out a
 /// 25-second D-Bus reply timeout", and is not trying to measure anything finer than that.
 ///
-/// @param exercise What to drive, taking whether it may actually send.
+/// @p exercise runs only where sending is permitted, so the gate lives here rather than as a
+/// prologue every future timed case has to remember -- forgetting it is what pops a notification up
+/// at whoever ran the suite. The timing bracket is taken either way: returning promptly with
+/// nothing to send is still the property under test.
+///
+/// @param exercise What to drive against the real bus.
 template <typename Exercise>
 void checkReturnsWithoutWaiting(Exercise exercise)
 {
     auto const startedAt = std::chrono::steady_clock::now();
 
-    exercise(notificationSendingEnabled());
+    if (notificationSendingEnabled())
+        exercise();
     QCoreApplication::processEvents();
 
     CHECK(std::chrono::steady_clock::now() - startedAt < std::chrono::seconds { 5 });

--- a/src/contour/test/NotificationFixtures.hpp
+++ b/src/contour/test/NotificationFixtures.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/DesktopNotification.hpp>
+
+#include <QtCore/QCoreApplication>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <string>
+#include <utility>
+
+namespace contour::test
+{
+
+/// A notification with nothing interesting about it but its identifier, which is what the routing
+/// cases are all actually about.
+/// @param identifier The OSC 99 notification identifier.
+/// @return The notification.
+[[nodiscard]] inline vtbackend::DesktopNotification aNotification(std::string identifier)
+{
+    auto notification = vtbackend::DesktopNotification {};
+    notification.identifier = std::move(identifier);
+    notification.title = "Title";
+    notification.body = "Body";
+    return notification;
+}
+
+/// Whether this run may put a notification on a real bus.
+///
+/// Gated so a run on a developer's own desktop does not pop a notification up at them and leave it
+/// there. The wedged-bus harness sets it, and there by construction nothing can be displayed -- so
+/// the send path is covered exactly where covering it is harmless.
+/// @return Whether to send.
+[[nodiscard]] inline bool notificationSendingEnabled()
+{
+    return qEnvironmentVariableIsSet("CONTOUR_TEST_NOTIFICATION_SEND");
+}
+
+/// Runs @p exercise against whatever session bus the machine has, and requires it to have returned
+/// promptly.
+///
+/// Every other case in these files talks to a recorder, which by construction cannot catch a
+/// backend that WAITS -- and waiting is the regression the whole transport seam exists to prevent.
+/// So the timed cases build their backend exactly as production does, and
+/// test/e2e/notification-nonblocking.sh is what makes the bus interesting: there the notification
+/// service is activatable and never answers, which is what a desktop with no working notification
+/// backend looks like, and what used to cost 25 seconds per session. @see issue #2051.
+///
+/// The bound is deliberately generous: it separates "returned promptly" from "waited out a
+/// 25-second D-Bus reply timeout", and is not trying to measure anything finer than that.
+///
+/// @param exercise What to drive, taking whether it may actually send.
+template <typename Exercise>
+void checkReturnsWithoutWaiting(Exercise exercise)
+{
+    auto const startedAt = std::chrono::steady_clock::now();
+
+    exercise(notificationSendingEnabled());
+    QCoreApplication::processEvents();
+
+    CHECK(std::chrono::steady_clock::now() - startedAt < std::chrono::seconds { 5 });
+}
+
+} // namespace contour::test

--- a/src/contour/test/e2e/notification-nonblocking.sh
+++ b/src/contour/test/e2e/notification-nonblocking.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# Asserts that a wedged desktop-notification daemon does not stall Contour -- the regression behind
+# Asserts that a wedged desktop-notification service does not stall Contour -- the regression behind
 # issue #2051, where starting Contour with dunst disabled took about two minutes.
 #
 # The setup reproduces "disabled notification daemon" the way a real desktop presents it: a private
@@ -7,6 +7,9 @@
 # whose activation never claims the name. Every synchronous D-Bus call towards it therefore sits
 # until the reply timeout expires -- Qt's default is 25 s -- and returns NoReply, which is exactly
 # the error the issue reports.
+#
+# org.freedesktop.portal.Desktop is wedged the same way, because a sandboxed Contour talks to the
+# notification portal instead and inherits the same requirement not to wait.
 #
 # Usage: notification-nonblocking.sh <path-to-contour_gui_test>
 
@@ -34,6 +37,16 @@ mkdir -p "$WORK_DIR/services"
 cat >"$WORK_DIR/services/org.freedesktop.Notifications.service" <<EOF
 [D-BUS Service]
 Name=org.freedesktop.Notifications
+Exec=/bin/sleep 600
+EOF
+
+# The same trap, set for the portal: a sandboxed Contour speaks org.freedesktop.portal.Notification
+# instead, and it must be no more willing to wait than the session-bus backend is. A desktop whose
+# xdg-desktop-portal is installed but not answering is the same failure, one bus name over.
+# @see issue #2074.
+cat >"$WORK_DIR/services/org.freedesktop.portal.Desktop.service" <<EOF
+[D-BUS Service]
+Name=org.freedesktop.portal.Desktop
 Exec=/bin/sleep 600
 EOF
 

--- a/src/vtbackend/DesktopNotification.cpp
+++ b/src/vtbackend/DesktopNotification.cpp
@@ -203,6 +203,20 @@ string buildOSC99QueryResponse(string_view identifier)
                        identifier);
 }
 
+string buildOSC99CloseResponse(string_view identifier, CloseReport report)
+{
+    auto const payload = [report]() -> string_view {
+        switch (report)
+        {
+            case CloseReport::Observed: return "";
+            case CloseReport::Untracked: return "untracked";
+        }
+        return "";
+    }();
+
+    return std::format("99;i={}:p=close;{}", identifier, payload);
+}
+
 void DesktopNotificationManager::handleOSC99(string_view payload, Terminal& terminal)
 {
     auto notification = parseOSC99(payload);

--- a/src/vtbackend/DesktopNotification.hpp
+++ b/src/vtbackend/DesktopNotification.hpp
@@ -30,6 +30,18 @@ enum class NotificationUrgency : uint8_t
     Critical = 2,
 };
 
+/// How the terminal came to know a notification was closed.
+///
+/// Not every desktop can say. org.freedesktop.Notifications emits a close signal, but
+/// org.freedesktop.portal.Notification -- the only service a Flatpak sandbox can reach -- has no
+/// equivalent, so there the terminal can at best assume the popup was retired once enough time has
+/// passed. OSC 99 has a word for exactly that case, and this is what selects it.
+enum class CloseReport : uint8_t
+{
+    Observed = 0,  ///< The desktop reported the close.
+    Untracked = 1, ///< Nobody reported it; a timer expired.
+};
+
 /// When to display the notification based on terminal focus state.
 enum class DisplayOccasion : uint8_t
 {
@@ -68,6 +80,17 @@ struct DesktopNotification
 /// @param identifier the notification identifier from the query.
 /// @return a formatted OSC 99 response string (without OSC prefix/terminator).
 [[nodiscard]] std::string buildOSC99QueryResponse(std::string_view identifier);
+
+/// Builds the close report for a notification the desktop retired.
+///
+/// A close the terminal could not observe is marked `untracked`, which is what the protocol defines
+/// for a platform whose desktop does not report closure. Reporting it as a bare close instead would
+/// tell the application the popup is gone as though we had watched it happen.
+///
+/// @param identifier the notification identifier being reported on.
+/// @param report how the terminal came to know about the close.
+/// @return a formatted OSC 99 response string (without OSC prefix/terminator).
+[[nodiscard]] std::string buildOSC99CloseResponse(std::string_view identifier, CloseReport report);
 
 /// Manages OSC 99 desktop notification state including chunking and active notification tracking.
 class DesktopNotificationManager

--- a/src/vtbackend/DesktopNotification.hpp
+++ b/src/vtbackend/DesktopNotification.hpp
@@ -42,6 +42,22 @@ enum class CloseReport : uint8_t
     Untracked = 1, ///< Nobody reported it; a timer expired.
 };
 
+/// Names a CloseReport, for diagnostics.
+///
+/// A switch rather than a conditional at each use site: a third way of coming to know about a close
+/// would then be a compile error here instead of a log line that quietly says the wrong word.
+/// @param report the provenance to name.
+/// @return the label.
+[[nodiscard]] constexpr std::string_view closeReportName(CloseReport report) noexcept
+{
+    switch (report)
+    {
+        case CloseReport::Observed: return "observed";
+        case CloseReport::Untracked: return "untracked";
+    }
+    return "observed";
+}
+
 /// When to display the notification based on terminal focus state.
 enum class DisplayOccasion : uint8_t
 {

--- a/src/vtbackend/DesktopNotification_test.cpp
+++ b/src/vtbackend/DesktopNotification_test.cpp
@@ -193,3 +193,17 @@ TEST_CASE("DesktopNotification.QueryResponse", "[DesktopNotification]")
     CHECK(response.contains("c=1"));
     CHECK(response.contains("w=1"));
 }
+
+TEST_CASE("DesktopNotification.CloseResponseObserved", "[DesktopNotification]")
+{
+    // A close the terminal watched happen carries no extra payload, and must not start carrying one.
+    CHECK(buildOSC99CloseResponse("test-id", CloseReport::Observed) == "99;i=test-id:p=close;");
+}
+
+TEST_CASE("DesktopNotification.CloseResponseUntracked", "[DesktopNotification]")
+{
+    // A close nobody reported is marked as such. The protocol defines `untracked` for a platform
+    // whose desktop cannot report closure -- which is every sandboxed Contour, because
+    // org.freedesktop.portal.Notification has no close signal at all.
+    CHECK(buildOSC99CloseResponse("test-id", CloseReport::Untracked) == "99;i=test-id:p=close;untracked");
+}


### PR DESCRIPTION
Desktop notifications have never worked in the Flatpak build. Inside the sandbox the session-bus name `org.freedesktop.Notifications` is unreachable without `--talk-name`, and adding that to the Flathub manifest was rejected in moderation: *"Your app should not need direct access to org.freedesktop.Notifications. There's a notifications portal."* The reviewer is right, and packaging cannot grant its way out — so a sandboxed Contour now speaks `org.freedesktop.portal.Notification`, which needs no permission at all. Outside a sandbox nothing changes: the session bus is strictly the more capable of the two, because it reports that a notification was dismissed.

Closes #2074.

The portal is not a drop-in in three ways, and each one shows up in the design:

- **It assigns no id.** `AddNotification` takes an application-chosen string and returns nothing, so the id every layer above deals in is minted in the transport and mapped to the portal's string. Deriving that string from the OSC 99 identifier gives replace-in-place for free, since the portal's own rule is that reusing an id updates the notification already showing.
- **`ActionInvoked` is broadcast and carries no app id**, so ids are namespaced per transport — per *process* is not enough, because a transport is built per terminal session and two panes may use the same OSC identifier.
- **There is no close signal at all.** After `notification_close_timeout` a close is assumed and reported as `p=close;untracked`, the payload OSC 99 defines for a terminal that cannot see the close happen. An application asking for close events with `c=1` is answered instead of waiting forever, and can still tell a guess from an observation.

## Changes

- Adds `PortalNotificationTransport`, selected when `Process::isFlatpak()`. The D-Bus call and the timer are both injected, so the id bookkeeping, replace-in-place and the assumed close are all driven headlessly — the suite never pops a real notification up at anyone.
- Moves the transport seam onto the domain type: `notify()` now carries the `DesktopNotification` and the id being replaced, rather than a pre-built freedesktop `Notify` tuple that a second protocol would have to take apart to rebuild. Each transport builds its own wire form.
- Extracts `DBusSignalSubscription`, so registering and removing a match rule name it argument for argument through one function. A mismatch there fails *silently*, leaving the rule installed for the life of the process while the bus delivers towards an object being destroyed.
- Builds the OSC 99 close report in `vtbackend`, where the protocol lives, and gives a close event its provenance so the notifier can forward what it cannot itself determine.
- Adds `notification_close_timeout` (10s default; a notification's own `w=` wins; `0` disables the assumption entirely).
- Extends the wedged-bus harness to trap the portal name too, holding the new transport to the same non-blocking budget as the old one (#2051).

The last nine commits are review fixes, each with a regression test: the transport's and the router's identifier↔id maps stayed mutual inverses only when the caller could name the id being replaced, which it cannot for a second send issued before the first reply arrived; `Qt::SingleShotConnection` broke a reporting handler on the first emission of the signal rather than the one it was waiting for, so with two notifications live the first to close silently retired the other's report; the portal id prefix was derived from `applicationPid()`, which Flatpak's PID namespace makes identical across instances — the one deployment that uses the portal; and both transports inferred "have I subscribed?" from a handler being non-empty, so subscribing without one left the match rule outliving its receiver.