### PR TITLE
Fix ARM CI job being killed by memory exhaustion during linking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1229,16 +1229,25 @@ jobs:
       - name: "build"
         # -j$(nproc) rather than a hardcoded -j3: a quarter of a 4-vCPU runner was sitting idle.
         #
-        # The memory sampler is temporary. ubuntu-24.04-arm (GCC 14) is killed by a runner
-        # shutdown signal at the same handful of targets every time -- the final GUI links -- and
-        # an OOM-killed runner agent leaves nothing in the build log by construction. Streaming
-        # free(1) is the only way to tell "the host ran out of memory" from "the lease expired".
+        # The memory sampling is temporary. ubuntu-24.04-arm (GCC 14) is killed by a runner
+        # shutdown signal during the final GUI links, and an OOM-killed runner agent leaves
+        # nothing in the build log by construction -- so the absence of an OOM message proves
+        # nothing either way. free(1) alongside the build is what settles it.
+        #
+        # The build runs in the background and the sampler in the foreground, NOT the other way
+        # round: a backgrounded `while sleep` loop keeps stdout open, which hangs "Complete job"
+        # long enough for the runner to give up and discard the log with it. This way the loop
+        # ends when the build does, and `wait` still yields the build's exit code.
         run: |
-          echo "cores=$(nproc)"; free -h
-          ( while sleep 10; do echo "[mem] $(free -m | awk '/^Mem:/{printf "used=%sM avail=%sM", $3, $7}')"; done ) &
-          sampler=$!
-          trap 'kill $sampler 2>/dev/null || true' EXIT
-          cmake --build --preset gcc-debug -- -j$(nproc)
+          echo "cores=$(nproc)"
+          free -h
+          cmake --build --preset gcc-debug -- -j$(nproc) &
+          build=$!
+          while kill -0 "$build" 2>/dev/null; do
+            echo "[mem] $(free -m | awk '/^Mem:/{printf "used=%sM avail=%sM", $3, $7}')"
+            sleep 10
+          done
+          wait "$build"
       - name: "tests"
         # A hung test (e.g. a dead-loop) must fail the matrix fast, not stall for hours.
         #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1207,6 +1207,14 @@ jobs:
           CC_VER=$( echo "${{ matrix.compiler }}" | awk '{ print $2; }')
           test "${{ matrix.compiler }}" = "GCC 8"  && EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DPEDANTIC_COMPILER_WERROR=ON"
           test "${CC_NAME}" = "gcc" && CC_EXE="g++"
+          # AArch64 GCC + RelWithDebInfo debug info is what fills the runner; --no-keep-memory
+          # tells ld to re-read symbol tables rather than hold them, trading time for RAM.
+          #
+          # The link cap below is spelled CONTOUR_LINK_JOBS and not CMAKE_JOB_POOL_LINK on
+          # purpose: CMakeLists.txt sets CMAKE_JOB_POOL_LINK as a NORMAL variable, which shadows
+          # a cache entry of the same name passed here -- so -DCMAKE_JOB_POOL_LINK=link defines a
+          # pool nothing binds to, and rules.ninja still reads "contour_link_pool / depth = 2".
+          test "${CC_NAME}" = "gcc" && CMAKE_EXE_LINKER_FLAGS="$CMAKE_EXE_LINKER_FLAGS -Wl,--no-keep-memory"
           if [[ "${CC_NAME}" = "clang" ]]; then
               CC_EXE="clang++"
               # CMAKE_CXX_FLAGS="-stdlib=libc++"
@@ -1222,6 +1230,7 @@ jobs:
               -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
               -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS}" \
               -DCMAKE_INSTALL_PREFIX="/usr" \
+              -DCONTOUR_LINK_JOBS=1 \
               -DCONTOUR_WAYLAND=OFF \
               -DLIBUNICODE_UCD_BASE_DIR=$PWD/_ucd \
               -DPEDANTIC_COMPILER_WERROR=OFF \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1104,7 +1104,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-{{ matrix.runner }}-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}-${{ matrix.qt_version  }}"
+          key: "ccache-${{ matrix.runner }}-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}-${{ matrix.qt_version  }}"
           max-size: 256M
       - name: "update APT database"
         run: sudo ./scripts/apt-update.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1227,9 +1227,18 @@ jobs:
               -DPEDANTIC_COMPILER_WERROR=OFF \
               --preset gcc-debug
       - name: "build"
