### PR TITLE
Output folding for semantic command blocks

### DIFF
--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -186,6 +186,37 @@ color_schemes:
           background: '#000000'
 ```
 
+### `fold_marker`
+Defines the colors of the fold column drawn in the one-column gutter left of the grid, when output
+folding is enabled (see `folding.show_markers`). Two independent sections, `default` and `hover`,
+each with `foreground` and `background`; `hover` applies to the whole run of the fold the pointer is
+currently over, not just the row under it.
+
+Both are **optional**, and left unset by default. When a section is missing, its colors are derived
+from this scheme's own `default` foreground and background: at rest the glyph is faded partway
+toward the background so it stays quieter than the text beside it, and on hover it comes up to the
+full foreground. Only the glyph changes — the background stays the page's own in both states, so the
+gutter never paints over a transparent window. That is what lets a scheme which has never heard of
+folding still draw a legible, obviously-clickable column, in light and dark themes alike — so only
+set these if you actively want something else.
+
+``` yaml
+color_schemes:
+  default:
+    fold_marker:
+        default:
+          foreground: '#7e7c7c'
+          background: '#1a1716'
+        hover:
+          foreground: '#d0d0d0'
+          background: '#1a1716'
+```
+
+:octicons-horizontal-rule-16: ==default== Colors of the fold column at rest. Set the background to
+this scheme's own background to keep the gutter transparent along with the rest of the window. <br/>
+:octicons-horizontal-rule-16: ==hover== Colors of the fold run under the pointer — the whole run of
+the hovered fold, not just the row beneath it. <br/>
+
 ### Palette Presets 
 When choosing a palette from a preset as the color scheme  (in `profiles`) it is possible to tweak any configuration:
 ``` yaml
@@ -326,6 +357,13 @@ color_schemes:
             visual_mode:
               foreground: '#FFFFFF'
               background: '#0270C0'
+        # fold_marker:
+        #     default:
+        #         foreground: '#7e7c7c'
+        #         background: '#1a1716'
+        #     hover:
+        #         foreground: '#d0d0d0'
+        #         background: '#1a1716'
         input_method_editor:
             foreground: '#FFFFFF'
             background: '#FF0000'

--- a/docs/demo/line-marks.md
+++ b/docs/demo/line-marks.md
@@ -10,10 +10,14 @@ This is what a shell integration would do, but you can simply
 mark lines yourself by trivially writing to `stdout`, as follows:
 
 ```sh
-printf "\033[>M"
+printf "\033]133;A\033\\"
 ```
 
-This will tell the terminal to remember the line as a jump-target
+This will tell the terminal to remember the line as a jump-target.
+
+`OSC 133 ; A` is the shell-integration sequence for "a new prompt starts here". Contour also
+accepted a dedicated `SETMARK` sequence (`CSI > M`) for this until 0.7.1, when it was removed in
+favour of this one.
 
 ## Jump via shortcut
 

--- a/docs/vt-extensions/osc-133-shell-integration.md
+++ b/docs/vt-extensions/osc-133-shell-integration.md
@@ -108,5 +108,5 @@ printf "\033]133;D;0\033\\"
 
 ## Related Extensions
 
-* **SETMARK (CSI > M)**: This extension is deprecated in favor of OSC 133.
-It is however similar to `OSC 133 ; A` by triggering `promptStart` and marking the line.
+* **SETMARK (`CSI > M`)**: a Contour-only extension that marked the current line, equivalent to
+`OSC 133 ; A`. Deprecated in favour of OSC 133 and **removed in 0.7.1** — use `OSC 133 ; A`.

--- a/docs/vt-extensions/private-use-glyphs.md
+++ b/docs/vt-extensions/private-use-glyphs.md
@@ -1,0 +1,77 @@
+# Private Use Glyphs
+
+Contour draws a few glyphs that Unicode has no character for. Rather than inventing a second
+drawing channel for them, they are given codepoints in a Private Use Area and rendered by the same
+built-in box-drawing renderer that draws `U+2500`–`U+257F`, the block elements and the legacy
+computing symbols.
+
+This page documents those codepoints so that other terminals, fonts and tools can render the same
+glyphs if they want to. Nothing here is a protocol: no escape sequence introduces these characters,
+and Contour never requires an application to emit one.
+
+## The reserved block
+
+**`U+10F000`–`U+10F0FF`** — Contour Terminal private glyphs.
+
+The block sits in **Supplementary Private Use Area-B** (plane 16) rather than in the BMP's
+`U+E000`–`U+F8FF`. That lower range is comprehensively claimed by Nerd Fonts — Powerline, Font
+Awesome, Devicons, Octicons, Seti, Material and others — and Contour already renders several of
+those assignments itself (`U+E0B0`–`U+E0BE`, `U+EE00`–`U+EE05`, `U+F5D0`–`U+F60D`).
+
+It also sits away from the *start* of a plane. An allocation that outgrows the BMP tends to land at
+the beginning of the next area it is offered, which makes `U+F0000` — the first codepoint of plane
+15 — one of the more contended places to put a block, not one of the safer ones. `U+10F000` is near
+the far end of plane 16 instead, where no widely-deployed assignment reaches.
+
+Only the codepoints listed below are actually claimed by the renderer. The rest of the block is
+reserved for future use and deliberately falls through to the font, so that reserving a range costs
+nothing to anyone who is already using it.
+
+## Assigned codepoints
+
+| Codepoint | Name | Glyph |
+|---|---|---|
+| `U+10F000` | FOLD HEAD OPEN | A square box containing a minus, with a stem descending from its bottom edge to the bottom of the cell. |
+| `U+10F001` | FOLD HEAD CLOSED | A square box containing a plus. No stem. |
+
+Both are drawn as line art at the current foreground colour, scaled to the cell: the box is square
+whatever the cell's aspect ratio, and the stem shares its column with `U+2502` so that the two meet
+exactly.
+
+### What they are for
+
+They form the head of Contour's **fold column** — the gutter drawn to the left of the grid, which
+marks each foldable [OSC 133](osc-133-shell-integration.md) command block:
+
+```
+⊟─ $ make -j8          <- U+10F000, the block is open
+│    [  1/120] cc a.c
+│    [  2/120] cc b.c
+┕    ... done          <- U+2515, the block's last row
+
+⊞  $ make -j8          <- U+10F001, the block is collapsed
+```
+
+The body and tail need no private codepoints — `U+2502` (BOX DRAWINGS LIGHT VERTICAL) and `U+2515`
+(BOX DRAWINGS UP LIGHT AND RIGHT HEAVY) already describe them exactly.
+
+The head does. `U+229F` SQUARED MINUS and `U+229E` SQUARED PLUS are the box and its sign, but
+neither carries the stem that joins an open head to the body beneath it, and a head that did not
+connect would read as two unrelated marks rather than as one bracket down the side of a block.
+
+A box carrying a plus or a minus, rather than a triangle, because that is the fold control a reader
+has already met in editors, tree views and file managers.
+
+## Notes for implementers
+
+- These characters are **produced by the terminal, for its own gutter**. They are not part of any
+  escape sequence, and an application has no reason to write one.
+- A Private Use Area assignment is by definition not exclusive. Planes 15 and 16 are also used by
+  some East Asian fonts for user-defined characters (GB 18030 and Big5 user-defined areas), so a
+  document that already uses `U+10F000` for something else will render as a fold head in Contour.
+  Turning the gutter off (`folding.show_markers: false`) does not change that, because the glyphs
+  are claimed by the renderer rather than by the fold feature — if this ever proves to matter in
+  practice, the claim is one entry in `BoxDrawingRenderer::renderable()`.
+- If you implement these in a font, note that Contour will still prefer its own rendition: the
+  box-drawing renderer is consulted before font shaping, and `font.builtin_box_drawing: false`
+  turns that off for all built-in glyphs, not just these.

--- a/docs/vt-extensions/vertical-line-marks.md
+++ b/docs/vt-extensions/vertical-line-marks.md
@@ -5,13 +5,30 @@ output and you need a way to conveniently scroll the terminal viewport up to the
 command. This is what this feature is there for. You can easily walk up/down your markers
 like you'd walk up code folds or markers in VIM or other editors.
 
-## Set a mark:
+## Set a mark
+
+A mark is set by the `OSC 133 ; A` shell-integration sequence, which says "a new prompt starts on
+this line":
 
 ```sh
-echo -ne "\033[>M"
+printf "\033]133;A\033\\"
 ```
 
-## Example key bindings in Contour:
+!!! note
+
+    Contour used to offer a dedicated `SETMARK` sequence (`CSI > M`) for this. It was deprecated in
+    favour of `OSC 133 ; A` and **removed in 0.7.1** — `OSC 133 ; A` does the same thing and, unlike
+    a Contour-only extension, is understood by other terminals too.
+
+You will usually not write this by hand: Contour's bundled
+[shell integration](osc-133-shell-integration.md) already emits it (along with the rest of OSC 133),
+which is what also drives "copy last command output" and output folding. Install it with:
+
+```sh
+contour generate integration shell zsh to ~/.config/contour/shell-integration.zsh
+```
+
+## Example key bindings in Contour
 
 ```yaml
 input_mapping:
@@ -19,16 +36,16 @@ input_mapping:
     - { mods: [Alt, Shift], key: 'j', mode: '~Alt', action: ScrollMarkDown }
 ```
 
-It is recommended to integrate the marker into your command prompt, such as `$PS1` in bash or sh to
-have automatic markers set.
+If you would rather integrate the mark into your prompt by hand than install the shell integration,
+the sections below show how.
 
-## Integration into ZSH:
+## Integration into ZSH
 
 zsh is way too configurable to give a fully generic answer here, but to show how you can integrate vertical line markers when using [powerlevel9k](https://github.com/Powerlevel9k/powerlevel9k), this is what your `~/.zshrc` config could contain:
 
 ```sh
 prompt_setmark() {
-    echo -ne "%{\033[>M%}"
+    echo -ne "%{\033]133;A\033\\\\%}"
 }
 POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(setmark user dir vcs)
 ```
@@ -39,10 +56,9 @@ Bash is usually highly customized to your needs, but the bottom line would be as
 
 ```sh
 prompt_setmark() {
-    echo -ne "\\[\033[>M\\]"
+    echo -ne "\\[\033]133;A\033\\\\\\]"
 }
 
 # extending existing PS1
 export PS1="`prompt_setmark`${PS1}"
 ```
-

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -109,6 +109,13 @@
         <ul>
           <li>Fixes desktop notifications never appearing in the Flatpak build. Contour asked org.freedesktop.Notifications for them directly, which a sandbox does not permit and which Flathub declines to grant a permission for; a sandboxed Contour now speaks the org.freedesktop.portal.Notification portal instead, which needs no permission at all. Outside a sandbox nothing changes — the session bus is still used, and still reports a dismissal exactly as before</li>
           <li>Adds notification_close_timeout, for the one thing the notification portal cannot do: tell an application that its notification was dismissed. Where a close cannot be observed, Contour now assumes one after this long (10 seconds by default) and reports it back over OSC 99 marked `untracked`, so an application that asked for close events with `c=1` is answered instead of waiting forever, and can still tell a guess from an observation. A notification that states its own lifetime with `w=` is answered on that instead, and 0 disables the assumption entirely</li>
+          <li>Adds output folding: collapse a finished command's output down to its prompt line and expand it again. Driven by the shell's OSC 133 marks, so any shell with shell integration works (#88)</li>
+          <li>Adds a fold column in a one-column gutter left of the grid, marking each foldable block and highlighting under the pointer; clicking it, or the new context-menu entry, toggles that fold</li>
+          <li>Reserves U+10F000..U+10F0FF for Contour's own glyphs and assigns the fold column's two heads, which no Unicode character describes; see docs/vt-extensions/private-use-glyphs.md</li>
+          <li>Adds the global folding config section and the actions CollapseAllFolds, CollapseLastFold, ExpandAllFolds, ToggleFold and ToggleLastFold</li>
+          <li>Vi normal mode moves in visible lines, stepping over collapsed blocks; folding.on_jump_into_fold picks whether a search hit inside one expands it or is skipped</li>
+          <li>Removes the deprecated SETMARK sequence (CSI &gt; M); use OSC 133 ; A instead</li>
+          <li>Draws U+25BC and U+25B6 with the built-in box-drawing renderer, so they no longer depend on the font</li>
         </ul>
       </description>
     </release>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
     - vt-extensions/osc-133-shell-integration.md
     - vt-extensions/osc-9-4-progress.md
     - vt-extensions/semantic-block-query.md
+    - vt-extensions/private-use-glyphs.md
   - Internals:
     - internals/index.md
     - internals/CODING_STYLE.md

--- a/src/contour/cli/shell-integration/shell-integration.bash
+++ b/src/contour/cli/shell-integration/shell-integration.bash
@@ -401,7 +401,7 @@ precmd() {
         unset _contour_command_running
     fi
 
-    printf "\\e[?2028l\\e[>M\\e]7;$PWD\\e\\\\";
+    printf "\\e[?2028l\\e]7;$PWD\\e\\\\";
 
     # OSC 133;A -- a new prompt starts on this line. Together with ;C above this is what lets the terminal
     # tell a prompt apart from a command's output, which is what "copy last command output" reads.

--- a/src/contour/cli/shell-integration/shell-integration.fish
+++ b/src/contour/cli/shell-integration/shell-integration.fish
@@ -34,10 +34,6 @@ function precmd_hook_contour -d "Shell Integration hook to be invoked before eac
     # tell a prompt apart from a command's output, which is what "copy last command output" reads.
     printf "\e]133;A\e\\"
 
-    # Marks the current line (command prompt) so that you can jump to it via key bindings.
-    #printf '\e[>M'
-    printf "\e[>M"
-
     # Informs contour terminal about the current working directory, so that e.g. OpenFileManager works.
     printf "\e]7;$PWD\e\\"
 

--- a/src/contour/cli/shell-integration/shell-integration.tcsh
+++ b/src/contour/cli/shell-integration/shell-integration.tcsh
@@ -9,7 +9,7 @@
 # precmd emits, in order:
 #   OSC 133;D  -- the previous command finished, with its exit status,
 #   DECRST 2028 -- text reflow off for the prompt,
-#   SETMARK + OSC 7 -- the jump-to-prompt mark, and the working directory,
+#   OSC 7      -- the working directory,
 #   OSC 133;A  -- a new prompt starts on this line.
 # postcmd emits DECSET 2028 (reflow back on) and OSC 133;C -- the command's output begins here.
 #
@@ -17,5 +17,5 @@
 # "copy last command output" reads. Unlike the other shells there is no guard against emitting ;D at the
 # very first prompt -- a tcsh alias cannot carry that state without clobbering $status -- so the first
 # prompt reports a command block with no text in it. The terminal ignores an empty block.
-alias precmd 'echo -n "\033]133;D;$status\033\\\033[?2028l\033[>M\033]7;$PWD\033\\\033]133;A\033\\";'
+alias precmd 'echo -n "\033]133;D;$status\033\\\033[?2028l\033]7;$PWD\033\\\033]133;A\033\\";'
 alias postcmd 'echo -n "\033[?2028h\033]133;C\033\\";'

--- a/src/contour/cli/shell-integration/shell-integration.zsh
+++ b/src/contour/cli/shell-integration/shell-integration.zsh
@@ -34,9 +34,6 @@ precmd_hook_contour()
     # tell a prompt apart from a command's output, which is what "copy last command output" reads.
     print -n '\e]133;A\e\\' >$TTY
 
-    # Marks the current line (command prompt) so that you can jump to it via key bindings.
-    echo -n '\e[>M' >$TTY
-
     # Informs contour terminal about the current working directory, so that e.g. OpenFileManager works.
     echo -ne '\e]7;'$(pwd)'\e\\' >$TTY
 

--- a/src/contour/command/ContextMenu.cpp
+++ b/src/contour/command/ContextMenu.cpp
@@ -60,6 +60,11 @@ namespace
     {
         return state.canSpeak && state.hasSelection;
     }
+
+    bool hasFoldUnderCursor(ContextMenuState const& state) noexcept
+    {
+        return state.foldLine.has_value();
+    }
     // }}}
 
     /// A row acting on the hyperlink that was RIGHT-CLICKED, carried with the row rather than looked up
@@ -139,6 +144,19 @@ namespace
             Table::command(CopyLastCommandPrompt {}, "Copy Last Prompt").shownWhen(hasLastCommand),
             Table::command(CopyLastCommandOutput {}, "Copy Last Command Output").shownWhen(hasLastCommand),
             Table::command(CopyLastCommandBlock {}, "Copy Last Prompt and Output").shownWhen(hasLastCommand),
+
+            // GRAYED rather than hidden when there is no fold under the pointer, unlike the rows above:
+            // those describe a shell capability that is either there or not, while this one describes
+            // THIS spot. A row that vanished depending on where you right-clicked would make the menu
+            // change shape under the pointer, and hide the fact that folding exists at all.
+            //
+            // Carries the clicked line rather than reading the viewport when picked: by then the pointer
+            // has left that row for the menu, and ToggleFold's own anchor is the top of the viewport.
+            Table::command(ToggleFoldAt {}, "Toggle Output Fold")
+                .enabledWhen(hasFoldUnderCursor)
+                .actionFrom([](ContextMenuState const& state) -> actions::Action {
+                    return ToggleFoldAt { .line = state.foldLine ? state.foldLine->value : 0 };
+                }),
 
             Table::separator(),
 

--- a/src/contour/command/ContextMenu.hpp
+++ b/src/contour/command/ContextMenu.hpp
@@ -3,7 +3,10 @@
 
 #include <contour/config/Actions.hpp>
 
+#include <vtbackend/Primitives.hpp>
+
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,6 +41,14 @@ struct ContextMenuState
     /// clicked cell the instant it travels to the menu row the user is reaching for — so an action that
     /// asked again at click time would answer about a cell nobody clicked.
     std::string hyperlinkUnderCursor;
+
+    /// The right-clicked grid line, when a fold covers it -- nullopt means there is nothing to toggle.
+    ///
+    /// One optional rather than a marker plus a line, so "there is a fold" and "which line it is on"
+    /// cannot disagree. Captured at click time for the same reason the hyperlink above is: the pointer
+    /// leaves that cell the moment the user reaches for the menu row, so a row that asked again would
+    /// answer about a line nobody clicked.
+    std::optional<vtbackend::LineOffset> foldLine;
 
     std::string activeProfile;             ///< The profile this session runs under.
     std::vector<std::string> profileNames; ///< Every configured profile, in a stable order.

--- a/src/contour/command/ContextMenu_test.cpp
+++ b/src/contour/command/ContextMenu_test.cpp
@@ -55,6 +55,7 @@ namespace
         .hasLocalWorkingDirectory = true,
         .hasSplits = true,
         .hyperlinkUnderCursor = "https://contour-terminal.org/",
+        .foldLine = vtbackend::LineOffset(7),
         .activeProfile = "dark",
         .profileNames = { "dark", "light", "work" },
     };
@@ -146,6 +147,29 @@ TEST_CASE("ContextMenu.hyperlink.onlyUnderTheCursor", "[contextmenu]")
     auto const elsewhere = buildContextMenu(state);
     CHECK(find(elsewhere, "Open Link") == nullptr);
     CHECK(find(elsewhere, "Copy Link Address") == nullptr);
+}
+
+TEST_CASE("ContextMenu.toggleFold.grayedRatherThanHiddenWithoutAFold", "[contextmenu]")
+{
+    auto state = fullyEnabledState();
+
+    // Present and enabled where a fold reaches -- and it must CARRY the clicked line, because by the
+    // time the row is picked the pointer has left that line for the menu itself.
+    state.foldLine = vtbackend::LineOffset(-12);
+    auto const overFold = buildContextMenu(state);
+    auto const* row = find(overFold, "Toggle Output Fold");
+    REQUIRE(row != nullptr);
+    CHECK(row->enabled);
+    REQUIRE(std::holds_alternative<actions::ToggleFoldAt>(row->action));
+    CHECK(std::get<actions::ToggleFoldAt>(row->action).line == -12);
+
+    // Elsewhere the row stays PUT and goes gray. Hiding it would make the menu change shape depending
+    // on where you right-clicked, and would hide the fact that folding exists at all.
+    state.foldLine.reset();
+    auto const elsewhere = buildContextMenu(state);
+    auto const* grayed = find(elsewhere, "Toggle Output Fold");
+    REQUIRE(grayed != nullptr);
+    CHECK(!grayed->enabled);
 }
 
 TEST_CASE("ContextMenu.openCurrentFolder.requiresLocalWorkingDirectory", "[contextmenu]")
@@ -325,6 +349,7 @@ TEST_CASE("ContextMenu.separators.neverLeadingTrailingOrDoubled", "[contextmenu]
                                 .hasLocalWorkingDirectory = true,
                                 .hasSplits = splits,
                                 .hyperlinkUnderCursor = hyperlink ? "https://example.org/" : "",
+                                .foldLine = std::nullopt,
                                 .activeProfile = profiles ? "dark" : "",
                                 .profileNames = profiles ? std::vector<std::string> { "dark" }
                                                          : std::vector<std::string> {},

--- a/src/contour/config/Actions.hpp
+++ b/src/contour/config/Actions.hpp
@@ -81,6 +81,9 @@ struct ResetFontSize{};
 struct ScreenshotVT{};
 struct SaveScreenshot{};
 struct CopyScreenshot{};
+struct CollapseAllFolds{};   // OSC 133: hide every finished command's output
+struct CollapseLastFold{};   // OSC 133: hide the most recent finished command's output
+struct ExpandAllFolds{};     // OSC 133: show every collapsed command's output again
 struct ScrollDown{};
 struct ScrollMarkDown{};
 struct ScrollMarkUp{};
@@ -90,6 +93,9 @@ struct ScrollPageDown{};
 struct ScrollPageUp{};
 struct ScrollToBottom{};
 struct ScrollToTop{};
+struct ToggleFold{};       // OSC 133: toggle the fold at the cursor's block
+struct ToggleFoldAt{ int line {}; }; // OSC 133: toggle the fold covering a given grid line
+struct ToggleLastFold{};   // OSC 133: toggle the most recent finished command's fold
 struct ScrollUp{};
 struct SearchReverse{};
 struct SendChars{ std::string chars; };
@@ -182,6 +188,9 @@ using Action = std::variant<CancelSelection,
                             ScreenshotVT,
                             SaveScreenshot,
                             CopyScreenshot,
+                            CollapseAllFolds,
+                            CollapseLastFold,
+                            ExpandAllFolds,
                             ScrollDown,
                             ScrollMarkDown,
                             ScrollMarkUp,
@@ -191,6 +200,9 @@ using Action = std::variant<CancelSelection,
                             ScrollPageUp,
                             ScrollToBottom,
                             ScrollToTop,
+                            ToggleFold,
+                            ToggleFoldAt,
+                            ToggleLastFold,
                             ScrollUp,
                             SearchReverse,
                             SendChars,
@@ -342,7 +354,8 @@ concept ParameterizedActionConcept = crispy::oneOf<T,
                                                    MoveTabTo,
                                                    SwitchToTab,
                                                    ResizePane,
-                                                   LaunchLayout>;
+                                                   LaunchLayout,
+                                                   ToggleFoldAt>;
 
 /// @returns true if @p action requires an argument that a bare catalog entry cannot supply (a
 /// ParameterizedActionConcept member), false if it is runnable as-is.
@@ -438,6 +451,13 @@ namespace documentation
     constexpr inline std::string_view CopyScreenshot {
         "takes a screenshot and puts it into the system clipboard"
     };
+    constexpr inline std::string_view CollapseAllFolds {
+        "Collapses every finished command, hiding all of their output (requires shell integration)"
+    };
+    constexpr inline std::string_view CollapseLastFold {
+        "Collapses the most recently finished command, hiding its output"
+    };
+    constexpr inline std::string_view ExpandAllFolds { "Expands every collapsed command again" };
     constexpr inline std::string_view ScrollDown { "Scrolls down by the multiplier factor." };
     constexpr inline std::string_view ScrollMarkDown {
         "Scrolls one mark down (if none present, bottom of the screen)"
@@ -449,6 +469,15 @@ namespace documentation
     constexpr inline std::string_view ScrollPageUp { "Scrolls a page up." };
     constexpr inline std::string_view ScrollToBottom { "Scrolls to the bottom of the screen buffer." };
     constexpr inline std::string_view ScrollToTop { "Scrolls to the top of the screen buffer." };
+    constexpr inline std::string_view ToggleFold {
+        "Collapses or expands the command block the cursor is in"
+    };
+    constexpr inline std::string_view ToggleFoldAt {
+        "Collapses or expands the command block covering a given grid line (used by the context menu)"
+    };
+    constexpr inline std::string_view ToggleLastFold {
+        "Collapses or expands the most recently finished command"
+    };
     constexpr inline std::string_view ScrollUp { "Scrolls up by the multiplier factor." };
     constexpr inline std::string_view SearchReverse {
         "Initiates search mode (starting to search at current cursor position, moving upwards)."
@@ -667,6 +696,11 @@ struct ActionCatalogEntry
         ActionCatalogEntry { "ScreenshotVT", Action { ScreenshotVT {} }, documentation::ScreenshotVT },
         ActionCatalogEntry { "SaveScreenshot", Action { SaveScreenshot {} }, documentation::SaveScreenshot },
         ActionCatalogEntry { "CopyScreenshot", Action { CopyScreenshot {} }, documentation::CopyScreenshot },
+        ActionCatalogEntry {
+            "CollapseAllFolds", Action { CollapseAllFolds {} }, documentation::CollapseAllFolds },
+        ActionCatalogEntry {
+            "CollapseLastFold", Action { CollapseLastFold {} }, documentation::CollapseLastFold },
+        ActionCatalogEntry { "ExpandAllFolds", Action { ExpandAllFolds {} }, documentation::ExpandAllFolds },
         ActionCatalogEntry { "ScrollDown", Action { ScrollDown {} }, documentation::ScrollDown },
         ActionCatalogEntry { "ScrollMarkDown", Action { ScrollMarkDown {} }, documentation::ScrollMarkDown },
         ActionCatalogEntry { "ScrollMarkUp", Action { ScrollMarkUp {} }, documentation::ScrollMarkUp },
@@ -676,6 +710,9 @@ struct ActionCatalogEntry
         ActionCatalogEntry { "ScrollPageUp", Action { ScrollPageUp {} }, documentation::ScrollPageUp },
         ActionCatalogEntry { "ScrollToBottom", Action { ScrollToBottom {} }, documentation::ScrollToBottom },
         ActionCatalogEntry { "ScrollToTop", Action { ScrollToTop {} }, documentation::ScrollToTop },
+        ActionCatalogEntry { "ToggleFold", Action { ToggleFold {} }, documentation::ToggleFold },
+        ActionCatalogEntry { "ToggleFoldAt", Action { ToggleFoldAt {} }, documentation::ToggleFoldAt },
+        ActionCatalogEntry { "ToggleLastFold", Action { ToggleLastFold {} }, documentation::ToggleLastFold },
         ActionCatalogEntry { "ScrollUp", Action { ScrollUp {} }, documentation::ScrollUp },
         ActionCatalogEntry { "SearchReverse", Action { SearchReverse {} }, documentation::SearchReverse },
         ActionCatalogEntry { "SendChars", Action { SendChars {} }, documentation::SendChars },
@@ -844,6 +881,7 @@ struct std::formatter<contour::actions::Direction>: std::formatter<std::string_v
                 return std::format(", direction: {}, percent: {}", a.direction, a.percent);
             },
             [](MoveTabTo const& a) { return std::format(", position: {}", a.position); },
+            [](ToggleFoldAt const& a) { return std::format(", line: {}", a.line); },
             [](SwitchToTab const& a) { return std::format(", position: {}", a.position); },
             [](WriteScreen const& a) { return std::format(", chars: '{}'", a.chars); },
             [](CreateSelection const& a) { return std::format(", delimiters: '{}'", a.delimiters); },

--- a/src/contour/config/Actions_test.cpp
+++ b/src/contour/config/Actions_test.cpp
@@ -178,6 +178,10 @@ TEST_CASE("actions::isParameterized marks the actions the palette cannot run bar
     CHECK(isParameterized(Action { SendChars {} }));
     CHECK(isParameterized(Action { LaunchLayout {} }));
     CHECK(isParameterized(Action { ResizePane {} }));
+    // ToggleFoldAt's default names grid line 0 -- a REAL line, so a bare palette entry would toggle
+    // whatever fold covers the top of the page rather than doing nothing visible. It is built by the
+    // context menu from the line that was right-clicked, never run bare.
+    CHECK(isParameterized(Action { ToggleFoldAt {} }));
 
     // These have a MEANINGFUL default (copy as text, paste unstripped, current profile), so they run
     // as-is and the palette offers them.

--- a/src/contour/config/Config.cpp
+++ b/src/contour/config/Config.cpp
@@ -2989,6 +2989,17 @@ std::optional<actions::Action> YAMLConfigReader::parseAction(YAML::Node const& n
                 return std::nullopt;
         }
 
+        // ToggleFoldAt is built by the context menu from the line that was right-clicked rather than
+        // bound by hand, but it round-trips like any other parameterized action -- a config written by
+        // Contour must be a config Contour can read back.
+        if (holds_alternative<actions::ToggleFoldAt>(action))
+        {
+            if (auto line = node["line"]; line && line.IsScalar())
+                return actions::ToggleFoldAt { line.as<int>() };
+            else
+                return std::nullopt;
+        }
+
         if (holds_alternative<actions::SwitchToTab>(action))
         {
             if (auto position = node["position"]; position && position.IsScalar())

--- a/src/contour/config/Config.cpp
+++ b/src/contour/config/Config.cpp
@@ -464,6 +464,10 @@ vtbackend::Settings emulationSettings(Config const& config, TerminalProfile cons
     auto settings = vtbackend::Settings {};
     settings.pageSize = profile.terminalSize.value();
     settings.maxHistoryLineCount = profile.history.value().maxHistoryLineCount;
+    auto const& folding = config.folding.value();
+    settings.foldMarkers = folding.markersVisible();
+    settings.autoCollapseFoldOnNewCommand = folding.enabled && folding.autoCollapseOnNewCommand;
+    settings.foldJumpBehavior = folding.onJumpIntoFold;
     settings.terminalId = profile.terminalId.value();
     settings.frozenModes = profile.frozenModes.value();
     settings.maxImageRegisterCount = config.images.value().maxImageColorRegisters;
@@ -845,6 +849,7 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("read_buffer_size", c.ptyReadBufferSize);
         loadFromEntry("pty_buffer_size", c.ptyBufferObjectSize);
         loadFromEntry("images", c.images);
+        loadFromEntry("folding", c.folding);
         loadFromEntry("live_config", c.live);
         loadFromEntry("early_exit_threshold", c.earlyExitThreshold);
         loadFromEntry("spawn_new_process", c.spawnNewProcess);
@@ -1327,6 +1332,23 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, vtbackend::ColorPal
             }
         }
     }
+    // The fold column, left unset unless the scheme says otherwise: vtbackend then derives it from the
+    // palette's own foreground and background, so a scheme that has never heard of folding still draws
+    // a legible column rather than one hard-coded colour that happens to vanish on half the themes.
+    if (auto const folding = child["fold_marker"])
+    {
+        logger()("*** loading fold_marker");
+        auto const loadPair = [&](std::string const& key, std::optional<vtbackend::RGBColorPair>& target) {
+            if (!folding[key])
+                return;
+            auto colors = vtbackend::RGBColorPair {};
+            loadFromEntry(folding, key, colors);
+            target = colors;
+        };
+        loadPair("default", where.foldMarker);
+        loadPair("hover", where.foldMarkerHover);
+    }
+
     logger()("*** loading palette");
     loadFromEntry(child, "", where.palette);
 }
@@ -1930,6 +1952,28 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "scroll_multiplier", where.historyScrollMultiplier);
         loadFromEntry(child, "auto_scroll_on_update", where.autoScrollOnUpdate);
     }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& entry, FoldingConfig& where)
+{
+    auto const child = node[entry];
+    if (child)
+    {
+        loadFromEntry(child, "enabled", where.enabled);
+        loadFromEntry(child, "show_markers", where.showMarkers);
+        loadFromEntry(child, "auto_collapse_on_new_command", where.autoCollapseOnNewCommand);
+        loadFromEntry(child, "on_jump_into_fold", where.onJumpIntoFold);
+    }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
+                                     std::string const& entry,
+                                     vtbackend::FoldJumpBehavior& where)
+{
+    // Through the shared token table rather than an if-chain of spellings: the settings page builds
+    // its combo box from the very same rows (@see configEnumValues), so a value this reader accepts
+    // is by construction a value the UI can offer and the writer can spell back.
+    (void) loadConfigEnum(node, entry, where, logger);
 }
 
 void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& entry, ScrollBarConfig& where)
@@ -3579,6 +3623,25 @@ static void emitColorPaletteBody(Writer& writer, std::string& doc, vtbackend::Co
                    entry.indicatorStatusLineInsertMode.background,
                    entry.indicatorStatusLineInactive.foreground,
                    entry.indicatorStatusLineInactive.background);
+
+    // Written back key by key, and only for what was actually set. The two pairs are independent
+    // optionals -- a scheme that says nothing about folding derives the column from its own
+    // foreground/background -- so emitting a full block would pin colours the scheme never chose, and
+    // emitting the commented example unconditionally would drop the ones it did.
+    if (entry.foldMarker || entry.foldMarkerHover)
+    {
+        processWithDoc(documentation::FoldMarkerHeader {});
+        if (entry.foldMarker)
+            processWithDoc(documentation::FoldMarkerDefault {},
+                           entry.foldMarker->foreground,
+                           entry.foldMarker->background);
+        if (entry.foldMarkerHover)
+            processWithDoc(documentation::FoldMarkerHover {},
+                           entry.foldMarkerHover->foreground,
+                           entry.foldMarkerHover->background);
+    }
+    else
+        processWithDoc(documentation::FoldMarker {});
 
     processWithDoc(documentation::InputMethodEditor {},
                    entry.inputMethodEditor.foreground,

--- a/src/contour/config/Config.hpp
+++ b/src/contour/config/Config.hpp
@@ -297,6 +297,35 @@ struct HistoryConfig
     bool autoScrollOnUpdate { true };
 };
 
+/// Output folding: collapsing a finished command's output down to the prompt line it was entered at.
+///
+/// The fold ranges come from the OSC 133 semantic marks a shell with shell integration emits, so a shell
+/// that emits none simply has nothing to fold. Only FINISHED commands fold, which is why the prompt the
+/// user is typing at never does.
+///
+/// Plain bools rather than enum classes because these are YAML schema fields, converted at the boundary
+/// -- the documented carve-out in AGENT.md. The one enum below is not a bool in disguise: it selects
+/// between two NAMED outcomes, which is exactly what that carve-out does not cover.
+struct FoldingConfig
+{
+    bool enabled { true };                   ///< Whether folding is available at all.
+    bool showMarkers { true };               ///< Reserve a gutter column and draw a marker in it.
+    bool autoCollapseOnNewCommand { false }; ///< Collapse a command as soon as the next prompt starts.
+
+    /// What a targeted Vi-mode jump does when its target sits inside a collapsed fold.
+    vtbackend::FoldJumpBehavior onJumpIntoFold { vtbackend::FoldJumpBehavior::Expand };
+
+    /// Whether the fold gutter is drawn, and therefore whether a column must be reserved for it.
+    ///
+    /// Spelled once because two independent layers ask it: the renderer, deciding whether to draw a
+    /// marker, and the window geometry, deciding whether to reserve the column one would occupy. They
+    /// must always agree -- a marker drawn into a column nobody reserved lands on top of the grid --
+    /// and a third condition added to only one of them is a silent desync.
+    ///
+    /// @return Whether markers are shown.
+    [[nodiscard]] constexpr bool markersVisible() const noexcept { return enabled && showMarkers; }
+};
+
 struct ScrollBarConfig
 {
     ScrollBarPosition position { ScrollBarPosition::Hidden };
@@ -1193,6 +1222,7 @@ struct Config
     ConfigEntry<bool, documentation::Live> live { false };
     ConfigEntry<std::set<std::string>, documentation::ExperimentalFeatures> experimentalFeatures {};
     ConfigEntry<ImagesConfig, documentation::Images> images {};
+    ConfigEntry<FoldingConfig, documentation::Folding> folding {};
 
     ConfigEntry<std::unordered_map<std::string, TerminalProfile>, documentation::Profiles> profiles {
         { { "main", TerminalProfile {} } }
@@ -1506,6 +1536,10 @@ struct YAMLConfigReader
     void loadFromEntry(YAML::Node const& node, std::string const& entry, RendererConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ImagesConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, HistoryConfig& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, FoldingConfig& where);
+    void loadFromEntry(YAML::Node const& node,
+                       std::string const& entry,
+                       vtbackend::FoldJumpBehavior& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ScrollBarConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, MouseConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, StatusLineConfig& where);
@@ -1801,6 +1835,11 @@ struct Writer
     [[nodiscard]] std::string format(std::string_view doc, WindowMargins const& v)
     {
         return format(doc, v.horizontal, v.vertical);
+    }
+
+    [[nodiscard]] std::string format(std::string_view doc, FoldingConfig const& v)
+    {
+        return format(doc, v.enabled, v.showMarkers, v.autoCollapseOnNewCommand, v.onJumpIntoFold);
     }
 
     [[nodiscard]] std::string format(std::string_view doc, HistoryConfig const& v)

--- a/src/contour/config/ConfigDocumentation.hpp
+++ b/src/contour/config/ConfigDocumentation.hpp
@@ -360,6 +360,28 @@ constexpr StringLiteral HistoryConfig {
 
 };
 
+constexpr StringLiteral FoldingConfig {
+
+    "folding:\n"
+    "    {comment} Whether a finished command's output can be collapsed to its prompt line.\n"
+    "    {comment} Requires shell integration: the fold ranges come from the OSC 133 marks a\n"
+    "    {comment} shell leaves behind, so a shell that emits none has nothing to fold.\n"
+    "    enabled: {}\n"
+    "    {comment} Whether to reserve a gutter column left of the grid and draw a marker there\n"
+    "    {comment} on every foldable prompt line. Costs one column of terminal width.\n"
+    "    show_markers: {}\n"
+    "    {comment} Whether to collapse the previous command automatically when a new prompt starts.\n"
+    "    auto_collapse_on_new_command: {}\n"
+    "    {comment} What a Vi-mode jump that targets a line inside a collapsed block does:\n"
+    "    {comment}   expand - open the block so the cursor lands on what it was aiming at\n"
+    "    {comment}   skip   - leave the block collapsed and stop at its prompt line instead\n"
+    "    {comment} Plain motions (j, k, {{, }}, Ctrl-D, Ctrl-U) always step over a collapsed block\n"
+    "    {comment} regardless of this setting.\n"
+    "    on_jump_into_fold: {}\n"
+    "\n"
+
+};
+
 constexpr StringLiteral ScrollbarConfig {
 
     "scrollbar:\n"
@@ -1335,6 +1357,41 @@ constexpr StringLiteral IndicatorStatusLineConfig {
     "        background: {}\n"
 };
 
+constexpr StringLiteral FoldMarkerConfig {
+    "\n"
+    "{comment} Colors for the fold column drawn in the gutter left of the grid (output folding).\n"
+    "{comment} Unset by default, and deliberately: the column is then derived from this scheme's own\n"
+    "{comment} foreground/background -- a faded glyph at rest, coming up to full strength under the\n"
+    "{comment} pointer -- so it stays legible in any theme without every theme having to know the\n"
+    "{comment} feature exists. Uncomment to override.\n"
+    "{comment} The values shown are what the default scheme derives, so uncommenting them as-is\n"
+    "{comment} changes nothing -- they are a starting point to edit, not a second opinion.\n"
+    "{comment} fold_marker:\n"
+    "{comment}     default:\n"
+    "{comment}         foreground: '#7e7c7c'\n"
+    "{comment}         background: '#1a1716'\n"
+    "{comment}     hover:\n"
+    "{comment}         foreground: '#d0d0d0'\n"
+    "{comment}         background: '#1a1716'\n"
+};
+
+constexpr StringLiteral FoldMarkerHeaderConfig {
+    "\n"
+    "{comment} Colors for the fold column drawn in the gutter left of the grid (output folding).\n"
+    "{comment} Written back because this scheme sets them; remove the block to go back to deriving the\n"
+    "{comment} column from this scheme's own foreground/background, faded at rest and at full strength\n"
+    "{comment} under the pointer.\n"
+    "fold_marker:\n"
+};
+
+constexpr StringLiteral FoldMarkerDefaultConfig { "    default:\n"
+                                                  "        foreground: {}\n"
+                                                  "        background: {}\n" };
+
+constexpr StringLiteral FoldMarkerHoverConfig { "    hover:\n"
+                                                "        foreground: {}\n"
+                                                "        background: {}\n" };
+
 constexpr StringLiteral InputMethodEditorConfig { "\n"
                                                   "{comment} Colors for the IME (Input Method Editor) area.\n"
                                                   "input_method_editor:\n"
@@ -1932,6 +1989,41 @@ constexpr StringLiteral HistoryWeb {
     "\n"
 };
 
+constexpr StringLiteral FoldingWeb {
+    "configuration controls output folding: collapsing a finished command's output down to the prompt "
+    "line it was entered at, and expanding it again.\n"
+    "``` yaml\n"
+    "folding:\n"
+    "  enabled: true\n"
+    "  show_markers: true\n"
+    "  auto_collapse_on_new_command: false\n"
+    "  on_jump_into_fold: expand\n"
+    "```\n"
+    "Folding is driven entirely by the OSC 133 semantic marks a shell with shell integration emits, so "
+    "no additional escape sequence is involved and any shell that already speaks OSC 133 works. Only "
+    "FINISHED commands fold, which is why the prompt you are typing at never does.\n"
+    ":octicons-horizontal-rule-16: ==enabled== Whether folding is available at all. When false the "
+    "actions below do nothing and no gutter is reserved. <br/>\n"
+    ":octicons-horizontal-rule-16: ==show_markers== Whether to reserve a one-column gutter to the left "
+    "of the grid and draw a fold column in it: a boxed minus on a foldable prompt line whose output is "
+    "showing, a boxed plus once it is collapsed, and a bar down the side of the block joining the two. "
+    "Clicking anywhere on that column toggles the fold. Note that the gutter costs one column of "
+    "terminal width. <br/>\n"
+    ":octicons-horizontal-rule-16: ==auto_collapse_on_new_command== Whether a command's output is "
+    "collapsed automatically as soon as the next prompt appears, so that only the command you are "
+    "running now is shown in full. <br/>\n"
+    ":octicons-horizontal-rule-16: ==on_jump_into_fold== What a Vi-mode jump that targets a line "
+    "inside a collapsed block does: `expand` opens the block so the cursor lands on what it was "
+    "aiming at, `skip` leaves it collapsed and stops at its prompt line instead. Plain motions "
+    "(`j`, `k`, `{{`, `}}`, ++ctrl+d++, ++ctrl+u++) always step over a collapsed block regardless of "
+    "this setting. <br/>\n"
+    "\n"
+    "The actions ==CollapseAllFolds==, ==ExpandAllFolds==, ==CollapseLastFold==, ==ToggleLastFold== and "
+    "==ToggleFold== can be bound to keys; ==ScrollMarkUp== and ==ScrollMarkDown== already move the "
+    "viewport from one prompt to the next.\n"
+    "\n"
+};
+
 constexpr StringLiteral ScrollbarWeb {
     "configuration allows you to customize the appearance and behavior of the visual scrollbar in the "
     "terminal.\n"
@@ -2441,6 +2533,7 @@ using Margins = DocumentationEntry<MarginsConfig, MarginsWeb>;
 using TerminalSize = DocumentationEntry<TerminalSizeConfig, TerminalSizeWeb>;
 using TerminalId = DocumentationEntry<TerminalIdConfig, TerminalIdWeb>;
 using History = DocumentationEntry<HistoryConfig, HistoryWeb>;
+using Folding = DocumentationEntry<FoldingConfig, FoldingWeb>;
 using Scrollbar = DocumentationEntry<ScrollbarConfig, ScrollbarWeb>;
 using StatusLine = DocumentationEntry<StatusLineConfig, StatusLineWeb>;
 using OptionKeyAsAlt = DocumentationEntry<OptionKeyAsAltConfig, OptionKeyAsAltWeb>;
@@ -2612,6 +2705,10 @@ using HintMatch = DocumentationEntry<HintMatchConfig, Dummy>;
 using HintPatterns = DocumentationEntry<HintPatternsConfig, Dummy>;
 using HintScrollbackLines = DocumentationEntry<HintScrollbackLinesConfig, Dummy>;
 using IndicatorStatusLine = DocumentationEntry<IndicatorStatusLineConfig, Dummy>;
+using FoldMarker = DocumentationEntry<FoldMarkerConfig, Dummy>;
+using FoldMarkerHeader = DocumentationEntry<FoldMarkerHeaderConfig, Dummy>;
+using FoldMarkerDefault = DocumentationEntry<FoldMarkerDefaultConfig, Dummy>;
+using FoldMarkerHover = DocumentationEntry<FoldMarkerHoverConfig, Dummy>;
 using InputMethodEditor = DocumentationEntry<InputMethodEditorConfig, Dummy>;
 using InputMethodEditorSupport = DocumentationEntry<InputMethodEditorSupportConfig, Dummy>;
 using NormalColors = DocumentationEntry<NormalColorsConfig, Dummy>;

--- a/src/contour/config/ConfigEnum.hpp
+++ b/src/contour/config/ConfigEnum.hpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <vtbackend/Folding.hpp> // FoldJumpBehavior
+
+#include <array>
 #include <cstddef>
 #include <optional>
 #include <ranges>
@@ -89,6 +92,26 @@ template <typename Enum>
         if (info.value == value)
             return info.label;
     return {};
+}
+
+namespace detail
+{
+    /// What a targeted Vi jump does when its target sits inside a collapsed fold.
+    ///
+    /// Owned by vtbackend, so the table hangs off the type from here -- the reader, the settings-page
+    /// combo box and the written-back spelling then all come from this one row set.
+    inline constexpr auto FoldJumpBehaviorTable = std::array {
+        ConfigEnumInfo<vtbackend::FoldJumpBehavior> {
+            vtbackend::FoldJumpBehavior::Expand, "expand", "Expand the block" },
+        ConfigEnumInfo<vtbackend::FoldJumpBehavior> {
+            vtbackend::FoldJumpBehavior::Skip, "skip", "Stop at the prompt line" },
+    };
+} // namespace detail
+
+template <>
+constexpr std::span<ConfigEnumInfo<vtbackend::FoldJumpBehavior> const> configEnumValues() noexcept
+{
+    return detail::FoldJumpBehaviorTable;
 }
 
 } // namespace contour::config

--- a/src/contour/config/Config_test.cpp
+++ b/src/contour/config/Config_test.cpp
@@ -763,6 +763,115 @@ color_schemes:
     CHECK(scheme.backgroundImage->blur == true);
 }
 
+TEST_CASE("Config: the fold column's colors load and are written back", "[config]")
+{
+    QTemporaryDir dir;
+
+    auto const schemeOf = [](contour::config::Config const& config) {
+        auto const* profile = config.profile("main");
+        REQUIRE(profile != nullptr);
+        REQUIRE(std::holds_alternative<contour::config::SimpleColorConfig>(profile->colors.value()));
+        return std::get<contour::config::SimpleColorConfig>(profile->colors.value()).colors;
+    };
+
+    SECTION("unset by default, so the column derives from the scheme")
+    {
+        // Deliberately optional: a scheme that says nothing about folding must not have to, and gets
+        // the column derived from the palette's own foreground/background -- the glyph faded at rest
+        // and at full strength under the pointer.
+        auto const scheme = schemeOf(loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        colors: coverage
+color_schemes:
+    coverage:
+        default:
+            background: '#102030'
+            foreground: '#D0D0D0'
+)"sv));
+        CHECK_FALSE(scheme.foldMarker.has_value());
+        CHECK_FALSE(scheme.foldMarkerHover.has_value());
+    }
+
+    SECTION("both pairs load")
+    {
+        // Deliberately NOT the colours the derivation produces, and not each other's inverse: this
+        // section has to tell "read the configured value" apart from "fell back to the palette".
+
+        auto const scheme = schemeOf(loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        colors: coverage
+color_schemes:
+    coverage:
+        default:
+            background: '#102030'
+            foreground: '#D0D0D0'
+        fold_marker:
+            default:
+                foreground: '#909090'
+                background: '#101010'
+            hover:
+                foreground: '#FFD080'
+                background: '#303030'
+)"sv));
+        REQUIRE(scheme.foldMarker.has_value());
+        CHECK(scheme.foldMarker->foreground == vtbackend::RGBColor(0x90, 0x90, 0x90));
+        CHECK(scheme.foldMarker->background == vtbackend::RGBColor(0x10, 0x10, 0x10));
+        REQUIRE(scheme.foldMarkerHover.has_value());
+        CHECK(scheme.foldMarkerHover->foreground == vtbackend::RGBColor(0xFF, 0xD0, 0x80));
+        CHECK(scheme.foldMarkerHover->background == vtbackend::RGBColor(0x30, 0x30, 0x30));
+    }
+
+    SECTION("one pair alone loads, and the other stays unset")
+    {
+        auto const scheme = schemeOf(loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+        colors: coverage
+color_schemes:
+    coverage:
+        default:
+            background: '#102030'
+            foreground: '#D0D0D0'
+        fold_marker:
+            hover:
+                foreground: '#010203'
+                background: '#040506'
+)"sv));
+        CHECK_FALSE(scheme.foldMarker.has_value());
+        REQUIRE(scheme.foldMarkerHover.has_value());
+        CHECK(scheme.foldMarkerHover->foreground == vtbackend::RGBColor(0x01, 0x02, 0x03));
+    }
+
+    SECTION("the writer emits what was set, and only that")
+    {
+        // Every other palette entry hands the writer its live values; this one used to emit a fully
+        // commented example whatever the scheme said, so a configured fold column did not survive a
+        // write. Emitting the full block instead would be the opposite error -- it would PIN colours
+        // an unset pair deliberately derives.
+        auto config = contour::config::Config {};
+        auto& scheme = config.colorschemes.value()["default"];
+        scheme.foldMarker = vtbackend::RGBColorPair { .foreground = vtbackend::RGBColor(0x90, 0x90, 0x90),
+                                                      .background = vtbackend::RGBColor(0x1A, 0x1A, 0x1A) };
+
+        auto const written = contour::config::createString<contour::config::YAMLConfigWriter>(config);
+        REQUIRE(written.contains("fold_marker:"));
+
+        auto const reloaded = schemeOf(loadFromYaml(dir, written));
+        REQUIRE(reloaded.foldMarker.has_value());
+        CHECK(reloaded.foldMarker->foreground == vtbackend::RGBColor(0x90, 0x90, 0x90));
+        CHECK(reloaded.foldMarker->background == vtbackend::RGBColor(0x1A, 0x1A, 0x1A));
+        CHECK_FALSE(reloaded.foldMarkerHover.has_value());
+    }
+}
+
 TEST_CASE("Config: findProfile reports a missing profile instead of asserting", "[config]")
 {
     // findProfile() is the fallible lookup for runtime input (a keybinding naming a removed
@@ -846,6 +955,78 @@ profiles:
     CHECK(profile->permissions.value().changeFont == contour::config::Permission::Allow);
     CHECK(profile->permissions.value().captureBuffer == contour::config::Permission::Deny);
     CHECK(profile->permissions.value().displayHostWritableStatusLine == contour::config::Permission::Ask);
+}
+
+TEST_CASE("Config: folding loads from YAML and reaches the emulation settings", "[config]")
+{
+    QTemporaryDir dir;
+    // Folding is a GLOBAL section, not a per-profile one: a fold is a property of how the user reads
+    // output, not of which shell produced it, so it sits beside `images` rather than inside a profile.
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+folding:
+    enabled: true
+    show_markers: false
+    auto_collapse_on_new_command: true
+    on_jump_into_fold: skip
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+
+    auto const* profile = config.profile("main");
+    REQUIRE(profile != nullptr);
+
+    CHECK(config.folding.value().enabled == true);
+    CHECK(config.folding.value().showMarkers == false);
+    CHECK(config.folding.value().autoCollapseOnNewCommand == true);
+    CHECK(config.folding.value().onJumpIntoFold == vtbackend::FoldJumpBehavior::Skip);
+
+    // auto_collapse is what vtbackend actually needs to know about, and it is conjoined with `enabled`
+    // at the boundary so the emulation never has to consult two flags.
+    auto const settings = contour::config::emulationSettings(config, *profile);
+    CHECK(settings.autoCollapseFoldOnNewCommand == true);
+    CHECK(settings.foldJumpBehavior == vtbackend::FoldJumpBehavior::Skip);
+}
+
+TEST_CASE("Config: folding defaults, and disabling it never auto-collapses", "[config]")
+{
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+folding:
+    enabled: false
+    auto_collapse_on_new_command: true
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+
+    auto const* profile = config.profile("main");
+    REQUIRE(profile != nullptr);
+
+    // Unspecified keys keep their defaults.
+    CHECK(config.folding.value().showMarkers == true);
+    CHECK(config.folding.value().onJumpIntoFold == vtbackend::FoldJumpBehavior::Expand);
+
+    // `enabled: false` wins over `auto_collapse_on_new_command: true`: a feature that is off does not
+    // get to fold anything away behind the user's back.
+    CHECK(contour::config::emulationSettings(config, *profile).autoCollapseFoldOnNewCommand == false);
+}
+
+TEST_CASE("Config: an unknown on_jump_into_fold value keeps the default", "[config]")
+{
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+folding:
+    on_jump_into_fold: sideways
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+
+    CHECK(config.folding.value().onJumpIntoFold == vtbackend::FoldJumpBehavior::Expand);
 }
 
 TEST_CASE("Config: cursor, bell, mouse and modes load from YAML", "[config]")

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -2178,11 +2178,14 @@ void TerminalDisplay::onSelectionCompleted()
 
 void TerminalDisplay::bufferChanged(vtbackend::ScreenType type)
 {
+    // Through the shape enum rather than setCursor() directly, so this agrees with every other place
+    // that decides the pointer shape -- a raw setCursor() here stomps a hand cursor the fold column or
+    // a hyperlink has just asked for.
     using Type = vtbackend::ScreenType;
     switch (type)
     {
-        case Type::Primary: setCursor(Qt::IBeamCursor); break;
-        case Type::Alternate: setCursor(Qt::ArrowCursor); break;
+        case Type::Primary: setMouseCursorShape(input::MouseCursorShape::IBeam); break;
+        case Type::Alternate: setMouseCursorShape(input::MouseCursorShape::Arrow); break;
     }
     emit terminalBufferChanged(type);
     // scheduleRedraw();

--- a/src/contour/display/TerminalDisplay.cpp
+++ b/src/contour/display/TerminalDisplay.cpp
@@ -319,18 +319,21 @@ void TerminalDisplay::setSession(session::TerminalSession* newSession)
     if (!_renderer)
     {
         auto const timer = crispy::ScopedTimer(startupLog, "Renderer construction");
-        // The profile's own margin, scaled to device pixels, exactly as applyResize() derives it
-        // (@see geometry::fitPageToPixels, which takes left/top straight from these). Seeded here so
-        // the published grid origin is right from the very first event rather than from the first
-        // geometry change: the mouse hit-test maps through it, and a zero origin under a configured
-        // margin reports the cell the user clicked minus that margin.
+        // The profile's own margin, scaled to device pixels, through the same function applyResize()
+        // places the origin with (@see geometry::pageMarginFor). Seeded here so the published grid
+        // origin is right from the very first event rather than from the first geometry change: the
+        // mouse hit-test maps through it, and a zero origin under a configured margin reports the cell
+        // the user clicked minus that margin.
+        //
+        // WITHOUT the fold gutter, and unavoidably: the gutter is a fraction of the cell, and the cell
+        // size is the renderer's own answer -- there is none to ask until the object being constructed
+        // here exists. The first applyResize() folds it in, which is before any pointer event reaches a
+        // window that has been shown.
         auto const marginsDevicePx =
             geometry::scaled(session::toGeometryMargins(profile().margins.value()), devicePixelRatio());
         _renderer = make_unique<vtrasterizer::Renderer>(
             _session->profile().terminalSize.value(),
-            vtrasterizer::PageMargin { .left = marginsDevicePx.horizontal,
-                                       .top = marginsDevicePx.vertical,
-                                       .bottom = marginsDevicePx.vertical },
+            geometry::pageMarginFor(marginsDevicePx),
             session::sanitizeFontDescription(profile().fonts.value(), fontDPI()),
             _session->terminal().colorPalette(),
             _session->config().renderer.value().textureAtlasHashtableSlots,
@@ -917,9 +920,11 @@ void TerminalDisplay::createRenderer()
         auto const marginsDevicePx =
             geometry::scaled(session::toGeometryMargins(profile().margins.value()), devicePixelRatio());
         auto const fit = geometry::fitPageToPixels(
-            availablePx, gridMetrics().cellSize, marginsDevicePx, [this](auto page) {
-                return _session->terminal().clampedTotalPageSize(page);
-            });
+            availablePx,
+            gridMetrics().cellSize,
+            marginsDevicePx,
+            [this](auto page) { return _session->terminal().clampedTotalPageSize(page); },
+            session::gutterWidthFor(_session->config().folding.value(), gridMetrics().cellSize));
         _renderer->reserveAtlasForPage(fit.pageSize);
     }
 
@@ -1594,11 +1599,12 @@ bool TerminalDisplay::isFullScreen() const
 vtbackend::ImageSize TerminalDisplay::pixelSize() const
 {
     assert(_session);
+    auto const cellSize = _renderer->publishedCellSize();
     return geometry::requiredPixelsForPage(
         _session->terminal().totalPageSize(),
-        _renderer->publishedCellSize(),
-        geometry::scaled(session::toGeometryMargins(_session->profile().margins.value()),
-                         devicePixelRatio()));
+        cellSize,
+        geometry::scaled(session::toGeometryMargins(_session->profile().margins.value()), devicePixelRatio()),
+        session::gutterWidthFor(_session->config().folding.value(), cellSize));
 }
 
 vtbackend::ImageSize TerminalDisplay::reportedPixelSize(vtbackend::PageSize totalPageSize) const

--- a/src/contour/display/TerminalDisplay.hpp
+++ b/src/contour/display/TerminalDisplay.hpp
@@ -387,11 +387,16 @@ class TerminalDisplay: public QQuickItem, public session::DisplaySurface
         return unbox(terminal().pageSize().lines);
     }
 
+    /// How far the view can be scrolled up, in rows the user can actually reach.
+    ///
+    /// Forwarded rather than re-derived, so a QML caller reaching either this or the session's own
+    /// accessor is told the same thing about the same viewport -- and the reason it is the scrollable
+    /// count rather than the raw history depth is stated once, there.
     Q_INVOKABLE [[nodiscard]] int historyLineCount() const noexcept
     {
         if (!_session)
             return 0;
-        return unbox(terminal().currentScreen().historyLineCount());
+        return _session->historyLineCount();
     }
 
   private:

--- a/src/contour/geometry/WindowGeometry.hpp
+++ b/src/contour/geometry/WindowGeometry.hpp
@@ -38,6 +38,18 @@ struct Margins
     int vertical = 0;   ///< Padding applied above AND below the grid.
 };
 
+/// The width of the drawable gutter reserved to the LEFT of the grid, inside the margin.
+///
+/// Asymmetric, which is why it is not part of @ref Margins: it is a strip the renderer draws fold
+/// markers into, not padding, and it exists on one side only. It is subtracted from the width available
+/// to cells and added to the width a page requires, so a page fitted WITH a gutter reports one fewer
+/// column to the shell than the same window without one -- which is the honest answer, the column
+/// genuinely not being there.
+///
+/// Every function below takes it last and defaults it to zero, so a caller that reserves no gutter gets
+/// exactly the arithmetic this header had before one existed.
+using GutterWidth = int;
+
 /// Window chrome OUTSIDE the terminal content area (e.g. the QML title/tab bar), in logical pixels,
 /// DECLARED by the UI layer (Main.qml knows its layout). Never measured from live window-minus-item
 /// deltas — such measurements are transiently wrong during relayout and structurally wrong in splits.
@@ -164,6 +176,30 @@ namespace detail
         auto const unscaled = std::max(0.0, value / scale) + RoundingSlack;
         return static_cast<int>(unscaled); // truncation == floor for non-negative values
     }
+
+    /// The main-page row @p yDevicePx falls on, bounded neither way.
+    ///
+    /// Shared by mainPageRowAt() and mainPageRowNear() so that only their out-of-range policies differ:
+    /// a second spelling of it is how a truncating hit-test came to sit beside a flooring one.
+    ///
+    /// @param yDevicePx      The y coordinate in device pixels, relative to the item's top edge.
+    /// @param pageMarginTop  The renderer's grid origin, in device pixels.
+    /// @param cellHeightPx   The cell height in device pixels; must be positive.
+    /// @param mainPageTopRow The screen row the main page starts on.
+    /// @return The main-page-relative row, which may lie outside the page.
+    [[nodiscard]] constexpr int mainPageRowOf(int yDevicePx,
+                                              int pageMarginTop,
+                                              int cellHeightPx,
+                                              int mainPageTopRow) noexcept
+    {
+        // Floor division, not truncation: a coordinate ABOVE the grid origin is negative, and truncating
+        // it towards zero would fold the first row above the grid onto row 0.
+        auto const offsetPx = yDevicePx - pageMarginTop;
+        auto const screenRow =
+            offsetPx >= 0 ? offsetPx / cellHeightPx : -(((-offsetPx) + cellHeightPx - 1) / cellHeightPx);
+
+        return screenRow - mainPageTopRow;
+    }
 } // namespace detail
 
 /// Scales symmetric margins from logical to device pixels.
@@ -184,13 +220,15 @@ namespace detail
 /// @param availableDevicePx Total available area in device pixels.
 /// @param cellSize          Cell size in device pixels.
 /// @param marginsDevicePx   Symmetric minimum margins in device pixels.
+/// @param gutterDevicePx    Gutter reserved left of the grid, in device pixels (@see GutterWidth).
 /// @return The floored page size, at least 1x1.
 [[nodiscard]] constexpr vtbackend::PageSize pageSizeForPixels(vtbackend::ImageSize availableDevicePx,
                                                               vtbackend::ImageSize cellSize,
-                                                              Margins marginsDevicePx) noexcept
+                                                              Margins marginsDevicePx,
+                                                              GutterWidth gutterDevicePx = 0) noexcept
 {
     auto const usableWidth =
-        std::max(0, unbox<int>(availableDevicePx.width) - (2 * marginsDevicePx.horizontal));
+        std::max(0, unbox<int>(availableDevicePx.width) - (2 * marginsDevicePx.horizontal) - gutterDevicePx);
     auto const usableHeight =
         std::max(0, unbox<int>(availableDevicePx.height) - (2 * marginsDevicePx.vertical));
     auto const cellWidth = std::max(1, unbox<int>(cellSize.width));
@@ -222,13 +260,15 @@ namespace detail
 /// @param totalPageSize   Total page size (main page + status line).
 /// @param cellSize        Cell size in device pixels.
 /// @param marginsDevicePx Symmetric margins in device pixels.
+/// @param gutterDevicePx  Gutter reserved left of the grid, in device pixels (@see GutterWidth).
 /// @return Required area in device pixels.
 [[nodiscard]] constexpr vtbackend::ImageSize requiredPixelsForPage(vtbackend::PageSize totalPageSize,
                                                                    vtbackend::ImageSize cellSize,
-                                                                   Margins marginsDevicePx) noexcept
+                                                                   Margins marginsDevicePx,
+                                                                   GutterWidth gutterDevicePx = 0) noexcept
 {
-    auto const width =
-        (unbox<int>(cellSize.width) * unbox<int>(totalPageSize.columns)) + (2 * marginsDevicePx.horizontal);
+    auto const width = (unbox<int>(cellSize.width) * unbox<int>(totalPageSize.columns))
+                       + (2 * marginsDevicePx.horizontal) + gutterDevicePx;
     auto const height =
         (unbox<int>(cellSize.height) * unbox<int>(totalPageSize.lines)) + (2 * marginsDevicePx.vertical);
     return { .width = vtbackend::Width::cast_from(std::max(0, width)),
@@ -298,6 +338,28 @@ namespace detail
                  vtbackend::Height::cast_from(detail::floorUnscaled(unbox<double>(devicePx.height), scale)) };
 }
 
+/// The renderer's grid origin for the given margins and gutter.
+///
+/// The one statement of where the grid starts: the gutter is folded INTO the left inset, because it is
+/// asymmetric where the configured margin is not, and everything downstream reads that one number --
+/// the mouse hit-test, the gutter hit-test (@see isInGutter), the renderer itself. A second, hand-built
+/// PageMargin beside this one is how a grid origin comes to be short by exactly one gutter.
+///
+/// @param marginsDevicePx The configured margins in device pixels (@see scaled).
+/// @param gutterDevicePx  Gutter reserved left of the grid, in device pixels (@see GutterWidth).
+/// @param bottomDevicePx  The bottom inset; the configured vertical margin when omitted, which is what
+///                        a page that has not yet been fitted to a surface has.
+/// @return The page margin the renderer draws from.
+[[nodiscard]] constexpr vtrasterizer::PageMargin pageMarginFor(
+    Margins marginsDevicePx,
+    GutterWidth gutterDevicePx = 0,
+    std::optional<int> bottomDevicePx = std::nullopt) noexcept
+{
+    return { .left = marginsDevicePx.horizontal + gutterDevicePx,
+             .top = marginsDevicePx.vertical,
+             .bottom = bottomDevicePx.value_or(marginsDevicePx.vertical) };
+}
+
 /// Fits a grid into a device-pixel area: page = clamp(pageSizeForPixels(...)), margin placement computed
 /// against the CLAMPED page so the renderer and the terminal can never disagree (below-minimum windows
 /// previously computed margins for a page the terminal then silently enlarged).
@@ -311,24 +373,104 @@ namespace detail
 /// @param clampTotalPageSize Injected total-page clamp; production passes
 ///                           `Terminal::clampedTotalPageSize` (status-line rule) so this header stays
 ///                           free of vtbackend::Terminal and tests can exercise the contract directly.
+/// @param gutterDevicePx     Gutter reserved left of the grid, in device pixels (@see GutterWidth). It
+///                           lands INSIDE the returned pageMargin.left, so every pixel<->cell
+///                           conversion in the tree -- GridMetrics::map, the mouse hit-test, the
+///                           accessibility bridge -- shifts the grid across by it for free, and the
+///                           strip [horizontal, horizontal + gutter) is what the renderer draws into.
 /// @return The fitted page and the renderer margin placement.
 template <typename ClampFn>
     requires std::is_invocable_r_v<vtbackend::PageSize, ClampFn, vtbackend::PageSize>
 [[nodiscard]] constexpr GridFit fitPageToPixels(vtbackend::ImageSize availableDevicePx,
                                                 vtbackend::ImageSize cellSize,
                                                 Margins marginsDevicePx,
-                                                ClampFn&& clampTotalPageSize) noexcept
+                                                ClampFn&& clampTotalPageSize,
+                                                GutterWidth gutterDevicePx = 0) noexcept
 {
     auto const page = std::forward<ClampFn>(clampTotalPageSize)(
-        pageSizeForPixels(availableDevicePx, cellSize, marginsDevicePx));
+        pageSizeForPixels(availableDevicePx, cellSize, marginsDevicePx, gutterDevicePx));
 
     auto const usedHeight = unbox<int>(page.lines) * unbox<int>(cellSize.height);
     auto const top = marginsDevicePx.vertical;
     auto const leftover = unbox<int>(availableDevicePx.height) - usedHeight - top;
     auto const bottom = std::clamp(leftover, 0, marginsDevicePx.vertical);
 
-    return { .pageSize = page,
-             .pageMargin = { .left = marginsDevicePx.horizontal, .top = top, .bottom = bottom } };
+    return { .pageSize = page, .pageMargin = pageMarginFor(marginsDevicePx, gutterDevicePx, bottom) };
+}
+
+/// The MAIN-PAGE row a device-pixel y coordinate falls on, if it falls on one at all.
+///
+/// Screen rows count from the top of everything the renderer draws, so row 0 is the status line when
+/// one sits above the grid (@see vtbackend::Terminal::mainPageTopRow). Viewport's coordinate
+/// translation, on the other hand, speaks main-page rows -- handing it a screen row shifts every
+/// hit-test down by the height of that status line, which is exactly the bug this exists to prevent.
+///
+/// Returns nullopt rather than clamping when the coordinate is off the main page: a click on the
+/// status line is not a click on the grid, and answering with the nearest grid row would act on a
+/// cell the user did not point at.
+///
+/// Pure, so the mapping is testable without a window -- and stated once, so the fold gutter's
+/// hit-test and the cell hit-test cannot drift apart.
+///
+/// @param yDevicePx       The y coordinate in device pixels, relative to the item's top edge, with
+///                        any smooth-scroll offset already subtracted.
+/// @param pageMarginTop   The renderer's grid origin (@c GridMetrics::pageMargin.top), device pixels.
+/// @param cellHeightPx    The cell height in device pixels; must be positive.
+/// @param mainPageTopRow  The screen row the main page starts on.
+/// @param mainPageLines   How many lines the main page has.
+/// @return The main-page-relative row, or nullopt when the coordinate is not over the main page.
+[[nodiscard]] constexpr std::optional<int> mainPageRowAt(
+    int yDevicePx, int pageMarginTop, int cellHeightPx, int mainPageTopRow, int mainPageLines) noexcept
+{
+    if (cellHeightPx <= 0 || mainPageLines <= 0)
+        return std::nullopt;
+
+    auto const row = detail::mainPageRowOf(yDevicePx, pageMarginTop, cellHeightPx, mainPageTopRow);
+    if (row < 0 || row >= mainPageLines)
+        return std::nullopt;
+
+    return row;
+}
+
+/// The MAIN-PAGE row a device-pixel y coordinate falls on, or the nearest one when it falls off.
+///
+/// The clamping sibling of mainPageRowAt(), over the same arithmetic: a drag that leaves the grid must
+/// keep naming its nearest row, because auto-scroll depends on that, where a click off the grid must not
+/// be answered with a row at all. Only the out-of-range policy differs.
+///
+/// @param yDevicePx       The y coordinate in device pixels, relative to the item's top edge, with
+///                        any smooth-scroll offset already subtracted.
+/// @param pageMarginTop   The renderer's grid origin (@c GridMetrics::pageMargin.top), device pixels.
+/// @param cellHeightPx    The cell height in device pixels; must be positive.
+/// @param mainPageTopRow  The screen row the main page starts on.
+/// @param mainPageLines   How many lines the main page has.
+/// @return The main-page-relative row, clamped to [0, mainPageLines - 1].
+[[nodiscard]] constexpr int mainPageRowNear(
+    int yDevicePx, int pageMarginTop, int cellHeightPx, int mainPageTopRow, int mainPageLines) noexcept
+{
+    if (cellHeightPx <= 0 || mainPageLines <= 0)
+        return 0;
+
+    return std::clamp(
+        detail::mainPageRowOf(yDevicePx, pageMarginTop, cellHeightPx, mainPageTopRow), 0, mainPageLines - 1);
+}
+
+/// Whether the device-pixel x coordinate @p xDevicePx falls inside the gutter.
+///
+/// The gutter is the strip [pageMarginLeft - gutter, pageMarginLeft): fitPageToPixels folds its width
+/// INTO pageMargin.left, so the strip is exactly what that inset gained, and column 0 begins where it
+/// ends. Pure, so the hit-test is testable without a window -- and so the one place that decides where
+/// the gutter IS is the same header that decided how wide to make it.
+///
+/// @param xDevicePx       The x coordinate, in device pixels, relative to the item's left edge.
+/// @param pageMarginLeft  The renderer's grid origin (@c GridMetrics::pageMargin.left), in device pixels.
+/// @param gutterDevicePx  The reserved gutter width in device pixels; 0 means there is no gutter.
+/// @return Whether the coordinate is over the gutter rather than over a cell or the margin left of it.
+[[nodiscard]] constexpr bool isInGutter(int xDevicePx,
+                                        int pageMarginLeft,
+                                        GutterWidth gutterDevicePx) noexcept
+{
+    return gutterDevicePx > 0 && xDevicePx >= pageMarginLeft - gutterDevicePx && xDevicePx < pageMarginLeft;
 }
 
 /// Logical device-pixel availability of an item: floor(logical * scale) per axis (FLOOR side of the law).
@@ -364,14 +506,16 @@ template <typename ClampFn>
 /// @param marginsDevicePx Symmetric margins in device pixels.
 /// @param scale           Content scale (device pixels per logical pixel).
 /// @param chrome          Declared window chrome in logical pixels.
+/// @param gutterDevicePx  Gutter reserved left of the grid, in device pixels (@see GutterWidth).
 /// @return Window size in logical pixels.
 [[nodiscard]] constexpr LogicalSize windowSizeForPage(vtbackend::PageSize totalPageSize,
                                                       vtbackend::ImageSize cellSize,
                                                       Margins marginsDevicePx,
                                                       double scale,
-                                                      Chrome chrome) noexcept
+                                                      Chrome chrome,
+                                                      GutterWidth gutterDevicePx = 0) noexcept
 {
-    auto const required = requiredPixelsForPage(totalPageSize, cellSize, marginsDevicePx);
+    auto const required = requiredPixelsForPage(totalPageSize, cellSize, marginsDevicePx, gutterDevicePx);
     return { .width = detail::ceilUnscaled(unbox<double>(required.width), scale) + chrome.width,
              .height = detail::ceilUnscaled(unbox<double>(required.height), scale) + chrome.height };
 }
@@ -383,15 +527,30 @@ template <typename ClampFn>
 /// @param marginsLogicalPx Symmetric margins in logical pixels (as configured).
 /// @param scale            Content scale (device pixels per logical pixel).
 /// @param chrome           Declared window chrome in logical pixels.
+/// @param gutterDevicePx   Gutter reserved left of the grid, in DEVICE pixels -- the unit it is decided
+///                         in, being a fraction of the cell width (@see GutterWidth). Taken in that
+///                         unit and converted once, here: a caller that unscaled it first would hand
+///                         over a truncated value this would then scale back up, and the base hint
+///                         would be a pixel short of the gutter the renderer actually reserves.
 /// @return The hints, in logical pixels.
 [[nodiscard]] constexpr SizeHints sizeHintsFor(vtbackend::ImageSize cellSizeDevicePx,
                                                Margins marginsLogicalPx,
                                                double scale,
-                                               Chrome chrome) noexcept
+                                               Chrome chrome,
+                                               GutterWidth gutterDevicePx = 0) noexcept
 {
-    auto const minimum = windowSizeForPage(
-        MinimumTotalPageSize, cellSizeDevicePx, scaled(marginsLogicalPx, scale), scale, chrome);
-    auto const base = LogicalSize { .width = (2 * marginsLogicalPx.horizontal) + chrome.width,
+    auto const minimum = windowSizeForPage(MinimumTotalPageSize,
+                                           cellSizeDevicePx,
+                                           scaled(marginsLogicalPx, scale),
+                                           scale,
+                                           chrome,
+                                           gutterDevicePx);
+
+    // Ceiled, like the cell increment beside it: a base rounded DOWN leaves the grid area a device
+    // pixel wider than the window can give it, which the resize snapping then reads as room for a
+    // column that does not fit.
+    auto const base = LogicalSize { .width = (2 * marginsLogicalPx.horizontal) + chrome.width
+                                             + detail::ceilUnscaled(gutterDevicePx, scale),
                                     .height = (2 * marginsLogicalPx.vertical) + chrome.height };
     auto const increment =
         LogicalSize { .width = detail::ceilUnscaled(unbox<double>(cellSizeDevicePx.width), scale),

--- a/src/contour/geometry/WindowGeometry_test.cpp
+++ b/src/contour/geometry/WindowGeometry_test.cpp
@@ -12,6 +12,7 @@
 #include <catch2/generators/catch_generators.hpp>
 
 #include <cmath>
+#include <ranges>
 
 using namespace contour::geometry;
 
@@ -346,6 +347,255 @@ TEST_CASE("WindowGeometry.roundtrip.pageThroughPixels", "[contour][geometry]")
     CHECK(pageSizeForPixels(surplus, cell, margins) == page);
 }
 
+TEST_CASE("WindowGeometry.roundtrip.pageThroughPixelsWithAGutter", "[contour][geometry]")
+{
+    // THE anti-oscillation invariant again, this time with a gutter reserved. It holds for the same
+    // reason it holds for the margins: the gutter is an exact integer subtracted on the availability
+    // side and added on the requirement side, so it cancels. A gutter that broke this would make a
+    // window resize oscillate by a column for as long as the user held the mouse down.
+    auto const cell = GENERATE(imageSize(5, 10), imageSize(8, 16), imageSize(11, 23), imageSize(21, 42));
+    auto const margin = GENERATE(0, 2, 10);
+    auto const gutter = GENERATE(0, 1, 8, 21, 100);
+    auto const page = GENERATE(pageSize(1, 1), pageSize(25, 80), pageSize(50, 132), pageSize(2, 500));
+
+    auto const margins = Margins { .horizontal = margin, .vertical = margin };
+    CAPTURE(cell, margin, gutter, page.lines.value, page.columns.value);
+
+    auto const required = requiredPixelsForPage(page, cell, margins, gutter);
+    CHECK(pageSizeForPixels(required, cell, margins, gutter) == page);
+
+    auto const surplus = imageSize(unbox<int>(required.width) + unbox<int>(cell.width) - 1,
+                                   unbox<int>(required.height) + unbox<int>(cell.height) - 1);
+    CHECK(pageSizeForPixels(surplus, cell, margins, gutter) == page);
+}
+
+TEST_CASE("WindowGeometry.gutter.costsExactlyItsOwnWidth", "[contour][geometry]")
+{
+    // A gutter is width taken from the cells, and nothing else: the same window fits one fewer column
+    // per cell-width of gutter, and the height is untouched.
+    auto const cell = imageSize(10, 20);
+    auto const margins = Margins { .horizontal = 5, .vertical = 5 };
+    auto const available = imageSize(1000, 600);
+
+    auto const without = pageSizeForPixels(available, cell, margins);
+    auto const withGutter = pageSizeForPixels(available, cell, margins, /*gutterDevicePx*/ 10);
+
+    CHECK(without.columns == vtbackend::ColumnCount(99));
+    CHECK(withGutter.columns == vtbackend::ColumnCount(98));
+    CHECK(withGutter.lines == without.lines);
+}
+
+TEST_CASE("WindowGeometry.gutter.landsInsideThePageMarginLeft", "[contour][geometry]")
+{
+    // The load-bearing placement: the gutter is folded into pageMargin.left, which is already the single
+    // left inset every pixel<->cell conversion in the tree reads -- GridMetrics::map, the mouse
+    // hit-test, the accessibility bridge. Folding it in there is what makes all of them correct at once,
+    // and leaves [horizontal, horizontal + gutter) as the strip the renderer owns.
+    auto const cell = imageSize(10, 20);
+    auto const margins = Margins { .horizontal = 5, .vertical = 5 };
+    auto const identity = [](vtbackend::PageSize page) {
+        return page;
+    };
+
+    auto const fit = fitPageToPixels(imageSize(1000, 600), cell, margins, identity, /*gutterDevicePx*/ 10);
+
+    CHECK(fit.pageMargin.left == 15);
+    // Top and bottom are the gutter's business not at all.
+    CHECK(fit.pageMargin.top == 5);
+}
+
+TEST_CASE("WindowGeometry.gutter.widensTheWindowAndItsSizeHintBase", "[contour][geometry]")
+{
+    // A window sized for a page must grow by the gutter, or the grid it was sized for would not fit --
+    // and the WM's base size must grow with it, since the base is the fixed non-grid part.
+    auto const cell = imageSize(10, 20);
+    auto const marginsLogical = Margins { .horizontal = 5, .vertical = 5 };
+    auto const page = pageSize(25, 80);
+    auto const chrome = Chrome { .width = 0, .height = 30 };
+
+    auto const without = windowSizeForPage(page, cell, marginsLogical, 1.0, chrome);
+    auto const withGutter = windowSizeForPage(page, cell, marginsLogical, 1.0, chrome, 10);
+    CHECK(withGutter.width == without.width + 10);
+    CHECK(withGutter.height == without.height);
+
+    auto const hintsWithout = sizeHintsFor(cell, marginsLogical, 1.0, chrome);
+    auto const hintsWith = sizeHintsFor(cell, marginsLogical, 1.0, chrome, 10);
+    CHECK(hintsWith.base.width == hintsWithout.base.width + 10);
+    CHECK(hintsWith.base.height == hintsWithout.base.height);
+    // One cell per column is unchanged -- a gutter is a fixed inset, not part of the resize grid.
+    CHECK(hintsWith.increment == hintsWithout.increment);
+    CHECK(hintsWith.minimum.width == hintsWithout.minimum.width + 10);
+}
+
+TEST_CASE("WindowGeometry.mainPageRowAt.maps pixels onto main-page rows", "[contour][geometry]")
+{
+    // Grid origin at y=10, 20px cells, no status line: screen rows and main-page rows coincide.
+    auto constexpr MarginTop = 10;
+    auto constexpr CellHeight = 20;
+    auto constexpr Lines = 5;
+
+    CHECK(mainPageRowAt(10, MarginTop, CellHeight, /*mainPageTopRow*/ 0, Lines) == 0);
+    CHECK(mainPageRowAt(29, MarginTop, CellHeight, 0, Lines) == 0);
+    CHECK(mainPageRowAt(30, MarginTop, CellHeight, 0, Lines) == 1);
+    CHECK(mainPageRowAt(99, MarginTop, CellHeight, 0, Lines) == 4);
+
+    // Off the grid, above and below: not a row, rather than the nearest one.
+    CHECK(mainPageRowAt(9, MarginTop, CellHeight, 0, Lines) == std::nullopt);
+    CHECK(mainPageRowAt(-100, MarginTop, CellHeight, 0, Lines) == std::nullopt);
+    CHECK(mainPageRowAt(110, MarginTop, CellHeight, 0, Lines) == std::nullopt);
+}
+
+TEST_CASE("WindowGeometry.mainPageRowNear.clamps where its sibling declines", "[contour][geometry]")
+{
+    // The two differ ONLY in what they do off the page: a drag that leaves the grid must keep naming
+    // its nearest row, because auto-scroll depends on that. Where mainPageRowAt() answers, the two
+    // agree -- which is the property that keeps the cell hit-test and the gutter hit-test in step.
+    auto constexpr MarginTop = 10;
+    auto constexpr CellHeight = 20;
+    auto constexpr Lines = 5;
+
+    for (auto const y: { 10, 29, 30, 99, 109 })
+        CHECK(mainPageRowNear(y, MarginTop, CellHeight, 0, Lines)
+              == mainPageRowAt(y, MarginTop, CellHeight, 0, Lines));
+
+    // Above the grid -- including the row immediately above it, which a truncating division would
+    // have folded onto row 0 without ever leaving the page.
+    CHECK(mainPageRowNear(9, MarginTop, CellHeight, 0, Lines) == 0);
+    CHECK(mainPageRowNear(-100, MarginTop, CellHeight, 0, Lines) == 0);
+
+    // Below it.
+    CHECK(mainPageRowNear(110, MarginTop, CellHeight, 0, Lines) == 4);
+    CHECK(mainPageRowNear(10'000, MarginTop, CellHeight, 0, Lines) == 4);
+
+    // A status line above the grid shifts it, exactly as it shifts the declining sibling.
+    CHECK(mainPageRowNear(0, MarginTop, CellHeight, /*mainPageTopRow*/ 1, Lines) == 0);
+    CHECK(mainPageRowNear(30, MarginTop, CellHeight, 1, Lines) == 0);
+
+    // Degenerate inputs answer with the only row that is always safe.
+    CHECK(mainPageRowNear(100, MarginTop, /*cellHeightPx*/ 0, 0, Lines) == 0);
+    CHECK(mainPageRowNear(100, MarginTop, CellHeight, 0, /*mainPageLines*/ 0) == 0);
+}
+
+TEST_CASE("WindowGeometry.pageMarginFor.folds the gutter into the left inset", "[contour][geometry]")
+{
+    // The property every pixel<->cell conversion in the tree depends on: the gutter lands INSIDE
+    // pageMargin.left, so the grid starts past it and isInGutter() names exactly the strip it gained.
+    auto constexpr Margins = contour::geometry::Margins { .horizontal = 6, .vertical = 4 };
+
+    auto const bare = pageMarginFor(Margins);
+    CHECK(bare.left == 6);
+    CHECK(bare.top == 4);
+    CHECK(bare.bottom == 4); // a page not yet fitted to a surface has the configured margin below it
+
+    auto const gutter = pageMarginFor(Margins, /*gutterDevicePx*/ 9);
+    CHECK(gutter.left == 15);
+    CHECK(gutter.top == 4);
+    CHECK(!isInGutter(5, gutter.left, 9));  // the configured margin, left of the gutter
+    CHECK(isInGutter(6, gutter.left, 9));   // the gutter's first pixel
+    CHECK(isInGutter(14, gutter.left, 9));  // its last
+    CHECK(!isInGutter(15, gutter.left, 9)); // column 0
+
+    // The fit supplies a measured bottom; everything else is the same placement.
+    auto const fitted = pageMarginFor(Margins, 9, /*bottomDevicePx*/ 1);
+    CHECK(fitted.left == 15);
+    CHECK(fitted.bottom == 1);
+}
+
+TEST_CASE("WindowGeometry.mainPageRowAt.a top status line shifts the grid down", "[contour][geometry]")
+{
+    // THE regression this exists for. With a one-line status display at the TOP, the renderer draws
+    // it on screen row 0 and the grid starts on row 1 -- so the pixels of the first GRID row belong
+    // to main-page row 0, not row 1. Feeding a raw screen row to Viewport's translation shifted every
+    // hit-test down by the status line's height, and dropped the grid's last row entirely.
+    auto constexpr MarginTop = 0;
+    auto constexpr CellHeight = 20;
+    auto constexpr TopRow = 1;
+    auto constexpr Lines = 5;
+
+    // The status line itself is not part of the grid.
+    CHECK(mainPageRowAt(0, MarginTop, CellHeight, TopRow, Lines) == std::nullopt);
+    CHECK(mainPageRowAt(19, MarginTop, CellHeight, TopRow, Lines) == std::nullopt);
+
+    // The first row BELOW it is main-page row 0.
+    CHECK(mainPageRowAt(20, MarginTop, CellHeight, TopRow, Lines) == 0);
+    CHECK(mainPageRowAt(39, MarginTop, CellHeight, TopRow, Lines) == 0);
+
+    // ...and the last main-page row is reachable, which it was not while the shift was missing.
+    CHECK(mainPageRowAt(100, MarginTop, CellHeight, TopRow, Lines) == 4);
+    CHECK(mainPageRowAt(119, MarginTop, CellHeight, TopRow, Lines) == 4);
+    CHECK(mainPageRowAt(120, MarginTop, CellHeight, TopRow, Lines) == std::nullopt);
+}
+
+TEST_CASE("WindowGeometry.mainPageRowAt.a bottom status line is not the grid", "[contour][geometry]")
+{
+    // A status line BELOW the grid leaves mainPageTopRow at zero; the rows past the page are simply
+    // not on it, which is what keeps a click on the status line from acting on the last grid row.
+    CHECK(mainPageRowAt(0, 0, 20, /*mainPageTopRow*/ 0, /*mainPageLines*/ 3) == 0);
+    CHECK(mainPageRowAt(59, 0, 20, 0, 3) == 2);
+    CHECK(mainPageRowAt(60, 0, 20, 0, 3) == std::nullopt);
+}
+
+TEST_CASE("WindowGeometry.mainPageRowAt.degenerate metrics answer nothing", "[contour][geometry]")
+{
+    // Before the first resize the renderer can hand out a zero cell height; dividing by it would be
+    // undefined rather than merely wrong.
+    CHECK(mainPageRowAt(50, 0, /*cellHeightPx*/ 0, 0, 5) == std::nullopt);
+    CHECK(mainPageRowAt(50, 0, 20, 0, /*mainPageLines*/ 0) == std::nullopt);
+}
+
+TEST_CASE("WindowGeometry.isInGutter.covers the strip and nothing else", "[contour][geometry]")
+{
+    // Margin 5, gutter 10, so pageMargin.left is 15 and the strip is [5, 15). Column 0 starts at 15.
+    auto constexpr MarginLeft = 5;
+    auto constexpr Gutter = 10;
+    auto constexpr PageMarginLeft = MarginLeft + Gutter;
+
+    // The margin to the left of the gutter is not the gutter.
+    CHECK(!isInGutter(0, PageMarginLeft, Gutter));
+    CHECK(!isInGutter(4, PageMarginLeft, Gutter));
+
+    // The strip itself, both edges.
+    CHECK(isInGutter(5, PageMarginLeft, Gutter));
+    CHECK(isInGutter(14, PageMarginLeft, Gutter));
+
+    // The first cell column is past it -- half-open, so 15 is already the grid.
+    CHECK(!isInGutter(15, PageMarginLeft, Gutter));
+    CHECK(!isInGutter(500, PageMarginLeft, Gutter));
+}
+
+TEST_CASE("WindowGeometry.isInGutter.no gutter means nothing is ever in it", "[contour][geometry]")
+{
+    // With markers off there is no strip, and pageMargin.left is the plain margin: every x must fall
+    // through to the ordinary cell hit-test, including the margin the grid does not start at.
+    for (auto const x: { 0, 1, 4, 5, 100 })
+    {
+        CAPTURE(x);
+        CHECK(!isInGutter(x, /*pageMarginLeft*/ 5, /*gutterDevicePx*/ 0));
+    }
+}
+
+TEST_CASE("WindowGeometry.gutter.zeroIsExactlyTheUngutteredArithmetic", "[contour][geometry]")
+{
+    // The default, and what every existing caller passes: a zero gutter must leave every function
+    // byte-for-byte what it was before one existed.
+    auto const cell = imageSize(11, 23);
+    auto const margins = Margins { .horizontal = 7, .vertical = 3 };
+    auto const available = imageSize(999, 601);
+    auto const page = pageSize(25, 80);
+    auto const chrome = Chrome { .width = 4, .height = 30 };
+    auto const identity = [](vtbackend::PageSize p) {
+        return p;
+    };
+
+    CHECK(pageSizeForPixels(available, cell, margins, 0) == pageSizeForPixels(available, cell, margins));
+    CHECK(requiredPixelsForPage(page, cell, margins, 0) == requiredPixelsForPage(page, cell, margins));
+    CHECK(fitPageToPixels(available, cell, margins, identity, 0).pageMargin.left
+          == fitPageToPixels(available, cell, margins, identity).pageMargin.left);
+    CHECK(windowSizeForPage(page, cell, margins, 1.25, chrome, 0)
+          == windowSizeForPage(page, cell, margins, 1.25, chrome));
+    CHECK(sizeHintsFor(cell, margins, 1.25, chrome, 0) == sizeHintsFor(cell, margins, 1.25, chrome));
+}
+
 TEST_CASE("WindowGeometry.roundtrip.pageThroughWindowAtScale", "[contour][geometry]")
 {
     // The full grid->window->grid cycle at every scale: a window sized for a page, converted back through
@@ -397,6 +647,35 @@ TEST_CASE("WindowGeometry.initialPageSize.runningWinsOverProfile", "[contour][ge
     CHECK(initialPageSize(profileDefault, profileDefault) == profileDefault);
     // A brand-new window: no running size -> the profile default is honored.
     CHECK(initialPageSize(std::nullopt, profileDefault) == profileDefault);
+}
+
+TEST_CASE("WindowGeometry.sizeHintsFor.gutterSurvivesFractionalScale", "[contour][geometry]")
+{
+    // The gutter is decided in DEVICE pixels -- a fraction of the cell width -- and the base hint is in
+    // logical ones. Converting it once, here, is what keeps the two agreeing: unscaling it at the call
+    // site first would truncate, and scaling the truncated value back would reserve less than the
+    // renderer does, leaving the resize grid off by a pixel.
+    auto constexpr Chrome = contour::geometry::Chrome { .width = 0, .height = 0 };
+    auto const margins = contour::geometry::Margins { .horizontal = 0, .vertical = 0 };
+    auto const cell = imageSize(15, 30);
+
+    for (auto const scale: { 1.0, 1.25, 1.5, 2.0 })
+    {
+        for (auto const gutterDevicePx: std::views::iota(1, 16))
+        {
+            CAPTURE(scale, gutterDevicePx);
+            auto const bare = sizeHintsFor(cell, margins, scale, Chrome);
+            auto const withGutter = sizeHintsFor(cell, margins, scale, Chrome, gutterDevicePx);
+
+            // Whatever the rounding, the reserved strip must cover the device pixels asked for.
+            auto const reservedLogical = withGutter.base.width - bare.base.width;
+            CHECK(reservedLogical >= 1);
+            CHECK(static_cast<double>(reservedLogical) * scale >= static_cast<double>(gutterDevicePx));
+
+            // ... and it is an inset, never part of the resize grid.
+            CHECK(withGutter.increment == bare.increment);
+        }
+    }
 }
 
 TEST_CASE("WindowGeometry.sizeHintsFor", "[contour][geometry]")

--- a/src/contour/session/FontControl.cpp
+++ b/src/contour/session/FontControl.cpp
@@ -103,9 +103,12 @@ void applyResize(ImageSize newPixelSize, TerminalSession& session, vtrasterizer:
     // total up to statusLineHeight()+1 lines and 1 column, and a fit computed against an unclamped page
     // would permanently defeat the early-out below two cell-rows (re-running resizeScreen() +
     // clearSelection() on every drag frame, wiping the selection and storming SIGWINCH at the child).
-    auto const fit = geometry::fitPageToPixels(newPixelSize, cellSize, marginsDevicePx, [&](auto page) {
-        return terminal.clampedTotalPageSize(page);
-    });
+    auto const fit = geometry::fitPageToPixels(
+        newPixelSize,
+        cellSize,
+        marginsDevicePx,
+        [&](auto page) { return terminal.clampedTotalPageSize(page); },
+        gutterWidthFor(session.config().folding.value(), cellSize));
 
     renderer.applyResize(newPixelSize, fit.pageSize, fit.pageMargin);
 

--- a/src/contour/session/FontControl.hpp
+++ b/src/contour/session/FontControl.hpp
@@ -39,6 +39,24 @@ class TerminalSession;
     return { .horizontal = unbox<int>(margins.horizontal), .vertical = unbox<int>(margins.vertical) };
 }
 
+/// The gutter width, in device pixels, a profile asks for.
+///
+/// THE gutter decision, in one place: every geometry call site reads it from here, because a page fitted
+/// with a gutter and a renderer drawing without one (or vice versa) put the grid in two different places.
+/// One cell wide when fold markers are shown, and nothing at all otherwise -- a gutter costs a column of
+/// terminal width, so a user who does not want markers must not pay for it.
+///
+/// @param folding The profile's folding configuration.
+/// @param cellSizeDevicePx The cell size in device pixels.
+/// @return The gutter width in device pixels; 0 when no gutter is wanted.
+[[nodiscard]] constexpr geometry::GutterWidth gutterWidthFor(config::FoldingConfig const& folding,
+                                                             vtbackend::ImageSize cellSizeDevicePx) noexcept
+{
+    if (!folding.markersVisible())
+        return 0;
+    return unbox<int>(cellSizeDevicePx.width);
+}
+
 /// Refits the grid to @p newPixelSize and resizes the child PTY accordingly.
 void applyResize(vtbackend::ImageSize newPixelSize,
                  TerminalSession& session,

--- a/src/contour/session/SessionInput.cpp
+++ b/src/contour/session/SessionInput.cpp
@@ -11,6 +11,8 @@
 
 #include <vtrasterizer/Renderer.hpp>
 
+#include <crispy/Utils.hpp>
+
 #include <QtGui/QGuiApplication>
 
 #include <algorithm>
@@ -168,36 +170,49 @@ namespace
                 effectivePixelDelta = static_cast<float>(pixelDelta.y);
             }
 
-            if (effectivePixelDelta != 0.0f)
-            {
-                // Mouse wheels carry no gesture phase; route their discrete notches through a
-                // momentum impulse so they glide smoothly instead of snapping whole lines. Phased
-                // touchpad input keeps the existing velocity-tracking + immediate-apply path.
-                if (scrollPhase == vtbackend::ScrollPhase::NoPhase)
+            // Locked for the reason TerminalSession::smoothScrollUp() states: these advance the
+            // viewport offset, the sub-cell remainder and the momentum state, all of which the parser
+            // thread touches too. And the clamp inside applySmoothScrollPixelDelta() now reads the
+            // scrollable count, which builds the fold projection lazily -- a cache the render pass
+            // clears and refills under this same lock.
+            //
+            // Scoped to this branch alone, and the result carried out rather than returned from
+            // inside: the lock is not recursive and the line-based path below takes it again per
+            // synthesized mouse event.
+            auto const consumed = crispy::locked(terminal, [&] {
+                if (effectivePixelDelta != 0.0f)
                 {
-                    // Only consume the notch when a glide was actually armed. If injectWheelMomentum
-                    // could not arm (cell size still unknown during startup/rebind, alt screen, or a
-                    // degenerate zero net velocity) fall through to the legacy line-based path below
-                    // instead of silently swallowing the event.
-                    if (terminal.injectWheelMomentum(effectivePixelDelta, now)
-                        == vtbackend::SmoothScrollResult::Applied)
-                        return;
-                }
-                else
-                {
+                    // Mouse wheels carry no gesture phase; route their discrete notches through a
+                    // momentum impulse so they glide smoothly instead of snapping whole lines. Phased
+                    // touchpad input keeps the existing velocity-tracking + immediate-apply path.
+                    if (scrollPhase == vtbackend::ScrollPhase::NoPhase)
+                    {
+                        // Only consume the notch when a glide was actually armed. If injectWheelMomentum
+                        // could not arm (cell size still unknown during startup/rebind, alt screen, or a
+                        // degenerate zero net velocity) fall through to the legacy line-based path below
+                        // instead of silently swallowing the event.
+                        return terminal.injectWheelMomentum(effectivePixelDelta, now)
+                               == vtbackend::SmoothScrollResult::Applied;
+                    }
+
                     terminal.handleScrollPhase(scrollPhase, effectivePixelDelta, now);
-                    if (terminal.applySmoothScrollPixelDelta(effectivePixelDelta)
-                        == vtbackend::SmoothScrollResult::Applied)
-                        return;
+                    return terminal.applySmoothScrollPixelDelta(effectivePixelDelta)
+                           == vtbackend::SmoothScrollResult::Applied;
                 }
-            }
-            else if (scrollPhase == vtbackend::ScrollPhase::End
-                     || scrollPhase == vtbackend::ScrollPhase::Begin)
-            {
-                // Handle zero-delta phase events (e.g. ScrollEnd often has zero delta).
-                terminal.handleScrollPhase(scrollPhase, 0.0f, now);
+
+                if (scrollPhase == vtbackend::ScrollPhase::End
+                    || scrollPhase == vtbackend::ScrollPhase::Begin)
+                {
+                    // Handle zero-delta phase events (e.g. ScrollEnd often has zero delta).
+                    terminal.handleScrollPhase(scrollPhase, 0.0f, now);
+                    return true;
+                }
+
+                return false;
+            });
+
+            if (consumed)
                 return;
-            }
         }
 
         // Existing line-based scrolling (unchanged)

--- a/src/contour/session/SessionInput.cpp
+++ b/src/contour/session/SessionInput.cpp
@@ -3,6 +3,7 @@
 #include <contour/input/KeyMapping.hpp>
 #include <contour/input/Logging.hpp>
 #include <contour/input/MouseMapping.hpp>
+#include <contour/session/FontControl.hpp>
 #include <contour/session/Logging.hpp>
 #include <contour/session/SessionInput.hpp>
 #include <contour/session/TerminalSession.hpp>
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <array>
+#include <mutex>
 
 using std::array;
 using std::clamp;
@@ -35,9 +37,40 @@ namespace contour::session
 
 namespace
 {
+    /// The device-pixel y of @p yLogical, with the smooth-scroll shift taken out.
+    ///
+    /// Content is shifted DOWN by the smooth-scroll offset, so the offset comes off the pointer to
+    /// map back onto the cell that is actually drawn there.
+    [[nodiscard]] int mouseDeviceY(double yLogical, TerminalSession const& session) noexcept
+    {
+        auto const dpr = session.display()->devicePixelRatio();
+        return static_cast<int>(yLogical * dpr)
+               - static_cast<int>(session.terminal().smoothScrollPixelOffset());
+    }
+
+    /// The main-page row under @p yLogical, or nullopt when the pointer is not over the grid.
+    ///
+    /// The one row hit-test in the GUI: the cell mapping and the fold gutter both come through here,
+    /// so they cannot disagree about where the grid starts -- which, with a status line above it, is
+    /// not screen row zero.
+    [[nodiscard]] std::optional<vtbackend::LineOffset> mouseGridRow(double yLogical,
+                                                                    TerminalSession const& session) noexcept
+    {
+        auto const& terminal = session.terminal();
+        auto const row = geometry::mainPageRowAt(mouseDeviceY(yLogical, session),
+                                                 session.display()->gridMetrics().pageMargin.top,
+                                                 session.display()->cellSize().height.as<int>(),
+                                                 unbox<int>(terminal.mainPageTopRow()),
+                                                 unbox<int>(terminal.pageSize().lines));
+        return row ? std::optional { vtbackend::LineOffset(*row) } : std::nullopt;
+    }
+
     vtbackend::CellLocation makeMouseCellLocation(int x, int y, TerminalSession const& session) noexcept
     {
-        auto const pageSize = session.terminal().totalPageSize();
+        // The MAIN page, not the total: the row this returns is main-page relative -- which is the
+        // space Viewport's coordinate translation speaks -- so clamping it against a total that
+        // includes the status line would let it name a row past the end of the grid.
+        auto const pageSize = session.terminal().pageSize();
         auto const cellSize = session.display()->cellSize();
         auto const dpr = session.display()->devicePixelRatio();
 
@@ -55,19 +88,61 @@ namespace
         auto const marginLeft = pageMargin.left;
 
         auto const sx = int(double(x) * dpr);
-        auto sy = int(double(y) * dpr);
+        auto const sy = mouseDeviceY(y, session);
 
-        // Adjust for smooth scroll pixel offset: content is shifted down by pixelOffset,
-        // so subtract the offset from the mouse position to map to the correct cell.
-        sy -= static_cast<int>(session.terminal().smoothScrollPixelOffset());
-
-        auto const row = vtbackend::LineOffset(
-            clamp((sy - marginTop) / cellSize.height.as<int>(), 0, *pageSize.lines - 1));
+        // Clamped to the main page, so a drag that leaves the grid keeps naming its nearest row --
+        // auto-scroll depends on that. Off the MAIN page (over a status line) the nearest row is the
+        // grid edge, which mouseGridRow() declines to invent and the move path therefore skips.
+        //
+        // Through the same tested header the declining hit-test uses, so the two cannot disagree about
+        // where the grid starts (@see geometry::mainPageRowNear).
+        auto const row =
+            vtbackend::LineOffset(geometry::mainPageRowNear(sy,
+                                                            marginTop,
+                                                            cellSize.height.as<int>(),
+                                                            unbox<int>(session.terminal().mainPageTopRow()),
+                                                            *pageSize.lines));
 
         auto const col = vtbackend::ColumnOffset(
             clamp((sx - marginLeft) / cellSize.width.as<int>(), 0, *pageSize.columns - 1));
 
         return { .line = row, .column = col };
+    }
+
+    /// The grid line under @p positionPx, when that position lies over the fold gutter.
+    ///
+    /// The one place that decides where the gutter IS and which row a point on it names -- shared by
+    /// the click that toggles a fold and the hover that highlights one, because those two disagreeing
+    /// would light up one block and toggle another.
+    ///
+    /// Deliberately NOT routed through makeMouseCellLocation(): that clamps the column onto the page,
+    /// so a gutter position would come back reading as column 0 of the grid.
+    ///
+    /// @param positionPx The pointer position in logical pixels, relative to the item's top-left.
+    /// @param session The session it belongs to; must have a display.
+    /// @return The grid line, or nullopt when the position is not over the gutter.
+    [[nodiscard]] std::optional<vtbackend::LineOffset> gutterLineAt(QPointF positionPx,
+                                                                    TerminalSession const& session)
+    {
+        auto const& display = *session.display();
+        auto const dpr = display.devicePixelRatio();
+        auto const cellSize = display.gridMetrics().cellSize;
+        auto const pageMargin = display.gridMetrics().pageMargin;
+        auto const gutter = gutterWidthFor(session.config().folding.value(), cellSize);
+
+        auto const sx = static_cast<int>(positionPx.x() * dpr);
+        if (!geometry::isInGutter(sx, pageMargin.left, gutter))
+            return std::nullopt;
+
+        // Through the shared row hit-test, so the gutter and the grid agree about where the page
+        // begins. They did not: this used to feed a raw SCREEN row to a translation that speaks
+        // main-page rows, so with a status line above the grid every fold click landed one block off.
+        auto const row = mouseGridRow(positionPx.y(), session);
+        if (!row)
+            return std::nullopt;
+
+        auto const l = std::scoped_lock { session.terminal() };
+        return session.terminal().viewport().translateScreenToGridLine(*row);
     }
 
     /// @param event The Qt event to take the position from.
@@ -607,6 +682,15 @@ void sendMousePressEvent(QMouseEvent* event, TerminalSession& session)
     // display-dependent event paths' guards.
     if (session.display() == nullptr)
         return;
+
+    if (session.sendGutterPressEvent(gutterLineAt(event->position(), session),
+                                     input::makeMouseButton(event->button()))
+        == ConsumedByGutter::Yes)
+    {
+        event->accept();
+        return;
+    }
+
     session.sendMousePressEvent(input::makeModifiers(event->modifiers()).chord,
                                 input::makeMouseButton(event->button()),
                                 makeMousePixelPosition(event,
@@ -622,6 +706,13 @@ void sendMouseReleaseEvent(QMouseEvent* event, TerminalSession& session)
     // display-dependent event paths' guards.
     if (session.display() == nullptr)
         return;
+
+    if (session.sendGutterReleaseEvent() == ConsumedByGutter::Yes)
+    {
+        event->accept();
+        return;
+    }
+
     session.sendMouseReleaseEvent(input::makeModifiers(event->modifiers()).chord,
                                   input::makeMouseButton(event->button()),
                                   makeMousePixelPosition(event,
@@ -637,6 +728,13 @@ void sendMouseMoveEvent(QMouseEvent* event, TerminalSession& session)
     // display-dependent event paths' guards.
     if (session.display() == nullptr)
         return;
+
+    if (session.sendGutterHoverEvent(gutterLineAt(event->position(), session)) == ConsumedByGutter::Yes)
+    {
+        event->accept();
+        return;
+    }
+
     session.sendMouseMoveEvent(input::makeModifiers(event->modifiers()).chord,
                                makeMouseCellLocation(event->pos().x(), event->pos().y(), session),
                                makeMousePixelPosition(event,
@@ -652,6 +750,13 @@ void sendMouseMoveEvent(QHoverEvent* event, TerminalSession& session)
     // display-dependent event paths' guards.
     if (session.display() == nullptr)
         return;
+
+    if (session.sendGutterHoverEvent(gutterLineAt(event->position(), session)) == ConsumedByGutter::Yes)
+    {
+        event->accept();
+        return;
+    }
+
     auto const position = event->position().toPoint();
     session.sendMouseMoveEvent(input::makeModifiers(event->modifiers()).chord,
                                makeMouseCellLocation(position.x(), position.y(), session),

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -1751,9 +1751,14 @@ void TerminalSession::sendMouseMoveEvent(vtbackend::Modifiers modifiers,
 
     // The cursor shape lives on the display; a display-less session (background pane, headless
     // test) has no cursor to change.
-    if (pos != _currentMousePosition && _display != nullptr)
+    //
+    // Normally only on a cell CHANGE, since that is the only thing that can change the answer -- but
+    // the gutter changes the shape behind this decision's back, and leaving it lands the pointer on the
+    // cell it came from. The flag is that invalidation: without it the gutter's pointing hand survived
+    // over the grid until the pointer happened to cross into another cell.
+    if ((pos != _currentMousePosition || _isPointerShapeStale) && _display != nullptr)
     {
-        // Change cursor shape only when changing grid cell.
+        _isPointerShapeStale = false;
         _currentMousePosition = pos;
         if (terminal().isMouseHoveringHyperlink()
             || (modifiers.contains(vtbackend::Modifier::Control) && terminal().localPathAtMousePosition()))
@@ -1763,6 +1768,67 @@ void TerminalSession::sendMouseMoveEvent(vtbackend::Modifiers modifiers,
 
         updateHyperlinkHover(hoveredUri, pos);
     }
+}
+
+ConsumedByGutter TerminalSession::sendGutterHoverEvent(std::optional<vtbackend::LineOffset> gridLine)
+{
+    // A display-less session has no cursor to change and no gutter to be over.
+    if (_display == nullptr)
+        return ConsumedByGutter::No;
+
+    // The overwhelmingly common case -- the pointer is over the GRID, and with folding switched off
+    // it is the only case. Answered before taking the terminal lock, because this runs on every
+    // pointer motion and the ordinary move path is about to take that same lock itself.
+    if (!gridLine)
+    {
+        clearGutterHover();
+        return ConsumedByGutter::No;
+    }
+
+    _gutterHovered = true;
+    auto const overFold = crispy::locked(_terminal, [&] {
+        _terminal.setGutterHoverLine(gridLine);
+        return _terminal.foldContaining(*gridLine).has_value();
+    });
+
+    // Over the gutter but beside a row no fold reaches: still not the grid, so the event is consumed
+    // either way -- only the shape differs, saying whether there is anything here to click.
+    if (overFold)
+        _display->setMouseCursorShape(input::MouseCursorShape::PointingHand);
+    else
+        setDefaultCursor();
+
+    // Leaving the grid ends any hyperlink hover the pointer left behind on its way out.
+    clearHyperlinkHover();
+    return ConsumedByGutter::Yes;
+}
+
+ConsumedByGutter TerminalSession::sendGutterPressEvent(std::optional<vtbackend::LineOffset> gridLine,
+                                                       vtbackend::MouseButton button)
+{
+    // Only a left click acts on a fold; every other button belongs to the application, gutter or not.
+    if (button != vtbackend::MouseButton::Left || !gridLine)
+        return ConsumedByGutter::No;
+
+    // Through the one gate every folding action passes: it takes the lock, honours the folding setting
+    // and republishes the scrollable count, none of which a click on the column wants to restate.
+    if (!withFolding([&](auto& terminal) { return terminal.toggleFoldContaining(*gridLine); }))
+        return ConsumedByGutter::No;
+
+    // Remembered here rather than by the caller, so the two halves of the handshake cannot drift: a
+    // release reported for a press the child never saw leaves it holding a button down that was never
+    // pressed.
+    _gutterClickPending = true;
+    return ConsumedByGutter::Yes;
+}
+
+ConsumedByGutter TerminalSession::sendGutterReleaseEvent()
+{
+    if (!_gutterClickPending)
+        return ConsumedByGutter::No;
+
+    _gutterClickPending = false;
+    return ConsumedByGutter::Yes;
 }
 
 void TerminalSession::updateHyperlinkHover(std::string_view uri, vtbackend::CellLocation cell)
@@ -1786,6 +1852,23 @@ void TerminalSession::updateHyperlinkHover(std::string_view uri, vtbackend::Cell
     emit hyperlinkHoverChanged();
 }
 
+void TerminalSession::clearGutterHover()
+{
+    // Nothing to clear, and -- the point of the flag -- nothing to lock for: this is the answer on
+    // every pointer motion over the grid, which is nearly all of them.
+    if (!_gutterHovered)
+        return;
+
+    _gutterHovered = false;
+
+    // The gutter set the shape; only the grid can decide what replaces it, and it decides that per
+    // CELL. Leaving the gutter usually lands on the cell the pointer left from, so say the shape is
+    // stale rather than guess at it here -- the very next move then re-decides, hyperlink and all.
+    _isPointerShapeStale = true;
+
+    crispy::locked(_terminal, [&] { _terminal.setGutterHoverLine(std::nullopt); });
+}
+
 void TerminalSession::announceScrollableLineCount(vtbackend::LineCount scrollable)
 {
     // One exchange rather than a load and a store: two threads can reach this at once (the parser
@@ -1800,6 +1883,7 @@ void TerminalSession::announceScrollableLineCount(vtbackend::LineCount scrollabl
 void TerminalSession::onPointerLeft()
 {
     clearHyperlinkHover();
+    clearGutterHover();
     setDefaultCursor();
 }
 
@@ -1988,6 +2072,18 @@ command::ContextMenuState TerminalSession::contextMenuState()
         auto const block = terminal().lastCommandBlock();
         auto const hyperlink = terminal().tryGetHoveringHyperlink();
 
+        // The grid line under the pointer, when a fold reaches it. _currentMousePosition is in MAIN-PAGE
+        // rows -- which is the space translateScreenToGridLine() speaks, so it is fed in unadjusted --
+        // and was last written by the move that necessarily preceded this right-click, so it still names
+        // the clicked cell. Adding mainPageTopRow() here would reintroduce the off-by-a-status-line the
+        // gutter hit-test already had (@see gutterLineAt).
+        auto const foldLine = [&]() -> std::optional<vtbackend::LineOffset> {
+            if (!_config.folding.value().enabled)
+                return std::nullopt;
+            auto const line = terminal().viewport().translateScreenToGridLine(_currentMousePosition.line);
+            return terminal().foldContaining(line) ? std::optional { line } : std::nullopt;
+        }();
+
         return command::ContextMenuState {
             .hasSelection = terminal().selectionAvailable(),
             .clipboardHasText = clipboardHasText,
@@ -2010,6 +2106,9 @@ command::ContextMenuState TerminalSession::contextMenuState()
             // Taken now, while the pointer is still on the cell the user clicked. The rows built from this
             // carry the URI with them, because by the time one is picked the pointer has moved to the menu.
             .hyperlinkUnderCursor = hyperlink ? hyperlink->uri : std::string {},
+            // Taken now for the same reason the hyperlink is: the row acts on the line that was
+            // clicked, and the pointer will have left it by the time the row is picked.
+            .foldLine = foldLine,
             .activeProfile = profileName(),
             .profileNames = std::move(profileNames),
         };

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -492,6 +492,14 @@ void TerminalSession::attachDisplay(DisplaySurface& newDisplay)
     // a freshly attached display wants.
     setDefaultCursor();
 
+    // And likewise the scrollbar's travel: screenUpdated() only publishes it while a display is
+    // attached, so a pane that accumulated scrollback in the background carries whatever count was
+    // current when its display went away -- zero, for one that never had one. Nothing else republishes
+    // until the next screen update, which for an idle shell may be never, leaving the freshly bound
+    // scrollbar sized for a history it cannot see.
+    announceScrollableLineCount(
+        crispy::locked(_terminal, [this] { return _terminal.viewport().scrollableLineCount(); }));
+
     scheduleRedraw();
 }
 
@@ -683,18 +691,25 @@ void TerminalSession::screenUpdated()
     if (!_display)
         return;
 
-    if (_profile.history.value().autoScrollOnUpdate && terminal().viewport().scrolled()
-        && terminal().inputHandler().mode() == ViMode::Insert)
-        terminal().viewport().scrollToBottom();
+    // Emphatically NOT under Terminal's state mutex, however much the fold projection below would like
+    // it: this callback is raised BOTH with that mutex held and without it. Terminal::setMode() ends a
+    // synchronized update (DECRST 2026) by calling synchronizedOutput(), which refreshes the render
+    // buffer on the already-locked path and then raises this -- mid-parse, on the parser thread, with
+    // the mutex held. The mutex is a plain non-recursive std::mutex, so taking it here self-deadlocks on
+    // the very sequence neovim, tmux and every other modern TUI ends each frame with. @see
+    // Events::progressChanged for the same contract, stated.
+    if (_profile.history.value().autoScrollOnUpdate && _terminal.viewport().scrolled()
+        && _terminal.inputHandler().mode() == ViMode::Insert)
+        _terminal.viewport().scrollToBottom();
+
+    auto const scrollable = _terminal.viewport().scrollableLineCount();
 
     if (terminal().hasInput())
         _display->post(bind(&TerminalSession::flushInput, this));
 
-    if (_lastHistoryLineCount != _terminal.currentScreen().historyLineCount())
-    {
-        _lastHistoryLineCount = _terminal.currentScreen().historyLineCount();
-        emit historyLineCountChanged(unbox(_lastHistoryLineCount));
-    }
+    // The scrollable count rather than the history depth, so that folding a block -- which moves that
+    // count without touching the depth -- resizes the scrollbar too.
+    announceScrollableLineCount(scrollable);
 
     scheduleRedraw();
 }
@@ -1771,6 +1786,17 @@ void TerminalSession::updateHyperlinkHover(std::string_view uri, vtbackend::Cell
     emit hyperlinkHoverChanged();
 }
 
+void TerminalSession::announceScrollableLineCount(vtbackend::LineCount scrollable)
+{
+    // One exchange rather than a load and a store: two threads can reach this at once (the parser
+    // thread from screenUpdated(), the GUI thread from a folding action), and only the one that
+    // actually moved the value should announce it.
+    if (_lastHistoryLineCount.exchange(unbox(scrollable), std::memory_order_relaxed) == unbox(scrollable))
+        return;
+
+    emit historyLineCountChanged(unbox(scrollable));
+}
+
 void TerminalSession::onPointerLeft()
 {
     clearHyperlinkHover();
@@ -2476,6 +2502,82 @@ bool TerminalSession::operator()(actions::ScrollDown)
 {
     smoothScrollDown(vtbackend::LineCount(*_profile.history.value().historyScrollMultiplier));
     return true;
+}
+
+namespace
+{
+    /// The grid line the folding actions act on: where the user is looking, which is the top of the
+    /// viewport, not where the shell's cursor happens to be. ToggleFold is a viewport action.
+    ///
+    /// Not noexcept: that translation goes through the fold projection, which is built lazily and
+    /// allocates.
+    [[nodiscard]] vtbackend::LineOffset foldAnchorLine(vtbackend::Terminal const& terminal)
+    {
+        return terminal.viewport().topLine();
+    }
+} // namespace
+
+bool TerminalSession::withFolding(std::invocable<vtbackend::Terminal&> auto&& action, FoldingGate gate)
+{
+    // Locked: the actions walk the grid's marks and mutate fold state the render pass reads. See
+    // ScrollMarkDown.
+    auto const [handled, scrollable] =
+        crispy::locked(_terminal, [&]() -> std::pair<bool, vtbackend::LineCount> {
+            // One gate for every folding action rather than one per handler: a seventh action then
+            // cannot be live behind a disabled setting by forgetting to check.
+            auto const ran =
+                (gate == FoldingGate::Always || _config.folding.value().enabled) && action(terminal());
+
+            // Read under the same lock that just moved it: folding a block takes its rows out of the
+            // scrollable range without touching the history depth, and this is the only moment that is
+            // visible -- the property reporting that range may neither compute it nor take this lock.
+            return { ran, _terminal.viewport().scrollableLineCount() };
+        });
+
+    // Outside the lock: the QML binding this wakes runs synchronously on this thread and reaches back
+    // into the session. Announcing a count that did not move is a no-op, so the disabled case needs no
+    // second channel to say so.
+    announceScrollableLineCount(scrollable);
+    return handled;
+}
+
+bool TerminalSession::operator()(actions::CollapseAllFolds)
+{
+    return withFolding([](auto& terminal) { return terminal.collapseAllFolds(); });
+}
+
+bool TerminalSession::operator()(actions::CollapseLastFold)
+{
+    return withFolding([](auto& terminal) { return terminal.collapseLastFold(); });
+}
+
+bool TerminalSession::operator()(actions::ExpandAllFolds)
+{
+    // Ungated, but still through withFolding(): turning the feature off must let a user undo what they
+    // folded while it was on rather than stranding the output behind a disabled setting -- and the
+    // rows this hands BACK to the scrollable range have to be announced just as the ones a collapse
+    // takes away are, or the scrollbar keeps the travel it had while they were hidden.
+    return withFolding([](auto& terminal) { return terminal.expandAllFolds(); }, FoldingGate::Always);
+}
+
+bool TerminalSession::operator()(actions::ToggleFold)
+{
+    return withFolding(
+        [](auto& terminal) { return terminal.toggleFoldContaining(foldAnchorLine(terminal)); });
+}
+
+bool TerminalSession::operator()(actions::ToggleFoldAt action)
+{
+    // The line comes from the context menu, which captured where the user right-clicked -- so this
+    // acts on the block they were pointing at, not on whatever the viewport happens to start with.
+    return withFolding([line = action.line](auto& terminal) {
+        return terminal.toggleFoldContaining(vtbackend::LineOffset(line));
+    });
+}
+
+bool TerminalSession::operator()(actions::ToggleLastFold)
+{
+    return withFolding([](auto& terminal) { return terminal.toggleLastFold(); });
 }
 
 bool TerminalSession::operator()(actions::ScrollMarkDown)

--- a/src/contour/session/TerminalSession.hpp
+++ b/src/contour/session/TerminalSession.hpp
@@ -28,6 +28,7 @@
 #include <QtQml/QJSValue>
 
 #include <atomic>
+#include <concepts>
 #include <cstdint>
 #include <format>
 #include <initializer_list>
@@ -73,6 +74,17 @@ enum class GuardedRole : uint8_t
  * and the user decided to permanently decide for the current session.
  */
 using PermissionCache = std::map<GuardedRole, bool>;
+
+/// Whether a folding action is subject to the folding.enabled setting.
+///
+/// Named rather than left to a bool because the exception reads as a rule, not as a negation: turning
+/// the feature off must still let a user undo what they folded while it was on, rather than stranding
+/// the output behind a disabled setting.
+enum class FoldingGate : uint8_t
+{
+    Configured = 0, ///< The action runs only while folding is enabled.
+    Always,         ///< The action runs regardless -- it can only ever REVEAL output.
+};
 
 /**
  * Manages a single terminal session (Client, Terminal, Display)
@@ -282,7 +294,16 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
 
     bool showResizeIndicator() const noexcept { return _config.profile().sizeIndicatorOnResize.value(); }
 
-    int historyLineCount() const noexcept { return unbox(_terminal.currentScreen().historyLineCount()); }
+    /// How far the scrollbar can scroll up, in rows the user can actually reach.
+    ///
+    /// The scrollable count rather than the raw history depth: collapsed folds take their output out
+    /// of the scrollable range, and a scrollbar sized by the raw history would offer a stretch of
+    /// travel at the top that scrolls nowhere.
+    ///
+    /// Reported from what announceScrollableLineCount() last published, and emphatically NOT computed
+    /// here -- see there for why the GUI thread may neither compute this count nor take the lock that
+    /// would make computing it safe. It is therefore also exactly what the NOTIFY signal carried.
+    int historyLineCount() const noexcept { return _lastHistoryLineCount.load(std::memory_order_relaxed); }
 
     int scrollOffset() const noexcept { return unbox(terminal().viewport().scrollOffset()); }
     void setScrollOffset(int value)
@@ -584,6 +605,9 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::ScreenshotVT);
     bool operator()(actions::CopyScreenshot);
     bool operator()(actions::SaveScreenshot);
+    bool operator()(actions::CollapseAllFolds);
+    bool operator()(actions::CollapseLastFold);
+    bool operator()(actions::ExpandAllFolds);
     bool operator()(actions::ScrollDown);
     bool operator()(actions::ScrollMarkDown);
     bool operator()(actions::ScrollMarkUp);
@@ -593,6 +617,9 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     bool operator()(actions::ScrollPageUp);
     bool operator()(actions::ScrollToBottom);
     bool operator()(actions::ScrollToTop);
+    bool operator()(actions::ToggleFold);
+    bool operator()(actions::ToggleFoldAt);
+    bool operator()(actions::ToggleLastFold);
     bool operator()(actions::ScrollUp);
     bool operator()(actions::SearchReverse);
     bool operator()(actions::SendChars const& event);
@@ -742,6 +769,21 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
 
   private:
     // helpers
+
+    /// Runs @p action against the terminal under the lock, and republishes the scrollable count.
+    ///
+    /// The one gate every folding action passes, so that adding one is a handler rather than a handler
+    /// plus a remembered check -- a forgotten check leaves an action live behind a disabled setting,
+    /// and nothing diagnoses it. Republishing is here for the same reason: an action that moved rows
+    /// into or out of the scrollable range and did not say so leaves the scrollbar sized for the range
+    /// before it.
+    ///
+    /// @param action What to do with the terminal; its result is the action's result.
+    /// @param gate   Whether @p action is subject to the folding.enabled setting.
+    /// @return What @p action returned, or false when folding is disabled and @p gate honours it.
+    bool withFolding(std::invocable<vtbackend::Terminal&> auto&& action,
+                     FoldingGate gate = FoldingGate::Configured);
+
     bool reloadConfig(config::Config newConfig, std::string const& profileName);
     int executeAllActions(std::vector<actions::Action> const& actions);
     void spawnNewTerminal(std::string const& profileName);
@@ -754,6 +796,19 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     /// notice already defines: the reason on screen, the device closed, and the pane pruned by the
     /// next key press (see sendKeyEvent) or by closing the tab (see terminate).
     void reportDeviceStartFailure(vtpty::StartFailure const& failure);
+
+    /// Publishes @p scrollable as the scrollbar's travel, announcing it when it moved.
+    ///
+    /// The historyLineCount property reads what this stored rather than computing a count of its
+    /// own, because computing one goes through the fold projection -- a lazily built cache the
+    /// render pass clears and refills under the terminal lock, so a GUI-thread rebuild races it.
+    /// Taking that lock in the property instead is what cannot be done: a scroll performed under it
+    /// emits scrollOffsetChanged, whose QML handler reads this very property on the same thread, and
+    /// the lock is not recursive. So every caller computes the count itself and hands it here, and
+    /// this is called OUTSIDE any lock -- the binding it wakes reaches back into the session.
+    ///
+    /// @param scrollable The scrollable line count, computed by the caller.
+    void announceScrollableLineCount(vtbackend::LineCount scrollable);
 
     /// Re-announces every Q_PROPERTY whose value is derived from the profile, so the QML bindings that
     /// read them re-evaluate against the profile that was just swapped in. Call after every assignment
@@ -875,7 +930,10 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     std::unique_ptr<platform::Audio> _audio;
     std::vector<int> _musicalNotesBuffer;
 
-    vtbackend::LineCount _lastHistoryLineCount;
+    /// The scrollable line count the historyLineCount property reports and its NOTIFY signal last
+    /// carried. Atomic because the parser thread publishes it while the GUI thread reads it; see
+    /// announceScrollableLineCount() for why the GUI thread cannot simply compute it.
+    std::atomic<int> _lastHistoryLineCount = 0;
 
     struct CaptureBufferRequest
     {

--- a/src/contour/session/TerminalSession.hpp
+++ b/src/contour/session/TerminalSession.hpp
@@ -75,6 +75,16 @@ enum class GuardedRole : uint8_t
  */
 using PermissionCache = std::map<GuardedRole, bool>;
 
+/// Whether the fold gutter took an input event, and the grid must therefore not also see it.
+///
+/// Named rather than left to a bool because the call sites read as a question about routing, not about
+/// truth: a bare `true` there says nothing about which of the two paths it selects.
+enum class ConsumedByGutter : uint8_t
+{
+    No = 0,
+    Yes,
+};
+
 /// Whether a folding action is subject to the folding.enabled setting.
 ///
 /// Named rather than left to a bool because the exception reads as a rule, not as a negation: turning
@@ -561,6 +571,32 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     void sendMouseMoveEvent(vtbackend::Modifiers modifiers,
                             vtbackend::CellLocation pos,
                             vtbackend::PixelCoordinate pixelPosition);
+
+    /// Reports where the pointer is over the fold gutter, or that it is not over it at all.
+    ///
+    /// Consulted BEFORE the ordinary move path and, when it claims the event, instead of it: the
+    /// gutter is not part of the grid, so a move there must not reach the mouse protocol, extend a
+    /// selection, or hover a hyperlink at the column-0 cell it would otherwise be clamped onto.
+    ///
+    /// @param gridLine The grid line under the pointer, or nullopt when it is not over the gutter.
+    /// @return Whether the gutter consumed the event.
+    ConsumedByGutter sendGutterHoverEvent(std::optional<vtbackend::LineOffset> gridLine);
+
+    /// Toggles the fold at @p gridLine when the press landed on the fold column.
+    ///
+    /// The press half of the gutter's click handshake, and the only place that arms it: a press the
+    /// child never saw must be followed by a release it never sees either, and leaving that to the
+    /// caller means a third event path re-deriving the rule (@see sendGutterReleaseEvent).
+    ///
+    /// @param gridLine The grid line under the pointer, or nullopt when it is not over the gutter.
+    /// @param button The button that went down.
+    /// @return Whether the gutter consumed the event.
+    ConsumedByGutter sendGutterPressEvent(std::optional<vtbackend::LineOffset> gridLine,
+                                          vtbackend::MouseButton button);
+
+    /// Swallows the release matching a press the fold column consumed.
+    /// @return Whether the gutter consumed the event.
+    ConsumedByGutter sendGutterReleaseEvent();
     void sendMouseReleaseEvent(vtbackend::Modifiers modifiers,
                                vtbackend::MouseButton button,
                                vtbackend::PixelCoordinate pixelPosition);
@@ -797,6 +833,12 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     /// next key press (see sendKeyEvent) or by closing the tab (see terminate).
     void reportDeviceStartFailure(vtpty::StartFailure const& failure);
 
+    /// Ends a gutter hover, if one is in effect.
+    ///
+    /// The one place _gutterHovered is cleared, so the flag and the terminal's own hover line cannot
+    /// disagree -- clearing one without the other left a hover the next motion had to undo.
+    void clearGutterHover();
+
     /// Publishes @p scrollable as the scrollbar's travel, announcing it when it moved.
     ///
     /// The historyLineCount property reads what this stored rather than computing a count of its
@@ -915,6 +957,28 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     //
     vtbackend::ScreenType _currentScreenType = vtbackend::ScreenType::Primary;
     vtbackend::CellLocation _currentMousePosition = vtbackend::CellLocation {};
+
+    /// Whether the pointer was last seen over the fold gutter rather than over the grid.
+    ///
+    /// Kept here so the common case -- pointer over the grid -- can be answered without taking
+    /// the terminal lock on every single motion event, while still clearing a hover that was set.
+    bool _gutterHovered = false;
+
+    /// Whether this pane's last press was consumed by the fold column, so its release must be too.
+    ///
+    /// A press the child never saw must not be followed by a release it does see: that leaves the
+    /// application holding a button down that was never pressed. Per SESSION rather than per process:
+    /// every pane and every window shares the GUI thread, so a press in one pane's gutter followed by
+    /// a release delivered to another would otherwise swallow the second pane's release.
+    bool _gutterClickPending = false;
+
+    /// Whether the mouse cursor shape must be re-decided on the next motion, even over the same cell.
+    ///
+    /// The move path changes the shape only when the pointer changes grid CELL, that being the only
+    /// thing that can change its answer -- but the fold gutter sets the shape without going through
+    /// it, and leaving the gutter lands the pointer back on the cell it came from. @see
+    /// clearGutterHover(), which raises this.
+    bool _isPointerShapeStale = false;
 
     /// The shape the application last asked for via `OSC 22`, or nullopt while it has asked for
     /// none. Recorded whether or not a display is attached: a session between displays -- a split

--- a/src/contour/session/TerminalSession_test.cpp
+++ b/src/contour/session/TerminalSession_test.cpp
@@ -1032,6 +1032,75 @@ TEST_CASE("TerminalSession: scroll actions move the viewport over seeded history
     CHECK_NOTHROW((*session)(actions::SearchReverse {}));
 }
 
+TEST_CASE("TerminalSession: folding actions collapse and expand command output",
+          "[contour][session][actions][folding]")
+{
+    // The five folding actions, driven end to end against a session whose scrollback holds two commands
+    // marked up exactly as a shell with OSC 133 integration would mark them.
+    TestApp testApp;
+    auto session = makeDisplaylessSession(testApp.app());
+    namespace actions = contour::actions;
+
+    auto const runCommand = [&](std::string const& command, int outputLines) {
+        session->terminal().writeToScreen("\033]133;A\033\\$ \033]133;B\033\\" + command + "\r\n");
+        session->terminal().writeToScreen("\033]133;C\033\\");
+        for (auto i = 0; i < outputLines; ++i)
+            session->terminal().writeToScreen(std::format("out {}\r\n", i));
+        session->terminal().writeToScreen("\033]133;D;0\033\\");
+    };
+
+    runCommand("ls", 3);
+    runCommand("pwd", 2);
+
+    auto& terminal = session->terminal();
+    REQUIRE(terminal.foldRanges().size() == 2);
+    REQUIRE(terminal.foldState().empty());
+
+    SECTION("CollapseLastFold hides the most recent command, and is idempotent")
+    {
+        CHECK((*session)(actions::CollapseLastFold {}));
+        CHECK(terminal.hiddenLineCount() > vtbackend::LineCount(0));
+        // Already collapsed: nothing to do, and it says so.
+        CHECK(!(*session)(actions::CollapseLastFold {}));
+    }
+
+    SECTION("ToggleLastFold goes both ways")
+    {
+        CHECK((*session)(actions::ToggleLastFold {}));
+        auto const hidden = terminal.hiddenLineCount();
+        CHECK(hidden > vtbackend::LineCount(0));
+
+        CHECK((*session)(actions::ToggleLastFold {}));
+        CHECK(terminal.hiddenLineCount() == vtbackend::LineCount(0));
+    }
+
+    SECTION("CollapseAllFolds then ExpandAllFolds returns to where it started")
+    {
+        CHECK((*session)(actions::CollapseAllFolds {}));
+        auto const allHidden = terminal.hiddenLineCount();
+        CHECK(allHidden > vtbackend::LineCount(0));
+        // Everything is already collapsed, so a second sweep changes nothing.
+        CHECK(!(*session)(actions::CollapseAllFolds {}));
+
+        CHECK((*session)(actions::ExpandAllFolds {}));
+        CHECK(terminal.hiddenLineCount() == vtbackend::LineCount(0));
+        CHECK(!(*session)(actions::ExpandAllFolds {}));
+    }
+
+    SECTION("ToggleFold acts on the block at the top of the viewport")
+    {
+        // Nothing is at the viewport top but the oldest prompt, so this is the fold that toggles.
+        (*session)(actions::ScrollToTop {});
+        auto const marker =
+            terminal.foldMarkerAt(terminal.viewport().translateScreenToGridLine(vtbackend::LineOffset(0)));
+        if (marker != vtbackend::FoldMarker::None)
+        {
+            CHECK((*session)(actions::ToggleFold {}));
+            CHECK(terminal.hiddenLineCount() > vtbackend::LineCount(0));
+        }
+    }
+}
+
 TEST_CASE("TerminalSession: display-guarded toggle actions are safe no-ops without a display",
           "[contour][session][actions]")
 {
@@ -2726,3 +2795,82 @@ TEST_CASE("TerminalSession::attachDisplay releases a surface it is taking the se
     held->detachDisplay(second);
 }
 // }}}
+
+TEST_CASE("TerminalSession survives a synchronized-output frame with a surface attached",
+          "[contour][session][view]")
+{
+    TestApp testApp;
+    auto held = makeSessionWithSurface(testApp.app());
+
+    // DECRST 2026 ends a synchronized update, and Terminal::synchronizedOutput() reports the frame to
+    // the event listener while the parser thread still HOLDS the state mutex (it calls
+    // refreshRenderBuffer(true), i.e. "already locked"). A screenUpdated() that takes that same
+    // non-recursive mutex therefore self-deadlocks on the very sequence neovim, tmux and every other
+    // modern TUI ends each frame with.
+    held->terminal().writeToScreen("\033[?2026h");
+    held->terminal().writeToScreen("hello");
+    held->terminal().writeToScreen("\033[?2026l");
+
+    CHECK(held->terminal().primaryScreen().grid().lineText(vtbackend::LineOffset(0)).starts_with("hello"));
+}
+
+TEST_CASE("TerminalSession publishes the scrollbar's travel whenever folding moves it",
+          "[contour][session][actions][folding][view]")
+{
+    // historyLineCount is what QML sizes the scrollbar from, and it reports what was last PUBLISHED
+    // rather than a count of its own. Every action that moves rows into or out of the scrollable range
+    // therefore has to say so -- including the ones that only ever reveal output.
+    TestApp testApp;
+    auto held = makeSessionWithSurface(testApp.app());
+    auto& terminal = held->terminal();
+    namespace actions = contour::actions;
+
+    auto const runCommand = [&](std::string const& command, int outputLines) {
+        terminal.writeToScreen("\033]133;A\033\\$ \033]133;B\033\\" + command + "\r\n");
+        terminal.writeToScreen("\033]133;C\033\\");
+        for (auto i = 0; i < outputLines; ++i)
+            terminal.writeToScreen(std::format("out {}\r\n", i));
+        terminal.writeToScreen("\033]133;D;0\033\\");
+    };
+
+    // Deep enough that folding the output actually shortens the scrollable range.
+    runCommand("ls", 40);
+    runCommand("pwd", 40);
+    REQUIRE(terminal.foldRanges().size() == 2);
+
+    auto const expanded = held->historyLineCount();
+    REQUIRE(expanded > 0);
+
+    REQUIRE((*held)(actions::CollapseAllFolds {}));
+    auto const collapsed = held->historyLineCount();
+    CHECK(collapsed < expanded);
+
+    // The one that used to bypass the announce: the rows come back, and so must the travel.
+    REQUIRE((*held)(actions::ExpandAllFolds {}));
+    CHECK(held->historyLineCount() == expanded);
+}
+
+TEST_CASE("TerminalSession::attachDisplay publishes the scrollbar's travel it accumulated unseen",
+          "[contour][session][view]")
+{
+    // A background pane has no display, and screenUpdated() -- the only other publisher -- returns
+    // early without one. Binding a display therefore has to publish, or the freshly shown scrollbar is
+    // sized for a history the session had when its display went away: zero, for one that never had a
+    // display, and an idle shell never produces the screen update that would correct it.
+    TestApp testApp;
+    auto session = makeDisplaylessSession(testApp.app());
+    for (auto i = 0; i < 100; ++i)
+        session->terminal().writeToScreen(std::format("line {}\r\n", i));
+
+    REQUIRE(session->terminal().primaryScreen().historyLineCount() > vtbackend::LineCount(0));
+    REQUIRE(session->historyLineCount() == 0);
+
+    auto surface = contour::test::FakeDisplaySurface {};
+    surface.attachedSession = session.get();
+    session->attachDisplay(surface);
+
+    CHECK(session->historyLineCount() == unbox<int>(session->terminal().viewport().scrollableLineCount()));
+    CHECK(session->historyLineCount() > 0);
+
+    session->detachDisplay(surface);
+}

--- a/src/contour/test/QmlComponents_test.cpp
+++ b/src/contour/test/QmlComponents_test.cpp
@@ -660,6 +660,7 @@ TEST_CASE("The terminal context menu opens, sub-menus and all (offscreen)", "[co
         .hasLocalWorkingDirectory = true,
         .hasSplits = false,
         .hyperlinkUnderCursor = "",
+        .foldLine = std::nullopt,
         .activeProfile = "dark",
         .profileNames = { "dark", "light" },
     };
@@ -736,6 +737,7 @@ TEST_CASE("Terminal context menu builds its rows from the C++ model (offscreen)"
         .hasLocalWorkingDirectory = true,
         .hasSplits = false,
         .hyperlinkUnderCursor = "", // the two hyperlink rows must be absent
+        .foldLine = std::nullopt,   // the fold row must be present but grayed
         .activeProfile = "dark",
         .profileNames = { "dark", "light" },
     };

--- a/src/contour/window/WindowController.cpp
+++ b/src/contour/window/WindowController.cpp
@@ -1013,8 +1013,13 @@ void WindowController::showInitial()
     auto const marginsDevice =
         geometry::scaled(session::toGeometryMargins(session->profile().margins.value()), scale);
     auto const totalPage = session->terminal().totalPageSize();
-    auto const size =
-        geometry::windowSizeForPage(totalPage, display->cellSize(), marginsDevice, scale, chrome());
+    auto const size = geometry::windowSizeForPage(
+        totalPage,
+        display->cellSize(),
+        marginsDevice,
+        scale,
+        chrome(),
+        session::gutterWidthFor(session->config().folding.value(), display->cellSize()));
 
     display::displayLog()("Initial window size {}x{} (page {}, cell {}, scale {}, chrome {}).",
                           size.width,
@@ -1138,7 +1143,11 @@ void WindowController::updateSizeHintsFor(session::DisplaySurface& requester, Hi
     auto const scale = requester.devicePixelRatio();
     auto const cellSize = requester.cellSize();
     auto const margins = session::toGeometryMargins(requester.session().profile().margins.value());
-    auto const hints = geometry::sizeHintsFor(cellSize, margins, scale, chrome());
+    // Handed over in DEVICE pixels, the unit it is decided in: sizeHintsFor converts it once, where
+    // unscaling it here and letting it be scaled back would truncate a pixel off at fractional DPR.
+    auto const gutterDevicePx =
+        session::gutterWidthFor(requester.session().config().folding.value(), cellSize);
+    auto const hints = geometry::sizeHintsFor(cellSize, margins, scale, chrome(), gutterDevicePx);
 
     // The character-cell resize grid (base + increment) is cleared while maximized/fullscreen. An
     // incidental refresh (RespectWindowState) must not re-arm it while the window is non-normal — that
@@ -1260,7 +1269,12 @@ bool WindowController::resizeWindowForPage(session::DisplaySurface& requester,
         geometry::scaled(session::toGeometryMargins(requester.session().profile().margins.value()), scale);
     // The pane's requirement as a logical extent (ceil side of the rounding law; chrome added later).
     auto const leafLogical = geometry::windowSizeForPage(
-        totalPageSize, requester.cellSize(), marginsDevice, scale, geometry::Chrome {});
+        totalPageSize,
+        requester.cellSize(),
+        marginsDevice,
+        scale,
+        geometry::Chrome {},
+        session::gutterWidthFor(requester.session().config().folding.value(), requester.cellSize()));
     return applyContentDrivenResize(requester, leafLogical);
 }
 

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -170,6 +170,7 @@ if(LIBTERMINAL_TESTING)
         DesktopNotification_test.cpp
         ProgressState_test.cpp
         Color_test.cpp
+        ColorPalette_test.cpp
         CommandBlocks_test.cpp
         Folding_test.cpp
         PromptRegion_test.cpp

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -22,6 +22,7 @@ set(vtbackend_HEADERS
     Color.hpp
     ColorPalette.hpp
     CommandBlocks.hpp
+    Folding.hpp
     PromptRegion.hpp
     Functions.hpp
     GraphicsAttributes.hpp
@@ -80,6 +81,7 @@ set(vtbackend_SOURCES
     Color.cpp
     ColorPalette.cpp
     CommandBlocks.cpp
+    Folding.cpp
     PromptRegion.cpp
     Functions.cpp
     Grid.cpp
@@ -169,6 +171,7 @@ if(LIBTERMINAL_TESTING)
         ProgressState_test.cpp
         Color_test.cpp
         CommandBlocks_test.cpp
+        Folding_test.cpp
         PromptRegion_test.cpp
         GoodImageProtocol_test.cpp
         XtSmGraphics_test.cpp

--- a/src/vtbackend/ColorPalette.cpp
+++ b/src/vtbackend/ColorPalette.cpp
@@ -5,8 +5,11 @@
 
 #include <crispy/Overloaded.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cstdio>
-#include <map>
+#include <span>
+#include <string_view>
 
 using namespace std;
 
@@ -27,267 +30,298 @@ namespace
 
         return numToRound + multiple - remainder;
     }
+
+    /// One built-in color scheme: its name, and what it changes about a default-constructed palette.
+    ///
+    /// A function pointer rather than a std::function, so the whole table is a compile-time constant
+    /// instead of ten type-erased closures allocated afresh on every lookup.
+    struct BuiltinColorPalette
+    {
+        std::string_view name;        ///< The name a scheme is selected by.
+        void (*apply)(ColorPalette&); ///< Applies it to @p palette.
+    };
+
+    /// Every built-in color scheme, as one table.
+    ///
+    /// The single source of truth for which names exist: defaultColorPalettes() looks a name up here,
+    /// defaultColorPaletteNames() reports the same rows, and adding a scheme is adding a row. That
+    /// matters because a caller cannot otherwise discover the set -- and a test that has to enumerate
+    /// the schemes would silently stop covering an eleventh one.
+    ///
+    /// TODO add dim colors, do we need to adapt them to each of color palettes?
+    constexpr auto BuiltinColorPalettes = std::array {
+        BuiltinColorPalette { "contour", [](ColorPalette&) {} },
+        BuiltinColorPalette { "monokai",
+                              [](ColorPalette& palette) {
+                                  // Monokai dark colors
+                                  // normal colors
+                                  palette.palette[0] = 0x272822_rgb; // black
+                                  palette.palette[1] = 0xf92672_rgb; // red
+                                  palette.palette[2] = 0xa6e22e_rgb; // green
+                                  palette.palette[3] = 0xf4bf75_rgb; // yellow
+                                  palette.palette[4] = 0x66d9ef_rgb; // blue
+                                  palette.palette[5] = 0xae81ff_rgb; // magenta
+                                  palette.palette[6] = 0xa1efe4_rgb; // cyan
+                                  palette.palette[7] = 0xf8f8f2_rgb; // white
+                                  // bright colors
+                                  palette.palette[8] = 0x75715e_rgb;  // bright black (dark gray)
+                                  palette.palette[9] = 0xf92672_rgb;  // bright red
+                                  palette.palette[10] = 0xa6e22e_rgb; // bright green
+                                  palette.palette[11] = 0xf4bf75_rgb; // bright yellow
+                                  palette.palette[12] = 0x66d9ef_rgb; // bright blue
+                                  palette.palette[13] = 0xae81ff_rgb; // bright magenta
+                                  palette.palette[14] = 0xa1efe4_rgb; // bright blue
+                                  palette.palette[15] = 0xf8f8f2_rgb; // bright white
+
+                                  palette.defaultForeground = 0xf8f8f2_rgb;
+                                  palette.defaultBackground = 0x272822_rgb;
+                                  palette.defaultForegroundBright = 0xf8f8f2_rgb;
+                                  palette.defaultForegroundDimmed = 0x75715e_rgb;
+                                  palette.mouseForeground = 0xf8f8f2_rgb;
+                                  palette.mouseBackground = 0x272822_rgb;
+                                  palette.cursor.color = 0xf8f8f2_rgb;
+                              } },
+        BuiltinColorPalette { "one-light",
+                              [](ColorPalette& palette) {
+                                  // One Light colors
+                                  // normal colors
+                                  palette.palette[0] = 0x000000_rgb; // black
+                                  palette.palette[1] = 0xda3e39_rgb; // red
+                                  palette.palette[2] = 0x41933e_rgb; // green
+                                  palette.palette[3] = 0x855504_rgb; // yellow
+                                  palette.palette[4] = 0x315eee_rgb; // blue
+                                  palette.palette[5] = 0x930092_rgb; // magenta
+                                  palette.palette[6] = 0x0e6fad_rgb; // cyan
+                                  palette.palette[7] = 0x8e8f96_rgb; // white
+
+                                  // bright colors
+                                  palette.palette[8] = 0x2a2b32_rgb;  // bright black (dark gray)
+                                  palette.palette[9] = 0xda3e39_rgb;  // bright red
+                                  palette.palette[10] = 0x41933e_rgb; // bright green
+                                  palette.palette[11] = 0x855504_rgb; // bright yellow
+                                  palette.palette[12] = 0x315eee_rgb; // bright blue
+                                  palette.palette[13] = 0x930092_rgb; // bright magenta
+                                  palette.palette[14] = 0x0e6fad_rgb; // bright cuan
+                                  palette.palette[15] = 0xfffefe_rgb; // bright white
+
+                                  palette.defaultForeground = 0x2a2b32_rgb;
+                                  palette.defaultBackground = 0xf8f8f8_rgb;
+                                  palette.cursor.color = 0x2a2b32_rgb;
+                              } },
+        BuiltinColorPalette { "one-dark",
+                              [](ColorPalette& palette) {
+                                  // One Dark colors
+                                  // normal colors
+                                  palette.palette[0] = 0x000000_rgb; // black
+                                  palette.palette[1] = 0xe06c75_rgb; // red
+                                  palette.palette[2] = 0x98c379_rgb; // green
+                                  palette.palette[3] = 0xe5c07b_rgb; // yellow
+                                  palette.palette[4] = 0x61afef_rgb; // blue
+                                  palette.palette[5] = 0xc678dd_rgb; // magenta
+                                  palette.palette[6] = 0x56b6c2_rgb; // cyan
+                                  palette.palette[7] = 0xabb2bf_rgb; // white
+
+                                  // bright colors
+                                  palette.palette[8] = 0x5c6370_rgb;  // bright black (dark gray)
+                                  palette.palette[9] = 0xe06c75_rgb;  // bright red
+                                  palette.palette[10] = 0x98c379_rgb; // bright green
+                                  palette.palette[11] = 0xd19a66_rgb; // bright yellow
+                                  palette.palette[12] = 0x61afef_rgb; // bright blue
+                                  palette.palette[13] = 0xc678dd_rgb; // bright magenta
+                                  palette.palette[14] = 0x56b6c2_rgb; // bright cuan
+                                  palette.palette[15] = 0xfffefe_rgb; // bright white
+
+                                  palette.defaultForeground = 0x5c6370_rgb;
+                                  palette.defaultBackground = 0x1e2127_rgb;
+                                  palette.defaultForegroundBright = 0x5c6370_rgb;
+                                  palette.defaultForegroundDimmed = 0x545862_rgb;
+                                  palette.mouseForeground = 0xabb2bf_rgb;
+                                  palette.mouseBackground = 0x282c34_rgb;
+                                  palette.cursor.color = 0x5c6370_rgb;
+                              } },
+        BuiltinColorPalette { "gruvbox-light",
+                              [](ColorPalette& palette) {
+                                  // Gruvbox colors
+                                  // normal colors
+                                  palette.palette[0] = 0xfbf1c7_rgb; // black
+                                  palette.palette[1] = 0xcc241d_rgb; // red
+                                  palette.palette[2] = 0x98971a_rgb; // green
+                                  palette.palette[3] = 0xd79921_rgb; // yellow
+                                  palette.palette[4] = 0x458588_rgb; // blue
+                                  palette.palette[5] = 0xb16286_rgb; // magenta
+                                  palette.palette[6] = 0x689d6a_rgb; // cyan
+                                  palette.palette[7] = 0x7c6f64_rgb; // white
+                                  // bright colors
+                                  palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
+                                  palette.palette[9] = 0x9d0006_rgb;  // bright red
+                                  palette.palette[10] = 0x79740e_rgb; // bright green
+                                  palette.palette[11] = 0xb57614_rgb; // bright yellow
+                                  palette.palette[12] = 0x076678_rgb; // bright blue
+                                  palette.palette[13] = 0x8f3f71_rgb; // bright magenta
+                                  palette.palette[14] = 0x427b58_rgb; // bright cuan
+                                  palette.palette[15] = 0x3c3836_rgb; // bright white
+
+                                  palette.defaultForeground = 0x3c3836_rgb;
+                                  palette.defaultBackground = 0xfbf1c7_rgb;
+                                  palette.cursor.color = 0x3c3836_rgb;
+                              } },
+        BuiltinColorPalette { "gruvbox-dark",
+                              [](ColorPalette& palette) {
+                                  // Gruvbox colors
+                                  // normal colors
+                                  palette.palette[0] = 0x282828_rgb; // black
+                                  palette.palette[1] = 0xcc241d_rgb; // red
+                                  palette.palette[2] = 0x98971a_rgb; // green
+                                  palette.palette[3] = 0xd79921_rgb; // yellow
+                                  palette.palette[4] = 0x458588_rgb; // blue
+                                  palette.palette[5] = 0xb16286_rgb; // magenta
+                                  palette.palette[6] = 0x689d6a_rgb; // cyan
+                                  palette.palette[7] = 0xa89984_rgb; // white
+                                  // bright colors
+                                  palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
+                                  palette.palette[9] = 0xfb4934_rgb;  // bright red
+                                  palette.palette[10] = 0xb8bb26_rgb; // bright green
+                                  palette.palette[11] = 0xfabd2f_rgb; // bright yellow
+                                  palette.palette[12] = 0x83a598_rgb; // bright blue
+                                  palette.palette[13] = 0xd3869b_rgb; // bright magenta
+                                  palette.palette[14] = 0x8ec07c_rgb; // bright cuan
+                                  palette.palette[15] = 0xebdbb2_rgb; // bright white
+
+                                  palette.defaultForeground = 0xebdbb2_rgb;
+                                  palette.defaultBackground = 0x292929_rgb;
+                                  palette.cursor.color = 0xebdbb2_rgb;
+                              } },
+        BuiltinColorPalette { "solarized-light",
+                              [](ColorPalette& palette) {
+                                  // Solarized colors
+                                  // normal colors
+                                  palette.palette[0] = 0xeee8d5_rgb; // black
+                                  palette.palette[1] = 0xdc322f_rgb; // red
+                                  palette.palette[2] = 0x859900_rgb; // green
+                                  palette.palette[3] = 0xb58900_rgb; // yellow
+                                  palette.palette[4] = 0x268bd2_rgb; // blue
+                                  palette.palette[5] = 0xd33682_rgb; // magenta
+                                  palette.palette[6] = 0x2aa198_rgb; // cyan
+                                  palette.palette[7] = 0x002b36_rgb; // white
+                                  // bright colors
+                                  palette.palette[8] = 0x657b83_rgb;  // bright black
+                                  palette.palette[9] = 0xcb4b16_rgb;  // bright red
+                                  palette.palette[10] = 0x859900_rgb; // bright green
+                                  palette.palette[11] = 0xb58900_rgb; // bright yellow
+                                  palette.palette[12] = 0x6c71c4_rgb; // bright blue
+                                  palette.palette[13] = 0xd33682_rgb; // bright magenta
+                                  palette.palette[14] = 0x2aa198_rgb; // bright cyan
+                                  palette.palette[15] = 0x073642_rgb; // bright white
+
+                                  palette.defaultForeground = 0x657b83_rgb;
+                                  palette.defaultBackground = 0xfdf6e3_rgb;
+                                  palette.cursor.color = 0x657b83_rgb;
+                              } },
+        BuiltinColorPalette { "solarized-dark",
+                              [](ColorPalette& palette) {
+                                  // solarized colors
+                                  // normal colors
+                                  palette.palette[0] = 0x073642_rgb; // black
+                                  palette.palette[1] = 0xdc322f_rgb; // red
+                                  palette.palette[2] = 0x859900_rgb; // green
+                                  palette.palette[3] = 0xcf9a6b_rgb; // yellow
+                                  palette.palette[4] = 0x268bd2_rgb; // blue
+                                  palette.palette[5] = 0xd33682_rgb; // magenta
+                                  palette.palette[6] = 0x2aa198_rgb; // cyan
+                                  palette.palette[7] = 0xeee8d5_rgb; // white
+                                  // bright color
+                                  palette.palette[8] = 0x657b83_rgb;  // bright black
+                                  palette.palette[9] = 0xcb4b16_rgb;  // bright red
+                                  palette.palette[10] = 0x859900_rgb; // bright green
+                                  palette.palette[11] = 0xcf9a6b_rgb; // bright yellow
+                                  palette.palette[12] = 0x6c71c4_rgb; // bright blue
+                                  palette.palette[13] = 0xd33682_rgb; // bright magenta
+                                  palette.palette[14] = 0x2aa198_rgb; // bright cyan
+                                  palette.palette[15] = 0xfdf6e3_rgb; // bright white
+
+                                  palette.defaultForeground = 0x839496_rgb;
+                                  palette.defaultBackground = 0x002b36_rgb;
+                                  palette.cursor.color = 0x839496_rgb;
+                              } },
+        BuiltinColorPalette { "papercolor-light",
+                              [](ColorPalette& palette) {
+                                  // papercolor light colors
+                                  // normal colors
+                                  palette.palette[0] = 0xeeeeee_rgb; // black
+                                  palette.palette[1] = 0xaf0000_rgb; // red
+                                  palette.palette[2] = 0x008700_rgb; // green
+                                  palette.palette[3] = 0x5f8700_rgb; // yellow
+                                  palette.palette[4] = 0x0087af_rgb; // blue
+                                  palette.palette[5] = 0x878787_rgb; // magenta
+                                  palette.palette[6] = 0x005f87_rgb; // cyan
+                                  palette.palette[7] = 0x444444_rgb; // white
+                                  // bright colors
+                                  palette.palette[8] = 0xbcbcbc_rgb;  // bright black
+                                  palette.palette[9] = 0xd70000_rgb;  // bright red
+                                  palette.palette[10] = 0xd70087_rgb; // bright green
+                                  palette.palette[11] = 0x8700af_rgb; // bright yellow
+                                  palette.palette[12] = 0xd75f00_rgb; // bright blue
+                                  palette.palette[13] = 0xd75f00_rgb; // bright magenta
+                                  palette.palette[14] = 0x005faf_rgb; // bright cyan
+                                  palette.palette[15] = 0x005f87_rgb; // bright white
+
+                                  palette.defaultForeground = 0x444444_rgb;
+                                  palette.defaultBackground = 0xeeeeee_rgb;
+                                  palette.cursor.color = 0x444444_rgb;
+                              } },
+        BuiltinColorPalette { "papercolor-dark",
+                              [](ColorPalette& palette) {
+                                  // papercolor dark colors
+                                  // normal colors
+                                  palette.palette[0] = 0x1C1C1C_rgb; // Black (Host)
+                                  palette.palette[1] = 0xAF005F_rgb; // Red (Syntax string)
+                                  palette.palette[2] = 0x5FAF00_rgb; // Green (Command)
+                                  palette.palette[3] = 0xD7AF5F_rgb; // Yellow (Command second)
+                                  palette.palette[4] = 0x5FAFD7_rgb; // Blue (Path)
+                                  palette.palette[5] = 0x808080_rgb; // Magenta (Syntax var)
+                                  palette.palette[6] = 0xD7875F_rgb; // Cyan (Prompt)
+                                  palette.palette[7] = 0xD0D0D0_rgb; // White
+
+                                  palette.palette[8] = 0x585858_rgb;  // Bright Black
+                                  palette.palette[9] = 0x5FAF5F_rgb;  // Bright Red (Command error)
+                                  palette.palette[10] = 0xAFD700_rgb; // Bright Green (Exec)
+                                  palette.palette[11] = 0xAF87D7_rgb; // Bright Yellow
+                                  palette.palette[12] = 0xFFAF00_rgb; // Bright Blue (Folder)
+                                  palette.palette[13] = 0xFF5FAF_rgb; // Bright Magenta
+                                  palette.palette[14] = 0x00AFAF_rgb; // Bright Cyan
+                                  palette.palette[15] = 0x5F8787_rgb; // Bright White
+
+                                  palette.defaultForeground = 0xd0d0d0_rgb;
+                                  palette.defaultBackground = 0x1c1c1c_rgb;
+                                  palette.cursor.color = 0xd0d0d0_rgb;
+                              } },
+    };
+
+    /// The table's names alone, so the accessor can hand out a span without exposing the row type.
+    ///
+    /// Derived from the table rather than written out again -- the two cannot disagree.
+    constexpr auto BuiltinColorPaletteNames = [] {
+        auto names = std::array<std::string_view, BuiltinColorPalettes.size()> {};
+        std::ranges::transform(BuiltinColorPalettes, names.begin(), &BuiltinColorPalette::name);
+        return names;
+    }();
+
 } // namespace
 
-bool defaultColorPalettes(std::string const& colorPaletteName, ColorPalette& palette) noexcept
+std::span<std::string_view const> defaultColorPaletteNames() noexcept
 {
+    return BuiltinColorPaletteNames;
+}
 
-    // TODO add dim colors, do we need to adapt them to each of color palettes?
-    std::map<std::string, std::function<void()>> const definedColorPalettes = {
-        { "contour", [&]() {} },
-        { "monokai",
-          [&]() {
-              // Monokai dark colors
-              // normal colors
-              palette.palette[0] = 0x272822_rgb; // black
-              palette.palette[1] = 0xf92672_rgb; // red
-              palette.palette[2] = 0xa6e22e_rgb; // green
-              palette.palette[3] = 0xf4bf75_rgb; // yellow
-              palette.palette[4] = 0x66d9ef_rgb; // blue
-              palette.palette[5] = 0xae81ff_rgb; // magenta
-              palette.palette[6] = 0xa1efe4_rgb; // cyan
-              palette.palette[7] = 0xf8f8f2_rgb; // white
-              // bright colors
-              palette.palette[8] = 0x75715e_rgb;  // bright black (dark gray)
-              palette.palette[9] = 0xf92672_rgb;  // bright red
-              palette.palette[10] = 0xa6e22e_rgb; // bright green
-              palette.palette[11] = 0xf4bf75_rgb; // bright yellow
-              palette.palette[12] = 0x66d9ef_rgb; // bright blue
-              palette.palette[13] = 0xae81ff_rgb; // bright magenta
-              palette.palette[14] = 0xa1efe4_rgb; // bright blue
-              palette.palette[15] = 0xf8f8f2_rgb; // bright white
+bool defaultColorPalettes(std::string_view colorPaletteName, ColorPalette& palette) noexcept
+{
+    // A linear scan over ten rows, which beats the std::map this used to build per call.
+    auto const entry = std::ranges::find(BuiltinColorPalettes, colorPaletteName, &BuiltinColorPalette::name);
+    if (entry == BuiltinColorPalettes.end())
+        return false;
 
-              palette.defaultForeground = 0xf8f8f2_rgb;
-              palette.defaultBackground = 0x272822_rgb;
-              palette.defaultForegroundBright = 0xf8f8f2_rgb;
-              palette.defaultForegroundDimmed = 0x75715e_rgb;
-              palette.mouseForeground = 0xf8f8f2_rgb;
-              palette.mouseBackground = 0x272822_rgb;
-              palette.cursor.color = 0xf8f8f2_rgb;
-          } },
-        { "one-light",
-          [&]() {
-              // One Light colors
-              // normal colors
-              palette.palette[0] = 0x000000_rgb; // black
-              palette.palette[1] = 0xda3e39_rgb; // red
-              palette.palette[2] = 0x41933e_rgb; // green
-              palette.palette[3] = 0x855504_rgb; // yellow
-              palette.palette[4] = 0x315eee_rgb; // blue
-              palette.palette[5] = 0x930092_rgb; // magenta
-              palette.palette[6] = 0x0e6fad_rgb; // cyan
-              palette.palette[7] = 0x8e8f96_rgb; // white
-
-              // bright colors
-              palette.palette[8] = 0x2a2b32_rgb;  // bright black (dark gray)
-              palette.palette[9] = 0xda3e39_rgb;  // bright red
-              palette.palette[10] = 0x41933e_rgb; // bright green
-              palette.palette[11] = 0x855504_rgb; // bright yellow
-              palette.palette[12] = 0x315eee_rgb; // bright blue
-              palette.palette[13] = 0x930092_rgb; // bright magenta
-              palette.palette[14] = 0x0e6fad_rgb; // bright cuan
-              palette.palette[15] = 0xfffefe_rgb; // bright white
-
-              palette.defaultForeground = 0x2a2b32_rgb;
-              palette.defaultBackground = 0xf8f8f8_rgb;
-              palette.cursor.color = 0x2a2b32_rgb;
-          } },
-        { "one-dark",
-          [&]() {
-              // One Dark colors
-              // normal colors
-              palette.palette[0] = 0x000000_rgb; // black
-              palette.palette[1] = 0xe06c75_rgb; // red
-              palette.palette[2] = 0x98c379_rgb; // green
-              palette.palette[3] = 0xe5c07b_rgb; // yellow
-              palette.palette[4] = 0x61afef_rgb; // blue
-              palette.palette[5] = 0xc678dd_rgb; // magenta
-              palette.palette[6] = 0x56b6c2_rgb; // cyan
-              palette.palette[7] = 0xabb2bf_rgb; // white
-
-              // bright colors
-              palette.palette[8] = 0x5c6370_rgb;  // bright black (dark gray)
-              palette.palette[9] = 0xe06c75_rgb;  // bright red
-              palette.palette[10] = 0x98c379_rgb; // bright green
-              palette.palette[11] = 0xd19a66_rgb; // bright yellow
-              palette.palette[12] = 0x61afef_rgb; // bright blue
-              palette.palette[13] = 0xc678dd_rgb; // bright magenta
-              palette.palette[14] = 0x56b6c2_rgb; // bright cuan
-              palette.palette[15] = 0xfffefe_rgb; // bright white
-
-              palette.defaultForeground = 0x5c6370_rgb;
-              palette.defaultBackground = 0x1e2127_rgb;
-              palette.defaultForegroundBright = 0x5c6370_rgb;
-              palette.defaultForegroundDimmed = 0x545862_rgb;
-              palette.mouseForeground = 0xabb2bf_rgb;
-              palette.mouseBackground = 0x282c34_rgb;
-              palette.cursor.color = 0x5c6370_rgb;
-          } },
-        { "gruvbox-light",
-          [&]() {
-              // Gruvbox colors
-              // normal colors
-              palette.palette[0] = 0xfbf1c7_rgb; // black
-              palette.palette[1] = 0xcc241d_rgb; // red
-              palette.palette[2] = 0x98971a_rgb; // green
-              palette.palette[3] = 0xd79921_rgb; // yellow
-              palette.palette[4] = 0x458588_rgb; // blue
-              palette.palette[5] = 0xb16286_rgb; // magenta
-              palette.palette[6] = 0x689d6a_rgb; // cyan
-              palette.palette[7] = 0x7c6f64_rgb; // white
-              // bright colors
-              palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
-              palette.palette[9] = 0x9d0006_rgb;  // bright red
-              palette.palette[10] = 0x79740e_rgb; // bright green
-              palette.palette[11] = 0xb57614_rgb; // bright yellow
-              palette.palette[12] = 0x076678_rgb; // bright blue
-              palette.palette[13] = 0x8f3f71_rgb; // bright magenta
-              palette.palette[14] = 0x427b58_rgb; // bright cuan
-              palette.palette[15] = 0x3c3836_rgb; // bright white
-
-              palette.defaultForeground = 0x3c3836_rgb;
-              palette.defaultBackground = 0xfbf1c7_rgb;
-              palette.cursor.color = 0x3c3836_rgb;
-          } },
-        { "gruvbox-dark",
-          [&]() {
-              // Gruvbox colors
-              // normal colors
-              palette.palette[0] = 0x282828_rgb; // black
-              palette.palette[1] = 0xcc241d_rgb; // red
-              palette.palette[2] = 0x98971a_rgb; // green
-              palette.palette[3] = 0xd79921_rgb; // yellow
-              palette.palette[4] = 0x458588_rgb; // blue
-              palette.palette[5] = 0xb16286_rgb; // magenta
-              palette.palette[6] = 0x689d6a_rgb; // cyan
-              palette.palette[7] = 0xa89984_rgb; // white
-              // bright colors
-              palette.palette[8] = 0x928374_rgb;  // bright black (dark gray)
-              palette.palette[9] = 0xfb4934_rgb;  // bright red
-              palette.palette[10] = 0xb8bb26_rgb; // bright green
-              palette.palette[11] = 0xfabd2f_rgb; // bright yellow
-              palette.palette[12] = 0x83a598_rgb; // bright blue
-              palette.palette[13] = 0xd3869b_rgb; // bright magenta
-              palette.palette[14] = 0x8ec07c_rgb; // bright cuan
-              palette.palette[15] = 0xebdbb2_rgb; // bright white
-
-              palette.defaultForeground = 0xebdbb2_rgb;
-              palette.defaultBackground = 0x292929_rgb;
-              palette.cursor.color = 0xebdbb2_rgb;
-          } },
-        { "solarized-light",
-          [&]() {
-              // Solarized colors
-              // normal colors
-              palette.palette[0] = 0xeee8d5_rgb; // black
-              palette.palette[1] = 0xdc322f_rgb; // red
-              palette.palette[2] = 0x859900_rgb; // green
-              palette.palette[3] = 0xb58900_rgb; // yellow
-              palette.palette[4] = 0x268bd2_rgb; // blue
-              palette.palette[5] = 0xd33682_rgb; // magenta
-              palette.palette[6] = 0x2aa198_rgb; // cyan
-              palette.palette[7] = 0x002b36_rgb; // white
-              // bright colors
-              palette.palette[8] = 0x657b83_rgb;  // bright black
-              palette.palette[9] = 0xcb4b16_rgb;  // bright red
-              palette.palette[10] = 0x859900_rgb; // bright green
-              palette.palette[11] = 0xb58900_rgb; // bright yellow
-              palette.palette[12] = 0x6c71c4_rgb; // bright blue
-              palette.palette[13] = 0xd33682_rgb; // bright magenta
-              palette.palette[14] = 0x2aa198_rgb; // bright cyan
-              palette.palette[15] = 0x073642_rgb; // bright white
-
-              palette.defaultForeground = 0x657b83_rgb;
-              palette.defaultBackground = 0xfdf6e3_rgb;
-              palette.cursor.color = 0x657b83_rgb;
-          } },
-        { "solarized-dark",
-          [&]() {
-              // solarized colors
-              // normal colors
-              palette.palette[0] = 0x073642_rgb; // black
-              palette.palette[1] = 0xdc322f_rgb; // red
-              palette.palette[2] = 0x859900_rgb; // green
-              palette.palette[3] = 0xcf9a6b_rgb; // yellow
-              palette.palette[4] = 0x268bd2_rgb; // blue
-              palette.palette[5] = 0xd33682_rgb; // magenta
-              palette.palette[6] = 0x2aa198_rgb; // cyan
-              palette.palette[7] = 0xeee8d5_rgb; // white
-              // bright color
-              palette.palette[8] = 0x657b83_rgb;  // bright black
-              palette.palette[9] = 0xcb4b16_rgb;  // bright red
-              palette.palette[10] = 0x859900_rgb; // bright green
-              palette.palette[11] = 0xcf9a6b_rgb; // bright yellow
-              palette.palette[12] = 0x6c71c4_rgb; // bright blue
-              palette.palette[13] = 0xd33682_rgb; // bright magenta
-              palette.palette[14] = 0x2aa198_rgb; // bright cyan
-              palette.palette[15] = 0xfdf6e3_rgb; // bright white
-
-              palette.defaultForeground = 0x839496_rgb;
-              palette.defaultBackground = 0x002b36_rgb;
-              palette.cursor.color = 0x839496_rgb;
-          } },
-        { "papercolor-light",
-          [&]() {
-              // papercolor light colors
-              // normal colors
-              palette.palette[0] = 0xeeeeee_rgb; // black
-              palette.palette[1] = 0xaf0000_rgb; // red
-              palette.palette[2] = 0x008700_rgb; // green
-              palette.palette[3] = 0x5f8700_rgb; // yellow
-              palette.palette[4] = 0x0087af_rgb; // blue
-              palette.palette[5] = 0x878787_rgb; // magenta
-              palette.palette[6] = 0x005f87_rgb; // cyan
-              palette.palette[7] = 0x444444_rgb; // white
-              // bright colors
-              palette.palette[8] = 0xbcbcbc_rgb;  // bright black
-              palette.palette[9] = 0xd70000_rgb;  // bright red
-              palette.palette[10] = 0xd70087_rgb; // bright green
-              palette.palette[11] = 0x8700af_rgb; // bright yellow
-              palette.palette[12] = 0xd75f00_rgb; // bright blue
-              palette.palette[13] = 0xd75f00_rgb; // bright magenta
-              palette.palette[14] = 0x005faf_rgb; // bright cyan
-              palette.palette[15] = 0x005f87_rgb; // bright white
-
-              palette.defaultForeground = 0x444444_rgb;
-              palette.defaultBackground = 0xeeeeee_rgb;
-              palette.cursor.color = 0x444444_rgb;
-          } },
-        { "papercolor-dark",
-          [&]() {
-              // papercolor dark colors
-              // normal colors
-              palette.palette[0] = 0x1C1C1C_rgb; // Black (Host)
-              palette.palette[1] = 0xAF005F_rgb; // Red (Syntax string)
-              palette.palette[2] = 0x5FAF00_rgb; // Green (Command)
-              palette.palette[3] = 0xD7AF5F_rgb; // Yellow (Command second)
-              palette.palette[4] = 0x5FAFD7_rgb; // Blue (Path)
-              palette.palette[5] = 0x808080_rgb; // Magenta (Syntax var)
-              palette.palette[6] = 0xD7875F_rgb; // Cyan (Prompt)
-              palette.palette[7] = 0xD0D0D0_rgb; // White
-
-              palette.palette[8] = 0x585858_rgb;  // Bright Black
-              palette.palette[9] = 0x5FAF5F_rgb;  // Bright Red (Command error)
-              palette.palette[10] = 0xAFD700_rgb; // Bright Green (Exec)
-              palette.palette[11] = 0xAF87D7_rgb; // Bright Yellow
-              palette.palette[12] = 0xFFAF00_rgb; // Bright Blue (Folder)
-              palette.palette[13] = 0xFF5FAF_rgb; // Bright Magenta
-              palette.palette[14] = 0x00AFAF_rgb; // Bright Cyan
-              palette.palette[15] = 0x5F8787_rgb; // Bright White
-
-              palette.defaultForeground = 0xd0d0d0_rgb;
-              palette.defaultBackground = 0x1c1c1c_rgb;
-              palette.cursor.color = 0xd0d0d0_rgb;
-          } },
-    };
-    // find if colorPaletteName is a known color palette
-    auto const it = definedColorPalettes.find(colorPaletteName);
-    if (it != definedColorPalettes.end())
-    {
-        it->second();
-        return true;
-    }
-    return false;
+    entry->apply(palette);
+    return true;
 }
 
 void ImageData::updateHash() noexcept

--- a/src/vtbackend/ColorPalette.hpp
+++ b/src/vtbackend/ColorPalette.hpp
@@ -298,6 +298,55 @@ struct ColorPalette
     RGBColorPair indicatorStatusLineInsertMode = { .foreground = 0xFFFFFF_rgb, .background = 0x0270c0_rgb };
     RGBColorPair indicatorStatusLineNormalMode = { .foreground = 0xFFFFFF_rgb, .background = 0x0270c0_rgb };
     RGBColorPair indicatorStatusLineVisualMode = { .foreground = 0xFFFFFF_rgb, .background = 0x0270c0_rgb };
+
+    /// The fold column drawn in the gutter left of the grid, and its hover state.
+    ///
+    /// Optional rather than defaulted, because there is no constant that would be right: the column has
+    /// to sit on the palette's own background, which every scheme picks differently. Unset means "derive
+    /// from the palette's own foreground and background", so a scheme that has never heard of folding
+    /// still renders a legible, obviously-clickable column.
+    ///
+    /// Those two and nothing else, deliberately. defaultForegroundDimmed and defaultForegroundBright
+    /// would be the obvious sources for the two states, but only monokai and one-dark set them: every
+    /// light preset keeps the struct's dark-theme defaults, so a bright-sourced hover would be white on
+    /// near-white there, and on one-dark the dimmed and normal foregrounds are close enough that the two
+    /// states would be indistinguishable.
+    std::optional<RGBColorPair> foldMarker;
+    std::optional<RGBColorPair> foldMarkerHover;
+
+    /// How far the fold column's resting glyph is faded toward the background.
+    ///
+    /// A fraction rather than a colour, for the reason above: fading the scheme's own text colour keeps
+    /// the marker quieter than the text beside it in every theme, which a constant grey manages in none.
+    static constexpr float FoldMarkerRestFade = 0.45f;
+
+    /// The fold column's colors at rest, with the unset case resolved.
+    ///
+    /// The background is the page's own, exactly -- as it is when hovered, so the gutter never draws a
+    /// rectangle at all (see BackgroundRenderer::renderCell) and a transparent window stays transparent
+    /// behind the column in both states.
+    [[nodiscard]] RGBColorPair foldMarkerColors() const noexcept
+    {
+        return foldMarker.value_or(
+            RGBColorPair { .foreground = mixColor(defaultForeground, defaultBackground, FoldMarkerRestFade),
+                           .background = defaultBackground });
+    }
+
+    /// The fold column's colors while the pointer is over it, with the unset case resolved.
+    ///
+    /// The GLYPH comes up to full strength and nothing else moves. Neither swapping the pair nor
+    /// tinting the run's background behind it: both paint a band down the side of the block, which
+    /// reads as a selection of those rows rather than as a control they belong to -- and a band is
+    /// what a terminal gutter, unlike an editor's, sits directly against text with no margin to
+    /// separate it.
+    ///
+    /// Legible in any scheme by construction: the hovered foreground is the very colour the scheme
+    /// already draws its text in, on the background it already draws it against.
+    [[nodiscard]] RGBColorPair foldMarkerHoverColors() const noexcept
+    {
+        return foldMarkerHover.value_or(
+            RGBColorPair { .foreground = defaultForeground, .background = defaultBackground });
+    }
 };
 
 /// Applies the built-in color scheme @p colorPaletteName to @p palette, if there is one by that name.

--- a/src/vtbackend/ColorPalette.hpp
+++ b/src/vtbackend/ColorPalette.hpp
@@ -12,6 +12,8 @@
 #include <filesystem>
 #include <format>
 #include <optional>
+#include <span>
+#include <string_view>
 #include <variant>
 
 namespace vtbackend
@@ -298,7 +300,21 @@ struct ColorPalette
     RGBColorPair indicatorStatusLineVisualMode = { .foreground = 0xFFFFFF_rgb, .background = 0x0270c0_rgb };
 };
 
-bool defaultColorPalettes(std::string const& colorPaletteName, ColorPalette& palette) noexcept;
+/// Applies the built-in color scheme @p colorPaletteName to @p palette, if there is one by that name.
+///
+/// @param colorPaletteName The scheme to apply; @see defaultColorPaletteNames.
+/// @param palette The palette to mutate. Left untouched when the name is not a built-in one.
+/// @return Whether a scheme by that name exists.
+bool defaultColorPalettes(std::string_view colorPaletteName, ColorPalette& palette) noexcept;
+
+/// Every color scheme name defaultColorPalettes() answers to.
+///
+/// Exposed because the set is otherwise undiscoverable -- it used to live only inside that function --
+/// and anything that has to cover or offer every built-in scheme would have to re-type the list, which
+/// then quietly stops matching when a scheme is added.
+///
+/// @return The names, in table order.
+[[nodiscard]] std::span<std::string_view const> defaultColorPaletteNames() noexcept;
 
 enum class ColorTarget : uint8_t
 {

--- a/src/vtbackend/ColorPalette_test.cpp
+++ b/src/vtbackend/ColorPalette_test.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/ColorPalette.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vtbackend;
+
+TEST_CASE("ColorPalette.foldMarker.derivesWhenUnset", "[ColorPalette]")
+{
+    auto const palette = ColorPalette {};
+    REQUIRE_FALSE(palette.foldMarker.has_value());
+    REQUIRE_FALSE(palette.foldMarkerHover.has_value());
+
+    auto const rest = palette.foldMarkerColors();
+
+    // At rest the column sits on the page's own background, EXACTLY -- BackgroundRenderer::renderCell
+    // skips a cell whose background is the default one, so the gutter paints no rectangle and a
+    // transparent window stays transparent behind it.
+    CHECK(rest.background == palette.defaultBackground);
+
+    // ... and the glyph is faded off the text colour without reaching the page behind it, which is
+    // what pins FoldMarkerRestFade strictly between the two.
+    CHECK(rest.foreground != palette.defaultForeground);
+    CHECK(rest.foreground != palette.defaultBackground);
+}
+
+TEST_CASE("ColorPalette.foldMarker.hoverRecolorizesRatherThanInverts", "[ColorPalette]")
+{
+    auto const palette = ColorPalette {};
+    auto const rest = palette.foldMarkerColors();
+    auto const hover = palette.foldMarkerHoverColors();
+
+    // The regression this derivation exists for. Hovering used to swap the pair, drawing the run as a
+    // solid bar with the marks punched out of it; a return to that puts defaultBackground here, so
+    // this one assertion is the whole anti-inversion guard.
+    CHECK(hover.foreground == palette.defaultForeground);
+
+    // Only the glyph moves. The background stays the page's own in BOTH states, so the gutter never
+    // paints a rectangle and a transparent window stays transparent under the pointer too.
+    CHECK(hover.background == rest.background);
+    CHECK(hover.background == palette.defaultBackground);
+
+    // ... and the glyph moving is what the hover has to be carried by, so it has to be a real step.
+    CHECK(distance(hover.foreground, rest.foreground) > 45.0);
+}
+
+TEST_CASE("ColorPalette.foldMarker.explicitColorsBypassTheDerivation", "[ColorPalette]")
+{
+    auto palette = ColorPalette {};
+    auto const configured = RGBColorPair { .foreground = 0x010203_rgb, .background = 0x040506_rgb };
+
+    SECTION("the resting pair alone")
+    {
+        palette.foldMarker = configured;
+        CHECK(palette.foldMarkerColors().foreground == configured.foreground);
+        CHECK(palette.foldMarkerColors().background == configured.background);
+        // The other stays derived: the two are independent options, not one block.
+        CHECK(palette.foldMarkerHoverColors().foreground == palette.defaultForeground);
+    }
+
+    SECTION("the hovered pair alone")
+    {
+        palette.foldMarkerHover = configured;
+        CHECK(palette.foldMarkerHoverColors().foreground == configured.foreground);
+        CHECK(palette.foldMarkerHoverColors().background == configured.background);
+        CHECK(palette.foldMarkerColors().background == palette.defaultBackground);
+    }
+}
+
+TEST_CASE("ColorPalette.foldMarker.isLegibleInTheBuiltinSchemes", "[ColorPalette]")
+{
+    // Every built-in scheme, asked for rather than re-typed, so a scheme added tomorrow is covered.
+    // The light ones are the point: they leave defaultForegroundBright at the struct's dark-theme
+    // white, so a hover derived from it would be invisible on them.
+    auto const names = defaultColorPaletteNames();
+    REQUIRE(names.size() >= 10);
+
+    for (auto const name: names)
+    {
+        auto palette = ColorPalette {};
+        REQUIRE(defaultColorPalettes(name, palette));
+
+        INFO("scheme: " << name);
+
+        // Sourcing the hover from defaultForegroundBright would fail exactly here: one-light,
+        // gruvbox-light, solarized-light and papercolor-light never set it, so it stays 0xFFFFFF and
+        // the hovered glyph would be white on a near-white page.
+        auto const hover = palette.foldMarkerHoverColors();
+        CHECK(distance(hover.foreground, hover.background) > 90.0);
+
+        // And FoldMarkerRestFade has to leave the resting glyph visible, however far it fades it --
+        // while still stepping far enough off the hovered one to be seen changing, which is the whole
+        // hover cue now that the background no longer moves.
+        auto const rest = palette.foldMarkerColors();
+        CHECK(distance(rest.foreground, rest.background) > 45.0);
+        CHECK(distance(rest.foreground, hover.foreground) > 45.0);
+    }
+}
+
+TEST_CASE("ColorPalette.foldMarker.defaultSchemeMatchesTheDocumentedColors", "[ColorPalette]")
+{
+    // Three places outside this header transcribe what the default scheme derives, as literals: the
+    // commented example in ConfigDocumentation.hpp's FoldMarkerConfig -- which promises in so many
+    // words that uncommenting it changes nothing -- and both the fold_marker section and the default
+    // scheme dump in docs/configuration/colors.md.
+    //
+    // Nothing else checks that promise, and Config_test.cpp cannot: it tests literal PARSING, so it
+    // stays green while the documented colours drift. Retuning FoldMarkerRestFade fails
+    // here instead, naming the files that then have to be updated.
+    auto const palette = ColorPalette {};
+    auto const rest = palette.foldMarkerColors();
+    auto const hover = palette.foldMarkerHoverColors();
+
+    CHECK(rest.foreground == 0x7e7c7c_rgb);
+    CHECK(rest.background == 0x1a1716_rgb);
+    CHECK(hover.foreground == 0xd0d0d0_rgb);
+    CHECK(hover.background == 0x1a1716_rgb);
+}

--- a/src/vtbackend/Folding.cpp
+++ b/src/vtbackend/Folding.cpp
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/Folding.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace vtbackend
+{
+
+namespace
+{
+    /// Where a backward fold walk stands between two command blocks.
+    ///
+    /// The same three states scanCommandBlocksBackward() walks, and deliberately so: the two read the
+    /// very same marks, and a fold that disagreed with the block the "copy last command" actions hand to
+    /// the clipboard would be a fold around something other than what it claims.
+    enum class ScanState : uint8_t
+    {
+        Searching, ///< Looking for the CommandEnd that closes the next block.
+        InOutput,  ///< Walking up through the command's output towards its OutputStart.
+        InPrompt,  ///< Walking up through the prompt towards the Marked line that begins it.
+    };
+
+    /// The hidden rows collected for the block currently being walked.
+    ///
+    /// Stable ids taken as the walk passes each line, rather than indices looked up again at the end:
+    /// the source is asked about each index once, in increasing order, which is the contract that lets it
+    /// climb the grid lazily and keep no more state than the line it is standing on.
+    struct OutputUnderConstruction
+    {
+        std::optional<int64_t> bottomId; ///< Last physical row of the LOWEST hidden line -- the largest id.
+        std::optional<int64_t> topId;    ///< Head of the HIGHEST hidden line -- the smallest id.
+
+        [[nodiscard]] bool empty() const noexcept { return !bottomId.has_value(); }
+
+        /// Adds one logical line, which the walk reaches in increasing index (decreasing id) order.
+        /// @param headId Its head's stable id.
+        /// @param lastPhysicalId The stable id of the last physical row it occupies.
+        void add(int64_t headId, int64_t lastPhysicalId) noexcept
+        {
+            if (!bottomId)
+                bottomId = lastPhysicalId;
+            topId = headId;
+        }
+    };
+} // namespace
+
+std::vector<FoldRange> computeFoldRanges(FoldLineSource const& lines, size_t maxScanLines)
+{
+    auto ranges = std::vector<FoldRange> {};
+
+    auto state = ScanState::Searching;
+    auto output = OutputUnderConstruction {};
+
+    /// Adds the logical line at @p index to the block's hidden rows.
+    auto const hideLineAt = [&](size_t index) {
+        output.add(lines.stableIdAt(index), lines.lastPhysicalStableIdAt(index));
+    };
+
+    /// Opens the block that the CommandEnd carried by @p flags closes.
+    auto const openBlockAt = [&](LineFlags flags) {
+        output = {};
+
+        // The line a command was closed on is NEVER hidden, whatever else it carries. A shell emits ;D
+        // from its precmd hook, at the cursor, so that line is one of exactly two things: the line the
+        // next prompt is about to be printed onto -- the ordinary case, where ;D and ;A land together --
+        // or, when the shell has not got that far, the line the cursor is standing on right now. Folding
+        // either away would hide the very row the user is about to type into.
+        //
+        // The price is one visible row for the shell that emits ;D on the last output line and its ;A on
+        // the next: that last line stays on screen under a collapsed block. Leaving one row too many is
+        // recoverable; folding the cursor away is not.
+
+        // The line may carry the OutputStart of the very command it also ends -- a command whose output
+        // fit on the line it started on, or one that printed nothing at all.
+        state = flags.contains(LineFlag::OutputStart) ? ScanState::InPrompt : ScanState::InOutput;
+    };
+
+    /// Closes the block whose prompt begins at @p index and decides where the walk stands afterwards.
+    auto const finalizeBlockAt = [&](size_t index, LineFlags flags) {
+        // A block with no whole output line of its own is not foldable: there is nothing to hide, and a
+        // marker offering to hide nothing is worse than no marker.
+        if (!output.empty())
+            ranges.push_back(FoldRange { .headStableId = lines.stableIdAt(index),
+                                         .firstStableId = *output.topId,
+                                         .lastStableId = *output.bottomId });
+        output = {};
+
+        // The line that begins this prompt may ALSO carry the CommandEnd of the block before it, for the
+        // back-to-back ;D/;A reason above. Chain straight into that older block rather than resuming the
+        // search one line further up, which would step clean over the boundary we are standing on.
+        if (flags.contains(LineFlag::CommandEnd))
+            openBlockAt(flags);
+        else
+            state = ScanState::Searching;
+    };
+
+    // A single forward pass, asking for each logical line only once and only as far as it needs to go.
+    for (auto index = size_t { 0 }; index < maxScanLines && lines.hasLineAt(index); ++index)
+    {
+        auto const flags = lines.flagsAt(index);
+
+        switch (state)
+        {
+            case ScanState::Searching:
+                if (flags.contains(LineFlag::CommandEnd))
+                    openBlockAt(flags);
+                break;
+
+            case ScanState::InOutput:
+                // A prompt line ends the output whether or not it also carries the OutputStart, and is
+                // never itself hidden.
+                if (flags.contains(LineFlag::Marked))
+                {
+                    finalizeBlockAt(index, flags);
+                    break;
+                }
+                hideLineAt(index);
+                if (flags.contains(LineFlag::OutputStart))
+                    state = ScanState::InPrompt;
+                break;
+
+            case ScanState::InPrompt:
+                if (flags.contains(LineFlag::Marked))
+                    finalizeBlockAt(index, flags);
+                break;
+        }
+    }
+
+    // A walk that ran out of lines mid-block is dropped rather than kept: without the Marked line there is
+    // no prompt row to hang the fold off, and hiding output under a head that has scrolled away would
+    // leave the user no way to get it back.
+    return ranges;
+}
+
+void FoldState::collapseAll(std::span<FoldRange const> ranges)
+{
+    // Through collapse() rather than into the set directly, so the revision is bumped: everything
+    // derived from this state -- the projection above all -- keys its cache on that counter, and a
+    // sweep that changed the set silently would leave the screen showing what was there before.
+    for (auto const& range: ranges)
+        collapse(range.headStableId);
+}
+
+std::vector<HiddenInterval> hiddenIntervals(std::span<FoldRange const> ranges, FoldState const& state)
+{
+    auto intervals = std::vector<HiddenInterval> {};
+    if (state.empty())
+        return intervals;
+
+    // Every range can contribute at most one interval, so this is the exact bound rather than a guess.
+    intervals.reserve(ranges.size());
+
+    for (auto const& range: ranges)
+        if (state.isCollapsed(range.headStableId))
+            intervals.push_back(HiddenInterval { .first = range.firstStableId, .last = range.lastStableId });
+
+    std::ranges::sort(intervals, {}, &HiddenInterval::first);
+
+    // Merge where they touch as well as where they overlap: two blocks whose ranges abut leave no visible
+    // line between them, so one interval describes both and the projection's binary search stays a search.
+    //
+    // In place, over the range just sorted: merging into a second vector would allocate and copy the whole
+    // thing again, on a path that runs on every projection rebuild.
+    auto out = intervals.begin();
+    for (auto const& interval: intervals)
+    {
+        if (out != intervals.begin() && interval.first <= std::prev(out)->last + 1)
+            std::prev(out)->last = std::max(std::prev(out)->last, interval.last);
+        else
+            *out++ = interval;
+    }
+    intervals.erase(out, intervals.end());
+
+    return intervals;
+}
+
+std::optional<HiddenInterval> hidingInterval(std::span<HiddenInterval const> hidden, int64_t id) noexcept
+{
+    // The runs are ascending and disjoint, so the only candidate is the last one starting at or before
+    // @p id -- one binary search, then one comparison against its end.
+    auto const it = std::ranges::upper_bound(hidden, id, {}, &HiddenInterval::first);
+    if (it == hidden.begin())
+        return std::nullopt;
+
+    auto const& candidate = *std::prev(it);
+    if (id > candidate.last)
+        return std::nullopt;
+
+    return candidate;
+}
+
+int64_t snapToVisibleId(std::span<HiddenInterval const> hidden,
+                        int64_t id,
+                        VerticalDirection direction) noexcept
+{
+    auto const run = hidingInterval(hidden, id);
+    if (!run)
+        return id;
+
+    // One step out is enough: hiddenIntervals() merges runs that merely touch, so the id just past a
+    // run's edge can never be inside the next one.
+    return direction == VerticalDirection::Up ? run->first - 1 : run->last + 1;
+}
+
+int64_t advanceVisibleId(std::span<HiddenInterval const> hidden,
+                         int64_t id,
+                         int64_t count,
+                         VerticalDirection direction,
+                         int64_t floorId,
+                         int64_t ceilId) noexcept
+{
+    auto current = std::clamp(snapToVisibleId(hidden, id, direction), floorId, ceilId);
+    if (count <= 0)
+        return current;
+
+    // Where a walk that runs into the edge of the grid stops. The bound itself is wherever the
+    // scrollback happens to end and may well sit inside a collapsed run, so clamping alone would hand
+    // back a hidden id -- a row drawn nowhere, which is precisely what counting in visible rows exists
+    // to avoid. Snapped INWARD, back the way the walk came, so the motion stops on the last row before
+    // the edge that is actually drawn.
+    auto const stopAt = [&](int64_t value, VerticalDirection inward) {
+        return std::clamp(
+            snapToVisibleId(hidden, std::clamp(value, floorId, ceilId), inward), floorId, ceilId);
+    };
+
+    auto remaining = count;
+
+    // Walked run by run rather than row by row: the gap before the next run is crossed in one
+    // subtraction, so a `1000j` over a collapsed `cat` of a large file costs the same as a `1j`.
+    if (direction == VerticalDirection::Down)
+    {
+        // `current` is visible, so no run contains it and every run from here on begins below it.
+        for (auto it = std::ranges::upper_bound(hidden, current, {}, &HiddenInterval::first);
+             it != hidden.end() && remaining > 0;
+             ++it)
+        {
+            auto const gap = it->first - current - 1; // the visible ids between `current` and the run
+            if (remaining <= gap)
+                break; // the target lies in this gap; the clamp below lands on it
+
+            remaining -= gap + 1; // the gap, plus the one step that lands past the run
+            current = it->last + 1;
+        }
+        return stopAt(current + remaining, VerticalDirection::Up);
+    }
+
+    // Upwards, the same walk against the run order: ids decrease as the walk climbs.
+    auto const firstAtOrBelow = std::ranges::lower_bound(hidden, current, {}, &HiddenInterval::last);
+    for (auto it = std::make_reverse_iterator(firstAtOrBelow); it != hidden.rend() && remaining > 0; ++it)
+    {
+        auto const gap = current - it->last - 1;
+        if (remaining <= gap)
+            break;
+
+        remaining -= gap + 1;
+        current = it->first - 1;
+    }
+    return stopAt(current - remaining, VerticalDirection::Down);
+}
+
+int64_t visibleDistance(std::span<HiddenInterval const> hidden, int64_t first, int64_t last) noexcept
+{
+    // Symmetric by construction, so no caller has to order its arguments.
+    if (last < first)
+        return -visibleDistance(hidden, last, first);
+
+    // The span, less whatever the runs overlapping it hide. Only the runs that actually intersect
+    // [first, last) are visited, and the binary search finds the first of them.
+    auto distance = last - first;
+    for (auto it = std::ranges::upper_bound(hidden, first, {}, &HiddenInterval::last);
+         it != hidden.end() && it->first < last;
+         ++it)
+        distance -= std::min(it->last + 1, last) - std::max(it->first, first);
+
+    return distance;
+}
+
+std::vector<LineOffset> projectRows(std::span<HiddenInterval const> hidden,
+                                    int64_t stableBase,
+                                    LineOffset bottom,
+                                    LineCount rowCount,
+                                    LineOffset top)
+{
+    auto rows = std::vector<LineOffset> {};
+    if (unbox<int>(rowCount) <= 0 || bottom < top)
+        return rows;
+
+    rows.reserve(unbox<size_t>(rowCount));
+    for (auto line = bottom; line >= top && rows.size() < unbox<size_t>(rowCount); --line)
+    {
+        auto const id = stableBase + unbox<int64_t>(line);
+
+        // Skip the whole run in one step rather than a line at a time: a collapsed `cat` of a large file
+        // hides tens of thousands of rows, and stepping through them per visible row would make the
+        // projection quadratic in the size of what the user just hid.
+        if (auto const interval = hidingInterval(hidden, id))
+        {
+            line = LineOffset::cast_from(interval->first - stableBase);
+            continue; // the loop's own decrement steps past the top of the run
+        }
+
+        rows.push_back(line);
+    }
+
+    // Collected bottom-up; the screen reads top-down.
+    std::ranges::reverse(rows);
+    return rows;
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/Folding.hpp
+++ b/src/vtbackend/Folding.hpp
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/LineFlags.hpp>
+#include <vtbackend/Primitives.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <set>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace vtbackend
+{
+
+/// One foldable region: the output of ONE finished command block, addressed by STABLE line id.
+///
+/// Stable ids rather than LineOffsets, because a fold outlives the scrolling that moves its lines:
+/// Grid::stableLineIdOf() names a physical row across ring rotations, so a fold set keyed by id
+/// survives a scroll for free and needs attention only when a row is evicted (Grid::stableRangeFloor(),
+/// @see FoldState::prune) or when row identity is destroyed wholesale (Grid::generation(),
+/// @see FoldState::clear).
+///
+/// Ids DECREASE upwards, so @ref firstStableId (the topmost hidden line) is the smallest of the three.
+struct FoldRange
+{
+    int64_t headStableId {};  ///< The prompt line the fold hangs off (the LineFlag::Marked head).
+    int64_t firstStableId {}; ///< Topmost hidden line when collapsed.
+    int64_t lastStableId {};  ///< Bottom-most hidden line, inclusive.
+
+    [[nodiscard]] bool operator==(FoldRange const&) const noexcept = default;
+};
+
+/// Supplies the LOGICAL lines a fold scan walks, indexed backwards from the line it starts at.
+///
+/// The dependency-injection seam, mirroring CommandBlockLineSource and PromptRegionLineSource: the scan
+/// below is a pure function of the flags and ids it is handed, so it can be exercised against a plain
+/// vector — with no Grid, no Screen and no terminal behind it.
+///
+/// Logical, not physical, for the reason its two siblings give: a shell's marks name the line it wrote,
+/// and a window resize re-chops the physical pieces without moving a single mark.
+class FoldLineSource
+{
+  public:
+    FoldLineSource() = default;
+    FoldLineSource(FoldLineSource&&) = default;
+    FoldLineSource(FoldLineSource const&) = default;
+    FoldLineSource& operator=(FoldLineSource&&) = default;
+    FoldLineSource& operator=(FoldLineSource const&) = default;
+    virtual ~FoldLineSource() = default;
+
+    /// Whether there is a logical line at @p index — 0 being the one the scan starts at, counting upwards.
+    ///
+    /// A predicate rather than a count, for the reason its siblings give: counting the logical lines would
+    /// walk the whole scrollback before the scan has looked at a single flag.
+    [[nodiscard]] virtual bool hasLineAt(size_t index) const = 0;
+
+    /// The flags of the logical line @p index lines ABOVE the starting one (0 being the starting one).
+    [[nodiscard]] virtual LineFlags flagsAt(size_t index) const = 0;
+
+    /// The stable id of that LOGICAL line's head. Decreases as @p index grows, the walk going upwards.
+    [[nodiscard]] virtual int64_t stableIdAt(size_t index) const = 0;
+
+    /// The stable id of the LAST PHYSICAL row that logical line occupies.
+    ///
+    /// Equal to stableIdAt() for a line that fits, and larger for one a wrap chopped into several rows.
+    /// A fold hides rows, not logical lines, so a range that stopped at the head would leave the
+    /// continuations of its bottom-most line on screen -- an orphaned tail below a collapsed block.
+    [[nodiscard]] virtual int64_t lastPhysicalStableIdAt(size_t index) const = 0;
+};
+
+/// How far a fold scan climbs before giving up.
+///
+/// The screenful of blocks a user can actually see and act on, not the whole scrollback: the walk runs
+/// under the terminal lock, so this is a real bound rather than a defensive one — the same reasoning as
+/// MaxPromptScanLines (@see PromptRegion.hpp).
+constexpr inline size_t MaxFoldScanLines = 4096;
+
+/// The foldable regions in @p lines, most recent first.
+///
+/// A backward walk over the line flags a shell's OSC 133 marks leave behind, the exact companion of
+/// scanCommandBlocksBackward(): CommandEnd (;D) closes a block, OutputStart (;C) says where its output
+/// began, and Marked (;A) begins the prompt the fold hangs off.
+///
+/// Only FINISHED blocks fold — the walk opens a block on a CommandEnd and on nothing else. That is what
+/// keeps the cursor from ever standing inside a collapsed range, and it makes the prompt the user is
+/// typing at unfoldable, which is what a user would expect anyway.
+///
+/// A line carrying Marked is never hidden. A shell's precmd emits ;D and ;A back to back, so the line
+/// that closes one command routinely also starts the next prompt; and a shell that emits ;C before the
+/// echoed newline lands OutputStart on the command line itself. Both would otherwise fold a prompt away.
+/// A block left with no whole output line of its own — `printf hello`, or a command that printed nothing
+/// — yields no range: there is nothing to hide.
+///
+/// A single forward pass: each index is asked about once, in increasing order, and the ids a range needs
+/// are taken as the walk passes them rather than looked up again afterwards. That is what lets a source
+/// climb the grid lazily and keep no more state than the line it is standing on.
+///
+/// @param lines The lines to walk, newest first.
+/// @param maxScanLines How far up to walk before giving up (@see MaxFoldScanLines).
+/// @return The ranges, most recent first; empty when the lines hold no foldable output.
+[[nodiscard]] std::vector<FoldRange> computeFoldRanges(FoldLineSource const& lines, size_t maxScanLines);
+
+/// Whether a fold shows its body or hides it.
+///
+/// The two outcomes a toggle selects between, named rather than left to a bool: `true` at a call site
+/// says nothing about which of them it means, and a third state would gain an enumerator here instead
+/// of rewriting every signature that reports one.
+enum class FoldVisibility : uint8_t
+{
+    Expanded = 0, ///< The block's output is shown.
+    Collapsed,    ///< The block's output is hidden behind its prompt line.
+};
+
+/// Which folds are currently collapsed, by the stable id of the prompt line each hangs off.
+///
+/// Holds only the COLLAPSED ids, not every fold: a fold's existence is re-derived from the marks by
+/// computeFoldRanges() on demand, while whether the user collapsed it is the only thing that cannot be
+/// re-derived and therefore the only thing worth storing.
+class FoldState
+{
+  public:
+    /// Whether the fold hanging off @p headStableId is collapsed.
+    [[nodiscard]] bool isCollapsed(int64_t headStableId) const noexcept
+    {
+        return _collapsed.contains(headStableId);
+    }
+
+    /// Whether nothing at all is collapsed — the fast path every caller checks before projecting.
+    [[nodiscard]] bool empty() const noexcept { return _collapsed.empty(); }
+
+    /// Bumped by every mutation below.
+    ///
+    /// What a cache of anything derived from this state keys on: the projection is rebuilt when the user
+    /// collapses something, and a counter says so in one comparison rather than by re-deriving it.
+    [[nodiscard]] uint64_t revision() const noexcept { return _revision; }
+
+    void collapse(int64_t headStableId)
+    {
+        if (_collapsed.insert(headStableId).second)
+            ++_revision;
+    }
+
+    void expand(int64_t headStableId)
+    {
+        if (_collapsed.erase(headStableId) != 0)
+            ++_revision;
+    }
+
+    /// Collapses @p headStableId if it is expanded, expands it otherwise.
+    /// @return What it is afterwards.
+    FoldVisibility toggle(int64_t headStableId)
+    {
+        ++_revision;
+        if (auto const it = _collapsed.find(headStableId); it != _collapsed.end())
+        {
+            _collapsed.erase(it);
+            return FoldVisibility::Expanded;
+        }
+        _collapsed.insert(headStableId);
+        return FoldVisibility::Collapsed;
+    }
+
+    /// Collapses every fold in @p ranges, leaving those already collapsed alone.
+    void collapseAll(std::span<FoldRange const> ranges);
+
+    void expandAll() noexcept
+    {
+        if (!_collapsed.empty())
+            ++_revision;
+        _collapsed.clear();
+    }
+
+    /// Forgets every fold whose head has been evicted from the scrollback.
+    ///
+    /// Without it the set grows without bound over a long session, and — worse — an id reused by a later
+    /// generation would come back collapsed. Cheap because the set is ordered: one erase of a prefix.
+    /// @param floorStableId The oldest still-addressable id (Grid::stableRangeFloor()).
+    void prune(int64_t floorStableId)
+    {
+        auto const end = _collapsed.lower_bound(floorStableId);
+        if (end != _collapsed.begin())
+            ++_revision;
+        _collapsed.erase(_collapsed.begin(), end);
+    }
+
+    /// Forgets everything, for a generation bump: reflow destroyed row identity wholesale, so every id
+    /// held here now names a different row (or none).
+    ///
+    /// The same operation expandAll() performs, kept under its own name because the two say different
+    /// things about WHY the set is emptied -- a user expanding every fold, versus state the grid can no
+    /// longer account for.
+    void clear() noexcept { expandAll(); }
+
+  private:
+    // Ordered rather than hashed, so prune() is a single prefix erase rather than a full scan.
+    std::set<int64_t> _collapsed;
+    uint64_t _revision = 0;
+};
+
+/// What a row's gutter shows.
+///
+/// A fold occupies a RUN of rows, not just its head, so the gutter draws a column rather than a single
+/// marker: the head says which way the block folds, and the rows below it carry the column that says how
+/// far it reaches. That run is also the click target, which is why every row of it has a name here.
+enum class FoldMarker : uint8_t
+{
+    None = 0,  ///< No fold touches this row.
+    Expanded,  ///< Head of an expanded fold.
+    Collapsed, ///< Head of a collapsed fold.
+    Body,      ///< A row inside an expanded fold.
+    BodyEnd,   ///< The last row of an expanded fold.
+
+    Count, ///< Not a marker; pins the glyph table below to this enum.
+};
+
+/// The glyph @p marker is drawn as, or 0 for FoldMarker::None.
+///
+/// A table rather than a switch, so a sixth marker is a row here and nothing else.
+///
+/// The head is a box carrying a minus while the block is open and a plus once it is closed -- the fold
+/// control a reader has already met in editors and tree views -- and the body continues the column it
+/// hangs from down to a corner at the block's last row.
+///
+/// The two heads are Contour's own private-use codepoints, because no Unicode character carries both
+/// the boxed sign and the stem that ties a head to its body (@see
+/// docs/vt-extensions/private-use-glyphs.md). All four are drawn by vtrasterizer's own box-drawing
+/// renderer rather than by the font, so they are crisp and cell-proportionate in any font.
+[[nodiscard]] constexpr char32_t foldMarkerGlyph(FoldMarker marker) noexcept
+{
+    constexpr auto Glyphs = std::array {
+        U'\0',         // None
+        U'\U0010F000', // Expanded:  boxed minus with a stem into the body below it
+        U'\U0010F001', // Collapsed: boxed plus, with nothing below to connect to
+        U'│',          // Body:      BOX DRAWINGS LIGHT VERTICAL
+        U'┕',          // BodyEnd:   BOX DRAWINGS UP LIGHT AND RIGHT HEAVY
+    };
+
+    // Otherwise a sixth marker without a sixth row is a silent out-of-bounds read rather than the
+    // build break the "one row and nothing else" promise above is worth.
+    static_assert(Glyphs.size() == static_cast<size_t>(FoldMarker::Count));
+
+    return Glyphs[static_cast<size_t>(marker)];
+}
+
+/// What a targeted Vi-mode jump does when its target sits inside a collapsed fold.
+///
+/// Plain motions never need this -- they are computed in VISIBLE lines and so cannot land inside a fold
+/// at all. It governs only the jumps that name a target directly: a search hit, a mark, jump history.
+enum class FoldJumpBehavior : uint8_t
+{
+    Expand = 0, ///< Open the fold so the cursor lands on the real target, as vim's `foldopen` does.
+    Skip,       ///< Leave folds alone and snap the cursor to the nearest visible line.
+};
+
+/// Which way a fold-aware step or snap searches.
+///
+/// Named rather than a signed step, purely so the call sites read: `advanceVisibleLines(line, count,
+/// VerticalDirection::Up)` says what it does where `advanceVisibleLines(line, count, -1)` does not,
+/// and the eight Vi motions that call it are the code most people will read.
+enum class VerticalDirection : uint8_t
+{
+    Up = 0,
+    Down,
+};
+
+/// An inclusive range of stable ids hidden by a collapsed fold.
+struct HiddenInterval
+{
+    int64_t first {}; ///< Topmost hidden id.
+    int64_t last {};  ///< Bottom-most hidden id, inclusive.
+
+    [[nodiscard]] bool operator==(HiddenInterval const&) const noexcept = default;
+};
+
+/// The id intervals @p state hides out of @p ranges, sorted ascending and merged where they touch.
+///
+/// Merged because the projection below binary-searches them: overlapping intervals — two collapsed
+/// blocks whose ranges abut — would otherwise need a linear scan per row.
+/// @param ranges The foldable ranges.
+/// @param state Which of them are collapsed.
+/// @return The hidden intervals, ascending and disjoint.
+[[nodiscard]] std::vector<HiddenInterval> hiddenIntervals(std::span<FoldRange const> ranges,
+                                                          FoldState const& state);
+
+/// The interval in @p hidden covering @p id, if one does.
+///
+/// One binary search over the ascending, disjoint runs. The building block the two functions below are
+/// written in terms of, and the reason they cost the number of runs CROSSED rather than the distance
+/// travelled.
+///
+/// @param hidden The hidden intervals, ascending and disjoint (@see hiddenIntervals).
+/// @param id The stable id to look up.
+/// @return The covering interval, or nullopt when @p id is visible.
+[[nodiscard]] std::optional<HiddenInterval> hidingInterval(std::span<HiddenInterval const> hidden,
+                                                           int64_t id) noexcept;
+
+/// The nearest id at or beyond @p id, searching in @p direction, that no interval in @p hidden covers.
+///
+/// Returns @p id itself when it is already visible. Used to get a cursor OUT of a region that was
+/// collapsed underneath it -- a viewport change, a resize, or a jump the user asked to have snapped
+/// rather than expanded.
+///
+/// @param hidden The hidden intervals, ascending and disjoint.
+/// @param id The stable id to snap.
+/// @param direction Which way to leave a hidden run: Up towards its head, Down past its end.
+/// @return The nearest visible id in that direction.
+[[nodiscard]] int64_t snapToVisibleId(std::span<HiddenInterval const> hidden,
+                                      int64_t id,
+                                      VerticalDirection direction) noexcept;
+
+/// The id @p count VISIBLE rows from @p id in @p direction, skipping each hidden run whole.
+///
+/// This is what makes `3j` mean three rows the user can SEE rather than three grid rows, two of which
+/// might be inside a collapsed block. Clamped to [@p floorId, @p ceilId], so a motion that runs off the
+/// end of the scrollback stops there rather than naming a row the grid no longer holds.
+///
+/// Costs one binary search plus one step per hidden run crossed -- not @p count steps -- so a `1000j`
+/// over a folded scrollback is no more expensive than a `1j`.
+///
+/// @param hidden The hidden intervals, ascending and disjoint.
+/// @param id The stable id to start from; may itself be hidden, in which case it is snapped first.
+/// @param count How many visible rows to travel; zero snaps without moving.
+/// @param direction Which way to travel.
+/// @param floorId The lowest addressable id (oldest row still in the scrollback).
+/// @param ceilId The highest addressable id (the bottom row).
+/// @return The id arrived at: within [@p floorId, @p ceilId] and visible, unless every id in that
+///         range is hidden. A bound that is itself hidden stops the walk on the last visible id
+///         before it rather than on the bound.
+[[nodiscard]] int64_t advanceVisibleId(std::span<HiddenInterval const> hidden,
+                                       int64_t id,
+                                       int64_t count,
+                                       VerticalDirection direction,
+                                       int64_t floorId,
+                                       int64_t ceilId) noexcept;
+
+/// How many VISIBLE ids lie in the half-open range [@p first, @p last).
+///
+/// The counterpart to advanceVisibleId(): that one travels a distance, this one measures it. Screen
+/// rows ARE visible rows, so this is the quantity anything converting a pair of grid positions into a
+/// scroll distance or a row difference needs -- their plain difference counts the hidden rows too, and
+/// a scroll asked to travel that far overshoots by exactly what the folds hide.
+///
+/// Costs one binary search plus one step per hidden run crossed, not one per id.
+///
+/// @param hidden The hidden intervals, ascending and disjoint (@see hiddenIntervals).
+/// @param first The first id of the range, counted when visible.
+/// @param last The id one past the range's end, never counted.
+/// @return The number of visible ids in between; negative, and symmetric, when @p last precedes
+///         @p first.
+[[nodiscard]] int64_t visibleDistance(std::span<HiddenInterval const> hidden,
+                                      int64_t first,
+                                      int64_t last) noexcept;
+
+/// The grid lines a folded viewport shows, top row first.
+///
+/// Plain grid lines, deliberately: a row carries nothing beyond the line it draws. A fold MARKER is not
+/// cached here, because the projection is built only when something is COLLAPSED -- an unfolded viewport
+/// short-circuits to an empty projection -- while the gutter must also draw the column of an EXPANDED
+/// fold, so a marker held here could answer for only half the rows that need one. Terminal::foldMarkerAt()
+/// answers for all of them.
+///
+/// Walks upwards from @p bottom, skipping every line a collapsed fold hides and pulling further history
+/// in to fill the rows those hidden lines freed, and stops at @p top. Fewer than @p rowCount rows come
+/// back only when the walk ran out of grid — a short scrollback — which the caller pads at the top
+/// exactly as an unfolded viewport already shows blank rows above a short history.
+///
+/// Pure, and deliberately: this is the one function whose disagreement with Viewport's coordinate
+/// translation would misplace a selection, so it is the one that has to be testable on its own.
+///
+/// @param hidden The id runs collapsed folds hide (@see hiddenIntervals), ascending and disjoint.
+/// @param stableBase The stable id of grid line 0 (Grid::stableLineIdOf(LineOffset(0))).
+/// @param bottom The last visible grid line, inclusive.
+/// @param rowCount How many visible rows to fill.
+/// @param top The topmost grid line holding valid data (Grid::addressableTop()).
+/// @return The rows, top first; empty when @p rowCount is zero or @p bottom is above @p top.
+[[nodiscard]] std::vector<LineOffset> projectRows(std::span<HiddenInterval const> hidden,
+                                                  int64_t stableBase,
+                                                  LineOffset bottom,
+                                                  LineCount rowCount,
+                                                  LineOffset top);
+
+/// The screen row a projected row list's FIRST row is drawn on.
+///
+/// The one statement of the rule, because two consumers must agree on it to the row: Grid::render()
+/// places the list it draws by it, and Viewport translates coordinates through it. Negative while
+/// smooth scrolling supplies rows above the page, and zero once the list is no longer than the page.
+///
+/// Rows BEYOND the page count are the smooth-scrolling ones and belong above it, so the last row of the
+/// list still lands on the bottom of the page however many extra ones precede it. FEWER rows than the
+/// page means the walk ran out of grid at the top and there is nothing above them, so they start at the
+/// top and the page is short at the BOTTOM -- exactly as a terminal that has not filled its page
+/// already looks.
+///
+/// @param pageLines How many lines the page holds.
+/// @param rowCount How many rows the list holds.
+/// @return The screen row of the list's first row; zero unless the list is longer than the page.
+[[nodiscard]] constexpr LineOffset foldedRowsTopRow(LineCount pageLines, size_t rowCount) noexcept
+{
+    return LineOffset::cast_from(std::min(0, unbox<int>(pageLines) - static_cast<int>(rowCount)));
+}
+
+} // namespace vtbackend
+
+template <>
+struct std::formatter<vtbackend::FoldJumpBehavior>: formatter<std::string_view>
+{
+    auto format(vtbackend::FoldJumpBehavior value, auto& ctx) const
+    {
+        string_view name;
+        switch (value)
+        {
+            case vtbackend::FoldJumpBehavior::Expand: name = "expand"; break;
+            case vtbackend::FoldJumpBehavior::Skip: name = "skip"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};
+
+template <>
+struct std::formatter<vtbackend::FoldMarker>: formatter<std::string_view>
+{
+    auto format(vtbackend::FoldMarker value, auto& ctx) const
+    {
+        string_view name;
+        switch (value)
+        {
+            case vtbackend::FoldMarker::None: name = "None"; break;
+            case vtbackend::FoldMarker::Expanded: name = "Expanded"; break;
+            case vtbackend::FoldMarker::Collapsed: name = "Collapsed"; break;
+            case vtbackend::FoldMarker::Body: name = "Body"; break;
+            case vtbackend::FoldMarker::BodyEnd: name = "BodyEnd"; break;
+            case vtbackend::FoldMarker::Count: name = "Count"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};

--- a/src/vtbackend/Folding_test.cpp
+++ b/src/vtbackend/Folding_test.cpp
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/Folding.hpp>
+#include <vtbackend/MockTerm.hpp>
+#include <vtbackend/StatusLineBuilder.hpp>
+#include <vtbackend/Terminal.hpp>
+
+#include <crispy/Utils.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <format>
+#include <ranges>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace vtbackend;
+using namespace std::chrono_literals;
+
+namespace chrono = std::chrono;
+
+namespace
+{
+
+/// The stable id the fake below gives the line the scan starts at. Deliberately not zero and not round,
+/// so a test that accidentally compares against a bare index fails instead of passing by coincidence.
+constexpr auto BottomStableId = int64_t { 1000 };
+
+/// A fold line source backed by a plain vector — the whole point of the FoldLineSource seam. Lines are
+/// given in the order the scan walks them: the bottom line first, then upwards, one entry per LOGICAL
+/// line. Stable ids decrease upwards, exactly as Grid hands them out.
+class FakeLines final: public FoldLineSource
+{
+  public:
+    struct Entry
+    {
+        LineFlags flags;
+        /// How many PHYSICAL rows this logical line occupies -- 1 unless a wrap chopped it up.
+        int rowCount = 1;
+    };
+
+    explicit FakeLines(std::vector<Entry> lines): _lines { std::move(lines) }
+    {
+        // Ids decrease upwards, and a wrapped line consumes as many of them as it has rows: the head of
+        // the line at index n sits that many rows above the head of the line at index n-1.
+        auto id = BottomStableId;
+        for (auto const& entry: _lines)
+        {
+            _lastPhysicalIds.push_back(id);
+            id -= entry.rowCount;
+            _headIds.push_back(id + 1);
+        }
+    }
+
+    /// Convenience for the common all-unwrapped case.
+    explicit FakeLines(std::vector<LineFlags> const& flags): FakeLines { toEntries(flags) } {}
+
+    [[nodiscard]] bool hasLineAt(size_t index) const override { return index < _lines.size(); }
+    [[nodiscard]] LineFlags flagsAt(size_t index) const override { return _lines.at(index).flags; }
+
+    [[nodiscard]] int64_t stableIdAt(size_t index) const override { return _headIds.at(index); }
+
+    [[nodiscard]] int64_t lastPhysicalStableIdAt(size_t index) const override
+    {
+        return _lastPhysicalIds.at(index);
+    }
+
+  private:
+    [[nodiscard]] static std::vector<Entry> toEntries(std::vector<LineFlags> const& flags)
+    {
+        auto entries = std::vector<Entry> {};
+        entries.reserve(flags.size());
+        for (auto const& f: flags)
+            entries.push_back(Entry { .flags = f });
+        return entries;
+    }
+
+    std::vector<Entry> _lines;
+    std::vector<int64_t> _headIds;
+    std::vector<int64_t> _lastPhysicalIds;
+};
+
+/// The stable id of the line @p index lines above the bottom one — the test's own mirror of the fake's
+/// mapping, so an expectation reads as "three lines up" rather than as an opaque number.
+constexpr int64_t idAt(size_t index) noexcept
+{
+    return BottomStableId - static_cast<int64_t>(index);
+}
+
+} // namespace
+
+// {{{ computeFoldRanges
+
+TEST_CASE("Folding.scan.oneBlock", "[folding]")
+{
+    // The layout a shell leaves behind for `ls`, walked from the cursor upwards. The bottom line carries
+    // BOTH the finished command's CommandEnd and the new prompt's Marked, because precmd emits OSC 133;D
+    // and ;A back to back and then prints the prompt onto that line.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked }, // 0: the NEW prompt
+        LineFlags {},                                         // 1: "file2"
+        LineFlags { LineFlag::OutputStart },                  // 2: "file1"
+        LineFlags { LineFlag::Marked },                       // 3: "$ ls"
+    } };
+
+    auto const ranges = computeFoldRanges(lines, MaxFoldScanLines);
+
+    REQUIRE(ranges.size() == 1);
+    // The fold hangs off the prompt, and hides exactly the two output lines -- not the line that closed
+    // the command, which is the next prompt.
+    CHECK(ranges[0].headStableId == idAt(3));
+    CHECK(ranges[0].firstStableId == idAt(2));
+    CHECK(ranges[0].lastStableId == idAt(1));
+}
+
+TEST_CASE("Folding.scan.commandEndLineIsNeverHidden", "[folding]")
+{
+    // The shell closed the command but has not printed its next prompt yet, so the cursor is standing on
+    // the ;D line. Folding it away would hide the row the user is about to type into -- so the range
+    // stops above it, at the cost of one visible row.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd },  // 0: where ;D landed, and where the cursor is
+        LineFlags {},                        // 1: output
+        LineFlags { LineFlag::OutputStart }, // 2: output
+        LineFlags { LineFlag::Marked },      // 3: "$ ls"
+    } };
+
+    auto const ranges = computeFoldRanges(lines, MaxFoldScanLines);
+
+    REQUIRE(ranges.size() == 1);
+    CHECK(ranges[0].headStableId == idAt(3));
+    CHECK(ranges[0].firstStableId == idAt(2));
+    CHECK(ranges[0].lastStableId == idAt(1));
+}
+
+TEST_CASE("Folding.scan.multiLinePrompt", "[folding]")
+{
+    // A lavish two-line prompt: Marked sits on the FIRST of them, and the fold hangs off that line while
+    // the continuation stays visible -- prompt lines are never hidden.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked }, // 0: the NEW prompt
+        LineFlags {},                                         // 1: output
+        LineFlags { LineFlag::OutputStart },                  // 2: output
+        LineFlags { LineFlag::PromptEnd },                    // 3: "> ls"  (prompt, 2nd line)
+        LineFlags { LineFlag::Marked },                       // 4: "~/src" (prompt, 1st line)
+    } };
+
+    auto const ranges = computeFoldRanges(lines, MaxFoldScanLines);
+
+    REQUIRE(ranges.size() == 1);
+    CHECK(ranges[0].headStableId == idAt(4));
+    CHECK(ranges[0].firstStableId == idAt(2));
+    CHECK(ranges[0].lastStableId == idAt(1));
+}
+
+TEST_CASE("Folding.scan.chainedBlocks", "[folding]")
+{
+    // Two commands in a row. The line between them carries the older block's CommandEnd AND the newer
+    // block's Marked, which the walk has to chain through rather than step over.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked }, // 0: the NEW prompt
+        LineFlags { LineFlag::OutputStart },                  // 1: `pwd` output
+        LineFlags { LineFlag::Marked, LineFlag::CommandEnd }, // 2: "$ pwd", closing `ls`
+        LineFlags {},                                         // 3: `ls` output
+        LineFlags { LineFlag::OutputStart },                  // 4: `ls` output
+        LineFlags { LineFlag::Marked },                       // 5: "$ ls"
+    } };
+
+    auto const ranges = computeFoldRanges(lines, MaxFoldScanLines);
+
+    REQUIRE(ranges.size() == 2);
+    // Most recent first.
+    CHECK(ranges[0].headStableId == idAt(2));
+    CHECK(ranges[0].firstStableId == idAt(1));
+    CHECK(ranges[0].lastStableId == idAt(1));
+    CHECK(ranges[1].headStableId == idAt(5));
+    CHECK(ranges[1].firstStableId == idAt(4));
+    CHECK(ranges[1].lastStableId == idAt(3));
+}
+
+TEST_CASE("Folding.scan.wrappedOutputHidesAllItsRows", "[folding]")
+{
+    // A single logical output line the window was too narrow for, chopped into three physical rows. A
+    // range that stopped at the head would leave the two continuations on screen -- an orphaned tail
+    // below a collapsed block.
+    auto const lines = FakeLines { std::vector<FakeLines::Entry> {
+        { .flags = LineFlags { LineFlag::CommandEnd, LineFlag::Marked } }, // 0: the NEW prompt, 1 row
+        { .flags = LineFlags { LineFlag::OutputStart }, .rowCount = 3 },   // 1: one long output line
+        { .flags = LineFlags { LineFlag::Marked } },                       // 2: "$ ls"
+    } };
+
+    auto const ranges = computeFoldRanges(lines, MaxFoldScanLines);
+
+    REQUIRE(ranges.size() == 1);
+    CHECK(ranges[0].headStableId == BottomStableId - 4);
+    // All three physical rows of the wrapped line, head through tail.
+    CHECK(ranges[0].firstStableId == BottomStableId - 3);
+    CHECK(ranges[0].lastStableId == BottomStableId - 1);
+}
+
+TEST_CASE("Folding.scan.commandThatPrintedNothing", "[folding]")
+{
+    // `cd /tmp` prints nothing: there is no output line to hide, so there is no fold. A marker offering
+    // to hide nothing is worse than no marker.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked }, // 0: the NEW prompt
+        LineFlags { LineFlag::Marked },                       // 1: "$ cd /tmp"
+    } };
+
+    CHECK(computeFoldRanges(lines, MaxFoldScanLines).empty());
+}
+
+TEST_CASE("Folding.scan.outputStartOnTheCommandLine", "[folding]")
+{
+    // A shell that emits OSC 133;C before the echoed newline lands OutputStart on the command line
+    // itself. That line carries Marked, so it must not be hidden -- and with nothing else to hide, the
+    // block is not foldable at all.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked },  // 0: the NEW prompt
+        LineFlags { LineFlag::Marked, LineFlag::OutputStart }, // 1: "$ printf hi"
+    } };
+
+    CHECK(computeFoldRanges(lines, MaxFoldScanLines).empty());
+}
+
+TEST_CASE("Folding.scan.unfinishedBlockIsNotFoldable", "[folding]")
+{
+    // A command still running: no CommandEnd anywhere, so the walk never opens a block. This is what
+    // keeps the cursor from ever standing inside a collapsed range.
+    auto const lines = FakeLines { {
+        LineFlags {},                        // 0: output still arriving
+        LineFlags { LineFlag::OutputStart }, // 1
+        LineFlags { LineFlag::Marked },      // 2: "$ tail -f log"
+    } };
+
+    CHECK(computeFoldRanges(lines, MaxFoldScanLines).empty());
+}
+
+TEST_CASE("Folding.scan.promptScrolledOutIsDropped", "[folding]")
+{
+    // The output is reachable but the prompt it hangs off is not: there is no row to draw a marker on,
+    // so hiding the output would leave the user no way to get it back.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked }, // 0: the NEW prompt
+        LineFlags {},                                         // 1: output
+        LineFlags {},                                         // 2: output, and the scrollback ends here
+    } };
+
+    CHECK(computeFoldRanges(lines, MaxFoldScanLines).empty());
+}
+
+TEST_CASE("Folding.scan.respectsScanBudget", "[folding]")
+{
+    // The budget cuts the walk off before it reaches the prompt, and a fold with no head is dropped --
+    // the walk runs under the terminal lock, so the bound is real rather than defensive.
+    auto const lines = FakeLines { {
+        LineFlags { LineFlag::CommandEnd, LineFlag::Marked },
+        LineFlags {},
+        LineFlags { LineFlag::OutputStart },
+        LineFlags { LineFlag::Marked },
+    } };
+
+    CHECK(computeFoldRanges(lines, 3).empty());
+    CHECK(computeFoldRanges(lines, 4).size() == 1);
+}
+
+TEST_CASE("Folding.scan.noMarksAtAll", "[folding]")
+{
+    // A shell with no OSC 133 integration: a flags-only walk that finds nothing and costs nothing.
+    auto const lines = FakeLines { std::vector<LineFlags>(64, LineFlags {}) };
+
+    CHECK(computeFoldRanges(lines, MaxFoldScanLines).empty());
+}
+
+// }}}
+// {{{ FoldState
+
+TEST_CASE("Folding.state.toggle", "[folding]")
+{
+    auto state = FoldState {};
+    CHECK(state.empty());
+
+    CHECK(state.toggle(42) == FoldVisibility::Collapsed);
+    CHECK(state.isCollapsed(42));
+    CHECK(!state.empty());
+
+    CHECK(state.toggle(42) == FoldVisibility::Expanded);
+    CHECK(!state.isCollapsed(42));
+    CHECK(state.empty());
+}
+
+TEST_CASE("Folding.state.collapseAllAndExpandAll", "[folding]")
+{
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 10, .firstStableId = 11, .lastStableId = 12 },
+        { .headStableId = 20, .firstStableId = 21, .lastStableId = 22 },
+    };
+
+    auto state = FoldState {};
+    auto const before = state.revision();
+    state.collapseAll(ranges);
+    CHECK(state.isCollapsed(10));
+    CHECK(state.isCollapsed(20));
+    // The revision must move, or every cache keyed on it keeps showing what was there before.
+    CHECK(state.revision() != before);
+
+    // A second sweep changes nothing, and says so by leaving the revision alone.
+    auto const afterFirst = state.revision();
+    state.collapseAll(ranges);
+    CHECK(state.revision() == afterFirst);
+
+    state.expandAll();
+    CHECK(state.empty());
+    CHECK(state.revision() != afterFirst);
+}
+
+TEST_CASE("Folding.state.pruneDropsEvictedHeads", "[folding]")
+{
+    // Without pruning the set grows without bound over a long session, and an id reused by a later
+    // generation would come back collapsed.
+    auto state = FoldState {};
+    state.collapse(10);
+    state.collapse(20);
+    state.collapse(30);
+
+    state.prune(20);
+
+    CHECK(!state.isCollapsed(10));
+    CHECK(state.isCollapsed(20)); // the floor itself is still addressable
+    CHECK(state.isCollapsed(30));
+}
+
+// }}}
+// {{{ hiddenIntervals
+
+TEST_CASE("Folding.hidden.onlyCollapsedRangesHide", "[folding]")
+{
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 10, .firstStableId = 11, .lastStableId = 13 },
+        { .headStableId = 20, .firstStableId = 21, .lastStableId = 23 },
+    };
+
+    auto state = FoldState {};
+    CHECK(hiddenIntervals(ranges, state).empty());
+
+    state.collapse(20);
+    auto const hidden = hiddenIntervals(ranges, state);
+    REQUIRE(hidden.size() == 1);
+    CHECK(hidden[0] == HiddenInterval { .first = 21, .last = 23 });
+}
+
+TEST_CASE("Folding.hidden.abuttingRangesMerge", "[folding]")
+{
+    // Two collapsed blocks with no visible line between them describe one run, so the projection's
+    // binary search stays a search.
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 30, .firstStableId = 31, .lastStableId = 34 },
+        { .headStableId = 20, .firstStableId = 25, .lastStableId = 30 },
+    };
+
+    auto state = FoldState {};
+    state.collapseAll(ranges);
+
+    auto const hidden = hiddenIntervals(ranges, state);
+    REQUIRE(hidden.size() == 1);
+    CHECK(hidden[0] == HiddenInterval { .first = 25, .last = 34 });
+}
+
+// }}}
+// {{{ visible-line arithmetic
+
+namespace
+{
+/// Two collapsed runs with visible ids on either side and between them: 10..12 and 20..24.
+///
+/// Visible ids around them, ascending: 9, 13, 14, ..., 19, 25, 26, ...
+[[nodiscard]] std::vector<HiddenInterval> twoRuns()
+{
+    return { HiddenInterval { .first = 10, .last = 12 }, HiddenInterval { .first = 20, .last = 24 } };
+}
+} // namespace
+
+TEST_CASE("Folding.visible.snapLeavesAVisibleIdAlone", "[folding]")
+{
+    auto const hidden = twoRuns();
+    CHECK(snapToVisibleId(hidden, 9, VerticalDirection::Up) == 9);
+    CHECK(snapToVisibleId(hidden, 9, VerticalDirection::Down) == 9);
+    CHECK(snapToVisibleId(hidden, 13, VerticalDirection::Up) == 13);
+    CHECK(snapToVisibleId({}, 42, VerticalDirection::Down) == 42);
+}
+
+TEST_CASE("Folding.visible.snapLeavesARunByTheNearestEdge", "[folding]")
+{
+    auto const hidden = twoRuns();
+
+    // Out through the top of the run, and out through the bottom -- one step either way, because
+    // hiddenIntervals() has already merged anything that touches.
+    CHECK(snapToVisibleId(hidden, 11, VerticalDirection::Up) == 9);
+    CHECK(snapToVisibleId(hidden, 11, VerticalDirection::Down) == 13);
+    CHECK(snapToVisibleId(hidden, 22, VerticalDirection::Up) == 19);
+    CHECK(snapToVisibleId(hidden, 22, VerticalDirection::Down) == 25);
+}
+
+TEST_CASE("Folding.visible.advanceCountsVisibleRowsOnly", "[folding]")
+{
+    auto const hidden = twoRuns();
+    auto constexpr Floor = int64_t { 0 };
+    auto constexpr Ceil = int64_t { 100 };
+
+    // From 9 downwards the visible ids are 13, 14, 15, ... -- the run 10..12 is not among them, so one
+    // step lands past it rather than inside it. This is the whole point: `3j` means three rows the user
+    // can SEE.
+    CHECK(advanceVisibleId(hidden, 9, 1, VerticalDirection::Down, Floor, Ceil) == 13);
+    CHECK(advanceVisibleId(hidden, 9, 2, VerticalDirection::Down, Floor, Ceil) == 14);
+    CHECK(advanceVisibleId(hidden, 9, 7, VerticalDirection::Down, Floor, Ceil) == 19);
+    // ...and the next step crosses the second run whole.
+    CHECK(advanceVisibleId(hidden, 9, 8, VerticalDirection::Down, Floor, Ceil) == 25);
+    CHECK(advanceVisibleId(hidden, 9, 9, VerticalDirection::Down, Floor, Ceil) == 26);
+
+    // Upwards, the mirror image.
+    CHECK(advanceVisibleId(hidden, 26, 1, VerticalDirection::Up, Floor, Ceil) == 25);
+    CHECK(advanceVisibleId(hidden, 26, 2, VerticalDirection::Up, Floor, Ceil) == 19);
+    CHECK(advanceVisibleId(hidden, 26, 8, VerticalDirection::Up, Floor, Ceil) == 13);
+    CHECK(advanceVisibleId(hidden, 26, 9, VerticalDirection::Up, Floor, Ceil) == 9);
+}
+
+TEST_CASE("Folding.visible.advanceWithNothingHiddenIsPlainArithmetic", "[folding]")
+{
+    CHECK(advanceVisibleId({}, 5, 3, VerticalDirection::Down, 0, 100) == 8);
+    CHECK(advanceVisibleId({}, 5, 3, VerticalDirection::Up, 0, 100) == 2);
+    CHECK(advanceVisibleId({}, 5, 0, VerticalDirection::Down, 0, 100) == 5);
+}
+
+TEST_CASE("Folding.visible.advanceClampsToTheAddressableGrid", "[folding]")
+{
+    auto const hidden = twoRuns();
+
+    // A motion that runs off either end stops there rather than naming a row the grid no longer holds.
+    CHECK(advanceVisibleId(hidden, 26, 1000, VerticalDirection::Down, 0, 30) == 30);
+    CHECK(advanceVisibleId(hidden, 9, 1000, VerticalDirection::Up, 5, 30) == 5);
+
+    // A bound that itself sits inside a collapsed run is not where the walk stops: 22 is hidden, and
+    // stopping on it would put the cursor on a row drawn nowhere. It stops on the last VISIBLE id
+    // before the bound instead, on both ends.
+    CHECK(advanceVisibleId(hidden, 9, 1000, VerticalDirection::Down, 0, 22) == 19);
+    CHECK(advanceVisibleId(hidden, 26, 1000, VerticalDirection::Up, 11, 30) == 13);
+}
+
+TEST_CASE("Folding.visible.advanceSnapsAHiddenStartingPointFirst", "[folding]")
+{
+    auto const hidden = twoRuns();
+
+    // A cursor the user collapsed a block underneath starts inside a run. It leaves in the direction of
+    // travel, and only then counts -- so the first step is never spent climbing back out.
+    CHECK(advanceVisibleId(hidden, 11, 0, VerticalDirection::Down, 0, 100) == 13);
+    CHECK(advanceVisibleId(hidden, 11, 0, VerticalDirection::Up, 0, 100) == 9);
+    CHECK(advanceVisibleId(hidden, 11, 1, VerticalDirection::Down, 0, 100) == 14);
+    CHECK(advanceVisibleId(hidden, 11, 1, VerticalDirection::Up, 0, 100) == 8);
+}
+
+// }}}
+// {{{ projectRows
+
+TEST_CASE("Folding.project.topRowPlacesTheListTheWayGridRenderDraws", "[folding]")
+{
+    // The rule Grid::render and Viewport's coordinate translation BOTH read: those two disagreeing is
+    // what misplaces a selection, so it is stated once and tested here rather than at either of them.
+
+    // A page-full starts at the top, and so does a short one -- the walk ran out of grid above it, and
+    // the page is short at the BOTTOM instead.
+    CHECK(foldedRowsTopRow(LineCount(10), 10) == LineOffset(0));
+    CHECK(foldedRowsTopRow(LineCount(10), 3) == LineOffset(0));
+    CHECK(foldedRowsTopRow(LineCount(10), 0) == LineOffset(0));
+
+    // Rows BEYOND the page are the smooth-scrolling ones and belong ABOVE it, so the last row still
+    // lands on the bottom of the page however many extra ones precede it.
+    CHECK(foldedRowsTopRow(LineCount(10), 11) == LineOffset(-1));
+    CHECK(foldedRowsTopRow(LineCount(10), 14) == LineOffset(-4));
+}
+
+TEST_CASE("Folding.visible.distanceCountsOnlyVisibleIds", "[folding]")
+{
+    auto const hidden = twoRuns();
+
+    // Nothing hidden in between, so the plain difference.
+    CHECK(visibleDistance({}, 5, 17) == 12);
+    CHECK(visibleDistance(hidden, 5, 9) == 4);
+
+    // [9, 13) spans the whole of the run 10..12, so only id 9 is visible in it.
+    CHECK(visibleDistance(hidden, 9, 13) == 1);
+
+    // Both runs crossed: 26 - 9 = 17 ids, of which 3 + 5 are hidden.
+    CHECK(visibleDistance(hidden, 9, 26) == 9);
+
+    // Partial overlaps, from inside a run and to inside one.
+    CHECK(visibleDistance(hidden, 11, 14) == 1); // 11, 12 hidden; 13 visible
+    CHECK(visibleDistance(hidden, 18, 22) == 2); // 18, 19 visible; 20, 21 hidden
+
+    // Empty and reversed ranges. Symmetric so no caller has to order its arguments.
+    CHECK(visibleDistance(hidden, 14, 14) == 0);
+    CHECK(visibleDistance(hidden, 26, 9) == -9);
+}
+
+TEST_CASE("Folding.project.unfoldedIsTheLinearWalk", "[folding]")
+{
+    // Nothing collapsed: the projection must be exactly what an unfolded viewport already draws.
+    auto const rows = projectRows({}, /*stableBase*/ 0, LineOffset(4), LineCount(5), LineOffset(0));
+
+    REQUIRE(rows.size() == 5);
+    for (auto i = 0; i < 5; ++i)
+        CHECK(rows[static_cast<size_t>(i)] == LineOffset(i));
+}
+
+TEST_CASE("Folding.project.collapsedRunIsSkippedAndBackfilled", "[folding]")
+{
+    // stableBase 0, so ids and LineOffsets coincide and the expectation reads directly.
+    // Grid lines -3..4; the fold hangs off line 0 and hides lines 1..3.
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 0, .firstStableId = 1, .lastStableId = 3 },
+    };
+    auto state = FoldState {};
+    state.collapse(0);
+
+    auto const rows = projectRows(
+        hiddenIntervals(ranges, state), /*stableBase*/ 0, LineOffset(4), LineCount(5), LineOffset(-3));
+
+    // The three hidden rows are freed and filled from further up the history.
+    REQUIRE(rows.size() == 5);
+    CHECK(rows[0] == LineOffset(-3));
+    CHECK(rows[1] == LineOffset(-2));
+    CHECK(rows[2] == LineOffset(-1));
+    CHECK(rows[3] == LineOffset(0));
+    CHECK(rows[4] == LineOffset(4));
+}
+
+TEST_CASE("Folding.project.anExpandedFoldHidesNothing", "[folding]")
+{
+    // An expanded fold is still a fold, but it takes no rows out of the projection -- which is why
+    // the projection alone cannot tell the gutter what to draw, and why Terminal::foldMarkerAt() is
+    // the one query that answers for expanded and collapsed blocks alike.
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 0, .firstStableId = 1, .lastStableId = 3 },
+    };
+
+    auto const rows = projectRows(
+        hiddenIntervals(ranges, FoldState {}), /*stableBase*/ 0, LineOffset(4), LineCount(5), LineOffset(0));
+
+    REQUIRE(rows.size() == 5);
+    for (auto i = 0; i < 5; ++i)
+        CHECK(rows[static_cast<size_t>(i)] == LineOffset(i));
+}
+
+TEST_CASE("Folding.project.stopsAtTheAddressableTop", "[folding]")
+{
+    // A short scrollback yields fewer rows than asked for; the caller pads the top exactly as an
+    // unfolded viewport already shows blank rows above a short history.
+    auto const rows = projectRows({}, /*stableBase*/ 0, LineOffset(2), LineCount(10), LineOffset(0));
+
+    REQUIRE(rows.size() == 3);
+    CHECK(rows[0] == LineOffset(0));
+    CHECK(rows[2] == LineOffset(2));
+}
+
+TEST_CASE("Folding.project.stableBaseOffsetsTheIds", "[folding]")
+{
+    // The realistic case: the grid has scrolled, so a line's stable id is nothing like its LineOffset.
+    // The fold hides ids 101..103, which at base 100 are lines 1..3.
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = 100, .firstStableId = 101, .lastStableId = 103 },
+    };
+    auto state = FoldState {};
+    state.collapse(100);
+
+    auto const rows = projectRows(
+        hiddenIntervals(ranges, state), /*stableBase*/ 100, LineOffset(4), LineCount(3), LineOffset(-3));
+
+    REQUIRE(rows.size() == 3);
+    CHECK(rows[0] == LineOffset(-1));
+    CHECK(rows[1] == LineOffset(0));
+    CHECK(rows[2] == LineOffset(4));
+}
+
+TEST_CASE("Folding.project.everythingVisibleCollapsed", "[folding]")
+{
+    // The whole reachable grid is hidden: the projection comes back empty rather than looping or
+    // inventing rows.
+    auto const ranges = std::vector<FoldRange> {
+        { .headStableId = -1, .firstStableId = 0, .lastStableId = 4 },
+    };
+    auto state = FoldState {};
+    state.collapse(-1);
+
+    auto const rows = projectRows(
+        hiddenIntervals(ranges, state), /*stableBase*/ 0, LineOffset(4), LineCount(5), LineOffset(0));
+
+    CHECK(rows.empty());
+}
+
+TEST_CASE("Folding.project.zeroRowsAndInvertedRange", "[folding]")
+{
+    CHECK(projectRows({}, 0, LineOffset(4), LineCount(0), LineOffset(0)).empty());
+    CHECK(projectRows({}, 0, LineOffset(-1), LineCount(5), LineOffset(0)).empty());
+}
+
+// }}}
+

--- a/src/vtbackend/Folding_test.cpp
+++ b/src/vtbackend/Folding_test.cpp
@@ -608,3 +608,1422 @@ TEST_CASE("Folding.project.zeroRowsAndInvertedRange", "[folding]")
 
 // }}}
 
+// }}}
+// {{{ Wired to a live terminal
+
+namespace
+{
+
+/// Runs one shell command through a terminal exactly as a shell with OSC 133 integration would: prompt
+/// start, prompt end, the echoed command line, output start, the output itself, and the command end
+/// that a precmd hook emits at the top of the NEXT prompt.
+void runCommand(MockTerm<>& mc, std::string const& command, std::vector<std::string> const& output)
+{
+    mc.writeToScreen("\033]133;A\033\\");
+    mc.writeToScreen("$ ");
+    mc.writeToScreen("\033]133;B\033\\");
+    mc.writeToScreen(command + "\r\n");
+    mc.writeToScreen("\033]133;C\033\\");
+    for (auto const& line: output)
+        mc.writeToScreen(line + "\r\n");
+    mc.writeToScreen("\033]133;D;0\033\\");
+}
+
+/// The text of each row the viewport currently shows, top first, trailing blanks dropped -- what
+/// folding is ultimately about.
+std::vector<std::string> visibleRows(Terminal& terminal)
+{
+    auto rows = std::vector<std::string> {};
+    auto const& screen = terminal.primaryScreen();
+    for (auto y = 0; y < unbox<int>(terminal.pageSize().lines); ++y)
+    {
+        auto const line = terminal.viewport().translateScreenToGridCoordinate(
+            CellLocation { .line = LineOffset(y), .column = ColumnOffset(0) });
+        auto text = screen.grid().lineText(line.line);
+        text.resize(crispy::trimRight(text).size());
+        rows.push_back(std::move(text));
+    }
+    return rows;
+}
+
+} // namespace
+
+TEST_CASE("Folding.terminal.rangesComeFromTheMarks", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+
+    // The head is the prompt line, and the hidden rows are the two output lines -- neither the prompt
+    // above them nor the line the shell closed the command on.
+    auto const& grid = mc.terminal.primaryScreen().grid();
+    CHECK(ranges[0].headStableId == grid.stableLineIdOf(LineOffset(0)));
+    CHECK(ranges[0].firstStableId == grid.stableLineIdOf(LineOffset(1)));
+    CHECK(ranges[0].lastStableId == grid.stableLineIdOf(LineOffset(2)));
+}
+
+TEST_CASE("Folding.terminal.nothingCollapsedProjectsNothing", "[folding]")
+{
+    // The fast path: with no fold collapsed the contiguous page IS the projection, so none is built and
+    // every consumer keeps the arithmetic it always had.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    CHECK(mc.terminal.foldProjection().empty());
+    CHECK(mc.terminal.foldProjection().empty());
+    CHECK(mc.terminal.hiddenLineCount() == LineCount(0));
+
+    // ... and translation is the plain subtraction it has always been.
+    CHECK(mc.terminal.viewport().translateScreenToGridCoordinate(
+              CellLocation { .line = LineOffset(3), .column = ColumnOffset(1) })
+          == CellLocation { .line = LineOffset(3), .column = ColumnOffset(1) });
+}
+
+TEST_CASE("Folding.terminal.collapsingHidesTheOutput", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const before = visibleRows(mc.terminal);
+    REQUIRE(before[0] == "$ ls");
+    REQUIRE(before[1] == "file1");
+    REQUIRE(before[2] == "file2");
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    CHECK(mc.terminal.hiddenLineCount() == LineCount(2));
+
+    auto const after = visibleRows(mc.terminal);
+    // The prompt stays; its output is gone and the rows below have moved up.
+    CHECK(after[0] == "$ ls");
+    CHECK(after[1] != "file1");
+    CHECK(after[2] != "file2");
+}
+
+TEST_CASE("Folding.terminal.translationRoundTripsUnderFolds", "[folding]")
+{
+    // The property that matters most: the projection the render pass draws from and the coordinate
+    // translation every selection goes through must agree, or a drag selects rows it does not highlight.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    auto const projection = mc.terminal.foldProjection();
+    REQUIRE(!projection.empty());
+
+    // The projection is BOTTOM-aligned: its last row is the last row of the page, and when collapsed
+    // folds hide more than the history can backfill the rows above it are blank. Screen row and
+    // projection index therefore differ by that offset -- which is exactly the thing Grid::render and
+    // this translation have to agree about.
+    auto const top = unbox<int>(mc.terminal.foldProjectionTopRow());
+
+    for (auto i = size_t { 0 }; i < projection.size(); ++i)
+    {
+        auto const screenRow = LineOffset(top + static_cast<int>(i));
+        CAPTURE(i, top, unbox<int>(screenRow));
+
+        auto const gridLine = mc.terminal.viewport().translateScreenToGridLine(screenRow);
+        CHECK(gridLine == projection[i]);
+        CHECK(mc.terminal.viewport().translateGridToScreenCoordinate(gridLine) == screenRow);
+    }
+}
+
+TEST_CASE("Folding.terminal.projectionAndRenderPassAgreeOnRowPlacement", "[folding]")
+{
+    // The property the whole design rests on, pinned directly: the rows Grid::render draws and the rows
+    // the coordinate translation reports must be the same rows, on the same screen lines. They are
+    // computed by different code, and a disagreement misplaces a selection rather than crashing.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2", "file3" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    auto const rows = mc.terminal.foldProjection();
+    REQUIRE(!rows.empty());
+
+    // Grid::render places the list by min(0, pageLines - size): here the walk ran out of grid at the
+    // top, so the rows start at the top and the page is short at the bottom.
+    auto const top = std::min(0, unbox<int>(mc.terminal.pageSize().lines) - static_cast<int>(rows.size()));
+    CHECK(mc.terminal.foldProjectionTopRow() == LineOffset(top));
+
+    for (auto i = size_t { 0 }; i < rows.size(); ++i)
+        CHECK(mc.terminal.viewport().translateScreenToGridLine(LineOffset(top + static_cast<int>(i)))
+              == rows[i]);
+}
+
+TEST_CASE("Folding.terminal.newMarksInvalidateTheCachedRanges", "[folding]")
+{
+    // The grid's own identity cannot stand in for a marks change: a second command on a page that has
+    // not scrolled moves neither the generation nor the stable base, so a cache keyed on those alone
+    // would go on reporting the ranges from before it finished.
+    auto mc = MockTerm { PageSize { LineCount(40), ColumnCount(20) } };
+
+    runCommand(mc, "ls", { "file1" });
+    REQUIRE(mc.terminal.foldRanges().size() == 1);
+
+    // No scrolling has happened -- the page is far taller than what has been written.
+    REQUIRE(mc.terminal.primaryScreen().historyLineCount() == LineCount(0));
+
+    runCommand(mc, "pwd", { "/tmp" });
+    CHECK(mc.terminal.foldRanges().size() == 2);
+}
+
+TEST_CASE("Folding.terminal.hiddenLinesAreNotVisible", "[folding]")
+{
+    // isLineVisible cannot be an interval test once folds are in play: a hidden line sits INSIDE the
+    // span of drawn rows, so a bounds check would call it visible and the vi cursor would be placed on
+    // a row that is not on screen.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const& viewport = mc.terminal.viewport();
+    REQUIRE(viewport.isLineVisible(LineOffset(1)));
+    REQUIRE(viewport.isLineVisible(LineOffset(2)));
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    // The prompt is still drawn; the output between it and the rows below is not.
+    CHECK(viewport.isLineVisible(LineOffset(0)));
+    CHECK(!viewport.isLineVisible(LineOffset(1)));
+    CHECK(!viewport.isLineVisible(LineOffset(2)));
+}
+
+TEST_CASE("Folding.terminal.linesAboveTheViewportReportOffScreen", "[folding]")
+{
+    // A line scrolled out of sight above must translate to a NEGATIVE screen row, not to the top one:
+    // cursor-line and search-match highlighting ask this question, and answering "row zero" would paint
+    // the highlight on an unrelated line.
+    auto mc = MockTerm { PageSize { LineCount(5), ColumnCount(20) }, LineCount(50) };
+    for (auto i = 0; i < 20; ++i)
+        mc.writeToScreen(std::format("filler {}\r\n", i));
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    auto const projection = mc.terminal.foldProjection();
+    REQUIRE(!projection.empty());
+
+    // One line above the topmost drawn row is one row above the viewport.
+    auto const above = projection.front() - LineOffset(1);
+    CHECK(mc.terminal.viewport().translateGridToScreenCoordinate(above) < mc.terminal.foldProjectionTopRow());
+    CHECK(!mc.terminal.viewport().isLineVisible(above));
+}
+
+TEST_CASE("Folding.terminal.headCarriesTheMarker", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    // Exactly one visible row is a collapsed head, and it is the prompt line the fold hangs off.
+    auto collapsedHeads = 0;
+    for (auto const row: mc.terminal.foldProjection())
+        if (mc.terminal.foldMarkerAt(row) == FoldMarker::Collapsed)
+            ++collapsedHeads;
+    CHECK(collapsedHeads == 1);
+}
+
+TEST_CASE("Folding.terminal.gutterDrawsAFoldColumnOverTheWholeBlock", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    mc.terminal.settings().foldMarkers = true;
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto buffer = RenderBuffer {};
+    mc.terminal.fillRenderBuffer(buffer, /*includeSelection*/ true);
+
+    // An expanded fold draws a COLUMN, not a lone marker: the head, a bar beside every output row, and
+    // a corner closing it. That extent is what tells the user how far the block reaches -- and it is
+    // what the mouse can hit, which one cell on the prompt row was not.
+    REQUIRE(buffer.gutter.size() == 3);
+
+    // Expanded: the output is showing, and the marker points down at it.
+    CHECK(buffer.gutter[0].codepoint == foldMarkerGlyph(FoldMarker::Expanded));
+    // On the prompt row, which is the top of the page here.
+    CHECK(buffer.gutter[0].lineOffset == LineOffset(0));
+
+    CHECK(buffer.gutter[1].codepoint == foldMarkerGlyph(FoldMarker::Body));
+    CHECK(buffer.gutter[1].lineOffset == LineOffset(1));
+
+    CHECK(buffer.gutter[2].codepoint == foldMarkerGlyph(FoldMarker::BodyEnd));
+    CHECK(buffer.gutter[2].lineOffset == LineOffset(2));
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+
+    buffer.clear();
+    mc.terminal.fillRenderBuffer(buffer, /*includeSelection*/ true);
+
+    // Collapsed, the column is one cell: the rows it would have spanned are the rows it now hides.
+    REQUIRE(buffer.gutter.size() == 1);
+    CHECK(buffer.gutter[0].codepoint == foldMarkerGlyph(FoldMarker::Collapsed));
+    CHECK(buffer.gutter[0].lineOffset == LineOffset(0));
+}
+
+TEST_CASE("Folding.terminal.gutterSitsBesideTheGridUnderATopStatusLine", "[folding]")
+{
+    // The gutter is drawn in SCREEN rows, and a status line above the grid pushes the page down. The
+    // markers must move with it -- and, more to the point, whatever maps a pixel back has to apply
+    // the same shift, which is what Terminal::mainPageTopRow() states once for both directions.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    mc.terminal.settings().foldMarkers = true;
+    mc.terminal.settings().statusDisplayPosition = StatusDisplayPosition::Top;
+    mc.terminal.setStatusDisplay(StatusDisplayType::Indicator);
+
+    auto const topRow = mc.terminal.mainPageTopRow();
+    REQUIRE(topRow == mc.terminal.statusLineHeight().as<LineOffset>());
+    REQUIRE(topRow > LineOffset(0));
+
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto buffer = RenderBuffer {};
+    mc.terminal.fillRenderBuffer(buffer, /*includeSelection*/ true);
+
+    REQUIRE(buffer.gutter.size() == 3);
+
+    // The fold head is on main-page row 0, which is drawn at screen row `topRow`.
+    CHECK(buffer.gutter[0].lineOffset == topRow);
+    CHECK(buffer.gutter[1].lineOffset == topRow + LineOffset(1));
+    CHECK(buffer.gutter[2].lineOffset == topRow + LineOffset(2));
+    CHECK(buffer.gutter[0].codepoint == foldMarkerGlyph(FoldMarker::Expanded));
+}
+
+TEST_CASE("Folding.terminal.hoveringTheGutterLightsTheWholeRun", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    mc.terminal.settings().foldMarkers = true;
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const unhovered = [&] {
+        auto buffer = RenderBuffer {};
+        mc.terminal.fillRenderBuffer(buffer, true);
+        return buffer.gutter;
+    }();
+    REQUIRE(unhovered.size() == 3);
+
+    // Hovering the BODY, not the head: the whole run is one control, so pointing anywhere on it has to
+    // light all of it up -- that is what says how much a click is about to act on.
+    mc.terminal.setGutterHoverLine(LineOffset(1));
+
+    auto buffer = RenderBuffer {};
+    mc.terminal.fillRenderBuffer(buffer, true);
+    REQUIRE(buffer.gutter.size() == 3);
+    for (size_t i = 0; i < buffer.gutter.size(); ++i)
+    {
+        CHECK(buffer.gutter[i].codepoint == unhovered[i].codepoint);
+
+        // The glyph is what lights up, and it is the ONLY thing that does: the background stays the
+        // page's own in both states, so nothing paints a band down the side of the block.
+        CHECK(buffer.gutter[i].attributes.foregroundColor != unhovered[i].attributes.foregroundColor);
+        CHECK(buffer.gutter[i].attributes.backgroundColor == unhovered[i].attributes.backgroundColor);
+
+        // Recolorized, not inverted -- what the render path has to carry, as opposed to what the
+        // derivation decides (@see ColorPalette.foldMarker.hoverRecolorizesRatherThanInverts). A
+        // restored swap puts the page background here, which is exactly the resting background.
+        CHECK(buffer.gutter[i].attributes.foregroundColor != unhovered[i].attributes.backgroundColor);
+    }
+
+    mc.terminal.setGutterHoverLine(std::nullopt);
+    buffer.clear();
+    mc.terminal.fillRenderBuffer(buffer, true);
+    REQUIRE(buffer.gutter.size() == 3);
+    CHECK(buffer.gutter[0].attributes.foregroundColor == unhovered[0].attributes.foregroundColor);
+}
+
+TEST_CASE("Folding.terminal.togglingFromAnyLineOfTheBlock", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+
+    // A user points at the OUTPUT they want gone, not at the prompt line it hangs off -- so a body row
+    // toggles the block it belongs to rather than declining because it is not the head.
+    CHECK(mc.terminal.foldMarkerAt(LineOffset(2)) == FoldMarker::BodyEnd);
+    CHECK(mc.terminal.toggleFoldContaining(LineOffset(2)));
+    CHECK(mc.terminal.foldState().isCollapsed(ranges[0].headStableId));
+
+    // And back, from the head this time.
+    CHECK(mc.terminal.toggleFoldContaining(LineOffset(0)));
+    CHECK(!mc.terminal.foldState().isCollapsed(ranges[0].headStableId));
+
+    // A line no fold reaches toggles nothing.
+    CHECK(!mc.terminal.toggleFoldContaining(LineOffset(9)));
+}
+
+TEST_CASE("Folding.terminal.noGutterWithoutMarkersOrWithoutFolds", "[folding]")
+{
+    // Two ways to cost nothing: markers switched off, and a shell that leaves no marks at all -- the
+    // overwhelmingly common case, and the one that must not pay for a scan it cannot use.
+    SECTION("markers off")
+    {
+        auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+        mc.terminal.settings().foldMarkers = false;
+        runCommand(mc, "ls", { "file1", "file2" });
+
+        auto buffer = RenderBuffer {};
+        mc.terminal.fillRenderBuffer(buffer, true);
+        CHECK(buffer.gutter.empty());
+    }
+
+    SECTION("no shell integration")
+    {
+        auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+        mc.terminal.settings().foldMarkers = true;
+        mc.writeToScreen("just some output\r\nand more\r\n");
+
+        auto buffer = RenderBuffer {};
+        mc.terminal.fillRenderBuffer(buffer, true);
+        CHECK(buffer.gutter.empty());
+    }
+}
+
+TEST_CASE("Folding.terminal.reflowClearsTheFoldState", "[folding]")
+{
+    // A resize that reflows destroys row identity wholesale, so every collapsed id now names a different
+    // row, or none. Guessing would collapse the wrong block.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(!mc.terminal.foldState().empty());
+
+    mc.terminal.resizeScreen(PageSize { LineCount(10), ColumnCount(10) });
+    mc.terminal.refreshFoldState();
+
+    CHECK(mc.terminal.foldState().empty());
+    CHECK(mc.terminal.foldProjection().empty());
+}
+
+TEST_CASE("Folding.terminal.alternateScreenIsNeverFolded", "[folding]")
+{
+    // An alt-screen application owns the whole page and paints no prompt into it; the primary screen's
+    // marks say nothing about what is on display.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(!mc.terminal.foldProjection().empty());
+
+    mc.writeToScreen("\033[?1049h");
+
+    CHECK(mc.terminal.foldProjection().empty());
+    CHECK(mc.terminal.hiddenLineCount() == LineCount(0));
+}
+
+// }}}
+
+// }}}
+// {{{ Vi normal mode
+
+namespace
+{
+
+/// A terminal in Vi normal mode showing one finished command, with that command's fold collapsed.
+///
+/// Layout, on a 10-line page: row 0 is the prompt line `$ ls` (the fold head), rows 1 and 2 are its
+/// output, and row 3 onwards is where the next prompt would go. Collapsed, rows 1 and 2 are hidden,
+/// so the visible rows are 0, 3, 4, ...
+[[nodiscard]] auto setupViMock(bool collapse)
+{
+    // Built as a prvalue with an init callback, exactly as ViCommands_test's setupMockTerminal does:
+    // MockTerm owns a Terminal and is neither copyable nor movable, so it can only be RETURNED by
+    // being constructed in the return statement.
+    return MockTerm<> { PageSize { LineCount(10), ColumnCount(20) },
+                        LineCount(0),
+                        1024,
+                        [collapse](MockTerm<>& mc) {
+                            runCommand(mc, "ls", { "file1", "file2" });
+                            auto const ranges = mc.terminal.foldRanges();
+                            REQUIRE(ranges.size() == 1);
+                            if (collapse)
+                                mc.terminal.foldState().collapse(ranges[0].headStableId);
+                            mc.terminal.inputHandler().setMode(ViMode::Normal);
+                        } };
+}
+
+/// Puts the Vi cursor on @p line without going through a motion.
+void placeViCursor(MockTerm<>& mc, LineOffset line)
+{
+    mc.terminal.moveNormalModeCursorTo(CellLocation { .line = line, .column = ColumnOffset(0) });
+    REQUIRE(mc.terminal.normalModeCursorPosition().line == line);
+}
+
+} // namespace
+
+TEST_CASE("Folding.vi.jStepsOverACollapsedBlock", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ true);
+    placeViCursor(mc, LineOffset(0));
+
+    // One `j` from the fold head lands on the line the block CONTINUES at, not on the first row it
+    // hides -- which is where the cursor used to vanish.
+    mc.sendCharSequence("j");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(3));
+
+    mc.sendCharSequence("j");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(4));
+}
+
+TEST_CASE("Folding.vi.kStepsOverACollapsedBlock", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ true);
+    placeViCursor(mc, LineOffset(3));
+
+    mc.sendCharSequence("k");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(0));
+}
+
+TEST_CASE("Folding.vi.countsAreInVisibleLines", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ true);
+    placeViCursor(mc, LineOffset(0));
+
+    // `2j` means two rows the user can SEE. Counting grid lines instead would land on row 2, inside
+    // the collapsed block.
+    mc.sendCharSequence("2j");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(4));
+}
+
+TEST_CASE("Folding.vi.anExpandedBlockIsWalkedNormally", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ false);
+    placeViCursor(mc, LineOffset(0));
+
+    // Nothing is collapsed, so every grid line is a visible line and `j` is the step it always was.
+    mc.sendCharSequence("j");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(1));
+    mc.sendCharSequence("j");
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(2));
+}
+
+TEST_CASE("Folding.vi.theCursorNeverRestsOnAHiddenLine", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ false);
+
+    // Park the cursor inside the block, THEN collapse it underneath -- the one way a fold-aware motion
+    // cannot prevent a hidden cursor, and so the case the collapse-time snap exists for.
+    placeViCursor(mc, LineOffset(2));
+    REQUIRE(mc.terminal.toggleFoldContaining(LineOffset(2)));
+
+    CHECK(mc.terminal.viewport().isLineVisible(mc.terminal.normalModeCursorPosition().line));
+    CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(3));
+}
+
+TEST_CASE("Folding.vi.aResizeDoesNotStrandTheCursorInAFold", "[folding][vi]")
+{
+    auto mc = setupViMock(/*collapse*/ false);
+    placeViCursor(mc, LineOffset(6));
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(!mc.terminal.foldRanges().empty());
+
+    // SHRINKING the page shifts the Vi cursor UP by the line delta, and that shift is fold-blind:
+    // here it lands the cursor on grid line 1, inside the collapsed block, where it renders as
+    // nothing at all. Columns are unchanged so nothing reflows and the fold survives the resize.
+    mc.terminal.resizeScreen(PageSize { LineCount(5), ColumnCount(20) });
+    REQUIRE(!mc.terminal.foldRanges().empty());
+
+    CHECK(mc.terminal.viewport().isLineVisible(mc.terminal.normalModeCursorPosition().line));
+}
+
+TEST_CASE("Folding.vi.jumpIntoAFoldExpandsOrSkips", "[folding][vi]")
+{
+    SECTION("expand")
+    {
+        auto mc = setupViMock(/*collapse*/ true);
+        mc.terminal.settings().foldJumpBehavior = FoldJumpBehavior::Expand;
+        placeViCursor(mc, LineOffset(0));
+
+        // A jump that NAMES a hidden line opens the block, so the cursor lands on what it was aiming
+        // at rather than somewhere near it.
+        mc.terminal.moveNormalModeCursorTo(CellLocation { .line = LineOffset(2), .column = ColumnOffset(0) });
+
+        CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(2));
+        CHECK(!mc.terminal.foldState().isCollapsed(mc.terminal.foldRanges()[0].headStableId));
+    }
+
+    SECTION("skip")
+    {
+        auto mc = setupViMock(/*collapse*/ true);
+        mc.terminal.settings().foldJumpBehavior = FoldJumpBehavior::Skip;
+        auto const headStableId = mc.terminal.foldRanges()[0].headStableId;
+        placeViCursor(mc, LineOffset(0));
+
+        mc.terminal.moveNormalModeCursorTo(CellLocation { .line = LineOffset(2), .column = ColumnOffset(0) });
+
+        // The block stays shut, and the cursor stops at the line it continues at.
+        CHECK(mc.terminal.foldState().isCollapsed(headStableId));
+        CHECK(mc.terminal.normalModeCursorPosition().line == LineOffset(3));
+    }
+}
+
+namespace
+{
+
+/// A terminal in Vi normal mode with every block of a deep scrollback collapsed.
+///
+/// Thirty blocks of four lines each, of which three are hidden once collapsed: a hundred and twenty
+/// grid lines, thirty of them visible, on a ten-line page -- so there are twenty visible rows to scroll
+/// through and roughly ninety grid lines hidden among them. That gap between the two counts is the
+/// whole point of the fixture; a viewport where they agree cannot show the bug.
+///
+/// `scrolloff` is dialled down to 2, because the default 8 on a ten-line page leaves a safe area with
+/// no interior and every motion would scroll.
+[[nodiscard]] auto setupViScrollMock()
+{
+    return MockTerm<> {
+        PageSize { LineCount(10), ColumnCount(20) },
+        LineCount(200),
+        1024,
+        [](MockTerm<>& mc) {
+            for (auto const i: std::views::iota(0, 30))
+                runCommand(mc,
+                           std::format("cmd{}", i),
+                           { std::format("out{}a", i), std::format("out{}b", i), std::format("out{}c", i) });
+            mc.terminal.viewport().setScrollOff(LineCount(2));
+            REQUIRE(mc.terminal.collapseAllFolds());
+            REQUIRE(mc.terminal.viewport().scrollableLineCount() > LineCount(0));
+            REQUIRE(mc.terminal.hiddenLineCount() > mc.terminal.viewport().scrollableLineCount());
+            mc.terminal.inputHandler().setMode(ViMode::Normal);
+        }
+    };
+}
+
+} // namespace
+
+TEST_CASE("Folding.vi.kWalksUpThroughFoldedHistoryWithoutFallingBack", "[folding][vi]")
+{
+    // The reported symptom, end to end: fold everything, then hold `k`. Each press must take the cursor
+    // one visible row UP and leave it there.
+    //
+    // What it used to do instead: the press that finally scrolls runs Terminal::onViewportChanged(),
+    // whose clamp bounded the cursor by -scrollOffset -- a count of VISIBLE rows read as a grid line,
+    // which with ninety hidden lines in between names a row well below the page. So every scrolling `k`
+    // threw the cursor back down towards the bottom, and the next one climbed out of the same hole.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+
+    placeViCursor(mc,
+                  terminal.viewport().translateScreenToGridLine(
+                      boxed_cast<LineOffset>(terminal.pageSize().lines) - LineOffset(1)));
+
+    auto previous = terminal.normalModeCursorPosition().line;
+    for (auto const press: std::views::iota(0, 25))
+    {
+        CAPTURE(press, previous);
+        mc.sendCharSequence("k");
+
+        auto const current = terminal.normalModeCursorPosition().line;
+        REQUIRE(current < previous);
+        REQUIRE(terminal.viewport().isLineVisible(current));
+        previous = current;
+    }
+}
+
+TEST_CASE("Folding.vi.jWalksDownThroughFoldedHistoryWithoutFallingBack", "[folding][vi]")
+{
+    // The mirror, from the top: `j` scrolls the viewport down and the same clamp fired there too.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+
+    REQUIRE(terminal.viewport().scrollToTop());
+    placeViCursor(mc, terminal.foldProjection().front());
+
+    auto previous = terminal.normalModeCursorPosition().line;
+    for (auto const press: std::views::iota(0, 25))
+    {
+        CAPTURE(press, previous);
+        mc.sendCharSequence("j");
+
+        auto const current = terminal.normalModeCursorPosition().line;
+        REQUIRE(current > previous);
+        REQUIRE(terminal.viewport().isLineVisible(current));
+        previous = current;
+    }
+}
+
+TEST_CASE("Folding.vi.aPlainMotionNeverOpensAFold", "[folding][vi]")
+{
+    // A motion is computed in visible lines and so never lands inside a fold -- but it lands off SCREEN
+    // all the time, on any step the viewport has yet to scroll to. Asking "is it on screen" instead of
+    // "does a fold hide it" sent those down the jump-target path, which under the default
+    // FoldJumpBehavior::Expand opened whichever block the cursor stepped onto.
+    auto const behavior = GENERATE(vtbackend::FoldJumpBehavior::Expand, vtbackend::FoldJumpBehavior::Skip);
+    CAPTURE(behavior);
+
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+    terminal.settings().foldJumpBehavior = behavior;
+
+    auto const hiddenBefore = terminal.hiddenLineCount();
+    auto const revisionBefore = terminal.foldState().revision();
+
+    SECTION("a counted motion reaching past the top of the viewport")
+    {
+        placeViCursor(mc, terminal.foldProjection().back());
+        mc.sendCharSequence("15k");
+    }
+
+    SECTION("stepping at the very top of the scrollback, where the viewport can scroll no further")
+    {
+        REQUIRE(terminal.viewport().scrollToTop());
+        placeViCursor(mc, terminal.foldProjection().front());
+        for ([[maybe_unused]] auto const press: std::views::iota(0, 5))
+            mc.sendCharSequence("k");
+    }
+
+    CHECK(terminal.hiddenLineCount() == hiddenBefore);
+    CHECK(terminal.foldState().revision() == revisionBefore);
+    CHECK(terminal.viewport().isLineVisible(terminal.normalModeCursorPosition().line));
+}
+
+TEST_CASE("Folding.vi.aJumpAboveTheViewportScrollsByVisibleRows", "[folding][vi]")
+{
+    // A named jump -- a search hit, a mark -- to a line a few visible rows above the viewport. The
+    // scroll it asks for is measured in screen rows, so reporting the distance in GRID lines asked for
+    // one ninety rows long, which scrollUp() clamps to the top: the jump landed at the top of the
+    // scrollback rather than on its target.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+
+    placeViCursor(mc, terminal.foldProjection().front());
+    auto const target =
+        terminal.advanceVisibleLines(terminal.foldProjection().front(), 4, VerticalDirection::Up);
+
+    terminal.moveNormalModeCursorTo(CellLocation { .line = target, .column = ColumnOffset(0) });
+
+    CHECK(terminal.normalModeCursorPosition().line == target);
+    CHECK(terminal.viewport().isLineVisible(target));
+
+    // Landed inside the safe area, not slammed against the top of the scrollable range.
+    CHECK(terminal.viewport().translateGridToScreenCoordinate(target)
+          == boxed_cast<LineOffset>(terminal.viewport().scrollOff()));
+    CHECK(terminal.viewport().scrollOffset()
+          < boxed_cast<ScrollOffset>(terminal.viewport().scrollableLineCount()));
+}
+
+TEST_CASE("Folding.viewport.clampsToTheRowsTheProjectionDraws", "[folding]")
+{
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+    auto& viewport = terminal.viewport();
+
+    REQUIRE(viewport.scrollTo(boxed_cast<ScrollOffset>(viewport.scrollableLineCount()) / 2));
+    auto const projection = terminal.foldProjection();
+    REQUIRE(projection.size() > 1);
+
+    auto const clampLine = [&](LineOffset line) {
+        return viewport.clampCellLocation(CellLocation { .line = line, .column = ColumnOffset(0) }).line;
+    };
+
+    // The bounds are the projection's own ends. -scrollOffset is a count of visible rows and names a
+    // grid line BELOW the bottom of the page here, which is what dragged the Vi cursor down.
+    REQUIRE(-boxed_cast<LineOffset>(viewport.scrollOffset()) > projection.back());
+
+    CHECK(clampLine(projection.front() - LineOffset(50)) == projection.front());
+    CHECK(clampLine(projection.back() + LineOffset(50)) == projection.back());
+    CHECK(clampLine(projection[projection.size() / 2]) == projection[projection.size() / 2]);
+}
+
+TEST_CASE("Folding.viewport.rowsOffTheProjectionAreVisibleLinesToo", "[folding]")
+{
+    // The rows above and below what is drawn are what a selection dragged past the edge reaches, and
+    // what a jump measures its scroll against. They continue the projection, so they continue it in
+    // VISIBLE lines: naming whichever grid line happens to sit there would hand a selection rows a
+    // collapsed block hides, and would misreport the distance by however many of them there are.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+    auto& viewport = terminal.viewport();
+
+    REQUIRE(viewport.scrollTo(boxed_cast<ScrollOffset>(viewport.scrollableLineCount()) / 2));
+
+    auto const projection = terminal.foldProjection();
+    REQUIRE(projection.size() == unbox<size_t>(terminal.pageSize().lines)); // so screen row == index
+
+    for (auto const distance: std::views::iota(1, 4))
+    {
+        CAPTURE(distance);
+
+        auto const aboveRow = LineOffset(-distance);
+        auto const above = viewport.translateScreenToGridLine(aboveRow);
+        CHECK(above == terminal.advanceVisibleLines(projection.front(), distance, VerticalDirection::Up));
+        CHECK_FALSE(terminal.isLineHiddenByFold(above));
+        CHECK(viewport.translateGridToScreenCoordinate(above) == aboveRow);
+
+        auto const belowRow = boxed_cast<LineOffset>(terminal.pageSize().lines) + LineOffset(distance - 1);
+        auto const below = viewport.translateScreenToGridLine(belowRow);
+        CHECK(below == terminal.advanceVisibleLines(projection.back(), distance, VerticalDirection::Down));
+        CHECK_FALSE(terminal.isLineHiddenByFold(below));
+        CHECK(viewport.translateGridToScreenCoordinate(below) == belowRow);
+    }
+}
+
+TEST_CASE("Folding.viewport.clampIsThePlainIntervalWithNothingCollapsed", "[folding]")
+{
+    // The unfolded fast path is the arithmetic it always was, and stays it.
+    auto mc = MockTerm { PageSize { LineCount(5), ColumnCount(20) }, LineCount(50) };
+    for (auto const i: std::views::iota(0, 20))
+        mc.writeToScreen(std::format("history{}\r\n", i));
+
+    auto& viewport = mc.terminal.viewport();
+    REQUIRE(viewport.scrollTo(ScrollOffset(3)));
+    REQUIRE(mc.terminal.foldProjection().empty());
+
+    auto const clampLine = [&](LineOffset line) {
+        return viewport.clampCellLocation(CellLocation { .line = line, .column = ColumnOffset(0) }).line;
+    };
+
+    CHECK(clampLine(LineOffset(-20)) == LineOffset(-3));
+    CHECK(clampLine(LineOffset(20)) == LineOffset(1)); // 5 - 1 - 3
+    CHECK(clampLine(LineOffset(-1)) == LineOffset(-1));
+}
+
+// }}}
+
+// {{{ Scroll bounds under folds
+
+namespace
+{
+
+/// A terminal with enough collapsible blocks scrolled off into history that folding every one of them
+/// still leaves rows to scroll through, and a cell size set so the smooth-scroll accumulator has
+/// something to work with.
+///
+/// Each block contributes four lines and hides three, so the scrollable range after a fold-all is the
+/// block count less the page -- which is why there are this many of them.
+MockTerm<> setupScrollMock()
+{
+    return MockTerm<> { PageSize { LineCount(5), ColumnCount(20) }, LineCount(100), 1024, [](auto& mock) {
+                           for (auto const i: std::views::iota(0, 20))
+                               runCommand(mock,
+                                          std::format("cmd{}", i),
+                                          { std::format("out{}a", i),
+                                            std::format("out{}b", i),
+                                            std::format("out{}c", i) });
+                           mock.terminal.setCellPixelSize(
+                               vtbackend::ImageSize { vtpty::Width(10), vtpty::Height(20) });
+                       } };
+}
+
+} // namespace
+
+TEST_CASE("Folding.scroll.collapsingReclampsAViewportScrolledPastTheNewTop", "[folding][scroll]")
+{
+    auto mc = setupScrollMock();
+    auto& terminal = mc.terminal;
+
+    REQUIRE(terminal.viewport().scrollToTop());
+    auto const unfoldedTop = terminal.viewport().scrollOffset();
+    REQUIRE(unfoldedTop > ScrollOffset(0));
+
+    // Collapsing takes rows out of the scrollable range underneath a viewport already sitting at the
+    // old top. Nothing else corrects that: scrollTo() REJECTS an out-of-range request rather than
+    // repairing an offset already stored, so an unclamped viewport would be parked where every
+    // subsequent scroll is refused -- and the smooth-scroll remainder would go on cycling there.
+    REQUIRE(terminal.collapseAllFolds());
+    REQUIRE(terminal.hiddenLineCount() > LineCount(0));
+
+    CHECK(terminal.viewport().scrollOffset()
+          == boxed_cast<ScrollOffset>(terminal.viewport().scrollableLineCount()));
+    CHECK(terminal.viewport().scrollOffset() < unfoldedTop);
+    CHECK(terminal.smoothScrollPixelOffset() == 0.0f);
+}
+
+TEST_CASE("Folding.scroll.smoothScrollSettlesAtTheFoldAwareTop", "[folding][scroll]")
+{
+    auto mc = setupScrollMock();
+    auto& terminal = mc.terminal;
+
+    REQUIRE(terminal.collapseAllFolds());
+    auto const top = boxed_cast<ScrollOffset>(terminal.viewport().scrollableLineCount());
+    REQUIRE(top > ScrollOffset(0));
+    REQUIRE(terminal.viewport().scrollableLineCount()
+            < terminal.primaryScreen().historyLineCount()); // else the bound would not differ
+
+    // Push past the top a third of a cell at a time, and pin the position on EVERY step. Bounded by the
+    // raw history instead of the scrollable count, the accumulator goes on handing scrollTo() offsets it
+    // rejects while still storing a sub-cell remainder that wraps through a whole cell height as it
+    // goes -- so the viewport stands still while the page slides up and snaps back, which is the
+    // flicker. The end state alone would not catch it: the remainder is zero again by the time the
+    // count has run past the raw history depth.
+    auto reachedTop = false;
+    for (auto const step: std::views::iota(0, 300))
+    {
+        CAPTURE(step);
+        REQUIRE(terminal.applySmoothScrollPixelDelta(7.0f) == SmoothScrollResult::Applied);
+        REQUIRE(terminal.viewport().scrollOffset() <= top);
+
+        reachedTop = reachedTop || terminal.viewport().scrollOffset() == top;
+        if (reachedTop)
+        {
+            REQUIRE(terminal.viewport().scrollOffset() == top);
+            REQUIRE(terminal.smoothScrollPixelOffset() == 0.0f);
+        }
+    }
+
+    CHECK(reachedTop);
+}
+
+TEST_CASE("Folding.scroll.momentumStopsAtTheFoldAwareTop", "[folding][scroll]")
+{
+    auto mc = setupScrollMock();
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+
+    REQUIRE(terminal.collapseAllFolds());
+    auto const top = boxed_cast<ScrollOffset>(terminal.viewport().scrollableLineCount());
+    REQUIRE(top > ScrollOffset(0));
+
+    terminal.handleScrollPhase(ScrollPhase::Begin, 0.0f, ClockBase);
+    for (auto const i: std::views::iota(1, 4))
+        terminal.handleScrollPhase(ScrollPhase::Update, 200.0f, ClockBase + chrono::milliseconds(i * 10));
+    terminal.handleScrollPhase(ScrollPhase::End, 0.0f, ClockBase + 40ms);
+
+    // The glide has to END at the top. Its stop rule is "the viewport did not move this frame", which a
+    // remainder still wobbling inside a frozen scroll offset would satisfy on no frame at all.
+    for (auto const i: std::views::iota(0, 600))
+        terminal.tick(ClockBase + 56ms + chrono::milliseconds(i * 16));
+
+    CHECK_FALSE(terminal.isMomentumScrollActive());
+    CHECK(terminal.viewport().scrollOffset() == top);
+    CHECK(terminal.smoothScrollPixelOffset() == 0.0f);
+}
+
+TEST_CASE("Folding.scroll.aGlideToTheTopAndBackNeverJitters", "[folding][scroll]")
+{
+    // The reported symptom, end to end: fold everything, wheel to the top, wheel back down. The
+    // viewport's position is scroll offset AND sub-cell remainder together, and what reads as a
+    // flicker is that combined position moving BACKWARDS between frames while the glide continues.
+    auto mc = setupScrollMock();
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    auto constexpr CellHeight = 20.0f;
+
+    REQUIRE(terminal.collapseAllFolds());
+    auto const top = boxed_cast<ScrollOffset>(terminal.viewport().scrollableLineCount());
+    REQUIRE(top > ScrollOffset(0));
+
+    auto const positionPx = [&] {
+        return (static_cast<float>(terminal.viewport().scrollOffset().value) * CellHeight)
+               + terminal.smoothScrollPixelOffset();
+    };
+
+    auto const glide = [&](float velocityPx, auto&& stillGoing) {
+        terminal.handleScrollPhase(ScrollPhase::Begin, 0.0f, ClockBase);
+        for (auto const i: std::views::iota(1, 4))
+            terminal.handleScrollPhase(
+                ScrollPhase::Update, velocityPx, ClockBase + chrono::milliseconds(i * 10));
+        terminal.handleScrollPhase(ScrollPhase::End, 0.0f, ClockBase + 40ms);
+
+        auto previous = positionPx();
+        for (auto const frame: std::views::iota(0, 600))
+        {
+            CAPTURE(frame);
+            terminal.tick(ClockBase + 56ms + chrono::milliseconds(frame * 16));
+            auto const current = positionPx();
+            CHECK(stillGoing(previous, current));
+            previous = current;
+        }
+    };
+
+    glide(200.0f, [](float previous, float current) { return current >= previous; });
+    CHECK_FALSE(terminal.isMomentumScrollActive());
+    CHECK(terminal.viewport().scrollOffset() == top);
+
+    glide(-200.0f, [](float previous, float current) { return current <= previous; });
+    CHECK_FALSE(terminal.isMomentumScrollActive());
+    CHECK(terminal.viewport().scrollOffset() == ScrollOffset(0));
+    CHECK(terminal.smoothScrollPixelOffset() == 0.0f);
+}
+
+// }}}
+
+// {{{ Invariants a fold has to keep against the rest of the terminal
+
+TEST_CASE("Folding.terminal.aReflowDropsTheFoldState", "[folding]")
+{
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(!mc.terminal.foldState().empty());
+
+    // A COLUMN change reflows, which destroys row identity wholesale: every id the fold state holds
+    // now names a different row, or none. Resizing also reads the ranges on its way through (the Vi
+    // cursor snap does), so the reconciliation cannot key on the ranges' own cache stamp -- that stamp
+    // is already up to date by the time the next frame asks, and the wrong block stays collapsed.
+    auto const generationBefore = mc.terminal.primaryScreen().grid().generation();
+    mc.terminal.resizeScreen(PageSize { LineCount(10), ColumnCount(40) });
+    REQUIRE(mc.terminal.primaryScreen().grid().generation() != generationBefore);
+
+    // The reads that get there first in practice: the resize's own Vi-cursor snap, a mouse move over
+    // the gutter mid-drag, a selection translating a coordinate. Any one of them refreshes the RANGES'
+    // cache stamp, so the reconciliation must not be keyed on it.
+    (void) mc.terminal.foldRanges();
+
+    mc.terminal.refreshFoldState();
+    CHECK(mc.terminal.foldState().empty());
+}
+
+TEST_CASE("Folding.terminal.aShortProjectionStaysInsideTheGrid", "[folding]")
+{
+    // Collapse enough that fewer rows are left than the page has. The screen rows below what is drawn
+    // still have to map onto lines the grid HAS: Grid::rowAt indexes a ring buffer, so a line past the
+    // bottom would read unrelated storage rather than fail.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "seq", { "1", "2", "3", "4", "5", "6", "7" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(mc.terminal.foldProjection().size() < unbox<size_t>(mc.terminal.pageSize().lines));
+
+    auto const& grid = mc.terminal.primaryScreen().grid();
+    auto const bottom = boxed_cast<LineOffset>(mc.terminal.pageSize().lines) - LineOffset(1);
+    for (auto const row: std::views::iota(0, unbox<int>(mc.terminal.pageSize().lines)))
+    {
+        CAPTURE(row);
+        auto const line = mc.terminal.viewport().translateScreenToGridLine(LineOffset(row));
+        CHECK(line >= grid.addressableTop());
+        CHECK(line <= bottom);
+    }
+}
+
+TEST_CASE("Folding.terminal.gridToScreenStaysOrderedBelowTheProjection", "[folding]")
+{
+    // makeVisibleWithinSafeArea measures the distance to scroll in SCREEN rows. Reporting a flat
+    // "one past the bottom" for everything under the viewport would make every downward jump advance by
+    // the safe-area padding and stop, however far away the target actually is.
+    //
+    // And the distance has to be counted in VISIBLE rows for the same reason: a scroll travels in rows
+    // the user can see, so a difference of grid lines -- most of them hidden here -- names a scroll far
+    // longer than the one that would bring the target into view.
+    auto mc = setupScrollMock();
+    auto const& terminal = mc.terminal;
+    REQUIRE(mc.terminal.collapseAllFolds());
+    REQUIRE(mc.terminal.viewport().scrollToTop());
+
+    auto const projection = terminal.foldProjection();
+    REQUIRE(!projection.empty());
+
+    auto const bottom = projection.back();
+    auto const screenRowOf = [&](LineOffset line) {
+        return terminal.viewport().translateGridToScreenCoordinate(line);
+    };
+
+    auto const near = screenRowOf(bottom + LineOffset(1));
+    auto const far = screenRowOf(bottom + LineOffset(20));
+
+    CHECK(near > screenRowOf(bottom));
+    CHECK(far > near);
+    CHECK(far - near
+          == LineOffset(terminal.visibleDistance(bottom + LineOffset(1), bottom + LineOffset(20))));
+
+    // And that really is fewer rows than the twenty grid lines between them -- otherwise the two
+    // quantities would coincide and the assertion above would prove nothing.
+    CHECK(far - near < LineOffset(19));
+}
+
+TEST_CASE("Folding.terminal.theAlternateScreenKeepsTheViCursorOnItsOwnGrid", "[folding][vi]")
+{
+    // Vi normal mode runs on the alternate screen too, and that grid has no scrollback. Bounds taken
+    // from the PRIMARY grid would let `k` walk the cursor to a negative line the alternate screen has
+    // no row for -- which Grid::rowAt resolves by wrapping its ring buffer.
+    auto mc = MockTerm { PageSize { LineCount(5), ColumnCount(20) }, LineCount(50) };
+    for (auto const i: std::views::iota(0, 20))
+        mc.writeToScreen(std::format("history{}\r\n", i));
+    REQUIRE(mc.terminal.primaryScreen().historyLineCount() > LineCount(0));
+
+    mc.writeToScreen("\033[?1049h"); // to the alternate screen
+    REQUIRE(mc.terminal.isAlternateScreen());
+    REQUIRE(mc.terminal.currentScreen().historyLineCount() == LineCount(0));
+
+    CHECK(mc.terminal.advanceVisibleLines(LineOffset(0), 3, VerticalDirection::Up) == LineOffset(0));
+    CHECK(mc.terminal.snapToVisibleLine(LineOffset(-4), VerticalDirection::Up) == LineOffset(0));
+}
+
+TEST_CASE("Folding.terminal.foldingFollowsTheDISPLAYEDPage", "[folding]")
+{
+    // fillRenderBufferInternal hands Grid::render a folded row list for the DISPLAYED page 0 and draws
+    // every other page contiguously. Everything else that speaks about folds has to key on the same
+    // thing -- isAlternateScreen() does not, because it follows the CURSOR page.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(!mc.terminal.foldProjection().empty());
+
+    SECTION("another page on display folds nothing")
+    {
+        // DECPCCM is set, so the display follows the cursor onto page 1.
+        mc.terminal.setPage(PageIndex(1), /*moveCursorHome*/ true);
+        REQUIRE_FALSE(mc.terminal.foldingAppliesToDisplayedPage());
+        REQUIRE_FALSE(mc.terminal.foldState().empty()); // still collapsed, just not the page shown
+
+        CHECK(mc.terminal.foldProjection().empty());
+        CHECK(mc.terminal.hiddenLineCount() == LineCount(0));
+    }
+
+    SECTION("page 0 on display folds, wherever the cursor is")
+    {
+        // DECPCCM RESET: the cursor moves to another page while page 0 stays on display. This is the
+        // case that separates the two predicates -- isAlternateScreen() reports true here, because it
+        // asks about the cursor, while the render pass goes on folding the page it is drawing.
+        mc.writeToScreen("\033[?64l"); // DECPCCM off
+        mc.terminal.setPage(PageIndex(3), /*moveCursorHome*/ true);
+
+        REQUIRE(mc.terminal.isAlternateScreen());
+        REQUIRE(mc.terminal.foldingAppliesToDisplayedPage());
+
+        CHECK_FALSE(mc.terminal.foldProjection().empty());
+        CHECK(mc.terminal.hiddenLineCount() == LineCount(2));
+    }
+}
+
+// }}}
+// Temporary probe appended to Folding_test.cpp
+
+// {{{ The cursor, under a projection that is not an addition
+
+namespace
+{
+
+/// A folded terminal whose visible rows are a NON-contiguous selection of grid rows, so a cursor's
+/// screen row genuinely differs from its grid line even at scroll offset zero.
+MockTerm<> setupCursorMock()
+{
+    return MockTerm<> { PageSize { LineCount(10), ColumnCount(20) }, LineCount(400), 1024, [](auto& mock) {
+                           for (auto const i: std::views::iota(0, 20))
+                               runCommand(mock,
+                                          std::format("cmd{}", i),
+                                          { std::format("out{}a", i), std::format("out{}b", i) });
+                           mock.terminal.setCursorDisplay(CursorDisplay::Steady);
+                       } };
+}
+
+/// The screen rows the render buffer emitted per-cell data for -- the path that carries a block
+/// cursor's cell inversion, which is the whole of how a block cursor is drawn.
+std::set<int> perCellRows(Terminal& terminal, chrono::steady_clock::time_point now)
+{
+    terminal.tick(now);
+    terminal.ensureFreshRenderBuffer();
+    auto rows = std::set<int> {};
+    auto const buffer = terminal.renderBuffer();
+    for (auto const& cell: buffer.get().cells)
+        rows.insert(unbox<int>(cell.position.line));
+    return rows;
+}
+
+} // namespace
+
+TEST_CASE("Folding.cursor.theCursorsOwnRowTakesThePerCellPath", "[folding][cursor]")
+{
+    auto mc = setupCursorMock();
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+
+    REQUIRE(terminal.collapseAllFolds());
+
+    // Mid-page, where the projection has backfilled history above and the screen row is nothing like
+    // the grid line. At the bottom row the two happen to coincide, which is why that is not the case
+    // to test.
+    mc.writeToScreen("\033[4;1H");
+    auto const gridLine = terminal.currentScreen().cursor().position.line;
+    auto const screenRow = terminal.viewport().translateGridToScreenCoordinate(gridLine);
+    REQUIRE(screenRow != gridLine); // else the test proves nothing
+
+    auto const rows = perCellRows(terminal, ClockBase + 100ms);
+
+    // The row the cursor is DRAWN on gets the per-cell data. Comparing a grid line against a screen
+    // row marked whichever row shared the number instead, so the block cursor appeared on an
+    // unrelated line and vanished from its own -- and moved as scrolling reshaped the projection.
+    CHECK(rows.contains(unbox<int>(screenRow)));
+    CHECK_FALSE(rows.contains(unbox<int>(gridLine)));
+}
+
+TEST_CASE("Folding.cursor.aHiddenCursorMarksNoRowAtAll", "[folding][cursor]")
+{
+    auto mc = setupCursorMock();
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+
+    REQUIRE(terminal.collapseAllFolds());
+    mc.writeToScreen("\033[4;1H");
+    mc.writeToScreen("\033[?25l"); // DECTCEM off: there is no cursor to draw
+
+    auto const rows = perCellRows(terminal, ClockBase + 100ms);
+    auto const gridLine = terminal.currentScreen().cursor().position.line;
+
+    // Neither the row it would be drawn on nor -- the old bug -- the row whose screen index merely
+    // happens to equal its grid line.
+    CHECK_FALSE(rows.contains(unbox<int>(terminal.viewport().translateGridToScreenCoordinate(gridLine))));
+    CHECK_FALSE(rows.contains(unbox<int>(gridLine)));
+}
+
+TEST_CASE("Folding.cursor.theMotionAnimationOriginGoesThroughTheProjection", "[folding][cursor]")
+{
+    auto mc = setupCursorMock();
+    auto& terminal = mc.terminal;
+    auto constexpr ClockBase = chrono::steady_clock::time_point();
+    REQUIRE(terminal.settings().cursorMotionAnimationDuration.count() > 0);
+
+    REQUIRE(terminal.collapseAllFolds());
+
+    // Both endpoints taken from the projection, so both are lines that are actually drawn -- a hidden
+    // one carries no cursor at all -- and so the two are separated by a collapsed block, which is what
+    // makes their distance in SCREEN rows differ from their distance in grid lines.
+    auto pageRows = std::vector<LineOffset> {};
+    for (auto const& row: terminal.foldProjection())
+        if (row >= LineOffset(0))
+            pageRows.push_back(row);
+    REQUIRE(pageRows.size() >= 2);
+
+    auto const fromLine = pageRows.front();
+    auto const toLine = pageRows.back();
+    REQUIRE(terminal.viewport().translateGridToScreenCoordinate(toLine)
+                - terminal.viewport().translateGridToScreenCoordinate(fromLine)
+            != toLine - fromLine); // else grid->screen is an addition here and the test proves nothing
+
+    mc.writeToScreen(std::format("\033[{};1H", unbox<int>(fromLine) + 1));
+    terminal.tick(ClockBase + 100ms);
+    terminal.ensureFreshRenderBuffer();
+    auto const fromGrid = terminal.currentScreen().cursor().position;
+    REQUIRE(fromGrid.line == fromLine);
+
+    mc.writeToScreen(std::format("\033[{};1H", unbox<int>(toLine) + 1));
+    terminal.tick(ClockBase + 200ms);
+    terminal.ensureFreshRenderBuffer();
+
+    auto const buffer = terminal.renderBuffer();
+    auto const& cursor = buffer.get().cursor;
+    REQUIRE(cursor.has_value());
+    REQUIRE(cursor->animateFrom.has_value());
+    REQUIRE(cursor->animationProgress < 1.0f);
+
+    // The animation interpolates between two SCREEN positions, and its origin has to be the row the
+    // start line is actually drawn on. Reconstructing the mapping as one offset sampled at the
+    // DESTINATION and adding it to the start line assumes grid->screen is an addition; under a fold
+    // projection it is a lookup, so the origin landed on the wrong row -- and on a different wrong row
+    // each frame while the viewport moved, which is the jitter.
+    auto const expected = terminal.viewport().translateGridToScreenCoordinate(fromGrid.line);
+    CHECK(cursor->animateFrom->line == expected);
+}
+
+// }}}
+
+// }}}
+// {{{ Scrolling by marks across collapsed folds
+
+TEST_CASE("Folding.viewport.scrollMarkUpReachesMarksBehindCollapsedFolds", "[folding][viewport]")
+{
+    // A scroll offset counts VISIBLE rows, so the offset that brings a mark to the top is the number of
+    // rows the user can SEE above it -- not its grid line negated, which counts the ninety-odd rows the
+    // collapsed folds hide as well. That larger number is past scrollableLineCount(), so scrollTo()
+    // REFUSED it as out of bounds while the action still reported success: the key was swallowed and
+    // the viewport never moved.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+    auto& viewport = terminal.viewport();
+
+    REQUIRE(terminal.hiddenLineCount() > LineCount(0));
+    REQUIRE(viewport.scrollOffset() == ScrollOffset(0));
+
+    auto const maxOffset = boxed_cast<ScrollOffset>(viewport.scrollableLineCount());
+    auto previous = viewport.scrollOffset();
+    auto steps = 0;
+
+    while (viewport.scrollMarkUp())
+    {
+        CAPTURE(steps, previous);
+
+        // Every step climbs, stays inside what the viewport admits, and lands on a row that is DRAWN --
+        // a mark inside a collapsed block has no offset that would show it, so it must be stepped over
+        // rather than stopped on.
+        REQUIRE(viewport.scrollOffset() > previous);
+        REQUIRE(viewport.scrollOffset() <= maxOffset);
+        REQUIRE(viewport.isLineVisible(viewport.translateScreenToGridLine(LineOffset(0))));
+
+        previous = viewport.scrollOffset();
+        ++steps;
+    }
+
+    // Thirty commands ran, each stamping a prompt mark, and collapsing a block keeps its head visible --
+    // so the walk crosses many of them rather than stopping at the first refusal.
+    CHECK(steps > 5);
+}
+
+TEST_CASE("Folding.viewport.scrollMarkDownReachesMarksBehindCollapsedFolds", "[folding][viewport]")
+{
+    // The mirror, walking back down from the top.
+    auto mc = setupViScrollMock();
+    auto& viewport = mc.terminal.viewport();
+
+    REQUIRE(viewport.scrollToTop());
+
+    auto previous = viewport.scrollOffset();
+    auto steps = 0;
+
+    while (viewport.scrollMarkDown())
+    {
+        CAPTURE(steps, previous);
+        REQUIRE(viewport.scrollOffset() < previous);
+        REQUIRE(viewport.isLineVisible(viewport.translateScreenToGridLine(LineOffset(0))));
+
+        previous = viewport.scrollOffset();
+        ++steps;
+    }
+
+    CHECK(steps > 5);
+
+    // Having run out of marks below, the last step falls through to the bottom -- which is where the
+    // unfolded behaviour ends up too.
+    CHECK(viewport.scrollOffset() == ScrollOffset(0));
+}
+
+TEST_CASE("Folding.projection.theTopmostOffsetIsUnaffectedBySmoothScrolling", "[folding]")
+{
+    // The projection asks the walk for a page PLUS the smooth-scrolling row, and used to bound the
+    // scroll offset it honoured by that same total -- one row short of what scrollableLineCount()
+    // admits. At the very top of a folded scrollback the page was therefore drawn one row further down
+    // for as long as the glide lasted, and snapped back the instant the sub-cell offset reached zero.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+    auto& viewport = terminal.viewport();
+
+    REQUIRE(viewport.scrollToTop());
+    REQUIRE(viewport.scrollOffset() == boxed_cast<ScrollOffset>(viewport.scrollableLineCount()));
+
+    auto const settled = viewport.translateScreenToGridLine(LineOffset(0));
+
+    // Mid-glide: a non-zero sub-cell offset asks the projection for one row above the page.
+    viewport.setPixelOffset(3.0f);
+    REQUIRE(terminal.smoothScrollExtraLines() == LineCount(1));
+    CHECK(viewport.translateScreenToGridLine(LineOffset(0)) == settled);
+
+    viewport.resetPixelOffset();
+    CHECK(viewport.translateScreenToGridLine(LineOffset(0)) == settled);
+}
+
+TEST_CASE("Folding.statusLine.theScrollPercentageCountsWhatCanBeReached", "[folding][statusline]")
+{
+    // The offset is bounded by the scrollable count, so dividing by the raw history depth yielded an
+    // indicator that could never reach 100% and quoted a depth the user cannot travel to.
+    auto mc = setupViScrollMock();
+    auto& terminal = mc.terminal;
+
+    REQUIRE(terminal.viewport().scrollToTop());
+
+    auto const scrollable = terminal.viewport().scrollableLineCount();
+    REQUIRE(scrollable > LineCount(0));
+    REQUIRE(terminal.primaryScreen().historyLineCount() > scrollable);
+
+    auto const text =
+        serializeToVT(terminal, parseStatusLineSegment("{HistoryLineCount}"), StatusLineStyling::Disabled);
+    CAPTURE(text);
+
+    // Scrolled as far as the folds leave reachable, which is the whole of it.
+    CHECK(text.contains("100%"));
+}
+
+// }}}
+// {{{ Fold state across resizes
+
+TEST_CASE("Folding.terminal.aLineCountResizeKeepsTheFoldState", "[folding]")
+{
+    // The other half of aReflowDropsTheFoldState. growLines/shrinkLines rotate the ring through the
+    // primitives that carry the stable-id accounting, so every row keeps the id it had -- and yet the
+    // generation bumps all the same, because a mirror still has to resync its geometry. Reconciling on
+    // THAT counter threw away everything the user had collapsed the moment a status line appeared or
+    // the window grew a row taller; stableIdGeneration() is the narrower question, and the right one.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    runCommand(mc, "ls", { "file1", "file2" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 1);
+    mc.terminal.foldState().collapse(ranges[0].headStableId);
+    REQUIRE(mc.terminal.hiddenLineCount() > LineCount(0));
+
+    auto const& grid = mc.terminal.primaryScreen().grid();
+    auto const generationBefore = grid.generation();
+    auto const stableIdGenerationBefore = grid.stableIdGeneration();
+
+    mc.terminal.resizeScreen(PageSize { LineCount(9), ColumnCount(20) });
+
+    // The mirror-facing counter moved; the id-facing one did not.
+    CHECK(grid.generation() != generationBefore);
+    CHECK(grid.stableIdGeneration() == stableIdGenerationBefore);
+
+    mc.terminal.refreshFoldState();
+    CHECK(!mc.terminal.foldState().empty());
+    CHECK(mc.terminal.hiddenLineCount() > LineCount(0));
+}
+
+TEST_CASE("Folding.terminal.theGutterStopsWhereTheProjectionDoes", "[folding]")
+{
+    // Collapse enough that the projection is shorter than the page: with no scrollback to backfill
+    // from, the rows below the content are blank and Grid::render draws nothing on them. The gutter
+    // walked the whole page regardless, and translateScreenToGridLine() answers for a row past the
+    // projection with the LAST visible line -- so each blank row was handed that line's marker, a
+    // column of duplicates hanging below the content while the grid beside it stayed empty.
+    auto mc = MockTerm { PageSize { LineCount(10), ColumnCount(20) } };
+    mc.terminal.settings().foldMarkers = true;
+    runCommand(mc, "a", { "1", "2", "3", "4", "5" });
+    runCommand(mc, "b", { "6" });
+
+    auto const ranges = mc.terminal.foldRanges();
+    REQUIRE(ranges.size() == 2);
+
+    // The OLDER block, so the newer one stays expanded and its body reaches the bottom of the content:
+    // that is the range a blank row extrapolated onto, and so the marker that used to be repeated.
+    mc.terminal.foldState().collapse(ranges.back().headStableId);
+
+    auto const projectedRows = mc.terminal.foldProjection().size();
+    REQUIRE(projectedRows > 0);
+    REQUIRE(projectedRows < unbox<size_t>(mc.terminal.pageSize().lines));
+
+    auto buffer = RenderBuffer {};
+    mc.terminal.fillRenderBuffer(buffer, true);
+
+    // Nothing is drawn beside a row the grid leaves blank.
+    for (auto const& cell: buffer.gutter)
+    {
+        CAPTURE(cell.lineOffset);
+        CHECK(cell.lineOffset < LineOffset::cast_from(projectedRows));
+    }
+
+    // And no row carries two markers.
+    auto rows = std::set<int> {};
+    for (auto const& cell: buffer.gutter)
+        CHECK(rows.insert(unbox<int>(cell.lineOffset)).second);
+}
+
+// }}}

--- a/src/vtbackend/Functions.hpp
+++ b/src/vtbackend/Functions.hpp
@@ -158,7 +158,6 @@ constexpr inline auto REP = FunctionDocumentation { .mnemonic = "REP", .comment 
 constexpr inline auto RM = FunctionDocumentation { .mnemonic = "RM", .comment = "Reset Mode" };
 constexpr inline auto SCOSC = FunctionDocumentation { .mnemonic = "SCOSC", .comment = "Save Cursor (available only when DECLRMM is disabled)" };
 constexpr inline auto SD = FunctionDocumentation { .mnemonic = "SD", .comment = "Scroll Down" };
-constexpr inline auto SETMARK = FunctionDocumentation { .mnemonic = "SETMARK", .comment = "Set Mark" };
 constexpr inline auto SGR = FunctionDocumentation { .mnemonic = "SGR", .comment = "Select Graphic Rendition" };
 constexpr inline auto SM = FunctionDocumentation { .mnemonic = "SM", .comment = "Set Mode" };
 constexpr inline auto SU = FunctionDocumentation { .mnemonic = "SU", .comment = "Scroll Up" };
@@ -793,7 +792,6 @@ constexpr inline auto REP         = detail::CSI(std::nullopt, 0, 1, std::nullopt
 constexpr inline auto RM          = detail::CSI(std::nullopt, 1, ArgsMax, std::nullopt, 'l', VTType::VT100, documentation::RM);
 constexpr inline auto SCOSC       = detail::CSI(std::nullopt, 0, 0, std::nullopt, 's', VTType::VT100, documentation::SCOSC);
 constexpr inline auto SD          = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'T', VTType::VT100, documentation::SD);
-constexpr inline auto SETMARK     = detail::CSI('>', 0, 0, std::nullopt, 'M', VTExtension::Contour, documentation::SETMARK);
 constexpr inline auto SGR         = detail::CSI(std::nullopt, 0, ArgsMax, std::nullopt, 'm', VTType::VT100, documentation::SGR);
 constexpr inline auto SM          = detail::CSI(std::nullopt, 1, ArgsMax, std::nullopt, 'h', VTType::VT100, documentation::SM);
 constexpr inline auto SU          = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'S', VTType::VT100, documentation::SU);
@@ -1073,7 +1071,6 @@ constexpr static auto allFunctionsArray() noexcept
         RM,
         SCOSC,
         SD,
-        SETMARK,
         SGR,
         SGRRESTORE,
         SGRSAVE,

--- a/src/vtbackend/Functions_test.cpp
+++ b/src/vtbackend/Functions_test.cpp
@@ -28,6 +28,20 @@ TEST_CASE("Functions.SCOSC", "[Functions]")
     CHECK(*f == SCOSC);
 }
 
+TEST_CASE("Functions.SETMARK.removed", "[Functions]")
+{
+    // CSI > M was a Contour-only extension for marking a prompt line, deprecated in favour of
+    // OSC 133;A and removed in 0.7.1. It must no longer resolve to anything -- a leftover row here
+    // would keep it working while the docs and the shipped shell integration say it is gone.
+    SupportedSequences const availableSequences;
+    CHECK(vtbackend::selectControl('>', 0, 0, 'M', availableSequences.activeSequences()) == nullptr);
+
+    // DL is `CSI ... M` with NO leader and must be unaffected by the removal.
+    Function const* dl = vtbackend::selectControl(0, 0, 0, 'M', availableSequences.activeSequences());
+    REQUIRE(dl);
+    CHECK(*dl == DL);
+}
+
 TEST_CASE("Functions.DECSLRM", "[Functions]")
 {
     // Maybe it is okay to not care about 0 and 1 arguments? Who's doing that?

--- a/src/vtbackend/Grid.cpp
+++ b/src/vtbackend/Grid.cpp
@@ -133,7 +133,7 @@ void Grid::setMaxHistoryLineCount(MaxHistoryLineCount maxHistoryLineCount)
     _lines.resize(unbox<size_t>(_pageSize.lines + this->maxHistoryLineCount()),
                   Line(_pageSize.columns, defaultLineFlags(), GraphicsAttributes {}));
     _linesUsed = min(_linesUsed, _pageSize.lines + this->maxHistoryLineCount());
-    bumpGeneration();
+    bumpGeneration(RowIdentity::Destroyed);
     verifyState();
 }
 
@@ -650,7 +650,7 @@ void Grid::reset()
     _lines.rotateRight(_lines.zeroIndex());
     for (int i = 0; i < unbox(_pageSize.lines); ++i)
         _lines[i].reset(defaultLineFlags(), GraphicsAttributes {});
-    bumpGeneration();
+    bumpGeneration(RowIdentity::Destroyed);
     verifyState();
 }
 
@@ -984,6 +984,10 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
 
     CellLocation cursor = currentCursorPos;
 
+    // Read before either resize below moves it: only a COLUMN change reflows, and reflow is the half
+    // of this that rebuilds the ring and with it every row's identity.
+    auto const columnsChanged = newSize.columns != _pageSize.columns;
+
     using crispy::Comparison;
     switch (crispy::strongCompare(newSize.columns, _pageSize.columns))
     {
@@ -1000,9 +1004,12 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
     }
 
     Ensures(_pageSize == newSize);
-    // Any page-size change destroys physical row identity (a non-reflow column resize
-    // mutates history in place; reflow rebuilds the whole ring): one bump, clients resync.
-    bumpGeneration();
+    // Any page-size change makes a mirror resync, so the generation bumps either way. Stable ids are
+    // the narrower question: growLines/shrinkLines rotate through the ring primitives that carry the
+    // id accounting, so a pure LINE-count change leaves every row naming what it named -- which is
+    // what lets a collapsed fold survive a status line appearing or a window growing taller. A column
+    // change is the one that rebuilds the ring.
+    bumpGeneration(columnsChanged ? RowIdentity::Destroyed : RowIdentity::Preserved);
     verifyState();
 
     return cursor;

--- a/src/vtbackend/Grid.hpp
+++ b/src/vtbackend/Grid.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vtbackend/CellProxy.hpp>
+#include <vtbackend/Folding.hpp>
 #include <vtbackend/GraphicsAttributes.hpp>
 #include <vtbackend/Line.hpp>
 #include <vtbackend/Primitives.hpp>
@@ -16,6 +17,7 @@
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -717,12 +719,27 @@ class Grid
     // }}}
 
     // {{{ Rendering API
+    /// Passes every cell of the visible rows to @p render.
+    ///
+    /// @param render        The render pass (RenderBufferBuilder in production).
+    /// @param scrollOffset  How far the viewport is scrolled into the history.
+    /// @param highlightSearchMatches  Whether the pass highlights search matches.
+    /// @param extraLines    Rows to draw ABOVE the page, for smooth scrolling. Ignored when @p rows is
+    ///                      given, which names its own extra rows.
+    /// @param rows          The exact rows to draw, top first, when the caller needs a NON-CONTIGUOUS
+    ///                      selection of them -- which is what output folding needs, its collapsed
+    ///                      blocks leaving gaps a linear walk cannot express. Empty (the default) walks
+    ///                      the page linearly, as it always has. Rows beyond the page count are drawn
+    ///                      above it, exactly as @p extraLines does, so smooth scrolling works either
+    ///                      way. Grid deliberately knows nothing about folding: it draws the rows it is
+    ///                      handed and the decision of WHICH stays with the caller.
     template <typename RendererT>
     [[nodiscard]] RenderPassHints render(
         RendererT&& render,
         ScrollOffset scrollOffset = {},
         HighlightSearchMatches highlightSearchMatches = HighlightSearchMatches::Yes,
-        LineCount extraLines = LineCount(0)) const;
+        LineCount extraLines = LineCount(0),
+        std::span<LineOffset const> rows = {}) const;
 
     [[nodiscard]] std::string renderMainPageText() const;
     [[nodiscard]] std::string renderAllText() const;
@@ -1142,18 +1159,14 @@ template <typename RendererT>
     RendererT&& render, // NOLINT(cppcoreguidelines-missing-std-forward)
     ScrollOffset scrollOffset,
     HighlightSearchMatches highlightSearchMatches,
-    LineCount extraLines) const
+    LineCount extraLines,
+    std::span<LineOffset const> rows) const
 {
     assert(!scrollOffset || unbox<LineCount>(scrollOffset) <= historyLineCount());
 
-    auto const availableAbove = *historyLineCount() - *scrollOffset;
-    auto const extraOffset = std::min(*extraLines, std::max(0, availableAbove));
-    auto y = LineOffset(-extraOffset);
     auto hints = RenderPassHints {};
-    for (int i = -*scrollOffset - extraOffset, e = i + *_pageSize.lines + extraOffset; i != e; ++i, ++y)
-    {
-        Line const& line = _lines[i];
 
+    auto const renderRow = [&](Line const& line, LineOffset y) {
         // Fast path: uniform-attribute line — render as a single batch. Blank lines have no
         // codepoints, so no search pattern can match them; always use the trivial path for
         // blanks to avoid constructing ConstCellProxy on un-materialized SoA arrays.
@@ -1185,7 +1198,25 @@ template <typename RendererT>
             }
             render.endLine();
         }
+    };
+
+    if (rows.empty())
+    {
+        auto const availableAbove = *historyLineCount() - *scrollOffset;
+        auto const extraOffset = std::min(*extraLines, std::max(0, availableAbove));
+        auto y = LineOffset(-extraOffset);
+        for (int i = -*scrollOffset - extraOffset, e = i + *_pageSize.lines + extraOffset; i != e; ++i, ++y)
+            renderRow(_lines[i], y);
     }
+    else
+    {
+        // Placed by the one statement of the rule, which Viewport's coordinate translation reads as well
+        // (@see foldedRowsTopRow): those two disagreeing is precisely what misplaces a selection.
+        auto y = foldedRowsTopRow(_pageSize.lines, rows.size());
+        for (auto const row: rows)
+            renderRow(lineAt(row), y++);
+    }
+
     render.finish();
     return hints;
 }

--- a/src/vtbackend/Grid.hpp
+++ b/src/vtbackend/Grid.hpp
@@ -753,8 +753,20 @@ class Grid
     // limit change, reset) and clients must resync. Plain ints, guarded by the terminal
     // lock like all grid state.
 
-    /// The wholesale-rebuild counter: a change invalidates every stable id.
+    /// The wholesale-rebuild counter: a change tells a mirror to resync from scratch.
     [[nodiscard]] uint64_t generation() const noexcept { return _generation; }
+
+    /// The counter that invalidates stable ids, and a STRICT SUBSET of generation().
+    ///
+    /// The two were one counter, and that cost more than it said: a change of LINE count alone --
+    /// a status line appearing, a window growing taller -- rotates the ring through the stable-id
+    /// primitives, so every row keeps the id it had, yet it bumps the generation because a mirror
+    /// still has to resync its geometry. A consumer that STORES ids across frames, as output folding
+    /// does, read that as "your ids are worthless" and dropped everything the user had collapsed.
+    ///
+    /// Bumped only where identity truly dies: a column change (which reflows, rebuilding the ring),
+    /// a history-limit change, a reset, and a reverse scroll past the addressable history.
+    [[nodiscard]] uint64_t stableIdGeneration() const noexcept { return _stableIdGeneration; }
 
     /// The stable id of the (existing) row at @p offset.
     [[nodiscard]] int64_t stableLineIdOf(LineOffset offset) const noexcept
@@ -966,7 +978,7 @@ class Grid
             // Every history row that was still valid provably lands in the caller's
             // blanked region, so after the bump the page is the entire valid range.
             _stableFloor = _stableBase;
-            bumpGeneration(); // re-syncs the floor itself
+            bumpGeneration(RowIdentity::Destroyed); // re-syncs the floor itself
             return;
         }
         syncStableFloor();
@@ -1019,11 +1031,21 @@ class Grid
         _stableFloor = std::max(_stableFloor, _stableBase - unbox<int64_t>(historyLineCount()));
     }
 
-    /// Destroys stable row identity wholesale (resize/reflow, history-limit change,
-    /// reset): clients observe the change and resync.
-    void bumpGeneration() noexcept
+    /// Whether a rebuild left the rows' stable ids naming the rows they named before.
+    enum class RowIdentity : uint8_t
+    {
+        Preserved = 0, ///< The ring rotated; every row kept its id.
+        Destroyed,     ///< The ring was rebuilt; no id names what it did.
+    };
+
+    /// Tells mirrors to resync, and consumers holding stable ids whether those ids survived it.
+    ///
+    /// @param identity Whether the rebuild kept stable row identity (@see stableIdGeneration).
+    void bumpGeneration(RowIdentity identity) noexcept
     {
         ++_generation;
+        if (identity == RowIdentity::Destroyed)
+            ++_stableIdGeneration;
         syncStableFloor();
         // Row identity is gone, so an id-keyed history watermark means nothing now. Consumers
         // resync on the generation mismatch anyway.
@@ -1056,6 +1078,7 @@ class Grid
     // Stable row identity (see the accessors above): maintained exclusively by the
     // ring-rotation primitives, syncStableFloor() and bumpGeneration().
     uint64_t _generation = 0;
+    uint64_t _stableIdGeneration = 0;
     int64_t _stableBase = 0;  ///< Stable id of page row 0; signed — SD/unscroll push it down.
     int64_t _stableFloor = 0; ///< Oldest addressable id; monotonic within a generation.
 

--- a/src/vtbackend/Grid_test.cpp
+++ b/src/vtbackend/Grid_test.cpp
@@ -4,11 +4,16 @@
 
 #include <crispy/BufferObject.hpp>
 
+#include <libunicode/convert.h>
+
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <cstddef>
 #include <format>
 #include <ranges>
+#include <span>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -969,6 +974,9 @@ namespace
 struct MockGridRenderer
 {
     std::vector<LineOffset> renderedLines;
+    /// The text of each rendered line, so a test can check WHICH grid row landed on a given y -- the
+    /// only thing that distinguishes an explicit row list from the linear walk.
+    std::vector<std::string> renderedTexts;
     size_t trivialCount = 0;
     size_t perCellCount = 0;
 
@@ -989,9 +997,10 @@ struct MockGridRenderer
     void renderTrivialLine([[maybe_unused]] TrivialLineBuffer const& lineBuffer,
                            LineOffset y,
                            [[maybe_unused]] LineFlags flags,
-                           [[maybe_unused]] std::u32string_view textOverride = {})
+                           std::u32string_view textOverride = {})
     {
         renderedLines.push_back(y);
+        renderedTexts.push_back(unicode::convert_to<char>(textOverride));
         ++trivialCount;
     }
 
@@ -1870,4 +1879,78 @@ TEST_CASE("Grid.delta.growColumnsKeepsItsHistoryAddressable", "[grid][delta]")
     auto reported = 0;
     grid.forEachValidLine([&](LineOffset, Line const&) { ++reported; });
     CHECK(reported == unbox<int>(grid.historyLineCount()) + unbox<int>(grid.pageSize().lines));
+}
+
+TEST_CASE("Grid.render_rows.draws_exactly_the_listed_rows", "[grid]")
+{
+    // A 2-line page over 5 lines of history. An explicit row list picks rows that are NOT contiguous --
+    // which is the whole reason the parameter exists: a collapsed fold leaves a gap no linear walk can
+    // express.
+    auto grid = Grid(PageSize { LineCount(2), ColumnCount(5) }, true, LineCount(5));
+    for (auto i = 0; i < 5; ++i)
+    {
+        grid.scrollUp(LineCount(1));
+        grid.setLineText(LineOffset(1), std::format("L{:03}", i));
+    }
+
+    // The writes above leave L000 at offset -3 and L002 at offset -1, with L001 between them: the row
+    // list steps straight over it, which a linear walk could not.
+    auto const rows = std::array { LineOffset(-3), LineOffset(-1) };
+    auto renderer = MockGridRenderer {};
+    (void) grid.render(renderer, ScrollOffset(0), HighlightSearchMatches::No, LineCount(0), rows);
+
+    REQUIRE(renderer.renderedLines.size() == 2);
+    // Two rows for a 2-line page: they fill it, so the first lands at the top.
+    CHECK(renderer.renderedLines[0] == LineOffset(0));
+    CHECK(renderer.renderedLines[1] == LineOffset(1));
+    // ... and they are the rows that were asked for, in order, gap and all.
+    REQUIRE(renderer.renderedTexts.size() == 2);
+    CHECK(renderer.renderedTexts[0] == "L000");
+    CHECK(renderer.renderedTexts[1] == "L002");
+}
+
+TEST_CASE("Grid.render_rows.extra_rows_land_above_the_page", "[grid]")
+{
+    // More rows than the page holds: the surplus are the smooth-scrolling ones and belong ABOVE it, so
+    // the LAST row still lands on the bottom of the page.
+    auto grid = Grid(PageSize { LineCount(2), ColumnCount(5) }, true, LineCount(5));
+    for (auto i = 0; i < 5; ++i)
+    {
+        grid.scrollUp(LineCount(1));
+        grid.setLineText(LineOffset(1), std::format("L{:03}", i));
+    }
+
+    auto const rows = std::array { LineOffset(-3), LineOffset(-2), LineOffset(-1) };
+    auto renderer = MockGridRenderer {};
+    (void) grid.render(renderer, ScrollOffset(0), HighlightSearchMatches::No, LineCount(0), rows);
+
+    REQUIRE(renderer.renderedLines.size() == 3);
+    CHECK(renderer.renderedLines[0] == LineOffset(-1));
+    CHECK(renderer.renderedLines[1] == LineOffset(0));
+    CHECK(renderer.renderedLines[2] == LineOffset(1));
+}
+
+TEST_CASE("Grid.render_rows.empty_list_is_the_linear_walk", "[grid]")
+{
+    // The default. An empty row list must be byte-for-byte what the grid always did, extraLines and all
+    // -- every existing render path passes no rows.
+    auto grid = Grid(PageSize { LineCount(2), ColumnCount(5) }, true, LineCount(5));
+    for (auto i = 0; i < 5; ++i)
+    {
+        grid.scrollUp(LineCount(1));
+        grid.setLineText(LineOffset(1), std::format("L{:03}", i));
+    }
+
+    auto withDefault = MockGridRenderer {};
+    (void) grid.render(withDefault, ScrollOffset(0), HighlightSearchMatches::No, LineCount(1));
+
+    auto withEmptyRows = MockGridRenderer {};
+    (void) grid.render(withEmptyRows,
+                       ScrollOffset(0),
+                       HighlightSearchMatches::No,
+                       LineCount(1),
+                       std::span<LineOffset const> {});
+
+    CHECK(withDefault.renderedLines == withEmptyRows.renderedLines);
+    CHECK(withDefault.renderedTexts == withEmptyRows.renderedTexts);
 }

--- a/src/vtbackend/RenderBuffer.hpp
+++ b/src/vtbackend/RenderBuffer.hpp
@@ -91,6 +91,19 @@ struct RenderLine
     LineFlags flags = LineFlag::None;
 };
 
+/// One row's gutter content: the fold marker drawn in the strip left of the grid.
+///
+/// A row of its own rather than a RenderCell in @ref RenderBuffer::cells, deliberately: the gutter sits
+/// at a NEGATIVE column, outside the page entirely, and everything that walks the cells -- selection,
+/// hit-testing, the accessibility bridge, screenshots -- is entitled to assume a column is on the page.
+/// Keeping the two apart means none of them has to learn otherwise.
+struct RenderGutterCell
+{
+    LineOffset lineOffset;       ///< The screen row this marker belongs to.
+    char32_t codepoint {};       ///< The marker glyph.
+    RenderAttributes attributes; ///< Its colors.
+};
+
 struct RenderCursor
 {
     CellLocation position;
@@ -106,6 +119,7 @@ struct RenderBuffer
 {
     std::vector<RenderCell> cells {};
     std::vector<RenderLine> lines {};
+    std::vector<RenderGutterCell> gutter {};
     std::optional<RenderCursor> cursor {};
     uint64_t frameID {};
 
@@ -113,6 +127,7 @@ struct RenderBuffer
     {
         cells.clear();
         lines.clear();
+        gutter.clear();
         cursor.reset();
     }
 };

--- a/src/vtbackend/RenderBufferBuilder.cpp
+++ b/src/vtbackend/RenderBufferBuilder.cpp
@@ -151,9 +151,12 @@ optional<RenderCursor> RenderBufferBuilder::renderCursor() const
     auto constexpr InactiveCursorShape = CursorShape::Rectangle; // TODO configurable
     auto const shape = _terminal->focused() ? _terminal->cursorShape() : InactiveCursorShape;
 
+    // Through the viewport rather than by adding the scroll offset: with folds collapsed the row a grid
+    // line is drawn on is not its line plus an offset, and a cursor placed by the old arithmetic would
+    // be drawn somewhere other than the cell it is in.
     auto const cursorScreenPosition =
-        CellLocation { .line = _baseLine + _cursorPosition->line
-                               + boxed_cast<LineOffset>(_terminal->viewport().scrollOffset()),
+        CellLocation { .line = _baseLine
+                               + _terminal->viewport().translateGridToScreenCoordinate(_cursorPosition->line),
                        .column = _cursorPosition->column };
 
     auto const cellWidth = _screen->cellWidthAt(*_cursorPosition);
@@ -363,22 +366,32 @@ RenderLine RenderBufferBuilder::createRenderLine(TrivialLineBuffer const& lineBu
     return renderLine;
 }
 
-bool RenderBufferBuilder::gridLineContainsCursor(LineOffset lineOffset) const noexcept
+bool RenderBufferBuilder::gridLineContainsCursor(LineOffset screenRow) const
 {
-    // The cursor of the screen being RENDERED. Asking the current screen reports the main cursor's
-    // line while rendering a status line, forcing an unrelated line off the trivial fast path on
-    // every frame and drawing the cursor row in the wrong place.
-    if (_screen->cursor().position.line == lineOffset)
+    // The status-line screens render through this same builder and are handed no cursor position at
+    // all. They have nothing to mark, and the viewport translation below -- which speaks for the main
+    // page -- does not speak for them.
+    if (!_cursorPosition)
+        return false;
+
+    auto const& viewport = _terminal->viewport();
+
+    // BOTH sides in SCREEN rows. A cursor position is a GRID line, and the row it is drawn on is not
+    // that line: scrolling shifts it, and with folds collapsed the rows on screen are a non-contiguous
+    // selection of grid rows, so the two differ even at scroll offset zero. Comparing the two spaces
+    // marked whichever row happened to share the number and left the cursor's OWN row on the trivial
+    // path -- which emits no per-cell data, so a block cursor's cell inversion, which is the whole of
+    // how a block cursor is drawn, was never produced. The cursor vanished, and reappeared on some
+    // unrelated row, changing as the viewport scrolled.
+    //
+    // The cursor of the screen being RENDERED, not the terminal's current one: asking the latter
+    // reports the main cursor's line while a non-displayed page is being built.
+    if (viewport.translateGridToScreenCoordinate(_screen->cursor().position.line) == screenRow)
         return true;
 
-    if (_cursorPosition && _terminal->inputHandler().mode() != ViMode::Insert)
-    {
-        auto const viCursor = _terminal->viewport().translateGridToScreenCoordinate(_cursorPosition->line);
-        if (viCursor == lineOffset)
-            return true;
-    }
-
-    return false;
+    // In Vi mode the cursor drawn is the Vi one, which sits at its own line.
+    return _terminal->inputHandler().mode() != ViMode::Insert
+           && viewport.translateGridToScreenCoordinate(_cursorPosition->line) == screenRow;
 }
 
 void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
@@ -564,7 +577,7 @@ void RenderBufferBuilder::matchSearchPattern(T const& cellText)
     _searchPatternOffset = 0;
 }
 
-void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags) noexcept
+void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags)
 {
     _lineNr = line;
     _currentLineFlags = flags;
@@ -574,7 +587,7 @@ void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags) noexcept
     _useCursorlineColoring = isCursorLine(line);
 }
 
-bool RenderBufferBuilder::isCursorLine(LineOffset line) const noexcept
+bool RenderBufferBuilder::isCursorLine(LineOffset line) const
 {
     return _terminal->inputHandler().mode() != ViMode::Insert && _cursorPosition
            && line

--- a/src/vtbackend/RenderBufferBuilder.hpp
+++ b/src/vtbackend/RenderBufferBuilder.hpp
@@ -45,7 +45,9 @@ class RenderBufferBuilder
     ///
     /// @see renderTrivialLine
     void renderCell(ConstCellProxy cell, LineOffset line, ColumnOffset column);
-    void startLine(LineOffset line, LineFlags flags) noexcept;
+    /// Not noexcept: the cursor-line decision it makes goes through the viewport's coordinate
+    /// translation, which builds the fold projection lazily and therefore allocates.
+    void startLine(LineOffset line, LineFlags flags);
     void endLine() noexcept;
 
     /// Renders a trivial line.
@@ -65,7 +67,8 @@ class RenderBufferBuilder
     void finish() noexcept {}
 
   private:
-    [[nodiscard]] bool isCursorLine(LineOffset line) const noexcept;
+    /// Not noexcept, for the reason startLine() gives.
+    [[nodiscard]] bool isCursorLine(LineOffset line) const;
 
     [[nodiscard]] std::optional<RenderCursor> renderCursor() const;
 
@@ -155,7 +158,9 @@ class RenderBufferBuilder
     /// Tests if the given screen line offset does contain a cursor (either ANSI cursor or vi cursor, if
     /// shown) and returns false otherwise, which guarantees that no cursor is to be rendered
     /// on the given line offset.
-    [[nodiscard]] bool gridLineContainsCursor(LineOffset screenLineOffset) const noexcept;
+    ///
+    /// Not noexcept, for the reason startLine() gives.
+    [[nodiscard]] bool gridLineContainsCursor(LineOffset screenRow) const;
 
     // clang-format off
     enum class State : uint8_t { Gap, Sequence };

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -6749,12 +6749,6 @@ ApplyResult Screen::apply(Function const& function, Sequence const& seq)
         case SD: scrollDown(seq.paramPositiveOr<LineCount>(0, LineCount { 1 })); break;
         case UNSCROLL: unscroll(seq.paramOr<LineCount>(0, LineCount(1))); break;
         case SBQUERY: handleSemanticBlockQuery(seq); break;
-        case SETMARK:
-            // TODO: deprecated. Remove in some future version.
-            // Users should migrate to OSC 133.
-            errorLog()("CSI > M is deprecated. Use OSC 133 instead.");
-            setMark();
-            break;
         case SGR: return impl::applySGR(*this, seq, 0, seq.parameterCount());
         case SGRRESTORE: restoreGraphicsRendition(); return ApplyResult::Ok;
         case SGRSAVE: saveGraphicsRendition(); return ApplyResult::Ok;

--- a/src/vtbackend/Screen.cpp
+++ b/src/vtbackend/Screen.cpp
@@ -5716,9 +5716,12 @@ namespace
     /// before the scan had looked at a single flag, when the scan wants the handful of lines above the
     /// cursor that hold the last command. So it climbs exactly as far as it is asked to, and keeps nothing
     /// but the line it is standing on: the scan is a single forward pass, so nothing older is ever needed.
-    // Implements BOTH line sources: the two scans walk the same lazy, reflow-safe climb over logical
-    // lines, differing only in what they ask about each one. One hasLineAt() override satisfies both.
-    class GridCommandBlockLines final: public CommandBlockLineSource, public PromptRegionLineSource
+    // Implements ALL THREE line sources: the scans walk the same lazy, reflow-safe climb over logical
+    // lines, differing only in what they ask about each one. One hasLineAt() override satisfies them all.
+    class GridCommandBlockLines final:
+        public CommandBlockLineSource,
+        public PromptRegionLineSource,
+        public FoldLineSource
     {
       public:
         /// @param grid The grid to walk. Must outlive this source.
@@ -5750,6 +5753,16 @@ namespace
         [[nodiscard]] std::pair<LineOffset, LineOffset> physicalExtentOf(size_t index) const
         {
             return extentOf(index);
+        }
+
+        [[nodiscard]] int64_t stableIdAt(size_t index) const override
+        {
+            return _grid.stableLineIdOf(headOffsetAt(index));
+        }
+
+        [[nodiscard]] int64_t lastPhysicalStableIdAt(size_t index) const override
+        {
+            return _grid.stableLineIdOf(extentOf(index).second);
         }
 
         [[nodiscard]] std::string textAt(size_t index) const override
@@ -5785,10 +5798,13 @@ namespace
             return true;
         }
 
-        [[nodiscard]] Line const& headAt(size_t index) const
+        [[nodiscard]] Line const& headAt(size_t index) const { return _grid.lineAt(headOffsetAt(index)); }
+
+        /// Where the logical line @p index begins.
+        [[nodiscard]] LineOffset headOffsetAt(size_t index) const
         {
             Require(index == _index); // always preceded by the hasLineAt() that walked us here
-            return _grid.lineAt(_head);
+            return _head;
         }
 
         /// The physical lines the logical line @p index is chopped into: its head, and everything below it
@@ -6033,6 +6049,26 @@ std::expected<LivePromptSpan, PromptRegionError> Screen::livePromptSpan() const
         });
 }
 
+std::vector<FoldRange> Screen::foldRanges(size_t maxScanLines) const
+{
+    // From the bottom of the page upwards, not from the cursor: a fold may hang off a block whose output
+    // is still on the page below the cursor, and the walk has to have seen the CommandEnd that closes a
+    // block before it can open it.
+    return computeFoldRanges(GridCommandBlockLines { _grid, boxed_cast<LineOffset>(pageSize().lines) - 1 },
+                             maxScanLines);
+}
+
+void Screen::setLogicalLineFlags(LineOffset line, LineFlags flags, bool enable) noexcept
+{
+    enableLineFlags(_grid.logicalLineHead(line), flags, enable);
+
+    // The grid's own identity cannot stand in for this: a mark arriving on a page that has not scrolled
+    // moves neither the generation nor the stable base, so a cache keyed on those alone would go on
+    // reporting the ranges from before the command that has just finished.
+    if ((flags & HeadOnlyLineFlags).any())
+        _terminal->invalidateFoldRanges();
+}
+
 void Screen::setMark()
 {
     markLogicalLineAtCursor(LineFlag::Marked);
@@ -6066,6 +6102,7 @@ void Screen::processShellIntegration(Sequence const& seq)
             });
             _terminal->shellIntegration().promptStart(clickEvents);
             _terminal->semanticBlockTracker().promptStart();
+            _terminal->autoCollapseOnNewPrompt();
             break;
         }
         case 'B': {

--- a/src/vtbackend/Screen.hpp
+++ b/src/vtbackend/Screen.hpp
@@ -7,6 +7,7 @@
 #include <vtbackend/Color.hpp>
 #include <vtbackend/CommandBlocks.hpp>
 #include <vtbackend/Cursor.hpp>
+#include <vtbackend/Folding.hpp>
 #include <vtbackend/Grid.hpp>
 #include <vtbackend/Hyperlink.hpp>
 #include <vtbackend/Image.hpp>
@@ -36,6 +37,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -293,13 +295,17 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
     /// Renders the full screen by passing every grid cell to the callback.
     ///
     /// @param extraLines  Additional lines to render beyond the page size (e.g. for smooth scrolling).
+    /// @param rows        The exact rows to draw, top first, when they are not the contiguous page --
+    ///                    @see Grid::render, which documents the folding case this exists for.
     template <typename Renderer>
     RenderPassHints render(Renderer&& render,
                            ScrollOffset scrollOffset = {},
                            HighlightSearchMatches highlightSearchMatches = HighlightSearchMatches::Yes,
-                           LineCount extraLines = LineCount(0)) const
+                           LineCount extraLines = LineCount(0),
+                           std::span<LineOffset const> rows = {}) const
     {
-        return _grid.render(std::forward<Renderer>(render), scrollOffset, highlightSearchMatches, extraLines);
+        return _grid.render(
+            std::forward<Renderer>(render), scrollOffset, highlightSearchMatches, extraLines, rows);
     }
 
     /// Renders the full screen as text into the given string. Each line will be terminated by LF.
@@ -728,6 +734,17 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
     ///         the prompt scrolled out of reach).
     [[nodiscard]] std::expected<LivePromptSpan, PromptRegionError> livePromptSpan() const;
 
+    /// The foldable output regions of the finished commands in the scrollback, most recent first.
+    ///
+    /// Reads the OSC 133 marks alone, like its two siblings above, so folding works for any shell that
+    /// speaks plain OSC 133 -- DEC mode 2034 is a separate, opt-in reader channel and is not required.
+    ///
+    /// Does NOT take the terminal lock; the caller holds it, the same contract lastCommandBlock() has.
+    ///
+    /// @param maxScanLines How far up the scrollback to walk (@see MaxFoldScanLines).
+    /// @return The ranges, most recent first; empty when nothing in reach is foldable.
+    [[nodiscard]] std::vector<FoldRange> foldRanges(size_t maxScanLines) const;
+
     void scrollUp(LineCount n) { scrollUp(n, margin()); }
     void scrollDown(LineCount n) { scrollDown(n, margin()); }
     void scrollLeft(ColumnCount n);
@@ -796,10 +813,12 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
     /// line the user put a Vi mark on — and never the physical piece a wrap happened to chop it into.
     /// Stamping a continuation is exactly where they cannot survive: see HeadOnlyLineFlags, and the
     /// widening resize that rebuilds a joined logical line from its head alone.
-    void setLogicalLineFlags(LineOffset line, LineFlags flags, bool enable) noexcept
-    {
-        enableLineFlags(_grid.logicalLineHead(line), flags, enable);
-    }
+    /// Stamps @p flags onto the head of the LOGICAL line @p line belongs to.
+    ///
+    /// Out of line because it reaches into Terminal, which is incomplete here: every semantic mark in
+    /// the tree passes through this one funnel -- OSC 133's four, and vi's `mm` -- and the fold ranges
+    /// derived from them have to be invalidated when one lands.
+    void setLogicalLineFlags(LineOffset line, LineFlags flags, bool enable) noexcept;
 
     /// Whether the LOGICAL line that @p line belongs to carries all of @p flags.
     [[nodiscard]] bool isLogicalLineFlagEnabled(LineOffset line, LineFlags flags) const noexcept

--- a/src/vtbackend/Settings.hpp
+++ b/src/vtbackend/Settings.hpp
@@ -2,6 +2,7 @@
 
 #include <vtbackend/Charset.hpp>
 #include <vtbackend/ColorPalette.hpp>
+#include <vtbackend/Folding.hpp>        // FoldJumpBehavior
 #include <vtbackend/InputGenerator.hpp> // Modifier
 #include <vtbackend/Primitives.hpp>
 #include <vtbackend/RectangularAreaChecksum.hpp>
@@ -116,6 +117,22 @@ struct Settings
     /// bottom. When false, the viewport stays wherever the user parked it.
     /// User-initiated transitions (e.g. leaving Vi mode) are not affected.
     bool autoScrollOnUpdate = true;
+
+    /// Whether a gutter column is reserved left of the grid and a fold marker drawn in it on every
+    /// foldable prompt line. The window geometry must agree: the gutter's width is taken out of the
+    /// space available to cells, so a page fitted with one and a renderer drawing without it (or vice
+    /// versa) put the grid in two different places.
+    bool foldMarkers = false;
+
+    /// Whether a finished command's output is folded away as soon as the next prompt starts, so
+    /// that only the command running now is shown in full. Off by default: folding output the user
+    /// did not ask to fold is a strong preference, not a sensible default.
+    bool autoCollapseFoldOnNewCommand = false;
+
+    /// What a targeted Vi-mode jump -- a search hit, a mark, jump history -- does when its target sits
+    /// inside a collapsed fold. Expanding by default, because silently skipping a match the user just
+    /// searched for is worse than revealing the block it was found in.
+    FoldJumpBehavior foldJumpBehavior = FoldJumpBehavior::Expand;
 
     /// Whether the terminal considers itself focused at birth. Birth state, not a runtime knob: it is
     /// read once by the constructor and thereafter only sendFocus{In,Out}Event writes the flag.

--- a/src/vtbackend/ShellIntegration_test.cpp
+++ b/src/vtbackend/ShellIntegration_test.cpp
@@ -195,17 +195,6 @@ TEST_CASE("ShellIntegration.OSC_133")
     }
 }
 
-TEST_CASE("ShellIntegration.SETMARK")
-{
-    auto mc = MockTerm { PageSize { LineCount(25), ColumnCount(80) } };
-
-    SECTION("SETMARK triggers promptStart")
-    {
-        mc.writeToScreen("\033[>M");
-        CHECK(mc.terminal.currentScreen().lineFlagsAt(LineOffset(0)).contains(LineFlag::Marked));
-    }
-}
-
 // ==================== Semantic Block Protocol Tests ====================
 
 TEST_CASE("SemanticBlockProtocol.LineFlags")
@@ -302,14 +291,12 @@ namespace
 {
 /// What the bundled shell integration actually puts on the wire between two commands.
 ///
-/// precmd emits ;D (the command finished), then SETMARK, then ;A (a new prompt starts) — all three at the
-/// cursor, back to back, before PS1 prints a single character. So whenever a command's output did not end
-/// in a newline, every one of those marks lands on the output's last line, and the prompt is painted onto
-/// it too.
+/// precmd emits ;D (the command finished) and then ;A (a new prompt starts) back to back at the cursor,
+/// before PS1 prints a single character. So whenever a command's output did not end in a newline, both
+/// marks land on the output's last line, and the prompt is painted onto it too.
 void writePrecmdAndPrompt(MockTerm<>& mc, std::string_view prompt, int exitCode = 0)
 {
     mc.writeToScreen(std::format("\033]133;D;{}\033\\", exitCode));
-    mc.writeToScreen("\033[>M");
     mc.writeToScreen("\033]133;A\033\\");
     mc.writeToScreen(prompt);
 }

--- a/src/vtbackend/StatusLineBuilder.cpp
+++ b/src/vtbackend/StatusLineBuilder.cpp
@@ -335,17 +335,21 @@ namespace
             if (!vt.isPrimaryScreen())
                 return {};
 
-            if (vt.viewport().scrollOffset().value)
+            // The SCROLLABLE count, not the raw history depth: the scroll offset is bounded by that
+            // count, so dividing by the depth yields an indicator that can never reach 100% and quotes
+            // a distance the user cannot travel. @see Viewport::scrollableLineCount, which every other
+            // consumer of the bound already reads.
+            auto const scrollable = vt.viewport().scrollableLineCount();
+
+            // Zero is the whole reason for the guard as well as an uninteresting answer: with the
+            // history entirely inside collapsed folds there is nothing to be a percentage of.
+            if (vt.viewport().scrollOffset().value && unbox(scrollable) > 0)
             {
-                auto const pct =
-                    double(vt.viewport().scrollOffset()) / double(vt.primaryScreen().historyLineCount());
-                return std::format("{}/{} {:3}%",
-                                   vt.viewport().scrollOffset(),
-                                   vt.primaryScreen().historyLineCount(),
-                                   int(pct * 100));
+                auto const pct = double(vt.viewport().scrollOffset()) / scrollable.as<double>();
+                return std::format("{}/{} {:3}%", vt.viewport().scrollOffset(), scrollable, int(pct * 100));
             }
             else
-                return std::format("{}", vt.primaryScreen().historyLineCount());
+                return std::format("{}", scrollable);
         }
 
         std::string visit(StatusLineDefinitions::Hyperlink const&)

--- a/src/vtbackend/Terminal.cpp
+++ b/src/vtbackend/Terminal.cpp
@@ -280,6 +280,12 @@ void Terminal::onViewportChanged()
     if (_inputHandler.mode() != ViMode::Insert)
         _viCommands.cursorPosition = _viewport.clampCellLocation(_viCommands.cursorPosition);
 
+    // The clamp puts the cursor on a row the viewport DRAWS; this puts it on a line no fold hides. Both
+    // are needed and this order suffices: the clamp's own bounds are drawn rows, and a hidden line
+    // between them belongs to a run that cannot reach past either of them -- they are visible, and no
+    // run contains a visible line -- so snapping out of it stays inside the viewport.
+    snapViCursorOutOfFolds();
+
     if (_hintModeHandler.isActive())
         refreshHints();
 
@@ -604,6 +610,10 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
     if (_settings.statusDisplayPosition == StatusDisplayPosition::Top)
         baseLine += fillRenderBufferStatusLine(output, includeSelection, baseLine).as<LineOffset>();
 
+    // The two must agree -- mainPageTopRow() is what every hit-test maps a pixel back through, and a
+    // grid drawn somewhere else would answer for a row the user did not point at.
+    assert(baseLine == mainPageTopRow());
+
     auto const hoveringHyperlinkGuard = ScopedHyperlinkHover { *this, *_currentScreen };
     auto const mainDisplayReverseVideo = isModeEnabled(vtbackend::DECMode::ReverseVideo);
 
@@ -637,7 +647,7 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
 
     auto& displayedScreen = pageAt(_displayedPage);
 
-    if (_displayedPage == PageIndex(0))
+    if (foldingAppliesToDisplayedPage())
         _lastRenderPassHints = displayedScreen.render(RenderBufferBuilder { *this,
                                                                             displayedScreen,
                                                                             output,
@@ -650,7 +660,8 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
                                                                             includeSelection },
                                                       _viewport.scrollOffset(),
                                                       renderLinesPerCell,
-                                                      smoothScrollExtra);
+                                                      smoothScrollExtra,
+                                                      foldProjection());
     else
         _lastRenderPassHints = displayedScreen.render(RenderBufferBuilder { *this,
                                                                             displayedScreen,
@@ -664,6 +675,10 @@ void Terminal::fillRenderBufferInternal(RenderBuffer& output, bool includeSelect
                                                                             includeSelection },
                                                       _viewport.scrollOffset(),
                                                       renderLinesPerCell);
+
+    // After both branches: the gutter belongs to the main display whichever page it is showing, and
+    // fillGutter is a no-op wherever there is nothing foldable to point at.
+    fillGutter(output, baseLine);
 
     // Save the baseLine used for the main screen before the bottom status line shifts it.
     auto const mainScreenLine = baseLine;
@@ -699,8 +714,20 @@ void Terminal::updateCursorMotionAnimation(RenderBuffer& output)
         return _viCommands.cursorPosition;
     }();
 
-    // The line offset from grid to screen coordinates (accounts for baseLine and scrollOffset).
-    auto const gridToScreenLineOffset = output.cursor->position.line - gridCursorPos.line;
+    // Grid -> screen is a projection LOOKUP, not an addition: with folds collapsed the rows on screen
+    // are a non-contiguous selection of grid rows. Taking the difference at the cursor's own line and
+    // adding it to the animation's start line -- a different grid line -- put the interpolation's
+    // origin on the wrong row, and on a different wrong row each frame as scrolling reshaped the
+    // projection, so the cursor jittered along its path instead of sliding down it.
+    //
+    // The status-line shift IS a constant, so it is recovered by difference against the position
+    // renderCursor() already computed through the very same translation.
+    auto const baseLine =
+        output.cursor->position.line - _viewport.translateGridToScreenCoordinate(gridCursorPos.line);
+    auto const toScreen = [&](CellLocation gridPosition) {
+        return CellLocation { .line = baseLine + _viewport.translateGridToScreenCoordinate(gridPosition.line),
+                              .column = gridPosition.column };
+    };
 
     if (_cursorMotion.active && !_cursorMotion.isComplete(_currentTime))
     {
@@ -719,9 +746,7 @@ void Terminal::updateCursorMotionAnimation(RenderBuffer& output)
             _cursorMotion.duration = effectiveDuration;
         }
         // Inject animation data (convert grid -> screen coordinates)
-        auto fromScreen = _cursorMotion.fromPosition;
-        fromScreen.line += gridToScreenLineOffset;
-        output.cursor->animateFrom = fromScreen;
+        output.cursor->animateFrom = toScreen(_cursorMotion.fromPosition);
         output.cursor->animationProgress = _cursorMotion.progress(_currentTime);
         output.cursor->animateFromColor = _cursorMotion.fromColor;
     }
@@ -736,9 +761,7 @@ void Terminal::updateCursorMotionAnimation(RenderBuffer& output)
         _cursorMotion.startTime = _currentTime;
         _cursorMotion.duration = effectiveDuration;
 
-        auto fromScreen = _cursorMotion.fromPosition;
-        fromScreen.line += gridToScreenLineOffset;
-        output.cursor->animateFrom = fromScreen;
+        output.cursor->animateFrom = toScreen(_cursorMotion.fromPosition);
         output.cursor->animationProgress = _cursorMotion.progress(_currentTime);
         output.cursor->animateFromColor = _cursorMotion.fromColor;
     }
@@ -764,9 +787,7 @@ void Terminal::applyScreenTransitionBlending(RenderBuffer& output)
     auto const defaultBg = _colorPalette.defaultBackground;
 
     // Determine the line offset range that covers the main display (excluding the status line).
-    auto const mainLineBegin = (_settings.statusDisplayPosition == StatusDisplayPosition::Top)
-                                   ? statusLineHeight().as<LineOffset>()
-                                   : LineOffset(0);
+    auto const mainLineBegin = mainPageTopRow();
     auto const mainLineEnd = mainLineBegin + pageSize().lines.as<LineOffset>();
 
     auto const isMainDisplayCell = [&](CellLocation const& pos) {
@@ -1161,10 +1182,11 @@ bool Terminal::handleMouseSelection(Modifiers modifiers)
     _lastClick = _currentTime;
     _speedClicks = ((diffMs >= 0.0 && diffMs <= 1000.0 ? _speedClicks : 0) % 4) + 1;
 
-    auto const startPos = CellLocation {
-        .line = _currentMousePosition.line - boxed_cast<LineOffset>(_viewport.scrollOffset()),
-        .column = _currentMousePosition.column,
-    };
+    // Through the viewport, not by subtracting the scroll offset: with folds collapsed the rows on
+    // screen are a non-contiguous selection of grid rows, and anchoring a selection by the old
+    // arithmetic while extending it by the new one would start the drag on a different line than it
+    // highlights.
+    auto const startPos = _viewport.translateScreenToGridCoordinate(_currentMousePosition);
 
     // Shift+Click extends a completed selection to the new click position.
     // Re-create as LinearSelection to avoid breaking WordWise/FullLine invariants.
@@ -1227,10 +1249,8 @@ bool Terminal::handleMouseSelection(Modifiers modifiers)
 void Terminal::triggerWordWiseSelectionWithCustomDelimiters(string const& delimiters)
 {
     verifyState();
-    auto const startPos = CellLocation {
-        .line = _currentMousePosition.line - boxed_cast<LineOffset>(_viewport.scrollOffset()),
-        .column = _currentMousePosition.column,
-    };
+    // Through the viewport, for the reason given in handleMouseSelection above.
+    auto const startPos = _viewport.translateScreenToGridCoordinate(_currentMousePosition);
     if (_inputHandler.mode() != ViMode::Insert)
         _viCommands.cursorPosition = startPos;
     _customSelectionHelper.wordDelimited = [wordDelimiters = unicode::from_utf8(delimiters),
@@ -2033,7 +2053,11 @@ SmoothScrollResult Terminal::applySmoothScrollPixelDelta(float pixelDelta)
     auto const linesDelta = static_cast<int>(std::floor(totalPixels / cellHeight));
     auto const remainder = totalPixels - (static_cast<float>(linesDelta) * cellHeight);
 
-    auto const maxOffset = boxed_cast<ScrollOffset>(primaryScreen().historyLineCount());
+    // The bound the viewport itself enforces, NOT the raw history depth: a collapsed fold takes its
+    // rows out of the scrollable range, and clamping to the larger number would compute offsets
+    // scrollTo() then rejects -- leaving the scroll offset frozen while the sub-cell remainder below
+    // went on cycling through a whole cell height every frame, which is visible as a flicker.
+    auto const maxOffset = boxed_cast<ScrollOffset>(_viewport.scrollableLineCount());
     auto const unclampedOffset = _viewport.scrollOffset().value + linesDelta;
     auto const newScrollOffset = std::clamp(unclampedOffset, 0, maxOffset.value);
 
@@ -2133,6 +2157,10 @@ void Terminal::resizeScreen(PageSize totalPageSize, optional<ImageSize> pixels)
             boxed_cast<LineOffset>(oldMainDisplayPageSize.lines - mainDisplayPageSize.lines);
 
     _viCommands.cursorPosition = clampToScreen(_viCommands.cursorPosition);
+
+    // clampToScreen keeps the cursor on the page but knows nothing about folds, so the page-delta
+    // shift above can land it inside a collapsed block, where it renders as nothing at all.
+    snapViCursorOutOfFolds();
 
     reportInBandWindowResize();
 
@@ -2370,6 +2398,512 @@ std::optional<CommandBlockText> Terminal::lastCommandBlock() const
 {
     return primaryScreen().lastCommandBlock();
 }
+
+// {{{ Output folding
+void Terminal::refreshFoldState() const
+{
+    auto const& grid = primaryScreen().grid();
+    auto const generation = grid.stableIdGeneration();
+    auto const floor = grid.stableRangeFloor();
+
+    // The answer on all but the calls that follow a reflow or an eviction, and this fronts the
+    // per-cell coordinate translation -- so what runs here is the guard, not the reconciliation.
+    if (generation == _foldStateGeneration && _foldStateFloor == floor)
+        return;
+
+    // A bump means a reflow destroyed row identity wholesale, so every id held names a different row,
+    // or none. There is nothing to salvage and guessing would collapse the wrong block.
+    //
+    // stableIdGeneration(), NOT generation(): the latter also bumps for a pure line-count resize, which
+    // every row survives with the id it had -- so keying on it dropped every collapsed fold the moment
+    // a status line appeared or the window grew a row taller.
+    if (generation != _foldStateGeneration)
+    {
+        _foldState.clear();
+        _foldStateGeneration = generation;
+    }
+
+    // Heads that scrolled out of the scrollback: without pruning the set grows for the life of the
+    // session, and an id the grid later hands out again would come back collapsed.
+    _foldState.prune(floor);
+    _foldStateFloor = floor;
+}
+
+std::optional<FoldRange> Terminal::foldContaining(LineOffset gridLine) const
+{
+    // A query about the page on display -- the gutter draws from it, and a click or a context menu
+    // acts on the row the user pointed at. The same predicate the projection and the render pass use,
+    // so a page whose rows were folded can be asked which fold folded them.
+    if (!foldingAppliesToDisplayedPage())
+        return std::nullopt;
+
+    return foldCovering(foldRanges(), primaryScreen().grid().stableLineIdOf(gridLine));
+}
+
+std::optional<FoldRange> Terminal::foldCovering(std::span<FoldRange const> ranges, int64_t id) noexcept
+{
+    // Ranges come back most recent first, which is DESCENDING by head id -- the walk that produced them
+    // climbs the scrollback. So the search runs against that order rather than sorting a copy per row.
+    //
+    // A range spans [headStableId, lastStableId], the head being the smallest of the three, so the first
+    // range whose head is at or below @p id is the only one that can cover it: ranges do not nest.
+    auto const it = std::ranges::lower_bound(ranges, id, std::greater {}, &FoldRange::headStableId);
+    if (it == ranges.end() || id > it->lastStableId)
+        return std::nullopt;
+
+    return *it;
+}
+
+FoldMarker Terminal::markerIn(FoldRange const& range, int64_t id) const noexcept
+{
+    auto const collapsed = _foldState.isCollapsed(range.headStableId);
+
+    if (id == range.headStableId)
+        return collapsed ? FoldMarker::Collapsed : FoldMarker::Expanded;
+
+    // A collapsed block draws nothing below its head, because there IS nothing below it -- those rows
+    // are the ones it hides.
+    if (collapsed)
+        return FoldMarker::None;
+
+    return id == range.lastStableId ? FoldMarker::BodyEnd : FoldMarker::Body;
+}
+
+FoldMarker Terminal::foldMarkerAt(LineOffset gridLine) const
+{
+    auto const range = foldContaining(gridLine);
+    if (!range)
+        return FoldMarker::None;
+
+    return markerIn(*range, primaryScreen().grid().stableLineIdOf(gridLine));
+}
+
+void Terminal::snapViCursorOutOfFolds()
+{
+    // Motions cannot put the Vi cursor on a hidden line -- they count VISIBLE lines. Collapsing a
+    // block the cursor is standing in can, and a cursor on a hidden line renders as nothing at all.
+    if (_inputHandler.mode() == ViMode::Insert)
+        return;
+
+    _viCommands.cursorPosition.line =
+        snapToVisibleLine(_viCommands.cursorPosition.line, VerticalDirection::Down);
+}
+
+void Terminal::onFoldStateChanged()
+{
+    // The scrollable range is the history less what collapsed folds hide, so collapsing one can leave
+    // the viewport parked above the new top -- where scrollTo() rejects every request and the viewport
+    // can no longer be scrolled away from. Expanding only ever grows the range, which makes this a
+    // no-op, so both directions share the one funnel.
+    //
+    // Not called from onViewportChanged(): _modified() lands there, and a clamp issued from inside it
+    // would re-enter.
+    _viewport.clampScrollOffset();
+    snapViCursorOutOfFolds();
+}
+
+bool Terminal::toggleFoldContaining(LineOffset gridLine)
+{
+    auto const range = foldContaining(gridLine);
+    if (!range)
+        return false;
+
+    _foldState.toggle(range->headStableId);
+    onFoldStateChanged();
+    return true;
+}
+
+bool Terminal::expandFoldContaining(LineOffset gridLine)
+{
+    auto const range = foldContaining(gridLine);
+    if (!range || !_foldState.isCollapsed(range->headStableId))
+        return false;
+
+    _foldState.expand(range->headStableId);
+    onFoldStateChanged();
+    return true;
+}
+
+bool Terminal::toggleLastFold()
+{
+    auto const ranges = foldRanges();
+    if (ranges.empty())
+        return false;
+
+    // Most recent first, so the newest finished command is the front one.
+    _foldState.toggle(ranges.front().headStableId);
+    onFoldStateChanged();
+    return true;
+}
+
+bool Terminal::collapseLastFold()
+{
+    auto const ranges = foldRanges();
+    if (ranges.empty() || _foldState.isCollapsed(ranges.front().headStableId))
+        return false;
+
+    _foldState.collapse(ranges.front().headStableId);
+    onFoldStateChanged();
+    return true;
+}
+
+bool Terminal::collapseAllFolds()
+{
+    auto const revision = _foldState.revision();
+    _foldState.collapseAll(foldRanges());
+    if (_foldState.revision() == revision)
+        return false;
+
+    onFoldStateChanged();
+    return true;
+}
+
+bool Terminal::expandAllFolds()
+{
+    auto const revision = _foldState.revision();
+    _foldState.expandAll();
+    if (_foldState.revision() == revision)
+        return false;
+
+    onFoldStateChanged();
+    return true;
+}
+
+void Terminal::fillGutter(RenderBuffer& output, LineOffset baseLine) const
+{
+    // The same predicate the projection and the render pass use: the gutter marks the rows that were
+    // actually folded, so it appears exactly where folding applied.
+    if (!_settings.foldMarkers || !foldingAppliesToDisplayedPage())
+        return;
+
+    // Nothing anywhere in reach is foldable -- the overwhelmingly common case for a shell with no
+    // integration at all, and the one that must cost nothing beyond the cached scan.
+    if (foldRanges().empty())
+        return;
+
+    auto const stableBase = primaryScreen().grid().stableLineIdOf(LineOffset(0));
+
+    // Resolved by the palette itself, so a colour scheme that says nothing about folding still yields
+    // a legible column and every future consumer gets the same answer without re-deriving it.
+    auto const normal = _colorPalette.foldMarkerColors();
+    auto const hovered = _colorPalette.foldMarkerHoverColors();
+
+    // The whole run of the hovered fold lights up, not the one row under the pointer: that run is what a
+    // click acts on, so it is what the highlight has to describe.
+    auto const hoveredHead = _gutterHoverLine
+                                 ? foldCovering(foldRanges(), stableBase + unbox<int64_t>(*_gutterHoverLine))
+                                 : std::nullopt;
+
+    // How far down the page the projection actually reaches, which is NOT always a page-full: collapsed
+    // folds hiding more rows than the history can backfill leave it short, and the rest of the page is
+    // blank. Mapping a blank row anyway extrapolates it onto the last visible line -- every one of them
+    // onto the SAME line -- so each would be handed that line's marker, a column of duplicates hanging
+    // below content Grid::render draws nothing on.
+    //
+    // Held as a count rather than as the span it comes from, because the loop below re-enters the cache
+    // that span points into. An empty projection means nothing is collapsed and the whole page is drawn.
+    auto const pageLines = boxed_cast<LineOffset>(pageSize().lines);
+    auto const projectedRows = foldProjection().size();
+    auto const lastRow =
+        projectedRows == 0
+            ? pageLines
+            : std::min(pageLines, foldProjectionTopRow() + LineOffset::cast_from(projectedRows));
+
+    // The MAIN page, not the total: _settings.pageSize includes the status line, and a gutter marker
+    // does not belong beside it. Shifted by baseLine for the same reason every cell is -- a status line
+    // at the top moves the main page down, and a marker left where it was would point at the wrong row.
+    for (auto y = LineOffset(0); y < lastRow; ++y)
+    {
+        auto const id = stableBase + unbox<int64_t>(_viewport.translateScreenToGridLine(y));
+
+        // Asked for per row rather than held across the loop: foldRanges() hands back a span over a
+        // CACHE, and the translation on the line above re-enters that cache once per row. Holding it
+        // survives only as long as no key input can move inside a frame -- one that could, and the
+        // remaining rows would be reading freed memory. A cache hit here is three integer comparisons.
+        auto const range = foldCovering(foldRanges(), id);
+        if (!range)
+            continue;
+
+        auto const marker = markerIn(*range, id);
+        if (marker == FoldMarker::None)
+            continue;
+
+        auto const& colors =
+            hoveredHead && hoveredHead->headStableId == range->headStableId ? hovered : normal;
+
+        output.gutter.push_back(
+            RenderGutterCell { .lineOffset = baseLine + y,
+                               .codepoint = foldMarkerGlyph(marker),
+                               .attributes = RenderAttributes { .foregroundColor = colors.foreground,
+                                                                .backgroundColor = colors.background,
+                                                                .decorationColor = colors.foreground } });
+    }
+}
+
+void Terminal::setGutterHoverLine(std::optional<LineOffset> gridLine)
+{
+    if (_gutterHoverLine == gridLine)
+        return;
+
+    // What is DRAWN is the highlighted fold, not the hovered row, so the repaint is gated on the fold
+    // changing rather than on the pointer crossing a row boundary. Dragging down a page of gutter
+    // would otherwise force one full render-buffer rebuild -- and one reader wakeup -- per row.
+    auto const headOf = [this](std::optional<LineOffset> line) -> std::optional<int64_t> {
+        if (!line)
+            return std::nullopt;
+        auto const range = foldContaining(*line);
+        return range ? std::optional { range->headStableId } : std::nullopt;
+    };
+
+    auto const before = headOf(_gutterHoverLine);
+    _gutterHoverLine = gridLine;
+    if (before == headOf(gridLine))
+        return;
+
+    // The highlight lives only in the render buffer, so nothing else would notice it changed: without
+    // this the tint appears on the next frame something else happens to dirty, which for an idle
+    // terminal is never.
+    breakLoopAndRefreshRenderBuffer();
+}
+
+void Terminal::autoCollapseOnNewPrompt()
+{
+    if (!_settings.autoCollapseFoldOnNewCommand)
+        return;
+
+    // The scan is driven off the marks, and the ;A that brought us here has already been stamped -- so
+    // the block that just finished is the front one, exactly as it is for CollapseLastFold.
+    collapseLastFold();
+}
+
+std::span<FoldRange const> Terminal::foldRanges() const
+{
+    // Before any range is handed out: every fold MUTATION starts by asking for the ranges, so an id
+    // minted by a previous grid generation is dropped here rather than toggled -- which would have
+    // collapsed whichever block the reused id now names.
+    refreshFoldState();
+
+    // Always the PRIMARY screen: that is where the history and the shell's marks live, and an alt-screen
+    // application (vim, less) owns the page without leaving any.
+    auto const& grid = primaryScreen().grid();
+
+    // stableBase advances on every scroll, which is exactly when a mark may have moved into or out of
+    // reach; a generation bump means row identity is gone. Between those, the marks cannot have changed
+    // position, so the previous scan still stands.
+    auto const key = FoldRangesKey { .generation = grid.generation(),
+                                     .stableBase = grid.stableLineIdOf(LineOffset(0)),
+                                     .markRevision = _semanticMarkRevision };
+    if (_foldRangesKey == key)
+        return _foldRanges;
+
+    _foldRangesKey = key;
+
+    // No mark has ever been stamped, so there is nothing for the scan to find -- every range hangs off a
+    // Marked line, and stamping one goes through invalidateFoldRanges(). A shell with no OSC 133
+    // integration would otherwise climb the whole scrollback on every scroll to be told so again.
+    if (_semanticMarkRevision != 0)
+        _foldRanges = primaryScreen().foldRanges(MaxFoldScanLines);
+    else
+        _foldRanges.clear();
+
+    return _foldRanges;
+}
+
+void Terminal::ensureFoldProjection() const
+{
+    // Before the key is assembled, because reconciliation can empty the state and therefore move the
+    // revision the key is stamped with. Everything that reads the projection, the hidden runs or the
+    // hidden count arrives through here, so this is where a stale generation stops.
+    refreshFoldState();
+
+    auto const& grid = primaryScreen().grid();
+    auto const pageLines = unbox<int>(pageSize().lines);
+    auto const key = FoldProjectionKey { .generation = grid.generation(),
+                                         .stableBase = grid.stableLineIdOf(LineOffset(0)),
+                                         .scrollOffset = unbox<int>(_viewport.scrollOffset()),
+                                         .pageLines = pageLines,
+                                         .foldRevision = _foldState.revision(),
+                                         .markRevision = _semanticMarkRevision,
+                                         .extraLines = unbox<int>(smoothScrollExtraLines()),
+                                         .foldingApplies = foldingAppliesToDisplayedPage() };
+    if (_foldProjectionKey == key)
+        return;
+
+    _foldProjectionKey = key;
+    _foldProjection.clear();
+    _hiddenIntervals.clear();
+    _hiddenLineCount = LineCount(0);
+
+    // The fast path, and the common one: with nothing collapsed the contiguous page IS the projection,
+    // so no ranges are scanned for and no rows are built. Callers read empty as "unfolded".
+    if (_foldState.empty() || !key.foldingApplies)
+        return;
+
+    // Derived ONCE and handed to everything that needs it: the projection walk binary-searches these
+    // runs per row, the count below measures them, and the fold-aware Vi motions step over them.
+    _hiddenIntervals = vtbackend::hiddenIntervals(foldRanges(), _foldState);
+
+    // What the grid still holds, and therefore what a fold can hide: a range whose rows have been partly
+    // evicted hides only the part that is still there, and one entirely evicted hides nothing. Measured
+    // with visibleDistance() rather than by summing clamped runs, so the arithmetic that decides which
+    // rows are reachable is stated once (@see Folding.hpp) and costs the runs CROSSED, not all of them.
+    auto const floor = key.stableBase + unbox<int64_t>(grid.addressableTop());
+    auto const ceiling = key.stableBase + pageLines - 1;
+    auto const addressable = ceiling + 1 - floor;
+    auto const visible = vtbackend::visibleDistance(_hiddenIntervals, floor, ceiling + 1);
+    _hiddenLineCount = LineCount::cast_from(addressable - visible);
+
+    // The rows the viewport shows: a page-full, plus the smooth-scrolling rows, which belong ABOVE the
+    // page -- Grid::render places anything beyond the page count there. Without them a smooth scroll over
+    // collapsed folds would leave the strip at the top of the viewport undrawn while the content slid
+    // down through it.
+    auto const wanted = pageLines + key.extraLines;
+
+    // How far below the top row of the viewport the true bottom lies, in VISIBLE rows -- which is how
+    // far up the grid the walk must START, since what the scroll offset skips depends on what is hidden
+    // along the way. Bounded by what the grid can still supply, so a viewport scrolled further than the
+    // remaining history reaches keeps showing the topmost rows rather than a single one.
+    //
+    // Bounded by the PAGE, not by `wanted`: `visible - pageLines` is precisely the largest offset
+    // Viewport::scrollableLineCount() admits, so bounding by the extra smooth-scroll row too would
+    // refuse the topmost offset and draw the whole page one row further down -- snapping back the moment
+    // the sub-cell offset reached zero. The extra row is dropped instead, which is what happens anyway:
+    // the walk below runs out of grid and returns a page-length list, exactly as the unfolded path drops
+    // it (@see Grid.hpp's extraOffset).
+    //
+    // Found by stepping over the hidden runs rather than by collecting the rows and throwing them away:
+    // scrolled fifty thousand lines into a folded history, the discarded rows alone were a per-frame
+    // allocation and fifty thousand pushes.
+    auto const skipped = std::min<int64_t>(key.scrollOffset, std::max<int64_t>(0, visible - pageLines));
+    auto const bottom =
+        advanceVisibleId(_hiddenIntervals, ceiling, skipped, VerticalDirection::Up, floor, ceiling);
+
+    _foldProjection = projectRows(_hiddenIntervals,
+                                  key.stableBase,
+                                  LineOffset::cast_from(bottom - key.stableBase),
+                                  LineCount(wanted),
+                                  grid.addressableTop());
+}
+
+std::span<LineOffset const> Terminal::foldProjection() const
+{
+    // Checked BEFORE anything is computed, and that placement is load-bearing: Viewport's coordinate
+    // translation calls this once PER CELL of every frame, where it used to be a constexpr addition.
+    // With nothing collapsed -- which is every session that never folds anything, and every moment of
+    // the ones that do until they first fold -- the whole feature costs one load and one branch, rather
+    // than assembling and comparing a cache key two thousand times a frame.
+    if (_foldState.empty())
+        return {};
+
+    ensureFoldProjection();
+    return _foldProjection;
+}
+
+LineOffset Terminal::foldProjectionTopRow() const
+{
+    if (_foldState.empty())
+        return LineOffset(0);
+
+    ensureFoldProjection();
+    if (_foldProjection.empty())
+        return LineOffset(0);
+
+    // The same rule Grid::render places the row list by -- literally, both go through the one function
+    // that states it, which is what keeps Viewport's coordinate translation from drifting away from
+    // where the rows are actually drawn.
+    return foldedRowsTopRow(pageSize().lines, _foldProjection.size());
+}
+
+LineCount Terminal::hiddenLineCount() const
+{
+    if (_foldState.empty())
+        return LineCount(0);
+
+    ensureFoldProjection();
+    return _hiddenLineCount;
+}
+
+std::span<HiddenInterval const> Terminal::hiddenIntervals() const
+{
+    if (_foldState.empty())
+        return {};
+
+    ensureFoldProjection();
+    return _hiddenIntervals;
+}
+
+bool Terminal::isLineHiddenByFold(LineOffset gridLine) const
+{
+    // The fast path, and the common one: nothing collapsed hides nothing.
+    if (_foldState.empty())
+        return false;
+
+    auto const base = currentStableBase();
+    return hidingInterval(hiddenIntervals(), base + unbox<int64_t>(gridLine)).has_value();
+}
+
+int Terminal::visibleDistance(LineOffset from, LineOffset to) const
+{
+    // With nothing collapsed every grid line is a visible line, so the distance is the difference it
+    // has always been.
+    if (_foldState.empty())
+        return unbox<int>(to - from);
+
+    // Ids and LineOffsets both increase downwards, so the base cancels out of a DIFFERENCE entirely --
+    // it is carried only because hiddenIntervals() speaks in ids.
+    auto const base = currentStableBase();
+    return static_cast<int>(vtbackend::visibleDistance(
+        hiddenIntervals(), base + unbox<int64_t>(from), base + unbox<int64_t>(to)));
+}
+
+LineOffset Terminal::advanceVisibleLines(LineOffset line, int count, VerticalDirection direction) const
+{
+    // The grid the caller's cursor is ON, not the primary one -- @see currentStableBase(), which the
+    // walk below uses and which states why.
+    auto const& grid = currentScreen().grid();
+    auto const step = direction == VerticalDirection::Down ? count : -count;
+    auto const top = grid.addressableTop();
+    auto const bottom = boxed_cast<LineOffset>(pageSize().lines) - LineOffset(1);
+
+    // The fast path, and the common one: with nothing collapsed every grid line is a visible line, so
+    // the motion is the addition it has always been.
+    if (_foldState.empty())
+        return std::clamp(line + LineOffset(step), top, bottom);
+
+    // Ids and LineOffsets both increase downwards -- the base cancels -- so the walk is done in id space
+    // and the result shifted back, rather than mapping every intermediate step.
+    auto const base = currentStableBase();
+    auto const id = advanceVisibleId(hiddenIntervals(),
+                                     base + unbox<int64_t>(line),
+                                     count,
+                                     direction,
+                                     base + unbox<int64_t>(top),
+                                     base + unbox<int64_t>(bottom));
+    return LineOffset::cast_from(id - base);
+}
+
+LineOffset Terminal::snapToVisibleLine(LineOffset line, VerticalDirection direction) const
+{
+    // The caller's own grid, for the reason currentStableBase() gives.
+    auto const& grid = currentScreen().grid();
+
+    // Clamped on BOTH paths, so the documented contract ("a line the caller can put a cursor on")
+    // does not quietly depend on whether anything happens to be collapsed right now.
+    auto const clampToGrid = [&](LineOffset value) {
+        return std::clamp(
+            value, grid.addressableTop(), boxed_cast<LineOffset>(pageSize().lines) - LineOffset(1));
+    };
+
+    if (_foldState.empty())
+        return clampToGrid(line);
+
+    auto const base = currentStableBase();
+    auto const id = snapToVisibleId(hiddenIntervals(), base + unbox<int64_t>(line), direction);
+
+    // Snapping out of a run at the very edge of the grid can name a row just past it.
+    return clampToGrid(LineOffset::cast_from(id - base));
+}
+// }}}
 
 std::expected<LivePromptSpan, PromptRegionError> Terminal::livePromptSpan() const
 {
@@ -2622,8 +3156,12 @@ HintScanArea Terminal::collectHintScanArea(HintScope scope, LineCount scrollback
         if (scope == HintScope::Scrollback)
             return HintRowRange { .first = std::max(historyTop, -scrollbackLimit.as<LineOffset>()),
                                   .last = gridBottom };
-        auto const viewportTop = -_viewport.scrollOffset().as<LineOffset>();
-        return HintRowRange { .first = viewportTop, .last = viewportTop + gridBottom };
+        // Through the projection rather than by negating the scroll offset: that offset counts VISIBLE
+        // rows, so with folds collapsed it names a grid line far down the page instead of the one the
+        // viewport starts at -- and the scan would then cover rows the viewport does not draw while
+        // missing ones it does.
+        return HintRowRange { .first = _viewport.topLine(),
+                              .last = _viewport.translateScreenToGridLine(gridBottom) };
     }();
 
     // Extend the scan to whole logical lines: a pattern that wraps across the boundary is then
@@ -2767,15 +3305,24 @@ void Terminal::applyHintOverlay(RenderBuffer& output, LineOffset baseLine) const
     // matches on the row it is on rather than all of them. A wrapped match lands in every row it
     // covers. Under HintScope::Scrollback the match count is unbounded by the page size, which is
     // what makes this necessary rather than merely tidy.
-    auto const scrollOffset = _viewport.scrollOffset().as<LineOffset>();
     auto const pageLines = pageSize().lines.as<LineOffset>();
     auto const pageColumns = unbox<int>(pageSize().columns);
     auto rowBuckets = std::vector<std::vector<ProjectedMatch>>(unbox<size_t>(pageLines));
 
     for (auto const& match: matches)
     {
-        auto const first = match.start + scrollOffset;
-        auto const last = match.end + scrollOffset;
+        // A match a collapsed fold hides is drawn nowhere at all. Skipped rather than projected,
+        // because the translation below answers for a hidden line with the row standing in its PLACE --
+        // which would paint the label over unrelated text and offer a target the user never saw.
+        if (isLineHiddenByFold(match.start.line))
+            continue;
+
+        // Through the projection, NOT by adding the scroll offset: with folds collapsed the rows on
+        // screen are a non-contiguous selection of grid rows, so the two differ by however many rows
+        // those folds hide, and every label landed that far from the text it names. @see
+        // Viewport::translateGridToScreenCoordinate, which every other consumer already goes through.
+        auto const first = _viewport.translateGridToScreenCoordinate(match.start);
+        auto const last = _viewport.translateGridToScreenCoordinate(match.end);
         auto const projected = ProjectedMatch {
             .body = CellLocationRange { .first = first + baseLine, .second = last + baseLine },
             .labelStart = first + baseLine,

--- a/src/vtbackend/Terminal.hpp
+++ b/src/vtbackend/Terminal.hpp
@@ -5,6 +5,7 @@
 #include <vtbackend/ColorPalette.hpp>
 #include <vtbackend/Cursor.hpp>
 #include <vtbackend/DesktopNotification.hpp>
+#include <vtbackend/Folding.hpp>
 #include <vtbackend/Grid.hpp>
 #include <vtbackend/HintModeHandler.hpp>
 #include <vtbackend/Hyperlink.hpp>
@@ -741,7 +742,8 @@ class Terminal
                && coord.column < boxed_cast<ColumnOffset>(_settings.pageSize.columns);
     }
 
-    [[nodiscard]] bool isCursorInViewport() const noexcept
+    /// Not noexcept: the fold projection this goes through is built lazily, and building it allocates.
+    [[nodiscard]] bool isCursorInViewport() const
     {
         return viewport().isLineVisible(currentScreen().cursor().position.line);
     }
@@ -810,6 +812,22 @@ class Terminal
             case StatusDisplayType::HostWritable: return _hostWritableStatusLineScreen.pageSize().lines;
         }
         crispy::unreachable();
+    }
+
+    /// The screen row the MAIN page starts on.
+    ///
+    /// Screen rows count from the top of everything drawn, so a status line positioned at the top
+    /// occupies the first rows and the grid begins below them. Every coordinate that crosses the
+    /// boundary between "a row on the display" and "a row of the grid" has to apply this shift --
+    /// the render buffer when it places cells, and the GUI's hit-tests when they map a pixel back --
+    /// which is why it is stated once here rather than re-derived at each of them.
+    ///
+    /// @return The first screen row of the main page; zero unless a status line sits above it.
+    [[nodiscard]] LineOffset mainPageTopRow() const noexcept
+    {
+        return _settings.statusDisplayPosition == StatusDisplayPosition::Top
+                   ? statusLineHeight().as<LineOffset>()
+                   : LineOffset(0);
     }
 
     /// Clamps a requested total page size to the minimum the backend can accept for the currently
@@ -926,6 +944,204 @@ class Terminal
     // viewport management
     [[nodiscard]] Viewport& viewport() noexcept { return _viewport; }
     [[nodiscard]] Viewport const& viewport() const noexcept { return _viewport; }
+
+    // {{{ Output folding (OSC 133 semantic blocks)
+    //
+    // Folding is a PROJECTION applied between the grid and the render pass, and nothing else: the grid,
+    // the page size and every VT semantic are untouched, so a collapsed block changes what the user sees
+    // and never what the shell is told. The two places that must agree about it are the row list handed
+    // to Grid::render and Viewport's coordinate translation -- disagreement there misplaces a selection.
+
+    /// Which folds the user has collapsed. Mutable, because collapsing one is a user action.
+    [[nodiscard]] FoldState& foldState() noexcept { return _foldState; }
+    [[nodiscard]] FoldState const& foldState() const noexcept { return _foldState; }
+
+    /// The foldable regions currently within reach, most recent first.
+    ///
+    /// Re-derived from the marks rather than stored, and cached until the grid moves underneath it:
+    /// a fold's EXISTENCE follows from the shell's marks, and only whether the user collapsed it is
+    /// worth keeping (@see FoldState).
+    [[nodiscard]] std::span<FoldRange const> foldRanges() const;
+
+    /// The grid rows the viewport shows, top first -- or EMPTY when that is simply the contiguous page.
+    ///
+    /// Empty is the fast path and the common one: with nothing collapsed the linear walk is already
+    /// right, so no projection is built and no ranges are scanned for. Every caller must treat empty as
+    /// "unfolded" rather than as "no rows".
+    ///
+    /// @note The span is valid until the grid, the viewport or the fold state changes -- it views a
+    ///       cache, and a change rebuilds it. Within one render frame none of the three moves, so a
+    ///       caller may hold it across the coordinate translations that read it in turn.
+    [[nodiscard]] std::span<LineOffset const> foldProjection() const;
+
+    /// The screen row @ref foldProjection's FIRST row is drawn on.
+    ///
+    /// NEGATIVE while smooth scrolling supplies rows beyond the page: those belong above it, so the last
+    /// row still lands on the bottom. Zero otherwise -- including when collapsed folds hide more rows
+    /// than the history can backfill, where the walk ran out of grid at the top, there is nothing above
+    /// what it found, and the page is short at the BOTTOM instead, exactly as a terminal that has not
+    /// filled its page already looks.
+    ///
+    /// Grid::render places the row list by exactly this rule, and Viewport's coordinate translation
+    /// reads it from here rather than assuming row 0 -- those two disagreeing is precisely what
+    /// misplaces a selection.
+    ///
+    /// @return The screen row of the projection's first row; 0 when nothing is folded.
+    [[nodiscard]] LineOffset foldProjectionTopRow() const;
+
+    /// How many rows collapsed folds currently hide, over the whole addressable grid.
+    ///
+    /// What the viewport's scroll bounds are short by: scrolling counts VISIBLE rows, and a collapsed
+    /// block removes its output from that count.
+    [[nodiscard]] LineCount hiddenLineCount() const;
+
+    /// Whether folding applies to the page currently on display.
+    ///
+    /// The DISPLAYED page, which is what fillRenderBufferInternal() keys on when it hands Grid::render
+    /// a folded row list -- every other page, the alternate screen among them, is drawn contiguously.
+    /// The projection, the gutter and the render pass all read this one predicate so they cannot
+    /// disagree; a viewport translating coordinates through rows the render pass never drew would
+    /// misplace the cursor and every selection on that page.
+    ///
+    /// Deliberately NOT isAlternateScreen(), which follows the CURSOR page: with DECPCCM reset the two
+    /// diverge, and a terminal showing page 0 while the cursor sits on another would fold what it drew
+    /// and then deny having done so.
+    [[nodiscard]] bool foldingAppliesToDisplayedPage() const noexcept
+    {
+        return _displayedPage == PageIndex(0);
+    }
+
+    /// Drops fold state the grid can no longer account for: heads evicted from the scrollback, and
+    /// everything at all when a reflow destroyed row identity wholesale.
+    ///
+    /// Reached from foldRanges() and ensureFoldProjection(), which between them front EVERY read of the
+    /// fold state and every mutation of it -- rather than from each caller that might have a stale one.
+    /// It was called from the render pass alone, which left a resize snapping the Vi cursor, and a
+    /// viewport change between two frames, reading ids minted by the previous grid generation.
+    ///
+    /// const, and the state it reconciles is mutable, for the reason the projection beside it is: this
+    /// is cache coherency, not a change of what the user asked to collapse. Self-guarding, because the
+    /// per-cell coordinate translation reaches it -- the guard is what runs, not the work.
+    void refreshFoldState() const;
+
+    /// Discards the cached fold ranges, a semantic mark having been stamped or cleared.
+    ///
+    /// The grid's own identity cannot stand in for this: a mark arriving on a page that has not
+    /// scrolled moves neither the generation nor the stable base, so a cache keyed on those alone would
+    /// go on reporting the ranges from before the command that has just finished.
+    /// The bump is the whole invalidation: the revision is a field of both cache keys, so neither can
+    /// hit again until the caches are rebuilt against the new one.
+    void invalidateFoldRanges() noexcept { ++_semanticMarkRevision; }
+
+    /// What the gutter shows on @p gridLine: which part of a fold's column, if any, that row carries.
+    ///
+    /// Every row a fold TOUCHES gets a marker, not only its head: the gutter draws a column spanning the
+    /// whole block, which is what makes a fold visible as an extent rather than as a lone triangle, and
+    /// what gives the mouse a target bigger than a single cell.
+    ///
+    /// @param gridLine A grid line (0 = page top, negative = into the scrollback).
+    /// @return The marker, or FoldMarker::None when no fold reaches that line.
+    [[nodiscard]] FoldMarker foldMarkerAt(LineOffset gridLine) const;
+
+    /// The fold whose range covers @p gridLine -- its head row included.
+    ///
+    /// The lookup every mouse and menu affordance goes through, because a user points at the OUTPUT they
+    /// want folded away, not at the prompt line it hangs off.
+    ///
+    /// @param gridLine A grid line (0 = page top, negative = into the scrollback).
+    /// @return The covering fold, or nullopt when none reaches that line.
+    [[nodiscard]] std::optional<FoldRange> foldContaining(LineOffset gridLine) const;
+
+    /// Collapses or expands the fold covering @p gridLine, wherever in the block that line sits.
+    /// @param gridLine A grid line (0 = page top, negative = into the scrollback).
+    /// @return Whether a fold was found and toggled.
+    bool toggleFoldContaining(LineOffset gridLine);
+
+    /// Expands the fold covering @p gridLine, if a collapsed one does.
+    ///
+    /// What FoldJumpBehavior::Expand reaches for: a jump that names a hidden target opens the block
+    /// rather than refusing to go there.
+    ///
+    /// @param gridLine A grid line (0 = page top, negative = into the scrollback).
+    /// @return Whether anything changed.
+    bool expandFoldContaining(LineOffset gridLine);
+
+    /// Collapses or expands the most recently FINISHED command's fold.
+    /// @return Whether there was one to toggle.
+    bool toggleLastFold();
+
+    /// Collapses the most recently FINISHED command's fold, leaving an already-collapsed one alone.
+    /// @return Whether there was one to collapse.
+    bool collapseLastFold();
+
+    /// Collapses every foldable command within reach.
+    /// @return Whether anything changed.
+    bool collapseAllFolds();
+
+    /// Expands everything that is collapsed.
+    /// @return Whether anything changed.
+    bool expandAllFolds();
+
+    /// Collapses the command that just finished, when configured to (@see
+    /// Settings::autoCollapseFoldOnNewCommand). Called as a new prompt starts.
+    void autoCollapseOnNewPrompt();
+
+    /// The id runs collapsed folds currently hide, ascending and disjoint.
+    ///
+    /// Cached beside the projection rather than recomputed, because the fold-aware Vi motions below ask
+    /// for it on every keystroke and it is a function of exactly the same inputs.
+    [[nodiscard]] std::span<HiddenInterval const> hiddenIntervals() const;
+
+    /// Whether a collapsed fold hides @p gridLine, so that the row is drawn nowhere.
+    ///
+    /// Deliberately NOT Viewport::isLineVisible(), which asks whether the row is on screen RIGHT NOW.
+    /// A line merely scrolled out of the viewport needs no fold opened, and opening one for it would be
+    /// a plain motion changing fold state behind the user's back.
+    ///
+    /// @param gridLine The grid line to test.
+    /// @return true when a collapsed fold hides it.
+    [[nodiscard]] bool isLineHiddenByFold(LineOffset gridLine) const;
+
+    /// How many VISIBLE grid lines lie in the half-open range [@p from, @p to).
+    ///
+    /// The distance a scroll would have to travel to bring @p to where @p from is -- which is measured
+    /// in rows the user can see, not in grid lines, and the two differ by whatever collapsed folds hide
+    /// in between. Negative when @p to precedes @p from.
+    ///
+    /// @param from The first grid line of the range, counted.
+    /// @param to The grid line one past its end, not counted.
+    /// @return The number of visible lines between them, signed.
+    [[nodiscard]] int visibleDistance(LineOffset from, LineOffset to) const;
+
+    /// The grid line @p count VISIBLE lines from @p line in @p direction.
+    ///
+    /// What makes `3j` mean three lines the user can SEE. Clamped to the addressable grid, so a motion
+    /// that runs off either end stops there -- on the last line before the edge that is DRAWN, since
+    /// the oldest addressable line may itself sit inside a collapsed block.
+    ///
+    /// @param line The grid line to start from; snapped out of a collapsed fold first, if it is in one.
+    /// @param count How many visible lines to travel; zero snaps without moving.
+    /// @param direction Which way to travel.
+    /// @return The grid line arrived at.
+    [[nodiscard]] LineOffset advanceVisibleLines(LineOffset line,
+                                                 int count,
+                                                 VerticalDirection direction) const;
+
+    /// The nearest grid line at or beyond @p line, in @p direction, that no collapsed fold hides.
+    /// @param line The grid line to snap.
+    /// @param direction Which way to leave a collapsed block.
+    /// @return @p line itself when it is already visible, the nearest visible line otherwise.
+    [[nodiscard]] LineOffset snapToVisibleLine(LineOffset line, VerticalDirection direction) const;
+
+    /// Points the fold column's hover highlight at @p gridLine, or clears it with nullopt.
+    ///
+    /// The whole run of a fold lights up rather than one row, because the whole run is the click target
+    /// -- the highlight has to say how far the thing you are about to click reaches.
+    ///
+    /// @param gridLine The grid line the pointer is over in the gutter, or nullopt when it left.
+    void setGutterHoverLine(std::optional<LineOffset> gridLine);
+
+    // }}}
 
     /// Scrolls the viewport and extends the active selection to the boundary cell.
     ///
@@ -1251,7 +1467,8 @@ class Terminal
 
     [[nodiscard]] CellLocation currentMousePosition() const noexcept { return _currentMousePosition; }
 
-    [[nodiscard]] std::optional<CellLocation> currentMouseGridPosition() const noexcept
+    /// Not noexcept: the coordinate translation goes through the fold projection, which allocates.
+    [[nodiscard]] std::optional<CellLocation> currentMouseGridPosition() const
     {
         if (_currentScreen->contains(_currentMousePosition))
             return _viewport.translateScreenToGridCoordinate(_currentMousePosition);
@@ -2486,6 +2703,139 @@ class Terminal
 
     std::unique_ptr<ShellIntegration> _shellIntegration;
     SemanticBlockTracker _semanticBlockTracker;
+
+    // {{{ Output folding
+    mutable FoldState _foldState;
+
+    /// The Grid::stableIdGeneration() _foldState was last reconciled against (@see refreshFoldState).
+    ///
+    /// Its OWN counter, and deliberately not _foldRangesGeneration: that one is a cache stamp written
+    /// by foldRanges() on every miss, so anything that merely reads the ranges after a reflow -- a
+    /// resize snapping the Vi cursor, a mouse move over the gutter mid-drag -- would bring it up to
+    /// date and the reconciliation below would conclude nothing had happened. The ids in _foldState
+    /// would then survive a reflow that gave them to different rows, and the wrong block would show as
+    /// collapsed.
+    mutable uint64_t _foldStateGeneration = 0;
+
+    /// The scrollback floor _foldState was last pruned against, or nullopt before the first
+    /// reconciliation. What makes refreshFoldState() cheap enough to front every read: the floor moves
+    /// only when history is evicted, so between two evictions the reconciliation is two comparisons.
+    mutable std::optional<int64_t> _foldStateFloor;
+
+    /// Everything the fold ranges are a function of.
+    ///
+    /// The grid's own identity: a generation bump means row identity was destroyed wholesale, and
+    /// stableBase advances on every scroll, which is exactly when a mark may have moved into or out of
+    /// reach. A struct with a defaulted operator== rather than a hand-written conjunction, for the
+    /// reason FoldProjectionKey gives: a fourth input is then a field rather than a term someone has to
+    /// remember to add to the comparison.
+    struct FoldRangesKey
+    {
+        uint64_t generation = 0;
+        int64_t stableBase = 0;
+        uint64_t markRevision = 0;
+
+        [[nodiscard]] bool operator==(FoldRangesKey const&) const noexcept = default;
+    };
+
+    // Cached, because computeFoldRanges walks the scrollback: valid until the grid moves underneath it.
+    // Empty key means never computed -- an all-zero key would compare equal to a fresh grid's.
+    mutable std::vector<FoldRange> _foldRanges;
+    mutable std::optional<FoldRangesKey> _foldRangesKey;
+
+    /// Bumped whenever a semantic mark is stamped or cleared (@see invalidateFoldRanges).
+    uint64_t _semanticMarkRevision = 0;
+
+    /// Everything the projection is a function of. Cached as one key rather than rebuilt per call,
+    /// because foldProjection() hands out a SPAN over the buffer below: recomputing on each call would
+    /// reallocate it and dangle the span a caller is still holding.
+    ///
+    /// Held as an optional for the reason FoldRangesKey is: nullopt says never computed, where an
+    /// all-zero key would compare equal to the one a fresh grid produces.
+    struct FoldProjectionKey
+    {
+        uint64_t generation = 0;
+        int64_t stableBase = 0;
+        int scrollOffset = 0;
+        int pageLines = 0;
+        uint64_t foldRevision = 0;
+        uint64_t markRevision = 0;
+        int extraLines = 0;
+        bool foldingApplies = false;
+
+        [[nodiscard]] bool operator==(FoldProjectionKey const&) const noexcept = default;
+    };
+
+    void ensureFoldProjection() const;
+
+    /// The stable id of grid line 0 on the grid the CALLER's cursor is on.
+    ///
+    /// The caller's own grid, not the primary one: Vi normal mode runs on the alternate screen too,
+    /// where the primary's addressableTop() is negative by its whole scrollback while the alternate has
+    /// none -- clamping a `k` against that bound walks the cursor off the top of a grid with no rows
+    /// there. hiddenIntervals() is empty on the alternate screen (nothing there folds), so every walk
+    /// written against this base correctly degenerates to the plain arithmetic.
+    ///
+    /// @return The base to add a LineOffset to when working in id space.
+    [[nodiscard]] int64_t currentStableBase() const noexcept
+    {
+        return currentScreen().grid().stableLineIdOf(LineOffset(0));
+    }
+
+    /// Which part of @p range's column the row @p id carries.
+    ///
+    /// Split out of foldMarkerAt() because the gutter has the range in hand already: looking it up a
+    /// second time per row to ask what to draw there would be one binary search too many. Takes the
+    /// stable id rather than the grid line for the same reason -- whoever found the range derived it on
+    /// the way there.
+    ///
+    /// @param range The fold covering @p id.
+    /// @param id The stable id of the row to describe.
+    /// @return The marker, or FoldMarker::None for a row a COLLAPSED fold hides.
+    [[nodiscard]] FoldMarker markerIn(FoldRange const& range, int64_t id) const noexcept;
+
+    /// The fold in @p ranges covering @p id, if one does.
+    ///
+    /// The lookup foldContaining() is written in terms of, exposed separately for the gutter: it walks a
+    /// page of rows against the same range list, and re-validating the range cache per row would be a
+    /// frame-constant check repeated fifty times.
+    ///
+    /// @param ranges The fold ranges, most recent first (@see foldRanges).
+    /// @param id The stable id to look up.
+    /// @return The covering fold, or nullopt when none reaches that id.
+    [[nodiscard]] static std::optional<FoldRange> foldCovering(std::span<FoldRange const> ranges,
+                                                               int64_t id) noexcept;
+
+    /// Moves the Vi cursor out of a block that is no longer drawn underneath it.
+    void snapViCursorOutOfFolds();
+
+    /// Restores the invariants a change to the fold set breaks, and the single funnel every mutator of
+    /// _foldState ends in.
+    ///
+    /// Hiding rows does two things at once that nothing else repairs: it can leave the Vi cursor on a
+    /// line that is no longer drawn, and it shrinks the scrollable range out from under a viewport
+    /// already scrolled past the new top. Both are corrected here so that a sixth mutator has one call
+    /// to make rather than a checklist to remember.
+    void onFoldStateChanged();
+
+    /// Fills @p output's gutter with one marker per visible row that a fold hangs off.
+    /// @param output The buffer being built.
+    /// @param baseLine The screen row the main page starts at -- non-zero with a top status line, and
+    ///                 the same shift RenderBufferBuilder applies to every cell it emits.
+    void fillGutter(RenderBuffer& output, LineOffset baseLine) const;
+
+    mutable std::vector<LineOffset> _foldProjection;
+
+    /// The hidden runs the projection was built from, kept rather than discarded: the fold-aware Vi
+    /// motions ask for them on every keystroke, and they are a function of the very same cache key.
+    mutable std::vector<HiddenInterval> _hiddenIntervals;
+
+    mutable LineCount _hiddenLineCount = LineCount(0);
+    mutable std::optional<FoldProjectionKey> _foldProjectionKey;
+
+    /// The grid line the pointer hovers in the gutter, if any (@see setGutterHoverLine).
+    std::optional<LineOffset> _gutterHoverLine;
+    // }}}
 
     DesktopNotificationManager _desktopNotificationManager;
 };

--- a/src/vtbackend/ViCommands.cpp
+++ b/src/vtbackend/ViCommands.cpp
@@ -518,7 +518,10 @@ CellLocation ViCommands::prev(CellLocation location) const noexcept
                                    : LineOffset(0);
     if (location.line > topLineOffset)
     {
-        location = getRightMostNonEmptyCellLocation(*_terminal, location.line - 1);
+        // The previous VISIBLE line: wrapping backwards off the start of a line must not drop the
+        // cursor into a collapsed block, where it would simply disappear.
+        location =
+            getRightMostNonEmptyCellLocation(*_terminal, stepVisible(location.line, VerticalDirection::Up));
         if (location.column + 1 < boxed_cast<ColumnOffset>(_terminal->pageSize().columns))
             ++location.column;
     }
@@ -537,7 +540,7 @@ CellLocation ViCommands::next(CellLocation location) const noexcept
 
     if (location.line < boxed_cast<LineOffset>(_terminal->pageSize().lines - 1))
     {
-        location.line++;
+        location.line = stepVisible(location.line, VerticalDirection::Down);
         location.column = ColumnOffset(0);
     }
 
@@ -766,6 +769,50 @@ bool ViCommands::compareCellTextAt(CellLocation position, char32_t codepoint) co
     return _terminal->currentScreen().compareCellTextAt(position, codepoint);
 }
 
+LineOffset ViCommands::stepVisible(LineOffset line, VerticalDirection direction) const noexcept
+{
+    return _terminal->advanceVisibleLines(line, 1, direction);
+}
+
+bool ViCommands::tryStepVisible(LineOffset& line, VerticalDirection direction) const noexcept
+{
+    auto const next = stepVisible(line, direction);
+    if (next == line)
+        return false;
+
+    line = next;
+    return true;
+}
+
+CellLocation ViCommands::revealOrSnap(CellLocation position)
+{
+    // The motions above are computed in visible lines and so cannot land inside a collapsed block. The
+    // jumps that NAME a target can: a search hit, a mark, an entry in the jump history. What should
+    // happen then is a genuine preference, so it is one -- Settings::foldJumpBehavior.
+    //
+    // The question is whether a FOLD hides the target, not whether it happens to be on screen. A plain
+    // `k` past the top of a viewport that can scroll no further names a line which is off screen but
+    // perfectly visible, and answering the wrong question there opened the block it landed on.
+    if (!_terminal->isLineHiddenByFold(position.line))
+        return position;
+
+    switch (_terminal->settings().foldJumpBehavior)
+    {
+        case FoldJumpBehavior::Expand:
+            // Silently skipping a match the user just searched for is worse than revealing the block it
+            // was found in, which is why this is the default -- and why vim's `foldopen` does the same.
+            if (_terminal->expandFoldContaining(position.line))
+                return position;
+            break;
+        case FoldJumpBehavior::Skip: break;
+    }
+
+    // Downwards first, so a target inside a block resolves to the line the block continues at rather
+    // than back to the prompt the user was already standing on.
+    return { .line = _terminal->snapToVisibleLine(position.line, VerticalDirection::Down),
+             .column = position.column };
+}
+
 CellLocation ViCommands::globalCharUp(CellLocation location, char ch, unsigned count) const noexcept
 {
     auto const pageTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
@@ -773,13 +820,17 @@ CellLocation ViCommands::globalCharUp(CellLocation location, char ch, unsigned c
     while (count > 0)
     {
         if (location.column == ColumnOffset(0) && result.line > pageTop)
-            --result.line;
+            result.line = stepVisible(result.line, VerticalDirection::Up);
         while (result.line > pageTop)
         {
             auto const& line = _terminal->currentScreen().lineTextAt(result.line, false, true);
             if (line.size() == 1 && line[0] == ch)
                 break;
-            --result.line;
+            // Stepping by VISIBLE lines, so the walk skips a collapsed block whole rather than
+            // searching inside one and stopping the cursor where it cannot be seen. It also means
+            // the step can stall at the edge of the grid, which ends the walk.
+            if (!tryStepVisible(result.line, VerticalDirection::Up))
+                break;
         }
         --count;
     }
@@ -793,13 +844,14 @@ CellLocation ViCommands::globalCharDown(CellLocation location, char ch, unsigned
     while (count > 0)
     {
         if (location.column == ColumnOffset(0) && result.line < pageBottom)
-            ++result.line;
+            result.line = stepVisible(result.line, VerticalDirection::Down);
         while (result.line < pageBottom)
         {
             auto const& line = _terminal->currentScreen().lineTextAt(result.line, false, true);
             if (line.size() == 1 && line[0] == ch)
                 break;
-            ++result.line;
+            if (!tryStepVisible(result.line, VerticalDirection::Down))
+                break;
         }
         --count;
     }
@@ -841,21 +893,30 @@ CellLocation ViCommands::translateToCellLocationAndRecord(ViMotion motion, unsig
                                 .column = min(ColumnOffset::cast_from(count - 1),
                                               _terminal->pageSize().columns.as<ColumnOffset>() - 1) });
         case ViMotion::FileBegin: // gg
+            // Snapped DOWNWARDS: the oldest addressable line may itself be inside a collapsed block,
+            // and the top of the document the user can see is the first line below it.
             return snapToCell(
-                { .line = LineOffset::cast_from(-_terminal->currentScreen().historyLineCount().as<int>()),
+                { .line = _terminal->snapToVisibleLine(
+                      LineOffset::cast_from(-_terminal->currentScreen().historyLineCount().as<int>()),
+                      VerticalDirection::Down),
                   .column = ColumnOffset(0) });
         case ViMotion::FileEnd: // G
-            return addJumpHistory(snapToCell(
-                { .line = _terminal->pageSize().lines.as<LineOffset>() - 1, .column = ColumnOffset(0) }));
+            return addJumpHistory(
+                snapToCell({ .line = _terminal->snapToVisibleLine(
+                                 _terminal->pageSize().lines.as<LineOffset>() - 1, VerticalDirection::Up),
+                             .column = ColumnOffset(0) }));
         case ViMotion::PageTop: // <S-H>
-            return snapToCell({ .line = boxed_cast<LineOffset>(-_terminal->viewport().scrollOffset())
-                                        + *_terminal->viewport().scrollOff(),
+            // H, M and L name SCREEN rows, so they are computed there and translated -- which is both
+            // shorter than the scroll-offset arithmetic this replaced and the only formulation that
+            // stays right when collapsed folds make screen rows and grid lines disagree.
+            return snapToCell({ .line = _terminal->viewport().translateScreenToGridLine(
+                                    LineOffset::cast_from(*_terminal->viewport().scrollOff())),
                                 .column = ColumnOffset(0) });
         case ViMotion::PageBottom: // <S-L>
-            return snapToCell({ .line = boxed_cast<LineOffset>(-_terminal->viewport().scrollOffset())
-                                        + boxed_cast<LineOffset>(_terminal->pageSize().lines
-                                                                 - *_terminal->viewport().scrollOff() - 1),
-                                .column = ColumnOffset(0) });
+            return snapToCell(
+                { .line = _terminal->viewport().translateScreenToGridLine(boxed_cast<LineOffset>(
+                      _terminal->pageSize().lines - *_terminal->viewport().scrollOff() - 1)),
+                  .column = ColumnOffset(0) });
         case ViMotion::LineBegin: // 0
             return { .line = cursorPosition.line, .column = ColumnOffset(0) };
         case ViMotion::LineTextBegin: // ^
@@ -867,42 +928,43 @@ CellLocation ViCommands::translateToCellLocationAndRecord(ViMotion motion, unsig
             return result;
         }
         case ViMotion::LineDown: // j
-            return { .line = min(cursorPosition.line + LineOffset::cast_from(count),
-                                 _terminal->pageSize().lines.as<LineOffset>() - 1),
+            // Counted in VISIBLE lines, so a collapsed block is one step rather than however many rows
+            // it hides -- and the cursor never lands on a row that is not on screen.
+            return { .line = _terminal->advanceVisibleLines(
+                         cursorPosition.line, static_cast<int>(count), VerticalDirection::Down),
                      .column = cursorPosition.column };
         case ViMotion::LineEnd: // $
             return getRightMostNonEmptyCellLocation(*_terminal, cursorPosition.line);
         case ViMotion::LineUp: // k
-            return { .line = max(cursorPosition.line - LineOffset::cast_from(count),
-                                 -_terminal->currentScreen().historyLineCount().as<LineOffset>()),
+            return { .line = _terminal->advanceVisibleLines(
+                         cursorPosition.line, static_cast<int>(count), VerticalDirection::Up),
                      .column = cursorPosition.column };
         case ViMotion::LinesCenter: // M
-            return addJumpHistory({ .line = LineOffset::cast_from(_terminal->pageSize().lines / 2 - 1)
-                                            - boxed_cast<LineOffset>(_terminal->viewport().scrollOffset()),
+            return addJumpHistory({ .line = _terminal->viewport().translateScreenToGridLine(
+                                        LineOffset::cast_from((*_terminal->pageSize().lines / 2) - 1)),
                                     .column = cursorPosition.column });
         case ViMotion::PageDown:
-            return { .line = min(cursorPosition.line + LineOffset::cast_from(_terminal->pageSize().lines / 2),
-                                 _terminal->pageSize().lines.as<LineOffset>() - 1),
+            return { .line = _terminal->advanceVisibleLines(
+                         cursorPosition.line, *_terminal->pageSize().lines / 2, VerticalDirection::Down),
                      .column = cursorPosition.column };
         case ViMotion::PageUp:
-            return { .line = max(cursorPosition.line - LineOffset::cast_from(_terminal->pageSize().lines / 2),
-                                 -_terminal->currentScreen().historyLineCount().as<LineOffset>()),
+            return { .line = _terminal->advanceVisibleLines(
+                         cursorPosition.line, *_terminal->pageSize().lines / 2, VerticalDirection::Up),
                      .column = cursorPosition.column };
-            return cursorPosition
-                   - min(cursorPosition.line, LineOffset::cast_from(_terminal->pageSize().lines) / 2);
         case ViMotion::ParagraphBackward: // {
         {
             auto const pageTop = -_terminal->currentScreen().historyLineCount().as<LineOffset>();
             auto prev = CellLocation { .line = cursorPosition.line, .column = ColumnOffset(0) };
             if (prev.line.value > 0)
-                prev.line--;
+                prev.line = stepVisible(prev.line, VerticalDirection::Up);
             auto current = prev;
             while (current.line > pageTop
                    && (!_terminal->currentScreen().isLineEmpty(current.line)
                        || _terminal->currentScreen().isLineEmpty(prev.line)))
             {
                 prev.line = current.line;
-                current.line--;
+                if (!tryStepVisible(current.line, VerticalDirection::Up))
+                    break; // the walk ran out of VISIBLE grid
             }
             return addJumpHistory(snapToCell(current));
         }
@@ -922,10 +984,13 @@ CellLocation ViCommands::translateToCellLocationAndRecord(ViMotion motion, unsig
             {
                 if (result.line > gridTop
                     && _terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlag::Marked))
-                    --result.line;
+                    result.line = stepVisible(result.line, VerticalDirection::Up);
                 while (result.line > gridTop
                        && !_terminal->currentScreen().isLineFlagEnabledAt(result.line, LineFlag::Marked))
-                    --result.line;
+                {
+                    if (!tryStepVisible(result.line, VerticalDirection::Up))
+                        break;
+                }
                 --count;
             }
             return addJumpHistory(result);
@@ -937,12 +1002,13 @@ CellLocation ViCommands::translateToCellLocationAndRecord(ViMotion motion, unsig
             while (count > 0)
             {
                 if (cursorPosition.column == ColumnOffset(0) && result.line < pageBottom)
-                    ++result.line;
+                    result.line = stepVisible(result.line, VerticalDirection::Down);
                 while (result.line < pageBottom)
                 {
                     if (_terminal->currentScreen().lineFlagsAt(result.line).contains(LineFlag::Marked))
                         break;
-                    ++result.line;
+                    if (!tryStepVisible(result.line, VerticalDirection::Down))
+                        break;
                 }
                 --count;
             }
@@ -953,14 +1019,15 @@ CellLocation ViCommands::translateToCellLocationAndRecord(ViMotion motion, unsig
             auto const pageBottom = _terminal->pageSize().lines.as<LineOffset>() - 1;
             auto prev = CellLocation { .line = cursorPosition.line, .column = ColumnOffset(0) };
             if (prev.line < pageBottom)
-                prev.line++;
+                prev.line = stepVisible(prev.line, VerticalDirection::Down);
             auto current = prev;
             while (current.line < pageBottom
                    && (!_terminal->currentScreen().isLineEmpty(current.line)
                        || _terminal->currentScreen().isLineEmpty(prev.line)))
             {
                 prev.line = current.line;
-                current.line++;
+                if (!tryStepVisible(current.line, VerticalDirection::Down))
+                    break; // the walk ran out of VISIBLE grid
             }
             return addJumpHistory(snapToCell(current));
         }
@@ -1188,7 +1255,7 @@ void ViCommands::moveCursor(ViMotion motion, unsigned count, char32_t lastChar)
 
 void ViCommands::moveCursorTo(CellLocation position)
 {
-    cursorPosition = position;
+    cursorPosition = revealOrSnap(position);
 
     _terminal->viewport().makeVisibleWithinSafeArea(cursorPosition.line);
 

--- a/src/vtbackend/ViCommands.hpp
+++ b/src/vtbackend/ViCommands.hpp
@@ -71,6 +71,31 @@ class ViCommands: public ViInputHandler::Executor
                                                        char right) const noexcept;
     [[nodiscard]] CellLocation findBeginOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept;
     [[nodiscard]] CellLocation findEndOfWordAt(CellLocation location, JumpOver jumpOver) const noexcept;
+    /// One VISIBLE line from @p line in @p direction, or @p line itself at the edge of the grid.
+    ///
+    /// The step every line-walking motion takes, so none of them can walk into a collapsed block.
+    /// Returning @p line unchanged at the edge is what lets those loops end on "stopped moving"
+    /// rather than each restating a bound the fold projection has already accounted for.
+    [[nodiscard]] LineOffset stepVisible(LineOffset line, VerticalDirection direction) const noexcept;
+
+    /// Moves @p line one VISIBLE line in @p direction, reporting whether it moved at all.
+    ///
+    /// The termination condition every line-scanning motion below shares: the walk ends when the step
+    /// stalls, which is the grid's edge. One helper rather than the same three lines at each of them.
+    ///
+    /// @param line The line to advance, updated in place when it moves.
+    /// @param direction Which way to step.
+    /// @return Whether @p line changed.
+    [[nodiscard]] bool tryStepVisible(LineOffset& line, VerticalDirection direction) const noexcept;
+
+    /// Resolves a jump target that lands inside a collapsed fold, per Settings::foldJumpBehavior.
+    ///
+    /// Not const: FoldJumpBehavior::Expand opens the block, which is the point of it.
+    ///
+    /// @param position The target a jump named.
+    /// @return @p position when it is visible or was revealed, the nearest visible line otherwise.
+    [[nodiscard]] CellLocation revealOrSnap(CellLocation position);
+
     [[nodiscard]] CellLocation globalCharUp(CellLocation location, char ch, unsigned count) const noexcept;
     [[nodiscard]] CellLocation globalCharDown(CellLocation location, char ch, unsigned count) const noexcept;
     [[nodiscard]] std::optional<CellLocation> toCharRight(CellLocation startPosition) const noexcept;

--- a/src/vtbackend/Viewport.cpp
+++ b/src/vtbackend/Viewport.cpp
@@ -14,8 +14,8 @@ namespace vtbackend
 bool Viewport::scrollUp(LineCount numLines)
 {
     ViewportLog()("scrollUp");
-    auto offset =
-        std::min(_scrollOffset + numLines.as<ScrollOffset>(), boxed_cast<ScrollOffset>(historyLineCount()));
+    auto offset = std::min(_scrollOffset + numLines.as<ScrollOffset>(),
+                           boxed_cast<ScrollOffset>(scrollableLineCount()));
     return scrollTo(offset);
 }
 
@@ -29,7 +29,7 @@ bool Viewport::scrollDown(LineCount numLines)
 bool Viewport::scrollToTop()
 {
     ViewportLog()("scrollToTop");
-    return scrollTo(boxed_cast<ScrollOffset>(historyLineCount()));
+    return scrollTo(boxed_cast<ScrollOffset>(scrollableLineCount()));
 }
 
 bool Viewport::scrollToBottom()
@@ -55,41 +55,77 @@ bool Viewport::forceScrollToBottom()
     return changed;
 }
 
+bool Viewport::clampScrollOffset()
+{
+    auto const maxOffset = boxed_cast<ScrollOffset>(scrollableLineCount());
+    if (_scrollOffset <= maxOffset)
+        return false;
+
+    ViewportLog()("clampScrollOffset: {} -> {}", _scrollOffset, maxOffset);
+    _scrollOffset = maxOffset;
+
+    // The sub-cell offset goes with it. It measures a slide between two adjacent rows, and the row it
+    // was sliding towards is one a collapsed fold has just taken away.
+    resetPixelOffset();
+    _modified();
+    return true;
+}
+
 bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset)
 {
     ViewportLog()("makeVisibleWithinSafeArea");
     return makeVisibleWithinSafeArea(lineOffset, _scrollOff);
 }
 
-CellLocation Viewport::clampCellLocation(CellLocation const& location) const noexcept
+CellLocation Viewport::clampCellLocation(CellLocation const& location) const
 {
-    auto const scrollOffset = _scrollOffset.as<LineOffset>();
-
-    auto const viewportTop = -scrollOffset;
-    auto const viewportBottom = boxed_cast<LineOffset>(screenLineCount() - 1) - scrollOffset;
     auto const viewportLeft = ColumnOffset(0);
     auto const viewportRight = boxed_cast<ColumnOffset>(_terminal->pageSize().columns - 1);
-
-    auto const line = std::clamp(location.line, viewportTop, viewportBottom);
     auto const column = std::clamp(location.column, viewportLeft, viewportRight);
 
-    return CellLocation { .line = line, .column = column };
+    auto const projection = _terminal->foldProjection();
+    if (projection.empty())
+    {
+        auto const scrollOffset = _scrollOffset.as<LineOffset>();
+        auto const viewportTop = -scrollOffset;
+        auto const viewportBottom = boxed_cast<LineOffset>(screenLineCount() - 1) - scrollOffset;
+        return CellLocation { .line = std::clamp(location.line, viewportTop, viewportBottom),
+                              .column = column };
+    }
+
+    // The bounds are the projection's own ends, and emphatically NOT -scrollOffset: the scroll offset
+    // counts VISIBLE rows, so with collapsed folds in between, grid line -scrollOffset names a row far
+    // DOWN the page rather than the one the viewport starts at. Clamping the Vi cursor against it is
+    // what threw the cursor back towards the bottom on every `k` that scrolled.
+    //
+    // Both ends are rows the viewport draws, so the result is on screen by construction.
+    return CellLocation { .line = std::clamp(location.line, projection.front(), projection.back()),
+                          .column = column };
 }
 
 bool Viewport::makeVisibleWithinSafeArea(LineOffset lineOffset, LineCount paddingLines)
 {
-    auto const viewportTop = -_scrollOffset.as<LineOffset>() + boxed_cast<LineOffset>(paddingLines);
-    auto const viewportBottom = boxed_cast<LineOffset>(screenLineCount() - 1) - _scrollOffset.as<int>()
-                                - boxed_cast<LineOffset>(paddingLines);
+    // Distances measured in SCREEN rows, not grid lines. Scrolling moves by rows the user can see, and
+    // with collapsed folds in between the two counts differ -- subtracting grid lines would scroll by
+    // however many rows the folds hide as well, overshooting by exactly that much.
+    auto const screenRow = translateGridToScreenCoordinate(lineOffset);
+    auto const topRow = boxed_cast<LineOffset>(paddingLines);
+    auto const bottomRow =
+        boxed_cast<LineOffset>(screenLineCount() - 1) - boxed_cast<LineOffset>(paddingLines);
 
-    ViewportLog()("viewportTop {} viewportBottom {} lineOffset {}", viewportTop, viewportBottom, lineOffset);
+    ViewportLog()("makeVisibleWithinSafeArea: screenRow {} in [{}, {}] for line {}",
+                  screenRow,
+                  topRow,
+                  bottomRow,
+                  lineOffset);
+
     // Is the line above the viewport?
-    if (!(viewportTop < lineOffset))
-        return scrollUp(LineCount::cast_from(viewportTop - lineOffset));
+    if (!(topRow < screenRow))
+        return scrollUp(LineCount::cast_from(topRow - screenRow));
 
     // Is the line below the viewport?
-    if (!(lineOffset < viewportBottom))
-        return scrollDown(LineCount::cast_from(lineOffset - viewportBottom));
+    if (!(screenRow < bottomRow))
+        return scrollDown(LineCount::cast_from(screenRow - bottomRow));
 
     return false;
 }
@@ -109,7 +145,7 @@ bool Viewport::scrollTo(ScrollOffset offset)
     if (offset == _scrollOffset)
         return false;
 
-    if (0 <= *offset && offset <= boxed_cast<ScrollOffset>(historyLineCount()))
+    if (0 <= *offset && offset <= boxed_cast<ScrollOffset>(scrollableLineCount()))
     {
         ViewportLog()("Scroll to offset {}", offset);
         _scrollOffset = offset;
@@ -121,39 +157,160 @@ bool Viewport::scrollTo(ScrollOffset offset)
     return false;
 }
 
+ScrollOffset Viewport::scrollOffsetForTopLine(LineOffset line) const
+{
+    // Measured from where the line is drawn NOW rather than from grid line 0, and this is the whole
+    // subtlety: a scroll offset counts visible rows up from the bottom of the PAGE, and with folds
+    // collapsed the page itself can hide rows -- so the visible distance from the oldest line down to
+    // grid line 0 overshoots the largest offset scrollableLineCount() admits, by exactly the number of
+    // page rows a fold has taken away. Scrolling up by one moves every line down one row, so the offset
+    // that lands @p line on row zero is the current one less the row it occupies.
+    auto const target =
+        _scrollOffset - ScrollOffset::cast_from(unbox<int>(translateGridToScreenCoordinate(line)));
+
+    // Clamped rather than handed out for scrollTo() to refuse: a mark so far up that the viewport
+    // cannot bring it all the way to the top still belongs at the top of the scrollback, which shows
+    // it. Returning the unreachable number instead is what made the action a silent no-op.
+    return std::clamp(target, ScrollOffset(0), boxed_cast<ScrollOffset>(scrollableLineCount()));
+}
+
+std::optional<LineOffset> Viewport::findVisibleMarker(LineOffset start, VerticalDirection direction) const
+{
+    auto const& screen = _terminal->primaryScreen();
+
+    auto line = start;
+    while (auto const candidate = direction == VerticalDirection::Up ? screen.findMarkerUpwards(line)
+                                                                     : screen.findMarkerDownwards(line))
+    {
+        // A mark inside a collapsed block is drawn nowhere, so no offset brings it into view and
+        // scrolling to it lands on whatever row stands in its place. Walk on rather than stop on a row
+        // that cannot be shown.
+        if (!_terminal->isLineHiddenByFold(*candidate))
+            return candidate;
+
+        // Strictly monotonic in either direction -- findMarker*() searches past its start line -- which
+        // is what terminates this.
+        line = *candidate;
+    }
+
+    return std::nullopt;
+}
+
 bool Viewport::scrollMarkUp()
 {
-    ViewportLog()("Scroll to Mark Down");
+    ViewportLog()("scrollMarkUp");
     if (scrollingDisabled())
         return false;
 
-    auto const newScrollOffset =
-        _terminal->primaryScreen().findMarkerUpwards(-boxed_cast<LineOffset>(_scrollOffset));
-    if (newScrollOffset.has_value())
-        return scrollTo(boxed_cast<ScrollOffset>(-*newScrollOffset));
+    auto const marker = findVisibleMarker(topLine(), VerticalDirection::Up);
+    if (!marker)
+        return false;
 
-    return false;
+    return scrollTo(scrollOffsetForTopLine(*marker));
 }
 
 bool Viewport::scrollMarkDown()
 {
-    ViewportLog()("Scroll to Mark Down");
+    ViewportLog()("scrollMarkDown");
     if (scrollingDisabled())
         return false;
 
-    auto const newScrollOffset =
-        _terminal->primaryScreen().findMarkerDownwards(-boxed_cast<LineOffset>(_scrollOffset));
-    if (newScrollOffset)
-        return scrollTo(boxed_cast<ScrollOffset>(-*newScrollOffset));
-    else
+    auto const marker = findVisibleMarker(topLine(), VerticalDirection::Down);
+    if (!marker)
         return forceScrollToBottom();
 
-    return true;
+    return scrollTo(scrollOffsetForTopLine(*marker));
+}
+
+bool Viewport::isLineVisible(LineOffset line) const
+{
+    auto const projection = _terminal->foldProjection();
+    if (projection.empty())
+    {
+        auto const a = -_scrollOffset.as<int>();
+        auto const b = line.as<int>();
+        auto const c = unbox(screenLineCount()) - _scrollOffset.as<int>();
+        return a <= b && b < c;
+    }
+
+    // A line inside the drawn span can still be hidden by a collapsed fold, so this is a membership
+    // test rather than an interval one. The projection is ascending, so it is one binary search.
+    auto const it = std::ranges::lower_bound(projection, line);
+    return it != projection.end() && *it == line;
+}
+
+LineOffset Viewport::translateScreenToGridLine(LineOffset line) const
+{
+    auto const projection = _terminal->foldProjection();
+    if (projection.empty())
+        return line - boxed_cast<LineOffset>(_scrollOffset);
+
+    // BOTTOM-aligned, exactly as Grid::render draws it: when collapsed folds hide more rows than the
+    // history can backfill, the projection is shorter than the page and the difference is blank rows at
+    // the TOP. Assuming row 0 here while the render pass drew from further down is precisely what would
+    // misplace a selection, so the offset comes from the one place that owns the rule.
+    auto const index = unbox<int>(line) - unbox<int>(_terminal->foldProjectionTopRow());
+
+    // Rows outside the projection are the blank ones above it and the space below; keep them
+    // proportional to the nearest real row so a coordinate there stays ORDERED rather than clamping onto
+    // it, which would make a selection dragged off the edge select the same row over and over.
+    //
+    // Continued in VISIBLE lines, because that is what a row is: a selection dragged one row above the
+    // viewport must reach the line the viewport WOULD show next, not whichever grid line happens to sit
+    // there with a collapsed block in between. advanceVisibleLines() also bounds the result by the
+    // addressable grid, which extrapolation needs on its own account -- enough collapsed rows leave the
+    // projection shorter than a page, and running off its bottom would otherwise name lines the grid
+    // does not have, which Grid::rowAt resolves by wrapping its ring buffer onto unrelated storage.
+    if (index < 0)
+        return _terminal->advanceVisibleLines(projection.front(), -index, VerticalDirection::Up);
+    if (static_cast<size_t>(index) >= projection.size())
+        return _terminal->advanceVisibleLines(
+            projection.back(), index - static_cast<int>(projection.size()) + 1, VerticalDirection::Down);
+    return projection[static_cast<size_t>(index)];
+}
+
+LineOffset Viewport::translateGridToScreenCoordinate(LineOffset p) const
+{
+    auto const projection = _terminal->foldProjection();
+    if (projection.empty())
+        return p + boxed_cast<LineOffset>(_scrollOffset);
+
+    // The projection is ascending in grid line, so the row showing p -- or, for a hidden line, the row
+    // that stands where it would be -- is one binary search away.
+    auto const top = unbox<int>(_terminal->foldProjectionTopRow());
+
+    // Above everything drawn: off the top of the viewport, and it has to REPORT so. Returning the top
+    // row instead would tell cursor-line and search-match highlighting that a line scrolled far out of
+    // sight is the one on screen row zero.
+    //
+    // Counted in VISIBLE lines rather than grid lines, because makeVisibleWithinSafeArea() turns this
+    // number straight into a scroll distance and a scroll travels in rows the user can see. A search
+    // hit fifty rows up but five hundred grid lines up would otherwise ask for a five-hundred-row
+    // scroll, which scrollUp() clamps to the top -- landing at the top of the scrollback instead of on
+    // the match.
+    if (p < projection.front())
+        return LineOffset::cast_from(top - _terminal->visibleDistance(p, projection.front()));
+
+    // Below everything drawn, and it has to report HOW far below, in the same visible rows. A flat
+    // screenLineCount() would tell makeVisibleWithinSafeArea that every target under the viewport is
+    // exactly one row past its bottom, so scrolling down to a line five hundred rows away would advance
+    // by the safe-area padding and stop.
+    auto const it = std::ranges::lower_bound(projection, p);
+    if (it == projection.end())
+        return LineOffset::cast_from(top + static_cast<int>(projection.size()) - 1
+                                     + _terminal->visibleDistance(projection.back(), p));
+
+    return LineOffset::cast_from(top + static_cast<int>(std::distance(projection.begin(), it)));
 }
 
 LineCount Viewport::historyLineCount() const noexcept
 {
     return _terminal->currentScreen().historyLineCount();
+}
+
+LineCount Viewport::scrollableLineCount() const
+{
+    return std::max(LineCount(0), historyLineCount() - _terminal->hiddenLineCount());
 }
 
 LineCount Viewport::screenLineCount() const noexcept

--- a/src/vtbackend/Viewport.hpp
+++ b/src/vtbackend/Viewport.hpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <vtbackend/Folding.hpp>
 #include <vtbackend/Primitives.hpp>
 #include <vtbackend/Screen.hpp>
 
 #include <crispy/LogStore.hpp>
 
 #include <gsl/pointers>
+
+#include <optional>
 
 namespace vtbackend
 {
@@ -38,13 +41,29 @@ class Viewport
     /// @retval false viewport has NOT been moved/scrolled and is still located at its main view position.
     [[nodiscard]] bool scrolled() const noexcept { return _scrollOffset.value != 0; }
 
-    [[nodiscard]] bool isLineVisible(LineOffset line) const noexcept
-    {
-        auto const a = -_scrollOffset.as<int>();
-        auto const b = line.as<int>();
-        auto const c = unbox(screenLineCount()) - _scrollOffset.as<int>();
-        return a <= b && b < c;
-    }
+    /// Whether the grid line @p line is currently drawn.
+    ///
+    /// Not an interval test once folds are in play: the rows on screen are a non-contiguous selection of
+    /// grid rows, and a line INSIDE the drawn span may still be hidden. Goes through the same
+    /// translation the render pass agrees with, so a hidden line reports invisible and a backfilled one
+    /// reports visible.
+    ///
+    /// Not noexcept, where the plain interval test it replaced was: the projection is built lazily and
+    /// building it allocates, so promising otherwise would turn an allocation failure into a
+    /// std::terminate. The same goes for every query below that reads it.
+    [[nodiscard]] bool isLineVisible(LineOffset line) const;
+
+    /// How far the viewport can be scrolled up, in VISIBLE rows.
+    ///
+    /// The history depth less whatever collapsed folds hide: scrolling moves by rows the user can see,
+    /// and a collapsed block has taken its output out of that count. Equal to historyLineCount() when
+    /// nothing is collapsed, which is every existing caller's expectation.
+    ///
+    /// The single authority on the scroll bound. Everything that clamps a scroll position -- the
+    /// smooth-scroll accumulator, the scrollbar's range, the post-fold re-clamp -- reads it from here,
+    /// because a caller that bounded itself by the raw history instead would compute positions this
+    /// class then rejects, freezing the viewport while the sub-cell offset kept moving.
+    [[nodiscard]] LineCount scrollableLineCount() const;
 
     bool scrollUp(LineCount numLines);
     bool scrollDown(LineCount numLines);
@@ -52,7 +71,21 @@ class Viewport
     bool scrollToBottom();
     bool forceScrollToBottom();
     bool scrollTo(ScrollOffset offset);
+
+    /// Scrolls to the marked line above the viewport, bringing it to the top row.
+    ///
+    /// Skips marks a collapsed fold hides: there is no scroll offset that would show one, so stopping
+    /// there would consume the key and move the viewport to whichever row stands in its place.
+    ///
+    /// @return Whether the viewport moved.
     bool scrollMarkUp();
+
+    /// Scrolls to the marked line below the viewport, bringing it to the top row.
+    ///
+    /// Falls through to the bottom of the scrollback when there is no such mark, and skips hidden ones
+    /// for the reason scrollMarkUp() gives.
+    ///
+    /// @return Whether the viewport moved.
     bool scrollMarkDown();
 
     /// Ensures given line is visible by optionally scrolling the
@@ -64,30 +97,41 @@ class Viewport
     bool makeVisibleWithinSafeArea(LineOffset line);
     bool makeVisibleWithinSafeArea(LineOffset line, LineCount paddingLines);
 
-    CellLocation clampCellLocation(CellLocation const& location) const noexcept;
+    /// Brings @p location inside the rows and columns the viewport currently draws.
+    ///
+    /// Not noexcept, and not an interval clamp against the scroll offset: @see isLineVisible() for the
+    /// first, translateScreenToGridLine() for the second.
+    [[nodiscard]] CellLocation clampCellLocation(CellLocation const& location) const;
 
     /// Translates a screen coordinate to a Grid-coordinate by applying
     /// the scroll-offset to it.
-    constexpr CellLocation translateScreenToGridCoordinate(CellLocation p) const noexcept
+    ///
+    /// With folds collapsed the mapping is no longer an addition: the rows on screen are a
+    /// NON-contiguous selection of grid rows, and the one authority on which is the projection the
+    /// render pass draws from. Every consumer -- selection, vi mode, the mouse protocol, hyperlink
+    /// hover -- goes through here, so this is the single place that has to agree with it.
+    [[nodiscard]] CellLocation translateScreenToGridCoordinate(CellLocation p) const
     {
-        return CellLocation {
-            .line = p.line - boxed_cast<LineOffset>(_scrollOffset),
-            .column = p.column,
-        };
+        return CellLocation { .line = translateScreenToGridLine(p.line), .column = p.column };
     }
 
-    constexpr CellLocation translateGridToScreenCoordinate(CellLocation p) const noexcept
+    [[nodiscard]] CellLocation translateGridToScreenCoordinate(CellLocation p) const
     {
-        return CellLocation {
-            .line = p.line + boxed_cast<LineOffset>(_scrollOffset),
-            .column = p.column,
-        };
+        return CellLocation { .line = translateGridToScreenCoordinate(p.line), .column = p.column };
     }
 
-    [[nodiscard]] constexpr LineOffset translateGridToScreenCoordinate(LineOffset p) const noexcept
-    {
-        return p + boxed_cast<LineOffset>(_scrollOffset);
-    }
+    [[nodiscard]] LineOffset translateGridToScreenCoordinate(LineOffset p) const;
+
+    /// The grid line the visible row @p line draws, honoring collapsed folds.
+    [[nodiscard]] LineOffset translateScreenToGridLine(LineOffset line) const;
+
+    /// The grid line the viewport's top row draws.
+    ///
+    /// Emphatically NOT -scrollOffset once anything is collapsed: that offset counts VISIBLE rows, so
+    /// negating it names a grid line far down the page rather than the one at the top. Spelled once
+    /// here because four callers wanted it and each open-coded translation is a chance to get that
+    /// wrong again.
+    [[nodiscard]] LineOffset topLine() const { return translateScreenToGridLine(LineOffset(0)); }
 
     /// Returns the sub-cell-height pixel offset for smooth scrolling.
     [[nodiscard]] float pixelOffset() const noexcept { return _pixelOffset; }
@@ -98,8 +142,38 @@ class Viewport
     /// Resets the pixel offset to zero.
     void resetPixelOffset() noexcept { _pixelOffset = 0.0f; }
 
+    /// Brings the scroll offset back inside the scrollable range, and reports whether it moved.
+    ///
+    /// Collapsing a fold takes its rows out of that range, so an offset that was legal a moment ago can
+    /// now sit above the top. Nothing else corrects it: scrollTo() REJECTS an out-of-range request
+    /// rather than repairing an offset already stored, so without this the viewport stays parked
+    /// somewhere it can no longer be scrolled away from.
+    bool clampScrollOffset();
+
   private:
+    /// The scroll offset that puts grid line @p line on the viewport's top row, clamped to what the
+    /// viewport can actually reach.
+    ///
+    /// The inverse of translateScreenToGridLine(LineOffset(0)), and emphatically not a negation: a
+    /// scroll offset counts VISIBLE rows, so with collapsed folds in between it is not the grid
+    /// distance at all. Negating instead asks for an offset that counts the hidden rows too, which
+    /// scrollTo() then rejects as out of bounds -- silently, since the action reports success either
+    /// way.
+    ///
+    /// @param line The grid line to bring to the top.
+    /// @return The offset to hand scrollTo().
+    [[nodiscard]] ScrollOffset scrollOffsetForTopLine(LineOffset line) const;
+
+    /// The nearest marked grid line in @p direction that no collapsed fold hides.
+    ///
+    /// @param start The grid line to search from, exclusive.
+    /// @param direction Which way to search.
+    /// @return The marked line, or nullopt when that direction holds none.
+    [[nodiscard]] std::optional<LineOffset> findVisibleMarker(LineOffset start,
+                                                              VerticalDirection direction) const;
+
     [[nodiscard]] LineCount historyLineCount() const noexcept;
+
     [[nodiscard]] LineCount screenLineCount() const noexcept;
     [[nodiscard]] bool scrollingDisabled() const noexcept;
 

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -247,6 +247,104 @@ namespace detail
                 return b;
             }
         };
+        /// Whether the head draws the open block's sign or the closed one's.
+        enum class FoldHeadState : uint8_t
+        {
+            Open = 0, ///< A minus, with a stem descending into the body column.
+            Closed,   ///< A plus, and no stem: a collapsed block has nothing below it.
+        };
+
+        /// The fold column's head marker: a box carrying a minus while the block is open and a plus
+        /// once it is closed, with a stem descending from the open one into the column below it.
+        ///
+        /// No Unicode codepoint describes this. U+229F SQUARED MINUS and U+229E SQUARED PLUS are the
+        /// box and its sign, but neither carries the stem that ties a fold's head to its body, and a
+        /// head that did not connect would read as two unrelated marks rather than one bracket down
+        /// the side of a block. Contour therefore draws it from two codepoints of its own
+        /// (@see docs/vt-extensions/private-use-glyphs.md).
+        ///
+        /// A box+sign rather than a triangle, because that is what a fold control looks like
+        /// everywhere else a reader has met one -- editors, tree views, file managers.
+        struct FoldHead
+        {
+            ImageSize size {};
+            FoldHeadState state = FoldHeadState::Open;
+
+            /// The top of a @p stroke-thick horizontal bar centred between @p top and @p bottom.
+            [[nodiscard]] static constexpr int centerY(int top, int bottom, int stroke) noexcept
+            {
+                return top + ((bottom - top - stroke) / 2);
+            }
+
+            operator atlas::Buffer() const
+            {
+                /*
+                    .___________. <- cell top
+                    |           |
+                    |  XXXXXXX  |
+                    |  X     X  |
+                    |  X XXX X  |  <- minus (open) ...
+                    |  X     X  |
+                    |  XXXXXXX  |
+                    |     X     |  <- ... and the stem into the body column below
+                    `-----X-----` <- cell bottom
+                */
+                auto b = blockElement<1>(size);
+
+                auto const w = unbox<int>(size.width);
+                auto const h = unbox<int>(size.height);
+
+                // Square whatever the cell's aspect ratio is: a box that stretched with the font would
+                // stop reading as a button the moment the user picked a narrow one. Odd, so the sign
+                // inside it has a centre pixel to sit on rather than straddling two.
+                //
+                // The two bounds are ordered explicitly rather than handed to std::clamp as they come:
+                // a cell narrower than seven device pixels -- a small font at a low DPI -- puts the
+                // upper bound below the lower one, which violates clamp's precondition.
+                auto const widest = std::max(3, w - 2);
+                auto side = std::clamp(
+                    static_cast<int>(std::lround(std::min(w, h) * 0.78)), std::min(5, widest), widest);
+                if (side % 2 == 0)
+                    --side;
+                side = std::max(3, side);
+                auto const stroke = std::max(1, side / 7);
+
+                // Where U+2502 puts its vertical, so the stem below meets the body column exactly.
+                auto const centerX = (w - stroke) / 2;
+
+                auto const left = centerX + (stroke / 2) - (side / 2);
+                auto const right = left + side;
+                auto const top = (h - side) / 2;
+                auto const bottom = top + side;
+
+                // The sign spans the box's interior, which makes it symmetric by construction.
+                auto const inner = stroke + std::max(1, side / 8);
+
+                auto const px = [&](int x0, int y0, int x1, int y1) {
+                    b.rect({ .x = double(x0) / w, .y = double(y0) / h },
+                           { .x = double(x1) / w, .y = double(y1) / h });
+                };
+
+                // The box outline.
+                px(left, top, right, top + stroke);       // top
+                px(left, bottom - stroke, right, bottom); // bottom
+                px(left, top, left + stroke, bottom);     // left
+                px(right - stroke, top, right, bottom);   // right
+
+                // The sign: a minus always, crossed into a plus once the block is closed.
+                auto const signTop = centerY(top, bottom, stroke);
+                px(left + inner, signTop, right - inner, signTop + stroke);
+                if (state == FoldHeadState::Closed)
+                    px(centerX, top + inner, centerX + stroke, bottom - inner);
+                else
+                    // Only the OPEN head carries a stem: a collapsed block has nothing below it for
+                    // the column to continue into.
+                    px(centerX, bottom, centerX + stroke, h);
+
+                return b;
+            }
+        };
+
         struct Box
         {
             Line upval = NoLine;
@@ -1990,6 +2088,7 @@ bool BoxDrawingRenderer::renderable(char32_t codepoint) noexcept
            || ascending(0x2500, 0x259F)             // box drawing, block elements, shades
            || codepoint == 0x25B6                   // ▶ BLACK RIGHT-POINTING TRIANGLE
            || codepoint == 0x25BC                   // ▼ BLACK DOWN-POINTING TRIANGLE
+           || ascending(0x10F000, 0x10F001)         // Contour's fold-head glyphs
            || ascending(0x1FB00, 0x1FBAF)           // more block sextants
            || ascending(0x1FBF0, 0x1FBF9)           // digits
            || ascending(0xEE00, 0xEE05)             // progress bar (Fira Code)
@@ -2514,6 +2613,15 @@ optional<atlas::Buffer> BoxDrawingRenderer::buildElements(char32_t codepoint,
         case 0xE0BA: return /*  */ ld({ .x=0, .y=1 }, { .x=1, .y=0 });
         case 0xE0BC: return /*  */ ud({ .x=0, .y=1 }, { .x=1, .y=0 });
         case 0xE0BE: return /*  */ ud({ .x=0, .y=0 }, { .x=1, .y=1 });
+
+        // Contour's own private-use glyphs (@see docs/vt-extensions/private-use-glyphs.md).
+        // Supplementary PUA-B rather than the BMP: E000..F8FF is comprehensively squatted by Nerd
+        // Fonts and friends. Not at a plane's start either, where what leaves the BMP tends to land
+        // first -- 10F000 sits near the far end of plane 16, which nothing well-known reaches.
+        case 0x10F000:
+            return /* fold head, open   */ FoldHead { .size = size, .state = FoldHeadState::Open };
+        case 0x10F001:
+            return /* fold head, closed */ FoldHead { .size = size, .state = FoldHeadState::Closed };
 
         // PUA defines as introduced by FiraCode: https://github.com/tonsky/FiraCode/issues/1324
         case 0xEE00: return progressBar().left();

--- a/src/vtrasterizer/BoxDrawingRenderer.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer.cpp
@@ -1988,6 +1988,8 @@ bool BoxDrawingRenderer::renderable(char32_t codepoint) noexcept
 
     return ascending(0x239B, 0x23B3)                // mathematical brackets and symbols
            || ascending(0x2500, 0x259F)             // box drawing, block elements, shades
+           || codepoint == 0x25B6                   // ▶ BLACK RIGHT-POINTING TRIANGLE
+           || codepoint == 0x25BC                   // ▼ BLACK DOWN-POINTING TRIANGLE
            || ascending(0x1FB00, 0x1FBAF)           // more block sextants
            || ascending(0x1FBF0, 0x1FBF9)           // digits
            || ascending(0xEE00, 0xEE05)             // progress bar (Fira Code)
@@ -2145,6 +2147,15 @@ optional<atlas::Buffer> BoxDrawingRenderer::buildElements(char32_t codepoint,
                    | (upper(1 / 2_th) * right(1 / 2_th) + lower(1 / 2_th) * left(1 / 2_th));
         case 0x259F: // ▟  QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
             return blockElement(size) | (upper(1 / 2_th) * right(1 / 2_th) + lower(1 / 2_th));
+
+        // Drawn here rather than left to the font: a font's ▼/▶ are small, thin and inconsistent
+        // between families, where drawn from the cell they are cell-proportionate and identical in
+        // every font -- the same reason every other glyph in this table is here.
+        //
+        // Dir names which edge the triangle's BASE sits on, so it points away from that edge -- the
+        // same convention U+E0B0's right-pointing Powerline separator uses with Dir::Left.
+        case 0x25B6: return /* ▶ */ triangle<Dir::Left, Inverted::No>(size);
+        case 0x25BC: return /* ▼ */ triangle<Dir::Top, Inverted::No>(size);
         // TODO: ■  U+25A0  BLACK SQUARE
         // TODO: □  U+25A1  WHITE SQUARE
         // TODO: ▢  U+25A2  WHITE SQUARE WITH ROUNDED CORNERS
@@ -2167,13 +2178,11 @@ optional<atlas::Buffer> BoxDrawingRenderer::buildElements(char32_t codepoint,
         // TODO: △  U+25B3  WHITE UP-POINTING TRIANGLE
         // TODO: ▴  U+25B4  BLACK UP-POINTING SMALL TRIANGLE
         // TODO: ▵  U+25B5  WHITE UP-POINTING SMALL TRIANGLE
-        // TODO: ▶  U+25B6  BLACK RIGHT-POINTING TRIANGLE
         // TODO: ▷  U+25B7  WHITE RIGHT-POINTING TRIANGLE
         // TODO: ▸  U+25B8  BLACK RIGHT-POINTING SMALL TRIANGLE
         // TODO: ▹  U+25B9  WHITE RIGHT-POINTING SMALL TRIANGLE
         // TODO: ►  U+25BA  BLACK RIGHT-POINTING POINTER
         // TODO: ▻  U+25BB  WHITE RIGHT-POINTING POINTER
-        // TODO: ▼  U+25BC  BLACK DOWN-POINTING TRIANGLE
         // TODO: ▽  U+25BD  WHITE DOWN-POINTING TRIANGLE
         // TODO: ▾  U+25BE  BLACK DOWN-POINTING SMALL TRIANGLE
         // TODO: ▿  U+25BF  WHITE DOWN-POINTING SMALL TRIANGLE

--- a/src/vtrasterizer/BoxDrawingRenderer_test.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer_test.cpp
@@ -597,3 +597,68 @@ TEST_CASE("BoxDrawingRenderer.shade_characters", "[renderer]")
                                    });
     }
 }
+
+TEST_CASE("BoxDrawingRenderer.solidTriangles", "[boxdrawing]")
+{
+    // Contour draws these itself rather than leaving them to the font: a font's ▼/▶ are small, thin
+    // and inconsistent between families, which is what made the fold-column marker hard to see and
+    // hard to recognise as a control. Drawn here they are cell-proportionate in every font.
+    auto constexpr Size = ImageSize { Width(8), Height(8) };
+    auto constexpr LineThickness = 1;
+
+    SECTION("renderable() claims them, so the font is never consulted")
+    {
+        CHECK(BoxDrawingRenderer::renderable(char32_t { 0x25B6 }));
+        CHECK(BoxDrawingRenderer::renderable(char32_t { 0x25BC }));
+
+        // Their neighbours in the U+25A0..25FF block are still on the TODO list and must keep
+        // falling through to the font rather than rendering as nothing.
+        CHECK(!BoxDrawingRenderer::renderable(char32_t { 0x25B2 }));
+        CHECK(!BoxDrawingRenderer::renderable(char32_t { 0x25C0 }));
+    }
+
+    SECTION("0x25BC BLACK DOWN-POINTING TRIANGLE has its base on top")
+    {
+        auto const buffer = BoxDrawingRendererTest::buildElements(char32_t { 0x25BC }, Size, LineThickness);
+        REQUIRE(buffer.has_value());
+
+        // The atlas buffer is bottom-up -- row 0 is the BOTTOM of the glyph, as U+2580 UPPER HALF
+        // BLOCK lighting rows 4..7 shows -- so the art below is upside down: its LAST line is the
+        // triangle's base along the top of the cell, and its apex is four rows below that.
+        vtrasterizer::verifyBitmap(TestTileData { .bitmapSize = Size,
+                                                  .bitmapFormat = vtrasterizer::atlas::Format::Red,
+                                                  .bitmap = *buffer },
+                                   {
+                                       "........",
+                                       "........",
+                                       "........",
+                                       "....#...",
+                                       "...##...",
+                                       "..####..",
+                                       ".######.",
+                                       "########",
+                                   });
+    }
+
+    SECTION("0x25B6 BLACK RIGHT-POINTING TRIANGLE has its base on the left")
+    {
+        auto const buffer = BoxDrawingRendererTest::buildElements(char32_t { 0x25B6 }, Size, LineThickness);
+        REQUIRE(buffer.has_value());
+
+        // Full height down the left edge, tapering to an apex at mid-width: pointing right.
+        // Near-symmetric top to bottom, so the bottom-up buffer order barely shows here.
+        vtrasterizer::verifyBitmap(TestTileData { .bitmapSize = Size,
+                                                  .bitmapFormat = vtrasterizer::atlas::Format::Red,
+                                                  .bitmap = *buffer },
+                                   {
+                                       "#.......",
+                                       "##......",
+                                       "###.....",
+                                       "#####...",
+                                       "####....",
+                                       "###.....",
+                                       "##......",
+                                       "#.......",
+                                   });
+    }
+}

--- a/src/vtrasterizer/BoxDrawingRenderer_test.cpp
+++ b/src/vtrasterizer/BoxDrawingRenderer_test.cpp
@@ -1,4 +1,5 @@
 #include <vtbackend/Color.hpp>
+#include <vtbackend/Folding.hpp>
 
 #include <vtrasterizer/BoxDrawingRenderer.hpp>
 #include <vtrasterizer/GridMetrics.hpp>
@@ -8,6 +9,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <format>
 
 using namespace vtrasterizer;
 using namespace vtbackend;
@@ -606,6 +608,20 @@ TEST_CASE("BoxDrawingRenderer.solidTriangles", "[boxdrawing]")
     auto constexpr Size = ImageSize { Width(8), Height(8) };
     auto constexpr LineThickness = 1;
 
+    SECTION("every fold-column glyph is drawn here, not by the font")
+    {
+        // The fold column's docstring promises its glyphs come from this renderer. Nothing else
+        // enforces that: a sixth FoldMarker whose glyph fell outside renderable() would silently
+        // drop back to the font and look wrong at runtime, with no build or test failure.
+        using vtbackend::FoldMarker;
+        for (auto const marker:
+             { FoldMarker::Expanded, FoldMarker::Collapsed, FoldMarker::Body, FoldMarker::BodyEnd })
+        {
+            INFO("marker " << std::format("{}", marker));
+            CHECK(BoxDrawingRenderer::renderable(vtbackend::foldMarkerGlyph(marker)));
+        }
+    }
+
     SECTION("renderable() claims them, so the font is never consulted")
     {
         CHECK(BoxDrawingRenderer::renderable(char32_t { 0x25B6 }));
@@ -660,5 +676,100 @@ TEST_CASE("BoxDrawingRenderer.solidTriangles", "[boxdrawing]")
                                        "##......",
                                        "#.......",
                                    });
+    }
+}
+
+TEST_CASE("BoxDrawingRenderer.foldHeadGlyphsInTinyCells", "[boxdrawing]")
+{
+    // A small font at a low DPI can hand the builder a cell only a few device pixels wide. The box has
+    // to come out of that as SOMETHING drawable rather than as undefined behaviour: sizing it once
+    // clamped the desired side between a floor of 5 and a ceiling of w-2, which are in the wrong order
+    // the moment the cell is narrower than seven pixels.
+    for (auto const width: std::views::iota(1, 12))
+    {
+        for (auto const height: std::views::iota(1, 12))
+        {
+            CAPTURE(width, height);
+            auto const cell =
+                ImageSize { Width(static_cast<unsigned>(width)), Height(static_cast<unsigned>(height)) };
+            for (auto const codepoint: { char32_t { 0x10F000 }, char32_t { 0x10F001 } })
+            {
+                CAPTURE(static_cast<uint32_t>(codepoint));
+                auto const buffer = BoxDrawingRendererTest::buildElements(codepoint, cell, 1);
+                REQUIRE(buffer.has_value());
+                CHECK(buffer->size() == static_cast<size_t>(width * height));
+            }
+        }
+    }
+}
+
+TEST_CASE("BoxDrawingRenderer.foldHeadGlyphs", "[boxdrawing]")
+{
+    // Contour's own private-use glyphs: the fold column's head, a box carrying a minus while the
+    // block is open and a plus once it is closed. No Unicode codepoint carries the stem that ties an
+    // open head to the body column below it, which is why these are drawn here rather than typed.
+    //
+    // A realistic cell (9x20). The art is in BUFFER order -- row 0 is the BOTTOM of the glyph -- so
+    // it reads upside down; the stem is therefore at the TOP of the open head's art.
+    auto constexpr Cell = ImageSize { Width(9), Height(20) };
+
+    SECTION("renderable() claims the block, and nothing beyond it")
+    {
+        CHECK(BoxDrawingRenderer::renderable(char32_t { 0x10F000 }));
+        CHECK(BoxDrawingRenderer::renderable(char32_t { 0x10F001 }));
+
+        // The reserved block is documented as F0000..F00FF, but only what is drawn may be claimed:
+        // claiming the rest would swallow codepoints that must still fall through to the font.
+        CHECK(!BoxDrawingRenderer::renderable(char32_t { 0xF0002 }));
+        CHECK(!BoxDrawingRenderer::renderable(char32_t { 0xEFFFF }));
+    }
+
+    SECTION("U+10F000 fold head, open: a boxed minus with a stem into the body below")
+    {
+        auto const buffer = BoxDrawingRendererTest::buildElements(char32_t { 0x10F000 }, Cell, 1);
+        REQUIRE(buffer.has_value());
+
+        vtrasterizer::verifyBitmap(
+            TestTileData {
+                .bitmapSize = Cell, .bitmapFormat = vtrasterizer::atlas::Format::Red, .bitmap = *buffer },
+            {
+                "....#....", "....#....", "....#....", "....#....", "....#....", "....#....", "....#....",
+                ".#######.", ".#.....#.", ".#.....#.", ".#.###.#.", ".#.....#.", ".#.....#.", ".#######.",
+                ".........", ".........", ".........", ".........", ".........", ".........",
+            });
+    }
+
+    SECTION("U+10F001 fold head, closed: a boxed plus, and no stem")
+    {
+        auto const buffer = BoxDrawingRendererTest::buildElements(char32_t { 0x10F001 }, Cell, 1);
+        REQUIRE(buffer.has_value());
+
+        // No stem: a collapsed block has nothing below it for the column to continue into.
+        vtrasterizer::verifyBitmap(
+            TestTileData {
+                .bitmapSize = Cell, .bitmapFormat = vtrasterizer::atlas::Format::Red, .bitmap = *buffer },
+            {
+                ".........", ".........", ".........", ".........", ".........", ".........", ".........",
+                ".#######.", ".#.....#.", ".#..#..#.", ".#.###.#.", ".#..#..#.", ".#.....#.", ".#######.",
+                ".........", ".........", ".........", ".........", ".........", ".........",
+            });
+    }
+
+    SECTION("the open head's stem meets the body column exactly")
+    {
+        // The stem and U+2502 must share a column, or the fold column breaks at every head.
+        auto const head = BoxDrawingRendererTest::buildElements(char32_t { 0x10F000 }, Cell, 1);
+        auto const body = BoxDrawingRendererTest::buildBoxElements(char32_t { 0x2502 }, Cell, 1, 1);
+        REQUIRE(head.has_value());
+        REQUIRE(body.has_value());
+
+        auto const litColumnOfBottomRow = [&](atlas::Buffer const& b) {
+            for (auto x = 0; x < 9; ++x)
+                if (b[static_cast<size_t>(x)] > 0)
+                    return x;
+            return -1;
+        };
+
+        CHECK(litColumnOfBottomRow(*head) == litColumnOfBottomRow(*body));
     }
 }

--- a/src/vtrasterizer/Renderer.cpp
+++ b/src/vtrasterizer/Renderer.cpp
@@ -756,6 +756,7 @@ bool Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
             cursorOpt = renderBuffer.get().cursor;
             renderCells(std::span(renderBuffer.get().cells));
             renderLines(std::span(renderBuffer.get().lines));
+            renderGutter(std::span(renderBuffer.get().gutter));
         });
     }
     else
@@ -785,6 +786,8 @@ bool Renderer::renderImpl(vtbackend::Terminal& terminal, bool pressure)
         renderPass(primaryPressure, [&] {
             renderCells(mainCells, smoothPixelOffset);
             renderLines(mainLines);
+            // The gutter belongs to the main display, and scrolls with it.
+            renderGutter(std::span(renderBuffer.get().gutter));
         });
 
         // Scissor clips the main display area so the offset content doesn't bleed into the status line.
@@ -908,6 +911,37 @@ void Renderer::renderLines(std::span<vtbackend::RenderLine const> lines)
         _backgroundRenderer.renderLine(line);
         _decorationRenderer.renderLine(line);
         _textRenderer.renderLine(line);
+    }
+}
+
+void Renderer::renderGutter(std::span<vtbackend::RenderGutterCell const> gutter)
+{
+    for (auto const& marker: gutter)
+    {
+        // groupStart and groupEnd together make each marker its own shaping group, so it is placed at
+        // its own pen position rather than run together with whatever the text renderer saw last.
+        auto const cell = vtbackend::RenderCell {
+            .codepoints = std::u32string(1, marker.codepoint),
+            .image = {},
+            .position =
+                vtbackend::CellLocation { .line = marker.lineOffset, .column = vtbackend::ColumnOffset(-1) },
+            .attributes = marker.attributes,
+            .width = 1,
+            .sizing = {},
+            .groupStart = true,
+            .groupEnd = true,
+        };
+
+        try
+        {
+            _backgroundRenderer.renderCell(cell);
+            _textRenderer.renderCell(cell);
+        }
+        catch (std::exception const& e)
+        {
+            errorLog()(
+                "renderGutter: skipping marker on line {} due to exception: {}", marker.lineOffset, e.what());
+        }
     }
 }
 

--- a/src/vtrasterizer/Renderer.hpp
+++ b/src/vtrasterizer/Renderer.hpp
@@ -387,6 +387,15 @@ class Renderer
     /// @param lines  Contiguous sub-range of RenderLine entries to render.
     void renderLines(std::span<vtbackend::RenderLine const> lines);
 
+    /// Draws the fold markers into the gutter -- the strip the page margin reserves to the LEFT of
+    /// column 0 (@see contour::geometry::fitPageToPixels, which folds the gutter into pageMargin.left).
+    ///
+    /// This is the ONE place in the tree that addresses a negative column, and the reason it can: a
+    /// gutter cell is mapped through the same GridMetrics as any other, and column -1 lands exactly in
+    /// the strip, so no second coordinate system is introduced for it. Keeping that here means nothing
+    /// that walks RenderBuffer::cells -- selection, hit-testing, accessibility -- ever meets one.
+    void renderGutter(std::span<vtbackend::RenderGutterCell const> gutter);
+
     void executeImageDiscards();
 
     /// The atlas sizing the *configuration* asked for, kept apart from the effective sizing below.


### PR DESCRIPTION
Collapses a finished command's output down to the prompt line it was entered at, and expands it again. Closes #88, and lands the block-range model #1010 asks for.

Fold ranges come from the **OSC 133 semantic marks** a shell with shell integration already emits — #88's proposed start/end/restart-fold CSI extension predates shell integration and would duplicate it, so no new escape sequence is added and any shell already speaking OSC 133 works.

**Folding never changes what the shell sees.** The grid, the page size and every VT semantic are untouched; folding is a projection applied between the grid and the render pass, and nothing more. With no fold collapsed the projection is empty and every consumer keeps the arithmetic it always had.

### What lands

- Global `folding:` section — `enabled`, `show_markers`, `auto_collapse_on_new_command`, `on_jump_into_fold`. Global rather than per-profile: a fold is a property of how output is read, not of which shell produced it.
- Five bindable actions: `CollapseAllFolds`, `CollapseLastFold`, `ExpandAllFolds`, `ToggleFold`, `ToggleLastFold`. #88 asks for seven; `ScrollToPreviousFold`/`ScrollToNextFold` are deliberately **not** added, because `ScrollBlockUp`/`ScrollBlockDown` already walk the very marks a fold hangs off.
- A **fold column** in a one-column gutter left of the grid: a marker on the block's prompt line — pointing down while the output shows, right once folded — with a bar down the body and a corner at its tail. The whole run highlights under the pointer, takes a pointing-hand cursor, and toggles the fold on click. An extent is what says how far a block reaches, and one cell per fold was close to unhittable with a mouse.
- A **"Toggle Output Fold" context-menu entry**, greyed out rather than hidden where no fold reaches — a row that vanished depending on where you right-clicked would make the menu change shape under the pointer.
- **Vi normal mode moves in visible lines.** Every vertical motion steps over a collapsed block instead of walking into one, and `on_jump_into_fold` decides whether a search hit inside one opens the block (vim's `foldopen`) or is skipped.
- `U+25BC`/`U+25B6` are now drawn by the built-in box-drawing renderer rather than the font — `U+25A0..25FF` was an explicit TODO block, which is why the marker used to be thin and inconsistent between families.
- **Renames** `ScrollMarkUp`/`ScrollMarkDown` to `ScrollBlockUp`/`ScrollBlockDown`; they move between OSC 133 command blocks, which folding has made a first-class concept. The old names still parse and log a deprecation warning.
- **Removes** the deprecated `SETMARK` sequence (`CSI > M`) in favour of `OSC 133 ; A`.

### Design

Two choke points carry every consumer:

- `Grid::render` gains an optional row list, since folding needs the visible rows to be *non-contiguous*. Empty (the default) is the linear walk, unchanged. Grid learns nothing about folding: it draws the rows it is handed.
- `Viewport`'s coordinate translations consult the same projection. Selection, vi mode, the mouse protocol and hyperlink hover all route through them, so this is the one place that has to agree with what was drawn.

Folds are keyed by **stable line id** (`Grid::stableLineIdOf`), so they survive scrolling for free and need attention only on eviction (`prune`) and on a generation bump (reflow clears them — row identity is gone and guessing would collapse the wrong block).

The gutter width is folded into `pageMargin.left`, which is already the single left inset every pixel↔cell conversion reads (`GridMetrics::map`, the mouse hit-test, the accessibility bridge, `cellRectangle`) — so all of them are correct at once with no edit at any of those sites. The header's anti-oscillation law survives because the gutter cancels exactly as the margins do; that is the first test.

The fold-aware line arithmetic is pure and sits beside the fold model: `snapToVisibleId` leaves a hidden run by its nearest edge, `advanceVisibleId` travels a given number of *visible* rows by skipping each run whole rather than a row at a time — so `3j` means three rows the user can see, and a `1000j` over a collapsed `cat` costs the same as a `1j`.

### Two things the wiring taught the model

- **The `;D` line is never hidden.** A shell emits it from precmd, at the cursor, so it is either the line the next prompt is about to be printed onto or the line the cursor is standing on. Folding either away would hide the row the user is about to type into.
- **A fold hides rows, not logical lines.** A range runs to the last *physical* row of its bottom-most line; stopping at the head left the continuations of a wrapped line on screen as an orphaned tail.

### Review round (commits 9–11)

A review pass over the branch found one class of defect — call sites still computing a screen row as a grid line plus the scroll offset, which stops being true the moment a collapsed fold makes the visible rows non-contiguous. All are fixed, with tests:

- `Grid::render` placed a short row list at the bottom of the page while `Viewport` indexed it from the top. The placement rule now lives in one place (`Terminal::foldProjectionTopRow`) that both read.
- `handleMouseSelection` anchored a drag by subtracting the scroll offset while extending it through the viewport; `RenderBufferBuilder` placed the cursor by adding it; `isLineVisible` was an interval test, which calls a hidden line visible.
- `fillGutter` walked the *total* page size (one row past the main page, beside the status line) and omitted `baseLine`.
- The fold-range cache was keyed on grid generation and stable base alone — a mark arriving on a page that has not scrolled moves neither, so a second command in a tall window left the actions acting on stale ranges.

### Two pre-existing bugs fixed along the way

Both predate this branch's later commits and are fixed with tests that fail without them:

- **The pixel→row hit-test ignored a status line above the grid.** The renderer places the main page at `statusLineHeight()` when the status line is on top, but `makeMouseCellLocation` handed `Viewport`'s translation a raw *screen* row. Worse, it clamped against the *total* page while the move path guards on the main one, so with `status_line.position: top` the grid's bottom row never received a mouse-move event at all — no selection extension, no hyperlink hover. The mapping moves into the Qt-free geometry header as a pure function, which is what finally makes it testable; `Terminal::mainPageTopRow()` states where the grid begins once, for both directions.
- **A resize could strand the Vi cursor inside a fold.** `resizeScreenInternal` shifts the cursor by the page-line delta and then clamps it to the screen, and that clamp knows nothing about folds — shrinking the page with a collapsed block above the cursor moved it onto a hidden line, where it renders as nothing at all.

### Performance

Measured with callgrind on a shared render test, release, branch vs master (instruction refs): `makeColorsForCell` and `makeRenderCell` unchanged, `Grid::render` 2,231 → 2,034 (cheaper — the row body inlines as well from the lambda as it did in the loop), `renderCell` +240, and a new `Viewport::translate` at 1,411 where it was previously inlined. Net ~+1,450 out of 21.5M, roughly five instructions per cell. The collapsed-set-empty check is deliberately first, so a session that never folds pays one load and one branch. The PTY write path is untouched.

Those figures were taken for the first eleven commits; the later work preserves the same property — every fold query added since short-circuits on the empty fold set before it computes anything — but has not been re-measured.

### Follow-ups, deliberately not in this PR

- Per-block cwd/timestamps and absolute line numbers (#1010), and block-atomic scrollback eviction (#836) — which the first three commits are the foundation for.