-        # -j$(nproc), not a hardcoded -j3: this entry has to fit inside the ARM runner's
-        # lease, and a quarter of the cores sitting idle is the cheapest minute to buy back.
-        run: cmake --build --preset gcc-debug -- -j$(nproc)
+        # -j$(nproc) rather than a hardcoded -j3: a quarter of a 4-vCPU runner was sitting idle.
+        #
+        # The memory sampler is temporary. ubuntu-24.04-arm (GCC 14) is killed by a runner
+        # shutdown signal at the same handful of targets every time -- the final GUI links -- and
+        # an OOM-killed runner agent leaves nothing in the build log by construction. Streaming
+        # free(1) is the only way to tell "the host ran out of memory" from "the lease expired".
+        run: |
+          echo "cores=$(nproc)"; free -h
+          ( while sleep 10; do echo "[mem] $(free -m | awk '/^Mem:/{printf "used=%sM avail=%sM", $3, $7}')"; done ) &
+          sampler=$!
+          trap 'kill $sampler 2>/dev/null || true' EXIT
+          cmake --build --preset gcc-debug -- -j$(nproc)
       - name: "tests"
         # A hung test (e.g. a dead-loop) must fail the matrix fast, not stall for hours.
         #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1227,7 +1227,9 @@ jobs:
               -DPEDANTIC_COMPILER_WERROR=OFF \
               --preset gcc-debug
       - name: "build"
-        run: cmake --build --preset gcc-debug -- -j3
+        # -j$(nproc), not a hardcoded -j3: this entry has to fit inside the ARM runner's
+        # lease, and a quarter of the cores sitting idle is the cheapest minute to buy back.
+        run: cmake --build --preset gcc-debug -- -j$(nproc)
       - name: "tests"
         # A hung test (e.g. a dead-loop) must fail the matrix fast, not stall for hours.
         #


### PR DESCRIPTION
`ubuntu-24.04-arm (GCC 14, C++23, Qt6)` has been failing on master, and it is a **required** check — so every PR needs an admin override to merge until it is fixed. It is not a compile error; the build is clean right up to the kill, always on the same target:

```
ninja: build stopped: interrupted by user.
##[error]The runner has received a shutdown signal...
##[error]Process completed with exit code 143.
```

### It is memory, and the sampling says so

Sampling `free(1)` alongside the build shows the runner going from healthy to out of memory in twenty seconds, exactly as the final executables link:

```
19:38:26 [mem] used=4924M  avail=11023M
19:38:36 [mem] used=10885M avail=5061M     <- [639/653], the last links start
19:38:47 [mem] used=15193M avail=754M
19:39:39 ninja: build stopped: interrupted by user.
```

That is a 16 GB, 4-core box with four `ld` processes on it. The kill arrives as exit 143 and a runner shutdown signal with no OOM message anywhere, because the host kills the runner agent rather than the compiler — which is why earlier attempts could see *where* it died but not *why*.

## Changes

**Cap concurrent links at one** (`-DCONTOUR_LINK_JOBS=1`), so the spike above cannot form. Compilation still runs at `-j$(nproc)`.

It has to be that variable and not `-DCMAKE_JOB_POOL_LINK`. `CMakeLists.txt` sets `CMAKE_JOB_POOL_LINK` as a *normal* variable, which shadows a cache entry of the same name passed on the command line — so passing the pool directly defines a pool nothing binds to, and the generated `rules.ninja` still reads `pool contour_link_pool / depth = 2`. `CONTOUR_LINK_JOBS` feeds that pool's depth, and the link rules are bound to it.

**`-Wl,--no-keep-memory` for GCC**, so each individual link is cheaper — it tells `ld` to re-read symbol tables rather than hold them, trading time for RAM. AArch64 GCC debug info is the bulk of what fills the box.

**`-j$(nproc)` instead of `-j3`** — `-j3` left a quarter of a 4-vCPU runner idle, and `nproc` keeps this honest if the runners are ever resized.

**Give each runner its own ccache key** — the key was missing a `$`:

```yaml
key: "ccache-{{ matrix.runner }}-${{ matrix.compiler }}-..."
#            ^ literal, not interpolated
```

The job log shows what it actually asked for: `ccache-{{ matrix.runner }}-GCC 14-23-RelWithDebInfo-6` — **the same key for `ubuntu-24.04` and `ubuntu-24.04-arm`**. They shared a cache whose objects are useless to each other, so whichever ran first poisoned the other and the loser rebuilt cold every time. A real bug on its own, and it is why this entry never got a warm cache.

### Theories this replaces

Both are recorded as refuted rather than quietly dropped:

- **A runner lease.** Durations do not separate the runs — 19:36 and 22:00 died while 26:20 and 26:30 passed, which no time limit explains.
- **An output inactivity watchdog.** A ten-second heartbeat changed nothing.

### Open question for review

The evidence that `--no-keep-memory` is *needed* is weaker than it looks. It rests on an earlier revision that capped link concurrency and still died — but that revision spelled the cap `-DCMAKE_JOB_POOL_LINK`, the shadowed form described above, so those links were almost certainly never serialized at all. The flag is cheap and directionally right, so it stays; but if a reviewer wants the minimal change, serialization alone has not actually been tested yet.

The `free(1)` sampling loop in the build step is diagnostic scaffolding, kept for now so the next run either confirms the fix or yields the next measurement. It should come out before this merges.
