### PR TITLE
Add support for OSC 3008 hierarchical context signalling

### DIFF
--- a/docs/vt-extensions/osc-3008-context.md
+++ b/docs/vt-extensions/osc-3008-context.md
@@ -1,0 +1,120 @@
+# OSC 3008 — Hierarchical Context Signalling
+
+Contour consumes **OSC 3008**, the [UAPI.15 hierarchical context signalling
+specification](https://uapi-group.org/specifications/specs/osc_context/).
+
+A terminal connects a user with programs, and control of the program side is passed around while the
+user works: a shell invokes a command, `run0` acquires privileges, `systemd-nspawn` enters a
+container, `ssh` connects to another machine. OSC 3008 lets each of those components tell the
+terminal that a new **context** begins, and carry metadata describing it.
+
+The value is not that this is more metadata. It is that it arrives **without any configuration**:
+systemd 258 and later ship a shell snippet that emits these sequences around every interactive
+command, so on such a system Contour learns command boundaries, exit statuses and working
+directories with no shell integration installed at all.
+
+## Sequences
+
+```
+OSC 3008 ; start= CTXID [ ; field=value ]... ST
+OSC 3008 ; end=   CTXID [ ; field=value ]... ST
+```
+
+`start=` initiates a context, **updates** one that already exists, or **returns to** one further up.
+`end=` terminates one. Contexts nest: the newest is active, and everything written while it is
+active belongs to it.
+
+Because `;` separates fields, a literal semicolon in a value is written as the four characters
+`\x3b`, and a literal backslash as `\x5c`. Values are UTF-8 and are stored as sent.
+
+### Fields on `start=`
+
+| Field | Meaning |
+|---|---|
+| `type=` | `service`, `session`, `shell`, `command`, `vm`, `container`, `elevate`, `chpriv`, `subcontext`, `remote`, `boot`, `app` |
+| `user=`, `hostname=`, `machineid=`, `bootid=`, `pid=`, `pidfdid=`, `comm=` | who and where the announcing process is |
+| `cwd=` | the working directory (`shell`, `command`) |
+| `cmdline=` | the command line (`command`) |
+| `vm=`, `container=` | the VM or container being entered |
+| `targetuser=`, `targethost=`, `sessionid=` | what is being connected or elevated to |
+
+### Fields on `end=`
+
+`exit=` (`success`, `failure`, `crash`, `interrupt`), `status=` (numeric), and `signal=` (symbolic,
+e.g. `SIGSEGV`). Note that `crash`, `interrupt` and `signal=` express things
+[OSC 133](osc-133-shell-integration.md)'s numeric exit code structurally cannot.
+
+## What Contour does with it
+
+- **Tracks the ancestry**, so every line of output is associated with the context that produced it.
+  The association survives reflow and scrolling into history.
+- **Derives semantic marks** when no shell integration is present, so prompt navigation, output
+  folding and "copy last command output" work with no setup. See *Interaction with OSC 133* below.
+- **Tints the page background** under a boundary context, if the colour scheme opts in.
+- **Shows a breadcrumb** in the indicator status line via the `{Context}` placeholder.
+- **Resolves the working directory** for the tab tooltip and "Open Current Folder".
+- **Replicates all of it to daemon clients**, so a `contour attach` pane behaves like a local one.
+
+## Interaction with OSC 133
+
+Both protocols describe the same prompt cycle, so exactly one of them owns a session's semantic
+marks, and the rule is one-way:
+
+- If **OSC 133 speaks at any point**, it owns the marks for the rest of the session. OSC 3008 then
+  contributes metadata only — working directories, identity, and the richer exit information — and
+  never a mark.
+- If OSC 133 has said nothing, OSC 3008 stands in for it: a `type=shell` update marks the prompt, a
+  `type=command` start marks where output begins, and its `end=` marks where output stopped.
+
+OSC 3008 can never take the marks back, which is what stops a session flapping between sources.
+There is one thing it cannot supply: OSC 133's `;B`, the border between the prompt and what the user
+types. OSC 3008 has no event there, so a session driven by it alone reports the prompt's line span
+but not the column input begins at.
+
+## Reset behaviour
+
+**RIS and DECSTR deliberately do not clear the context stack.** The specification makes this a
+safety property: a program running down the ancestry must not be able to erase context a program
+above it established, and RIS is something any program can send. A shell that announced "you are
+inside container X" must still be able to say so after a program inside that container resets the
+terminal. The stack is destroyed when the session is.
+
+## Limits
+
+Configurable through the [`osc_context`](../configuration/README.md) section: `max_depth` (default
+16) bounds the ancestry, and `max_retained_contexts` (default 256) bounds how much history is kept
+for scrolled-back output. Per the specification, hitting the depth limit drops the **newer**
+contexts, so a program deep in the ancestry cannot push out the one above it. Field lengths are
+protocol constants and are not configurable.
+
+## Security
+
+**Every field is a display hint. Nothing gates behaviour on one.**
+
+Any program that can write to the terminal can emit `type=elevate` or `user=root`, so nothing
+Contour draws from these sequences is an assurance. Two consequences worth stating outright:
+
+- **The absence of an elevate context is not a statement that nothing is running as root.** A
+  program in a genuinely elevated shell can simply `end=` the context, and no terminal can detect
+  that. This is why Contour ships no default tint and never decorates a context with a lock, a
+  shield or a warning colour: doing so would teach users to read a spoofable signal as authority.
+- **A `cwd=` is not trusted for opening or spawning unless it is provably this machine's.** A
+  context carries no host authority, so a container's `/app` would otherwise pass every locality
+  test and open the host's directory of the same name. Contour requires a matching `machineid=` (or
+  failing that a matching `hostname=`) and refuses when a container, VM or remote boundary is in
+  force. A context that claims nothing at all is treated as unknown, not local — which matters
+  because nothing emits a `remote` context for `ssh` today, so a remote host's own sequences look
+  entirely local.
+
+To opt out of all of it: `osc_context: { enabled: false }`.
+
+## Not implemented
+
+- **Killing a context tree via `pidfdid=`.** That field is a pidfd *inode*, not a handle, so it can
+  only *verify* a `pidfd_open(pid)` — and the protocol carries no process-group id and no cgroup
+  path, so "kill this context and its children" is not implementable from the fields that exist.
+  Inside a container `pid=` names another PID namespace, so opening it locally names an unrelated
+  process, and a `run0` context's pid is root-owned, so the case a user most wants would fail with
+  `EPERM`.
+- **Re-entering a container or remote host to open its working directory.** Executing `nsenter` or
+  `ssh` on the basis of a spoofable field is exactly the rule above being broken.

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -115,6 +115,14 @@
           <li>Adds the global folding config section and the actions CollapseAllFolds, CollapseLastFold, ExpandAllFolds, ToggleFold and ToggleLastFold</li>
           <li>Vi normal mode moves in visible lines, stepping over collapsed blocks; folding.on_jump_into_fold picks whether a search hit inside one expands it or is skipped</li>
           <li>Removes the deprecated SETMARK sequence (CSI &gt; M); use OSC 133 ; A instead</li>
+          <li>Adds support for OSC 3008, systemd's hierarchical context signalling (UAPI.15): the nested stack of contexts a shell, run0, ssh or a container runtime opens around whatever runs inside it. systemd 258 and later emit these around every interactive command with no configuration at all, so on such a system Contour learns command boundaries, exit statuses and working directories for free (#2078)</li>
+          <li>On a system where OSC 3008 arrives and no shell integration is installed, prompts now get fold controls, mark-jump stops and "copy last command output" without any setup. A shell integration, if one is installed, keeps full ownership of the markers and nothing changes</li>
+          <li>Reports how a command really ended: OSC 3008 distinguishes a crash from an interruption from a plain non-zero exit, and names the signal — which OSC 133's numeric exit code cannot express</li>
+          <li>Adds the {Context} indicator status-line placeholder: a breadcrumb of the contexts above the one you are typing in. It shows only privilege and machine boundaries by default and draws nothing at all when there are none, so an ordinary shell session is unchanged</li>
+          <li>Adds an optional tint map to color schemes, giving the page background a different shade under an elevated, containerised, virtualised or remote context. No shipped scheme sets one, deliberately: every field OSC 3008 carries is a display hint any program on the terminal can write, so the colour is something you opt into rather than something that appears</li>
+          <li>The tab tooltip and "Open Current Folder" now follow the working directory OSC 3008 reports. A directory belonging to a container, a VM or another machine is never opened locally — the menu entry greys out rather than opening the host's directory of the same name. Set osc_context.enabled to false to opt out of all of it</li>
+          <li>A contour attach pane gets the same context tracking, tinting and breadcrumb a local one does</li>
+          <li>Fixes stale fold ranges after a command finished: OSC 133's ;B and ;D wrote their line flag without invalidating the ranges derived from it, so anything reading them between the end of a command and the next prompt saw the state from before</li>
           <li>Draws U+25BC and U+25B6 with the built-in box-drawing renderer, so they no longer depend on the font</li>
         </ul>
       </description>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
     - vt-extensions/line-reflow-mode.md
     - vt-extensions/save-and-restore-sgr-attributes.md
     - vt-extensions/osc-133-shell-integration.md
+    - vt-extensions/osc-3008-context.md
     - vt-extensions/osc-9-4-progress.md
     - vt-extensions/semantic-block-query.md
     - vt-extensions/private-use-glyphs.md

--- a/src/contour/config/Config.cpp
+++ b/src/contour/config/Config.cpp
@@ -1361,6 +1361,23 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, vtbackend::ColorPal
         loadPair("hover", where.foldMarkerHover);
     }
 
+    if (auto const tints = child["tint"])
+    {
+        logger()("*** loading tint");
+        // Driven by ContextTypeList, so a thirteenth context type is one row in vtbackend and nothing
+        // here. Lenient in the same way the sequence parser is: an unknown key is skipped and every
+        // other entry still loads.
+        for (auto const type: vtbackend::ContextTypeList)
+        {
+            auto const key = std::string { vtbackend::contextTypeName(type) };
+            if (!tints[key])
+                continue;
+            auto color = vtbackend::RGBColor {};
+            loadFromEntry(tints, key, color);
+            where.contextTints[static_cast<size_t>(type)] = color;
+        }
+    }
+
     logger()("*** loading palette");
     loadFromEntry(child, "", where.palette);
 }
@@ -3700,6 +3717,17 @@ static void emitColorPaletteBody(Writer& writer, std::string& doc, vtbackend::Co
     }
     else
         processWithDoc(documentation::FoldMarker {});
+
+    // Same rule, same reason: only what the scheme actually set, and the commented example otherwise.
+    if (entry.hasContextTints())
+    {
+        processWithDoc(documentation::ContextTintHeader {});
+        for (auto const type: vtbackend::ContextTypeList)
+            if (auto const& color = entry.contextTints[static_cast<size_t>(type)])
+                processWithDoc(documentation::ContextTintEntry {}, vtbackend::contextTypeName(type), *color);
+    }
+    else
+        processWithDoc(documentation::ContextTint {});
 
     processWithDoc(documentation::InputMethodEditor {},
                    entry.inputMethodEditor.foreground,

--- a/src/contour/config/Config.cpp
+++ b/src/contour/config/Config.cpp
@@ -468,6 +468,17 @@ vtbackend::Settings emulationSettings(Config const& config, TerminalProfile cons
     settings.foldMarkers = folding.markersVisible();
     settings.autoCollapseFoldOnNewCommand = folding.enabled && folding.autoCollapseOnNewCommand;
     settings.foldJumpBehavior = folding.onJumpIntoFold;
+
+    // `enabled` travels as itself rather than being conjoined into the two policies below: the engine
+    // honours it where the sequence arrives, which is what makes it gate the ancestry -- and with it
+    // the breadcrumb and the daemon's replication -- and not merely the two knobs somebody remembered.
+    auto const& oscContext = config.oscContext.value();
+    settings.contextSignalling =
+        oscContext.enabled ? vtbackend::ContextSignalling::Enabled : vtbackend::ContextSignalling::Disabled;
+    settings.contextLimits = vtbackend::ContextStackLimits { .maxDepth = oscContext.maxDepth,
+                                                             .maxRetained = oscContext.maxRetained };
+    settings.contextMarkPolicy = oscContext.deriveMarkers;
+    settings.contextTintScope = oscContext.tinting;
     settings.terminalId = profile.terminalId.value();
     settings.frozenModes = profile.frozenModes.value();
     settings.maxImageRegisterCount = config.images.value().maxImageColorRegisters;
@@ -850,6 +861,7 @@ void YAMLConfigReader::load(Config& c)
         loadFromEntry("pty_buffer_size", c.ptyBufferObjectSize);
         loadFromEntry("images", c.images);
         loadFromEntry("folding", c.folding);
+        loadFromEntry("osc_context", c.oscContext);
         loadFromEntry("live_config", c.live);
         loadFromEntry("early_exit_threshold", c.earlyExitThreshold);
         loadFromEntry("spawn_new_process", c.spawnNewProcess);
@@ -1964,6 +1976,41 @@ void YAMLConfigReader::loadFromEntry(YAML::Node const& node, std::string const& 
         loadFromEntry(child, "auto_collapse_on_new_command", where.autoCollapseOnNewCommand);
         loadFromEntry(child, "on_jump_into_fold", where.onJumpIntoFold);
     }
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
+                                     std::string const& entry,
+                                     OscContextConfig& where)
+{
+    auto const child = node[entry];
+    if (!child)
+        return;
+
+    loadFromEntry(child, "enabled", where.enabled);
+    loadFromEntry(child, "max_depth", where.maxDepth);
+    loadFromEntry(child, "max_retained_contexts", where.maxRetained);
+    loadFromEntry(child, "derive_markers", where.deriveMarkers);
+    loadFromEntry(child, "tinting", where.tinting);
+
+    // Clamped rather than rejected, and the ORDER matters: a retained bound below the depth bound
+    // would let a context that is still an ancestor be evicted, leaving the chain holding a record
+    // nothing can resolve -- which ContextStack's constructor treats as a programmer error.
+    where.maxDepth = std::clamp(where.maxDepth, uint16_t { 1 }, uint16_t { 256 });
+    where.maxRetained = std::max(where.maxRetained, where.maxDepth);
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
+                                     std::string const& entry,
+                                     vtbackend::ContextMarkPolicy& where)
+{
+    (void) loadConfigEnum(node, entry, where, logger);
+}
+
+void YAMLConfigReader::loadFromEntry(YAML::Node const& node,
+                                     std::string const& entry,
+                                     vtbackend::ContextTintScope& where)
+{
+    (void) loadConfigEnum(node, entry, where, logger);
 }
 
 void YAMLConfigReader::loadFromEntry(YAML::Node const& node,

--- a/src/contour/config/Config.hpp
+++ b/src/contour/config/Config.hpp
@@ -394,6 +394,9 @@ struct IndicatorConfig
                        "{TraceMode:Bold,Color=#FFFF00,Left= │ }"
                        "{Tabs:ActiveColor=#FFFF00,Left= │ }"
                        "{ProtectedMode:Bold,Left= │ }"
+                       // Draws NOTHING until a privilege or machine boundary is in force, so an
+                       // ordinary session is unchanged by its presence.
+                       "{Context:Left= │ }"
                        "{SearchPrompt:Left= │ }" };
     std::string middle { "« {Title} »" };
     std::string right { "{HistoryLineCount:Faint,Color=#c0c0c0} │ {Clock:Bold}" };

--- a/src/contour/config/Config.hpp
+++ b/src/contour/config/Config.hpp
@@ -11,10 +11,12 @@
 #include <vtbackend/core/Color.hpp>
 #include <vtbackend/core/ColorPalette.hpp>
 #include <vtbackend/core/Primitives.hpp> // CursorDisplay
+#include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/input/InputBinding.hpp>
 #include <vtbackend/input/InputGenerator.hpp>
 #include <vtbackend/input/MatchModes.hpp>
 #include <vtbackend/screen/Settings.hpp>
+#include <vtbackend/shell/MarkArbiter.hpp>
 #include <vtbackend/vt/ControlCode.hpp>
 #include <vtbackend/vt/VTType.hpp>
 
@@ -324,6 +326,52 @@ struct FoldingConfig
     ///
     /// @return Whether markers are shown.
     [[nodiscard]] constexpr bool markersVisible() const noexcept { return enabled && showMarkers; }
+};
+
+/// OSC 3008 (UAPI.15) hierarchical context signalling: the nested stack of contexts a shell, `run0`,
+/// `ssh` or a container runtime opens around whatever runs inside it.
+///
+/// GLOBAL rather than per-profile, for the reason FoldingConfig is: this describes how the terminal
+/// READS a protocol the shell speaks, not how a pane looks. The two knobs that ARE presentation live
+/// where presentation already lives -- the color scheme's `tint:` map, and the profile's indicator
+/// template. There is deliberately no third place, and in particular no `status_line_breadcrumb` flag:
+/// the status line has exactly one placeholder vocabulary, and a boolean elsewhere that force-injected
+/// a segment would be invisible to its parser, its serializer and its settings editor.
+///
+/// The two limits are global on a safety argument as well: a depth cap a profile could lower is a cap
+/// an attacker picks by getting the user to open a profile.
+///
+/// SECURITY: every field OSC 3008 carries is a DISPLAY HINT. Any program holding the tty can write
+/// `type=elevate` or `user=root`, so nothing here gates behaviour -- and the ABSENCE of an elevate
+/// context is not a statement that nothing is elevated.
+///
+/// Plain bool for `enabled` because it is a YAML schema field, converted at the boundary -- the
+/// documented carve-out in AGENT.md. The two enums below are not bools in disguise: each selects
+/// between three NAMED outcomes.
+struct OscContextConfig
+{
+    bool enabled { true }; ///< Whether OSC 3008 is decoded at all.
+
+    /// How deep the ancestry may grow before further pushes are refused.
+    ///
+    /// Real nesting is ssh -> container -> elevate -> shell -> command, i.e. five. Sixteen leaves room
+    /// for the pathological-but-honest case without letting a hostile program cost unbounded memory.
+    /// Per the specification the NEWER contexts are dropped on overflow, so a program deep in the
+    /// ancestry cannot evict the elevate context above it.
+    uint16_t maxDepth { 16 };
+
+    /// How many context records are kept for scrolled-back lines that still point at them.
+    /// Must be at least maxDepth, which the reader enforces.
+    uint16_t maxRetained { 256 };
+
+    /// Whether OSC 3008 may stand in for a shell integration that is not installed.
+    vtbackend::ContextMarkPolicy deriveMarkers { vtbackend::ContextMarkPolicy::WhenAlone };
+
+    /// Which context types may tint the page background.
+    ///
+    /// The COLORS come from the color scheme's `tint:` map, which is empty in every shipped scheme;
+    /// this decides which of its entries are honoured at all.
+    vtbackend::ContextTintScope tinting { vtbackend::ContextTintScope::Boundaries };
 };
 
 struct ScrollBarConfig
@@ -1223,6 +1271,7 @@ struct Config
     ConfigEntry<std::set<std::string>, documentation::ExperimentalFeatures> experimentalFeatures {};
     ConfigEntry<ImagesConfig, documentation::Images> images {};
     ConfigEntry<FoldingConfig, documentation::Folding> folding {};
+    ConfigEntry<OscContextConfig, documentation::OscContext> oscContext {};
 
     ConfigEntry<std::unordered_map<std::string, TerminalProfile>, documentation::Profiles> profiles {
         { { "main", TerminalProfile {} } }
@@ -1537,6 +1586,9 @@ struct YAMLConfigReader
     void loadFromEntry(YAML::Node const& node, std::string const& entry, ImagesConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, HistoryConfig& where);
     void loadFromEntry(YAML::Node const& node, std::string const& entry, FoldingConfig& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, OscContextConfig& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, vtbackend::ContextMarkPolicy& where);
+    void loadFromEntry(YAML::Node const& node, std::string const& entry, vtbackend::ContextTintScope& where);
     void loadFromEntry(YAML::Node const& node,
                        std::string const& entry,
                        vtbackend::FoldJumpBehavior& where);
@@ -1840,6 +1892,11 @@ struct Writer
     [[nodiscard]] std::string format(std::string_view doc, FoldingConfig const& v)
     {
         return format(doc, v.enabled, v.showMarkers, v.autoCollapseOnNewCommand, v.onJumpIntoFold);
+    }
+
+    [[nodiscard]] std::string format(std::string_view doc, OscContextConfig const& v)
+    {
+        return format(doc, v.enabled, v.maxDepth, v.maxRetained, v.deriveMarkers, v.tinting);
     }
 
     [[nodiscard]] std::string format(std::string_view doc, HistoryConfig const& v)

--- a/src/contour/config/ConfigDocumentation.hpp
+++ b/src/contour/config/ConfigDocumentation.hpp
@@ -1424,6 +1424,36 @@ constexpr StringLiteral FoldMarkerHoverConfig { "    hover:\n"
                                                 "        foreground: {}\n"
                                                 "        background: {}\n" };
 
+constexpr StringLiteral ContextTintConfig {
+    "\n"
+    "{comment} Background tints for OSC 3008 hierarchical contexts: the page is painted in a different\n"
+    "{comment} shade while an elevated, containerised, virtualised or remote context is in force, so\n"
+    "{comment} that output produced under one is distinguishable at a glance.\n"
+    "{comment} Unset by default, and deliberately. No colour is right in both a light and a dark scheme,\n"
+    "{comment} a background that changes on upgrade reads as a rendering fault rather than a feature,\n"
+    "{comment} and this is a signal worth opting into knowingly rather than inheriting.\n"
+    "{comment} A context is something the session ANNOUNCED. Anything that can write to your terminal\n"
+    "{comment} can announce one, or fail to announce one, so the absence of a tint is NOT a statement\n"
+    "{comment} that nothing is running as root.\n"
+    "{comment} These are deliberately subtle -- a few percent off the background, not a slab. On a\n"
+    "{comment} light scheme you want the mirror image.\n"
+    "{comment} tint:\n"
+    "{comment}     elevate: '#2a1a1a'\n"
+    "{comment}     container: '#161c26'\n"
+    "{comment}     remote: '#1a2018'\n"
+};
+
+constexpr StringLiteral ContextTintHeaderConfig {
+    "\n"
+    "{comment} Background tints for OSC 3008 hierarchical contexts. Written back because this scheme\n"
+    "{comment} sets them; remove the block to stop tinting. Note that a context is something the\n"
+    "{comment} session announced, and anything that can write to your terminal can announce one -- or\n"
+    "{comment} fail to. The absence of a tint is not a statement that nothing is running as root.\n"
+    "tint:\n"
+};
+
+constexpr StringLiteral ContextTintEntryConfig { "    {}: {}\n" };
+
 constexpr StringLiteral InputMethodEditorConfig { "\n"
                                                   "{comment} Colors for the IME (Input Method Editor) area.\n"
                                                   "input_method_editor:\n"
@@ -2777,6 +2807,9 @@ using FoldMarker = DocumentationEntry<FoldMarkerConfig, Dummy>;
 using FoldMarkerHeader = DocumentationEntry<FoldMarkerHeaderConfig, Dummy>;
 using FoldMarkerDefault = DocumentationEntry<FoldMarkerDefaultConfig, Dummy>;
 using FoldMarkerHover = DocumentationEntry<FoldMarkerHoverConfig, Dummy>;
+using ContextTint = DocumentationEntry<ContextTintConfig, Dummy>;
+using ContextTintHeader = DocumentationEntry<ContextTintHeaderConfig, Dummy>;
+using ContextTintEntry = DocumentationEntry<ContextTintEntryConfig, Dummy>;
 using InputMethodEditor = DocumentationEntry<InputMethodEditorConfig, Dummy>;
 using InputMethodEditorSupport = DocumentationEntry<InputMethodEditorSupportConfig, Dummy>;
 using NormalColors = DocumentationEntry<NormalColorsConfig, Dummy>;

--- a/src/contour/config/ConfigDocumentation.hpp
+++ b/src/contour/config/ConfigDocumentation.hpp
@@ -382,6 +382,38 @@ constexpr StringLiteral FoldingConfig {
 
 };
 
+constexpr StringLiteral OscContextConfig {
+
+    "osc_context:\n"
+    "    {comment} Whether to read OSC 3008, systemd's hierarchical context signalling (UAPI.15).\n"
+    "    {comment} systemd 258 and later emit these around every interactive command with no\n"
+    "    {comment} configuration at all, so on those systems the terminal learns command\n"
+    "    {comment} boundaries, exit statuses and working directories for free.\n"
+    "    {comment} Set to false to restore the behaviour from before this was consumed.\n"
+    "    enabled: {}\n"
+    "    {comment} How deep the context stack may grow before further contexts are ignored.\n"
+    "    {comment} Per the specification the NEWER contexts are dropped, so a program cannot\n"
+    "    {comment} push the elevate context above it out of the stack.\n"
+    "    max_depth: {}\n"
+    "    {comment} How many contexts are remembered for scrolled-back output that refers to them.\n"
+    "    max_retained_contexts: {}\n"
+    "    {comment} Whether OSC 3008 may stand in for a shell integration that is not installed:\n"
+    "    {comment}   when_alone - derive marks from OSC 3008 only while OSC 133 has said nothing\n"
+    "    {comment}   never      - only OSC 133 ever leaves marks\n"
+    "    {comment} Once a shell integration speaks, it owns the marks for the rest of the session.\n"
+    "    derive_markers: {}\n"
+    "    {comment} Which contexts may tint the page background. The COLOURS come from the colour\n"
+    "    {comment} scheme's tint: map, which no shipped scheme sets -- so nothing is tinted until\n"
+    "    {comment} you choose a colour there. A context is something the session ANNOUNCED, and\n"
+    "    {comment} anything that can write to your terminal can announce one, or fail to.\n"
+    "    {comment}   boundaries - only elevate, chpriv, container, vm and remote\n"
+    "    {comment}   all        - every type the colour scheme sets a tint for\n"
+    "    {comment}   off        - ignore the tint map entirely\n"
+    "    tinting: {}\n"
+    "\n"
+
+};
+
 constexpr StringLiteral ScrollbarConfig {
 
     "scrollbar:\n"
@@ -1989,6 +2021,41 @@ constexpr StringLiteral HistoryWeb {
     "\n"
 };
 
+constexpr StringLiteral OscContextWeb {
+    "configuration controls whether Contour reads OSC 3008, systemd's hierarchical context signalling "
+    "(UAPI.15): the nested stack of contexts a shell, `run0`, `ssh` or a container runtime opens around "
+    "whatever runs inside it.\n"
+    "``` yaml\n"
+    "osc_context:\n"
+    "  enabled: true\n"
+    "  max_depth: 16\n"
+    "  max_retained_contexts: 256\n"
+    "  derive_markers: when_alone\n"
+    "  tinting: boundaries\n"
+    "```\n"
+    "systemd 258 and later ship a shell snippet that emits these sequences around every interactive "
+    "command with no configuration at all, so on such a system Contour learns command boundaries, exit "
+    "statuses (including whether a command crashed or was interrupted, which OSC 133 cannot express) "
+    "and working directories without any shell integration being installed.\n"
+    ":octicons-horizontal-rule-16: ==enabled== Whether the sequences are read at all. When false "
+    "nothing is tracked, nothing is derived and nothing is tinted. <br/>\n"
+    ":octicons-horizontal-rule-16: ==max_depth== How deep the context stack may grow. Beyond it, "
+    "further contexts are ignored -- the NEWER ones, so that a program cannot push the context "
+    "established above it out of the stack. <br/>\n"
+    ":octicons-horizontal-rule-16: ==max_retained_contexts== How many contexts are remembered for "
+    "scrolled-back output that still refers to them. Older ones are forgotten, and output belonging to "
+    "them simply stops being attributed. <br/>\n"
+    ":octicons-horizontal-rule-16: ==derive_markers== Whether OSC 3008 may stand in for a shell "
+    "integration that is not installed. `when_alone` derives prompt and command marks from it only "
+    "while OSC 133 has said nothing; once a shell integration speaks, it owns the marks for the rest of "
+    "the session. `never` leaves marks entirely to OSC 133. <br/>\n"
+    ":octicons-horizontal-rule-16: ==tinting== Which contexts may tint the page background. The "
+    "colours themselves come from the colour scheme's `tint:` map, which no shipped scheme sets, so "
+    "nothing is tinted until you choose a colour there. Note that a context is something the session "
+    "**announced**: anything that can write to your terminal can announce one, or fail to announce one, "
+    "so the absence of a tint is not a statement that nothing is elevated. <br/>\n"
+};
+
 constexpr StringLiteral FoldingWeb {
     "configuration controls output folding: collapsing a finished command's output down to the prompt "
     "line it was entered at, and expanding it again.\n"
@@ -2534,6 +2601,7 @@ using TerminalSize = DocumentationEntry<TerminalSizeConfig, TerminalSizeWeb>;
 using TerminalId = DocumentationEntry<TerminalIdConfig, TerminalIdWeb>;
 using History = DocumentationEntry<HistoryConfig, HistoryWeb>;
 using Folding = DocumentationEntry<FoldingConfig, FoldingWeb>;
+using OscContext = DocumentationEntry<OscContextConfig, OscContextWeb>;
 using Scrollbar = DocumentationEntry<ScrollbarConfig, ScrollbarWeb>;
 using StatusLine = DocumentationEntry<StatusLineConfig, StatusLineWeb>;
 using OptionKeyAsAlt = DocumentationEntry<OptionKeyAsAltConfig, OptionKeyAsAltWeb>;

--- a/src/contour/config/ConfigEnum.hpp
+++ b/src/contour/config/ConfigEnum.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/shell/Folding.hpp> // FoldJumpBehavior
+#include <vtbackend/shell/MarkArbiter.hpp>
 
 #include <array>
 #include <cstddef>
@@ -106,12 +108,40 @@ namespace detail
         ConfigEnumInfo<vtbackend::FoldJumpBehavior> {
             vtbackend::FoldJumpBehavior::Skip, "skip", "Stop at the prompt line" },
     };
+    /// Whether OSC 3008 may stand in for a shell integration that is not installed.
+    inline constexpr auto ContextMarkPolicyTable = std::array {
+        ConfigEnumInfo<vtbackend::ContextMarkPolicy> {
+            vtbackend::ContextMarkPolicy::Never, "never", "Only OSC 133 leaves marks" },
+        ConfigEnumInfo<vtbackend::ContextMarkPolicy> {
+            vtbackend::ContextMarkPolicy::WhenAlone, "when_alone", "Only while OSC 133 has said nothing" },
+    };
+
+    /// Which context types a color scheme's tint map may paint.
+    inline constexpr auto ContextTintScopeTable = std::array {
+        ConfigEnumInfo<vtbackend::ContextTintScope> { vtbackend::ContextTintScope::Off, "off", "Never tint" },
+        ConfigEnumInfo<vtbackend::ContextTintScope> {
+            vtbackend::ContextTintScope::Boundaries, "boundaries", "Only privilege and machine boundaries" },
+        ConfigEnumInfo<vtbackend::ContextTintScope> {
+            vtbackend::ContextTintScope::All, "all", "Every type the scheme sets" },
+    };
 } // namespace detail
 
 template <>
 constexpr std::span<ConfigEnumInfo<vtbackend::FoldJumpBehavior> const> configEnumValues() noexcept
 {
     return detail::FoldJumpBehaviorTable;
+}
+
+template <>
+constexpr std::span<ConfigEnumInfo<vtbackend::ContextMarkPolicy> const> configEnumValues() noexcept
+{
+    return detail::ContextMarkPolicyTable;
+}
+
+template <>
+constexpr std::span<ConfigEnumInfo<vtbackend::ContextTintScope> const> configEnumValues() noexcept
+{
+    return detail::ContextTintScopeTable;
 }
 
 } // namespace contour::config

--- a/src/contour/config/Config_test.cpp
+++ b/src/contour/config/Config_test.cpp
@@ -989,6 +989,129 @@ profiles:
     CHECK(settings.foldJumpBehavior == vtbackend::FoldJumpBehavior::Skip);
 }
 
+TEST_CASE("Config: osc_context loads from YAML and reaches the emulation settings", "[config]")
+{
+    QTemporaryDir dir;
+    // A GLOBAL section, not per-profile: this says how the terminal READS a protocol the shell speaks,
+    // not how a pane looks. The two knobs that are presentation live in the colour scheme and the
+    // indicator template instead.
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+osc_context:
+    enabled: true
+    max_depth: 8
+    max_retained_contexts: 64
+    derive_markers: never
+    tinting: all
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+
+    auto const* profile = config.profile("main");
+    REQUIRE(profile != nullptr);
+
+    CHECK(config.oscContext.value().enabled == true);
+    CHECK(config.oscContext.value().maxDepth == 8);
+    CHECK(config.oscContext.value().maxRetained == 64);
+    CHECK(config.oscContext.value().deriveMarkers == vtbackend::ContextMarkPolicy::Never);
+    CHECK(config.oscContext.value().tinting == vtbackend::ContextTintScope::All);
+
+    auto const settings = contour::config::emulationSettings(config, *profile);
+    CHECK(settings.contextLimits.maxDepth == 8);
+    CHECK(settings.contextLimits.maxRetained == 64);
+    CHECK(settings.contextMarkPolicy == vtbackend::ContextMarkPolicy::Never);
+    CHECK(settings.contextTintScope == vtbackend::ContextTintScope::All);
+}
+
+TEST_CASE("Config: osc_context defaults, and disabling it silences marks and tints", "[config]")
+{
+    QTemporaryDir dir;
+    auto const defaults = loadFromYaml(dir, R"(
+default_profile: main
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    CHECK(defaults.oscContext.value().enabled == true);
+    CHECK(defaults.oscContext.value().maxDepth == 16);
+    CHECK(defaults.oscContext.value().maxRetained == 256);
+    CHECK(defaults.oscContext.value().deriveMarkers == vtbackend::ContextMarkPolicy::WhenAlone);
+    CHECK(defaults.oscContext.value().tinting == vtbackend::ContextTintScope::Boundaries);
+
+    QTemporaryDir off;
+    // The single kill switch. It travels as itself rather than being folded into the two policies
+    // below, because it has to gate the ANCESTRY: a `false` that only forced Never/Off would still
+    // leave the stack tracking, the breadcrumb drawing and the daemon replicating -- which is what the
+    // documented "nothing is tracked, nothing is derived and nothing is tinted" promises it does not.
+    auto const disabled = loadFromYaml(off, R"(
+default_profile: main
+osc_context:
+    enabled: false
+    derive_markers: when_alone
+    tinting: all
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    auto const* profile = disabled.profile("main");
+    REQUIRE(profile != nullptr);
+    auto const settings = contour::config::emulationSettings(disabled, *profile);
+    CHECK(settings.contextSignalling == vtbackend::ContextSignalling::Disabled);
+    // The two policies pass through untouched: with the sequence refused outright there is no ancestry
+    // for either to describe, so silencing them a second time would say nothing extra.
+    CHECK(settings.contextMarkPolicy == vtbackend::ContextMarkPolicy::WhenAlone);
+    CHECK(settings.contextTintScope == vtbackend::ContextTintScope::All);
+
+    // That the engine then HONOURS this is asserted where the engine lives:
+    // Screen_context_test.cpp, "osc3008 is not read at all when signalling is disabled".
+}
+
+TEST_CASE("Config: osc_context limits are clamped to a usable range", "[config]")
+{
+    QTemporaryDir dir;
+    // A retained bound below the depth bound would let a context that is still an ancestor be evicted,
+    // leaving the chain holding a record nothing can resolve.
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+osc_context:
+    max_depth: 0
+    max_retained_contexts: 1
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    CHECK(config.oscContext.value().maxDepth >= 1);
+    CHECK(config.oscContext.value().maxRetained >= config.oscContext.value().maxDepth);
+
+    QTemporaryDir huge;
+    auto const big = loadFromYaml(huge, R"(
+default_profile: main
+osc_context:
+    max_depth: 60000
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    CHECK(big.oscContext.value().maxDepth <= 256);
+}
+
+TEST_CASE("Config: an unknown osc_context enum value keeps the default", "[config]")
+{
+    QTemporaryDir dir;
+    auto const config = loadFromYaml(dir, R"(
+default_profile: main
+osc_context:
+    derive_markers: nonsense
+    tinting: alsononsense
+profiles:
+    main:
+        shell: /bin/sh
+)"sv);
+    CHECK(config.oscContext.value().deriveMarkers == vtbackend::ContextMarkPolicy::WhenAlone);
+    CHECK(config.oscContext.value().tinting == vtbackend::ContextTintScope::Boundaries);
+}
+
 TEST_CASE("Config: folding defaults, and disabling it never auto-collapses", "[config]")
 {
     QTemporaryDir dir;

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -83,6 +83,22 @@ namespace contour::session
 
 namespace
 {
+
+    /// This machine's /etc/machine-id, or empty where there is none.
+    ///
+    /// Read once at session construction rather than on every question: it cannot change while the
+    /// process runs, and the callers that need it are on the GUI path. Absent on Windows and on a system
+    /// without systemd, where the host-name comparison carries the locality test alone.
+    [[nodiscard]] std::string readLocalMachineId()
+    {
+        auto file = std::ifstream { "/etc/machine-id" };
+        if (!file)
+            return {};
+        auto value = std::string {};
+        std::getline(file, value);
+        // Trimmed, because trailing whitespace would make every comparison against a wire value fail.
+        return std::string { crispy::trimRight(value) };
+    }
     string unhandledExceptionMessage(string_view const& where, exception const& e)
     {
         return std::format("{}: Unhandled exception caught ({}). {}", where, typeid(e).name(), e.what());
@@ -330,6 +346,7 @@ TerminalSession::TerminalSession(TerminalSessionManager* manager,
     _app { app },
     _currentColorPreference { app.colorPreference() },
     _localHostName { QHostInfo::localHostName().toStdString() },
+    _localMachineId { readLocalMachineId() },
     _accumulatedPixelScroll {},
     _accumulatedAngleScroll {},
     _hyperlinkHover { _localHostName },
@@ -2091,11 +2108,15 @@ command::ContextMenuState TerminalSession::contextMenuState()
             // cannot guard against that in an alias) reports a command that never ran, with no text to
             // copy — offering the user three rows that would all yield nothing.
             .hasLastCommand = block.has_value() && !(block->prompt.empty() && block->output.empty()),
-            // Only a working directory on this host can be opened by the local file manager. OSC 7 gives a
-            // file://HOST/PATH; a remote (SSH) cwd resolves to nullopt and grays the "Open Current Folder".
+            // Only a working directory on this host can be opened by the local file manager, and the row
+            // and the action behind it go through ONE resolver so they cannot disagree. A remote OSC 7
+            // cwd grays it out, and so does an OSC 3008 cwd behind a container boundary or from another
+            // machine -- which would otherwise open the HOST's directory of the same name, a false
+            // positive OSC 7 never had, because a context cwd carries no host authority to test.
+            // The LOCKED resolver: this whole lambda runs inside crispy::locked() above, and the
+            // terminal's mutex is not recursive.
             .hasLocalWorkingDirectory =
-                vtbackend::localWorkingDirectory(terminal().currentWorkingDirectory(), _localHostName)
-                    .has_value(),
+                resolveWorkingDirectoryLocked(vtbackend::CwdPurpose::OpenLocally).has_value(),
             // Left for the window to fill in: whether this tab holds more than one pane is not something
             // a session knows about itself.
             .hasSplits = false,
@@ -2434,25 +2455,20 @@ bool TerminalSession::operator()(actions::OpenFileManager)
     // host authority is read as a network share ("//fedora/home/..."), which does not exist locally.
     // Resolve it to a plain local path first, and only when it is on THIS host — a remote (SSH) cwd is
     // not openable here (its menu row is grayed out, but a keybinding could still reach this handler).
-    auto localPath = std::optional<std::string> {};
-    auto cwd = std::string {};
+    // The same resolver the menu row's enablement uses, so the two can never disagree about whether a
+    // directory is openable.
+    auto const resolved = resolveWorkingDirectory(vtbackend::CwdPurpose::OpenLocally);
+    if (!resolved)
     {
-        auto const l = scoped_lock { terminal() };
-        cwd = terminal().currentWorkingDirectory();
-        localPath = vtbackend::localWorkingDirectory(cwd, _localHostName);
-    }
-
-    if (!localPath)
-    {
-        // A remote (SSH) or otherwise non-local cwd cannot be opened in this host's file manager. The
-        // context-menu row for this is grayed out, but a keybinding can still reach this handler — so
-        // report why nothing happened rather than silently swallowing the request.
-        errorLog()("Cannot open file manager: working directory \"{}\" is not on the local host.", cwd);
+        // A remote (SSH) cwd, or one behind a container/VM boundary, cannot be opened in this host's
+        // file manager. The context-menu row is grayed out, but a keybinding can still reach this
+        // handler — so report why nothing happened rather than silently swallowing the request.
+        errorLog()("Cannot open file manager: the working directory is not on the local host.");
         return true;
     }
 
-    if (!_app.externalLauncher().openUrl(QUrl::fromLocalFile(QString::fromStdString(*localPath))))
-        errorLog()("Could not open folder \"{}\".", *localPath);
+    if (!_app.externalLauncher().openUrl(QUrl::fromLocalFile(QString::fromStdString(resolved->path))))
+        errorLog()("Could not open folder \"{}\".", resolved->path);
 
     return true;
 }
@@ -3275,49 +3291,61 @@ bool TerminalSession::executeAction(actions::Action const& action)
     return visit(*this, action);
 }
 
+std::optional<vtbackend::ResolvedWorkingDirectory> TerminalSession::resolveWorkingDirectory(
+    vtbackend::CwdPurpose purpose) const
+{
+    // Resolved AND returned under the lock: the resolver's intermediate views point into the ancestry,
+    // while ResolvedWorkingDirectory owns its path, so nothing escaping here outlives the guard.
+    auto const lock = scoped_lock { _terminal };
+    return resolveWorkingDirectoryLocked(purpose);
+}
+
+std::optional<vtbackend::ResolvedWorkingDirectory> TerminalSession::resolveWorkingDirectoryLocked(
+    vtbackend::CwdPurpose purpose) const
+{
+    auto const osc7 = _terminal.currentWorkingDirectory();
+    return vtbackend::resolveWorkingDirectory(_terminal.contexts(), osc7, localIdentity(), purpose);
+}
+
 std::string TerminalSession::workingDirectory() const
 {
 #ifndef _WIN32
+    // /proc FIRST on POSIX, and deliberately: it reads the pty child's own cwd, so it is always a real
+    // path on THIS machine and can never hand fork+exec a path from another filesystem namespace. It
+    // is a genuine trade rather than a free win -- it names the LOGIN shell, so it does not follow a
+    // subshell the way an OSC 3008 cwd would -- and this side of it is the conservative one.
+    //
+    // An OSC 3008 cwd is consulted only where /proc has nothing to say (see the Windows branch
+    // below), which is why the display path resolves separately.
     if (auto const* ptyProcess = dynamic_cast<vtpty::Process const*>(&_terminal.device()))
         return ptyProcess->workingDirectory();
 #else
-    // On Windows the CWD is only known via OSC 7, which reports it as a file:// URL. Passing that raw
-    // URL to CreateProcess() as a new tab/split's working directory fails with ERROR_DIRECTORY and
-    // crashes the app, so extract the filesystem path first (fix from master's OSC-7 crash fix).
-    std::string cwdUrl;
+    // On Windows there is no /proc, so the advertised cwd is all there is: the OSC 3008 ancestry
+    // first, then OSC 7. Both are filtered for locality by the resolver -- an OSC 3008 cwd behind a
+    // container or from another machine, and an OSC 7 cwd naming a remote host, are both refused.
+    if (auto const resolved = resolveWorkingDirectory(vtbackend::CwdPurpose::Spawn))
     {
-        auto const _l = scoped_lock { _terminal };
-        cwdUrl = _terminal.currentWorkingDirectory();
+        // Existence is checked on top of that, and the reason is a crash rather than a nicety: an SSH
+        // session advertises its REMOTE cwd, and handing a path that does not exist here to a new
+        // tab's CreateProcess() fails, makes Process::start() throw, and -- being reached from a QML
+        // `session:` binding write inside a Qt event handler -- aborts the whole process.
+        std::error_code ec;
+        if (std::filesystem::is_directory(fs::path(resolved->path), ec))
+            return resolved->path;
     }
-    if (!cwdUrl.empty())
-        if (auto path = vtbackend::extractPathFromFileUrl(cwdUrl); !path.empty())
-        {
-            // The path is only usable to CreateProcess() if it exists on THIS machine. An SSH session
-            // advertises its *remote* cwd over OSC 7 (e.g. "file://remotehost/home/user" -> "/home/user"),
-            // which does not exist locally; handing it to a new local tab/split's CreateProcess() fails
-            // and Process::start() throws, and — being reached from a QML `session:` binding write inside
-            // a Qt event handler — that exception aborts the whole process. Only inherit a directory that
-            // actually exists locally; otherwise fall through to the "." sentinel (inherit our own cwd).
-            std::error_code ec;
-            if (std::filesystem::is_directory(fs::path(path), ec))
-                return path;
-        }
 #endif
     return "."s;
 }
 
 std::string TerminalSession::displayWorkingDirectory() const
 {
-    // OSC 7 first: it is the shell speaking, so it tracks a `cd` made inside a full-screen application
-    // and it is the only source that can be right for a remote session. Reported as a file:// URL.
-    auto cwdUrl = std::string {};
-    {
-        auto const lock = scoped_lock { _terminal };
-        cwdUrl = _terminal.currentWorkingDirectory();
-    }
-    if (!cwdUrl.empty())
-        if (auto path = vtbackend::extractPathFromFileUrl(cwdUrl); !path.empty())
-            return path;
+    // The OSC 3008 ancestry first, then OSC 7: both are the shell speaking, so both track a `cd` made
+    // inside a full-screen application, and both can be right for a session that is not on this
+    // machine. NOT filtered for locality, unlike workingDirectory() above -- a container's /app is
+    // exactly what the user is looking at, and a path worth SHOWING need not be one a child could be
+    // spawned in.
+    if (auto const resolved = resolveWorkingDirectory(vtbackend::CwdPurpose::Display))
+        return resolved->path;
 
     // Nothing reported (no shell integration, or not yet): fall back to where the session was started.
     // Unlike workingDirectory() this is NOT filtered for local existence — a path worth SHOWING need not

--- a/src/contour/session/TerminalSession.hpp
+++ b/src/contour/session/TerminalSession.hpp
@@ -14,6 +14,7 @@
 #include <contour/session/DisplaySurface.hpp>
 #include <contour/session/HyperlinkTooltip.hpp>
 
+#include <vtbackend/core/WorkingDirectory.hpp>
 #include <vtbackend/screen/Terminal.hpp>
 
 #include <vtpty/Pty.hpp>
@@ -465,6 +466,32 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     /// split pane — using the same logic, including the Windows fallback.
     /// @return The working directory path, or "." if unavailable.
     [[nodiscard]] std::string workingDirectory() const;
+
+    /// This machine's identity, for deciding whether a context describes it.
+    [[nodiscard]] vtbackend::LocalIdentity localIdentity() const noexcept
+    {
+        return vtbackend::LocalIdentity { .machineId = _localMachineId, .hostname = _localHostName };
+    }
+
+    /// The working directory for @p purpose, resolved from the OSC 3008 ancestry and then OSC 7.
+    ///
+    /// One resolution consulted by every caller, so "where does a new tab start" and "what does the
+    /// tab tooltip say" can never disagree about the ORDER even though they deliberately disagree
+    /// about the FILTER: a path worth SHOWING need not be one a child could be spawned in.
+    ///
+    /// Takes the terminal lock. A caller that already holds it must use
+    /// @ref resolveWorkingDirectoryLocked instead.
+    [[nodiscard]] std::optional<vtbackend::ResolvedWorkingDirectory> resolveWorkingDirectory(
+        vtbackend::CwdPurpose purpose) const;
+
+    /// As @ref resolveWorkingDirectory, for a caller that ALREADY holds the terminal lock.
+    ///
+    /// Two named functions rather than a `locked` flag, per the project's own rule about boolean
+    /// parameters -- and the distinction is load-bearing rather than stylistic: the terminal's mutex is
+    /// NOT recursive, so taking it a second time deadlocks the GUI thread outright. contextMenuState()
+    /// is exactly such a caller, its whole body being one locked snapshot.
+    [[nodiscard]] std::optional<vtbackend::ResolvedWorkingDirectory> resolveWorkingDirectoryLocked(
+        vtbackend::CwdPurpose purpose) const;
 
     /// The working directory to SHOW the user, as opposed to the one to spawn a child in.
     ///
@@ -926,6 +953,14 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
     /// This machine's host name, asked once because one of the file:// URLs measured against it is
     /// resolved on the GUI thread under the terminal lock. @see vtbackend::isLocalHost
     std::string _localHostName;
+
+    /// This machine's /etc/machine-id, read once, empty where there is none.
+    ///
+    /// The STRONG half of the locality test an OSC 3008 working directory needs. Nothing emits a
+    /// `remote` context for ssh today, so a remote host's own sequences look entirely local and its
+    /// paths may well exist here too; comparing machine ids is the only thing that catches it, and
+    /// systemd's shim emits one for free. @see vtbackend::LocalIdentity.
+    std::string _localMachineId;
 
     crispy::Point _accumulatedPixelScroll;
     crispy::Point _accumulatedAngleScroll;

--- a/src/contour/test/e2e/coverage-config.yml.in
+++ b/src/contour/test/e2e/coverage-config.yml.in
@@ -16,6 +16,15 @@ live_config: false
 tab_bar_position: Bottom
 tab_bar_visibility: Multiple
 
+# OSC 3008 hierarchical context signalling, driven with a non-default scope so the tint lookup and
+# the mark-derivation path are both exercised.
+osc_context:
+    enabled: true
+    max_depth: 8
+    max_retained_contexts: 64
+    derive_markers: when_alone
+    tinting: all
+
 profiles:
     main:
         shell: /bin/sh
@@ -69,3 +78,10 @@ color_schemes:
         cursor:
             default: '#B0B0B0'
             text: '#101010'
+        # No shipped scheme sets these; the coverage scheme does, so the tint parse and the renderer
+        # blend both run under the offscreen pass.
+        tint:
+            elevate: '#2a1a1a'
+            container: '#161c26'
+            remote: '#1a2018'
+            command: '#141414'

--- a/src/contour/test/e2e/vt-stream.sh
+++ b/src/contour/test/e2e/vt-stream.sh
@@ -36,4 +36,16 @@ done
 printf '\033[r'
 
 sleep 0.3
+# OSC 3008 hierarchical context signalling: a nested ancestry, per-line association, the tint path and
+# the {Context} breadcrumb, all through the real parser and the real renderer.
+printf '\033]3008;start=e2e-session;type=session;user=%s;hostname=%s\033\\' "$(id -un)" "$(uname -n)"
+printf '\033]3008;start=e2e-box;type=container;container=coverage-e2e;cwd=/app\033\\'
+printf 'inside a container\n'
+printf '\033]3008;start=e2e-root;type=elevate;targetuser=root\033\\'
+printf 'elevated line\n'
+sleep 0.3
+printf '\033]3008;end=e2e-root;exit=failure;status=139;signal=SIGSEGV\033\\'
+printf '\033]3008;end=e2e-box;exit=success\033\\'
+printf '\033]3008;end=e2e-session\033\\'
+
 exit 0

--- a/src/contour/window/SettingsController.cpp
+++ b/src/contour/window/SettingsController.cpp
@@ -1791,6 +1791,17 @@ QVariantList SettingsController::parseIndicatorSegment(QString const& templateSt
                         QString::fromStdString(v.separator.value_or(std::string {}));
                     row[QStringLiteral("displayName")] = toQString(ItemTraits<T>::Label);
                 }
+                else if constexpr (std::same_as<T, Context>)
+                {
+                    // Carried through even though the page offers no control for them yet: an item is
+                    // round-tripped through here on EVERY edit of the segment, so a payload the reader
+                    // drops is a payload the writer silently deletes from the user's profile.
+                    row[QStringLiteral("verbosity")] = toQString(contextVerbosityName(v.verbosity));
+                    row[QStringLiteral("separator")] =
+                        QString::fromStdString(v.separator.value_or(std::string {}));
+                    row[QStringLiteral("maxWidth")] = unbox<int>(v.maxWidth);
+                    row[QStringLiteral("displayName")] = toQString(ItemTraits<T>::Label);
+                }
                 else
                     row[QStringLiteral("displayName")] = toQString(ItemTraits<T>::Label);
 
@@ -1838,6 +1849,20 @@ QString SettingsController::serializeIndicatorSegment(QVariantList const& items)
                     // rendering the tabs run together.
                     separator.isEmpty() ? std::nullopt : std::optional { separator.toStdString() },
                 });
+            }
+            else if constexpr (std::same_as<T, Context>)
+            {
+                auto item = Context { styles };
+                item.verbosity =
+                    contextVerbosityFrom(row.value(QStringLiteral("verbosity")).toString().toStdString());
+                auto const separator = row.value(QStringLiteral("separator")).toString();
+                if (!separator.isEmpty())
+                    item.separator = separator.toStdString();
+                // A missing or nonsensical width keeps the default rather than collapsing the
+                // breadcrumb to nothing.
+                if (auto const width = row.value(QStringLiteral("maxWidth")).toInt(); width > 0)
+                    item.maxWidth = vtbackend::ColumnCount(width);
+                segment.emplace_back(std::move(item));
             }
             else
                 segment.emplace_back(T { styles });

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -29,6 +29,7 @@ set(vtbackend_HEADERS
     vt/Functions.hpp
     core/GraphicsAttributes.hpp
     grid/Grid.hpp
+    vt/HierarchicalContext.hpp
     input/vi/HintModeHandler.hpp
     core/Hyperlink.hpp
     core/Image.hpp
@@ -94,6 +95,7 @@ set(vtbackend_SOURCES
     core/Color.cpp
     core/ColorPalette.cpp
     core/TerminalContext.cpp
+    vt/HierarchicalContext.cpp
     shell/CommandBlocks.cpp
     shell/Folding.cpp
     shell/PromptRegion.cpp
@@ -183,6 +185,7 @@ if(LIBTERMINAL_TESTING)
         core/Color_test.cpp
         core/ColorPalette_test.cpp
         core/TerminalContext_test.cpp
+        vt/HierarchicalContext_test.cpp
         shell/CommandBlocks_test.cpp
         shell/Folding_test.cpp
         shell/PromptRegion_test.cpp

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -43,6 +43,7 @@ set(vtbackend_HEADERS
     core/LineFlags.hpp
     grid/LineSoA.hpp
     Logging.hpp
+    shell/MarkArbiter.hpp
     input/MatchModes.hpp
     graphics/MessageParser.hpp
     testing/MockTerm.hpp
@@ -187,6 +188,7 @@ if(LIBTERMINAL_TESTING)
         core/TerminalContext_test.cpp
         vt/HierarchicalContext_test.cpp
         screen/Screen_context_test.cpp
+        shell/MarkArbiter_test.cpp
         shell/CommandBlocks_test.cpp
         shell/Folding_test.cpp
         shell/PromptRegion_test.cpp

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -186,6 +186,7 @@ if(LIBTERMINAL_TESTING)
         core/ColorPalette_test.cpp
         core/TerminalContext_test.cpp
         vt/HierarchicalContext_test.cpp
+        screen/Screen_context_test.cpp
         shell/CommandBlocks_test.cpp
         shell/Folding_test.cpp
         shell/PromptRegion_test.cpp

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -79,6 +79,7 @@ set(vtbackend_HEADERS
     input/vi/ViInputHandler.hpp
     screen/Viewport.hpp
     core/WindowSizeStack.hpp
+    core/WorkingDirectory.hpp
     graphics/regis/ReGISColor.hpp
     graphics/regis/ReGISContext.hpp
     graphics/regis/ReGISFont.hpp
@@ -97,6 +98,7 @@ set(vtbackend_SOURCES
     core/ColorPalette.cpp
     core/TerminalContext.cpp
     vt/HierarchicalContext.cpp
+    core/WorkingDirectory.cpp
     shell/CommandBlocks.cpp
     shell/Folding.cpp
     shell/PromptRegion.cpp
@@ -189,6 +191,7 @@ if(LIBTERMINAL_TESTING)
         vt/HierarchicalContext_test.cpp
         screen/Screen_context_test.cpp
         shell/MarkArbiter_test.cpp
+        core/WorkingDirectory_test.cpp
         shell/CommandBlocks_test.cpp
         shell/Folding_test.cpp
         shell/PromptRegion_test.cpp

--- a/src/vtbackend/CMakeLists.txt
+++ b/src/vtbackend/CMakeLists.txt
@@ -18,6 +18,7 @@ set(vtbackend_HEADERS
     grid/CellUtil.hpp
     vt/Charset.hpp
     core/Color.hpp
+    core/ContextId.hpp
     core/ColorPalette.hpp
     shell/CommandBlocks.hpp
     vt/ControlCode.hpp
@@ -67,6 +68,7 @@ set(vtbackend_HEADERS
     screen/Terminal.hpp
     screen/TerminalTestFixtures.hpp
     testing/TestHelpers.hpp
+    core/TerminalContext.hpp
     core/TextScale.hpp
     vt/TextSizing.hpp
     vt/VTType.hpp
@@ -91,6 +93,7 @@ set(vtbackend_SOURCES
     vt/ProgressState.cpp
     core/Color.cpp
     core/ColorPalette.cpp
+    core/TerminalContext.cpp
     shell/CommandBlocks.cpp
     shell/Folding.cpp
     shell/PromptRegion.cpp
@@ -179,6 +182,7 @@ if(LIBTERMINAL_TESTING)
         vt/ProgressState_test.cpp
         core/Color_test.cpp
         core/ColorPalette_test.cpp
+        core/TerminalContext_test.cpp
         shell/CommandBlocks_test.cpp
         shell/Folding_test.cpp
         shell/PromptRegion_test.cpp

--- a/src/vtbackend/core/ColorPalette.hpp
+++ b/src/vtbackend/core/ColorPalette.hpp
@@ -3,9 +3,11 @@
 
 #include <vtbackend/core/Color.hpp>
 #include <vtbackend/core/Image.hpp>
+#include <vtbackend/core/TerminalContext.hpp>
 
 #include <crispy/StrongHash.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -346,6 +348,53 @@ struct ColorPalette
     {
         return foldMarkerHover.value_or(
             RGBColorPair { .foreground = defaultForeground, .background = defaultBackground });
+    }
+
+    /// The page background under each kind of OSC 3008 context, when the scheme chooses to tint one.
+    ///
+    /// An array indexed by ContextType rather than twelve named members or a map, and both
+    /// alternatives are worth naming. Twelve std::optional members would be twelve rows in the reader,
+    /// twelve in the writer, twelve in the settings page and twelve in the renderer -- forty-eight
+    /// edits for a thirteenth context type, and exactly the drift CellFlagNames and configEnumValues
+    /// were each written about. An unordered_map allocates, and this struct is copied per terminal and
+    /// per XTPUSHCOLORS push, for a feature that is EMPTY in every shipped scheme; the array is a few
+    /// dozen bytes and trivially copyable. Every consumer loops ContextTypeList, so a thirteenth type
+    /// is one row in core/TerminalContext.hpp.
+    ///
+    /// UNSET IS A COMPLETE ANSWER, and this is where it differs from foldMarker above. A fold marker
+    /// must be visible or the feature is broken, so an absent one is derived. An absent tint means the
+    /// scheme does not tint that context, which needs no derivation and must not get one: a background
+    /// that appears unbidden after an upgrade reads as a rendering fault rather than a feature, no
+    /// constant works across light and dark (see the foldMarker comment above, which records exactly
+    /// that), and a tint is a security-adjacent signal any program on the tty can trigger -- shipping
+    /// one on would teach users to read a spoofable colour as authority. So every shipped scheme
+    /// leaves this entirely empty and the generated config carries a commented example instead.
+    std::array<std::optional<RGBColor>, ContextTypeCount> contextTints {};
+
+    /// The tint for @p type, honouring @p scope.
+    ///
+    /// @param type  The context type of the line being drawn.
+    /// @param scope Which types the configuration allows to tint at all.
+    /// @return The background to stand in for the page background, or nullopt -- which is a final
+    ///         answer, not a request for a default.
+    [[nodiscard]] std::optional<RGBColor> contextTint(ContextType type, ContextTintScope scope) const noexcept
+    {
+        switch (scope)
+        {
+            case ContextTintScope::Off: return std::nullopt;
+            case ContextTintScope::Boundaries:
+                if (!isBoundaryContext(type))
+                    return std::nullopt;
+                break;
+            case ContextTintScope::All: break;
+        }
+        return contextTints[static_cast<size_t>(type)];
+    }
+
+    /// Whether any tint is set at all, so the render path can skip the per-line lookup entirely.
+    [[nodiscard]] bool hasContextTints() const noexcept
+    {
+        return std::ranges::any_of(contextTints, [](auto const& c) { return c.has_value(); });
     }
 };
 

--- a/src/vtbackend/core/ContextId.hpp
+++ b/src/vtbackend/core/ContextId.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <format>
+
+#include <boxed-cpp/boxed.hpp>
+
+namespace vtbackend
+{
+
+namespace detail
+{
+    struct ContextIdTag
+    {
+    };
+} // namespace detail
+
+/// The terminal's own handle on a hierarchical context (OSC 3008), as carried by a grid line.
+///
+/// Small and dense on purpose: it rides in the two bytes of padding Line already had between its flags
+/// and its first column offset, so associating every line with the context that produced it costs
+/// nothing per line. Zero means "no context" -- the state a session is in before the first `start=`,
+/// and the state a blank line is in.
+///
+/// The APPLICATION's identifier is not this: the protocol's ids are up to 64 bytes of free-form text,
+/// which no grid line can carry. The mapping between the two lives in @ref ContextStack, which is also
+/// what keeps a record alive after its context has ended.
+///
+/// Its own header, separate from TerminalContext.hpp, so that grid/Line.hpp -- the hottest header in
+/// the tree -- carries two bytes without acquiring <deque>, <span> and the whole stack model. The same
+/// leaf role core/FileUrl.hpp plays for URL decisions.
+using ContextId = boxed::boxed<uint16_t, detail::ContextIdTag>;
+
+} // namespace vtbackend
+
+template <>
+struct std::formatter<vtbackend::ContextId>: formatter<uint16_t> // NOLINT(readability-identifier-naming)
+{
+    auto format(vtbackend::ContextId id, auto& ctx) const
+    {
+        return formatter<uint16_t>::format(id.value, ctx);
+    }
+};

--- a/src/vtbackend/core/TerminalContext.cpp
+++ b/src/vtbackend/core/TerminalContext.cpp
@@ -225,6 +225,23 @@ ContextTransition ContextStack::apply(ContextCommand const& command)
              .change = ContextChange::Yes };
 }
 
+ContextId ContextStack::nextAdoptedId() noexcept
+{
+    // Skips zero, which means "no context", and skips anything already stored -- a mirror adopts in
+    // an order this stack does not control, so a bare counter could collide with a record it has
+    // already been handed.
+    for (auto attempts = size_t {}; attempts <= 0xFFFF; ++attempts)
+    {
+        auto const candidate = _nextId;
+        _nextId = ContextId { static_cast<uint16_t>(_nextId.value + 1) };
+        if (!_nextId.value)
+            _nextId = ContextId { 1 };
+        if (!!candidate && !_byId.contains(candidate))
+            return candidate;
+    }
+    return ContextId { 1 };
+}
+
 void ContextStack::adopt(TerminalContext record)
 {
     Require(!!record.id);

--- a/src/vtbackend/core/TerminalContext.cpp
+++ b/src/vtbackend/core/TerminalContext.cpp
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/core/TerminalContext.hpp>
+
+#include <crispy/Assert.hpp>
+
+#include <algorithm>
+#include <utility>
+
+using std::optional;
+using std::shared_ptr;
+using std::span;
+using std::string_view;
+
+namespace vtbackend
+{
+
+namespace
+{
+    /// Assigns @p value to @p target if @p field was supplied, and clears it otherwise.
+    /// @return Whether @p target changed.
+    bool assignField(std::string& target, ContextFields present, ContextField field, string_view value)
+    {
+        auto const supplied = (present & field).any();
+        auto const& wanted = supplied ? value : string_view {};
+        if (target == wanted)
+            return false;
+        target.assign(wanted); // reuses the destination's capacity: the systemd hot path never allocates
+        return true;
+    }
+
+    /// The scalar twin of @ref assignField, serving the Uint64 and Enum kinds.
+    ///
+    /// An OVERLOAD rather than a separate name, which is what lets the table below expand to one
+    /// spelling for every row: the string overload wins for a `std::string` target (the template
+    /// deduces T from both parameters and fails), and this one takes every other kind.
+    template <typename T>
+    bool assignField(T& target, ContextFields present, ContextField field, T value)
+    {
+        auto const wanted = (present & field).any() ? value : T {};
+        if (target == wanted)
+            return false;
+        target = wanted;
+        return true;
+    }
+
+    /// Reinitialises @p record from @p command, flushing every field the payload did NOT name back to
+    /// its default -- what the specification means by "any previously set metadata fields are flushed
+    /// out, reset to their defaults, and then reinitialized from the newly supplied data".
+    ///
+    /// Reports whether anything actually moved, because the systemd shell context is re-announced on
+    /// every prompt with byte-identical metadata and a frontend must not be told to redraw for that.
+    /// @return Whether @p record changed.
+    bool reinitialize(TerminalContext& record, ContextCommand const& command)
+    {
+        auto changed = false;
+
+        // Generated from VTBACKEND_CONTEXT_FIELDS, so a sixteenth field really is one row there. Written
+        // out by hand this was the one consumer that could be forgotten SILENTLY: a missing line keeps a
+        // stale value across a re-`start=`, which is precisely the flush the specification mandates, and
+        // neither the compiler nor a test would say so.
+#define VTBACKEND_CONTEXT_FIELD_ASSIGN(Name, Bit, Spelling, Member, Kind, Max) \
+    changed |= assignField(record.Member, command.present, ContextField::Name, command.Member);
+        VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_ASSIGN)
+#undef VTBACKEND_CONTEXT_FIELD_ASSIGN
+
+        if (record.present != command.present)
+        {
+            record.present = command.present;
+            changed = true;
+        }
+
+        // A re-`start=` describes a context that is running again, so any outcome recorded from a
+        // previous life is stale. Part of the flush, not an exception to it.
+        if (record.outcome != ContextOutcome {})
+        {
+            record.outcome = {};
+            changed = true;
+        }
+
+        return changed;
+    }
+} // namespace
+
+ContextStack::ContextStack(ContextStackLimits limits) noexcept: _limits { limits }
+{
+    // A programmer error, not a recoverable one: an ancestor evicted from the store would leave the
+    // chain holding a record nothing else can resolve.
+    Require(_limits.maxRetained >= _limits.maxDepth);
+    Require(_limits.maxDepth >= 1);
+    // The depth is what popFrom() counts, and ContextTransition reports that count in a uint16_t.
+    Require(_limits.maxDepth <= 0xFFFF);
+}
+
+optional<size_t> ContextStack::indexOf(string_view identifier) const noexcept
+{
+    for (auto index = _chain.size(); index-- > 0;)
+        if (_chain[index].record->identifier == identifier)
+            return index;
+    return std::nullopt;
+}
+
+uint16_t ContextStack::popFrom(size_t firstIndex)
+{
+    auto retired = uint16_t {};
+    while (_chain.size() > firstIndex)
+    {
+        _chain.pop_back();
+        ++retired;
+    }
+    return retired;
+}
+
+bool ContextStack::isOnChain(ContextId id) const noexcept
+{
+    return std::ranges::any_of(_chain, [id](Entry const& entry) { return entry.record->id == id; });
+}
+
+void ContextStack::store(shared_ptr<TerminalContext> record)
+{
+    auto const id = record->id;
+    _byId.insert_or_assign(id, std::move(record));
+    _creationOrder.push_back(id);
+
+    // Evict oldest-first, but never a context that is still an ancestor: the chain must be resolvable
+    // through find(), and the constructor's maxRetained >= maxDepth requirement guarantees there is
+    // always something else to drop. A chain-held id rotates to the back rather than being discarded
+    // from the queue, so it is reconsidered once it leaves the ancestry.
+    //
+    // The bound is on ATTEMPTS, not on the queue: without it, a queue made entirely of ancestors would
+    // rotate forever.
+    auto attempts = _creationOrder.size();
+    while (_byId.size() > _limits.maxRetained && attempts-- > 0)
+    {
+        auto const oldest = _creationOrder.front();
+        _creationOrder.pop_front();
+
+        if (isOnChain(oldest))
+        {
+            _creationOrder.push_back(oldest);
+            continue;
+        }
+
+        // A caller holding the record through retain() keeps the OBJECT alive; dropping the map entry
+        // only means this stack stops resolving the id, which is the defined answer for an aged-out
+        // context.
+        _byId.erase(oldest);
+    }
+}
+
+ContextTransition ContextStack::apply(ContextCommand const& command)
+{
+    auto const known = indexOf(command.identifier);
+
+    if (command.verb == ContextVerb::End)
+    {
+        // An `end=` naming something outside the ancestry does NOTHING. This is the protocol's stated
+        // safety property expressed in code: if an unknown end could pop, a program could terminate the
+        // context established above it by guessing an identifier.
+        if (!known)
+            return {};
+
+        auto const record = _chain[*known].record;
+        // The named context takes the payload's outcome; its descendants are terminated implicitly and
+        // so have none to report.
+        record->outcome = command.outcome;
+        auto const retired = popFrom(*known);
+        ++_revision;
+        return { .kind = ContextTransitionKind::Ended,
+                 .subject = record->id,
+                 .subjectType = record->type,
+                 .change = ContextChange::Yes,
+                 .implicitlyEnded = static_cast<uint16_t>(retired - 1) };
+    }
+
+    if (known)
+    {
+        auto const isActive = *known + 1 == _chain.size();
+        // Everything below the named context is implicitly terminated -- for an update of the active
+        // context there is nothing below it, so the two cases share one line.
+        auto const retired = popFrom(*known + 1);
+        auto const record = _chain[*known].record;
+        auto const changed = reinitialize(*record, command);
+        if (changed || retired)
+            ++_revision;
+        return { .kind = isActive ? ContextTransitionKind::Updated : ContextTransitionKind::ReturnedTo,
+                 .subject = record->id,
+                 .subjectType = record->type,
+                 .change = (changed || retired) ? ContextChange::Yes : ContextChange::None,
+                 .implicitlyEnded = retired };
+    }
+
+    // The spec's overflow rule is the opposite of MaxSavedTitles': keep the EARLIER contexts and
+    // discard the newer, so a program deep in the ancestry cannot evict the elevate context above it.
+    // Output written while the refused context is notionally active is attributed to its parent, and
+    // its matching `end=` falls through the unknown-identifier arm above -- which is consistent, and is
+    // why that arm has to come first.
+    if (_chain.size() >= _limits.maxDepth)
+    {
+        ++_droppedPushes;
+        return { .kind = ContextTransitionKind::DepthExceeded };
+    }
+
+    auto record = std::make_shared<TerminalContext>();
+    record->id = _nextId;
+    record->parent = activeId();
+    record->identifier.assign(command.identifier);
+    reinitialize(*record, command);
+
+    // Wraps at 65535 like HyperlinkId does, and skips zero because zero means "no context". With only
+    // maxRetained records kept, an id old enough to be reused resolves to nothing long before it could
+    // collide with a line still pointing at it.
+    _nextId = ContextId { static_cast<uint16_t>(_nextId.value + 1) };
+    if (!_nextId.value)
+        _nextId = ContextId { 1 };
+
+    auto const id = record->id;
+    auto const type = record->type;
+    store(record);
+    _chain.push_back(Entry { .record = std::move(record) });
+    ++_revision;
+
+    return { .kind = ContextTransitionKind::Pushed,
+             .subject = id,
+             .subjectType = type,
+             .change = ContextChange::Yes };
+}
+
+void ContextStack::adopt(TerminalContext record)
+{
+    Require(!!record.id);
+    auto const id = record.id;
+
+    if (auto const it = _byId.find(id); it != _byId.end())
+    {
+        // In place, so the ancestry's shared_ptr and every line already stamped with this id keep
+        // resolving to the record they named.
+        if (*it->second != record)
+        {
+            *it->second = std::move(record);
+            ++_revision;
+        }
+        return;
+    }
+
+    store(std::make_shared<TerminalContext>(std::move(record)));
+    ++_revision;
+
+    // Keep the local counter ahead of anything adopted, so a context this stack later creates itself
+    // cannot collide with a mirrored one.
+    if (_nextId.value <= id.value)
+    {
+        _nextId = ContextId { static_cast<uint16_t>(id.value + 1) };
+        if (!_nextId.value)
+            _nextId = ContextId { 1 };
+    }
+}
+
+void ContextStack::setChain(span<ContextId const> ids)
+{
+    auto rebuilt = std::vector<Entry> {};
+    rebuilt.reserve(ids.size());
+    for (auto const id: ids)
+        if (auto const it = _byId.find(id); it != _byId.end())
+            rebuilt.push_back(Entry { .record = it->second });
+
+    if (rebuilt.size() == _chain.size()
+        && std::ranges::equal(
+            rebuilt, _chain, [](Entry const& a, Entry const& b) { return a.record == b.record; }))
+        return;
+
+    _chain = std::move(rebuilt);
+    ++_revision;
+}
+
+void ContextStack::clear() noexcept
+{
+    _chain.clear();
+    _byId.clear();
+    _creationOrder.clear();
+    _nextId = ContextId { 1 };
+    _droppedPushes = 0;
+    ++_revision;
+}
+
+TerminalContext const* ContextStack::find(ContextId id) const noexcept
+{
+    if (!id)
+        return nullptr;
+    auto const it = _byId.find(id);
+    return it != _byId.end() ? it->second.get() : nullptr;
+}
+
+shared_ptr<TerminalContext const> ContextStack::retain(ContextId id) const noexcept
+{
+    if (!id)
+        return {};
+    auto const it = _byId.find(id);
+    return it != _byId.end() ? it->second : shared_ptr<TerminalContext const> {};
+}
+
+std::vector<TerminalContext> ContextStack::records() const
+{
+    auto out = std::vector<TerminalContext> {};
+    out.reserve(_creationOrder.size());
+    for (auto const id: _creationOrder)
+        if (auto const it = _byId.find(id); it != _byId.end())
+            out.push_back(*it->second);
+    return out;
+}
+
+ContextLocality ContextStack::localityOf(ContextId id, LocalIdentity const& self) const noexcept
+{
+    if (!id)
+        return ContextLocality::Unknown;
+
+    // Walk from the outermost down to the named context: a boundary crossed above it is never escaped
+    // by a deeper context, so the first one found decides.
+    auto found = false;
+    auto sawIdentity = false;
+    for (auto const& entry: _chain)
+    {
+        auto const& record = *entry.record;
+        if (contextTypeCrossesHost(record.type) == HostBoundary::Crossed)
+            return ContextLocality::Foreign;
+
+        if (!record.machineId.empty() && !self.machineId.empty())
+        {
+            if (record.machineId != self.machineId)
+                return ContextLocality::Foreign;
+            sawIdentity = true;
+        }
+        else if (!record.hostname.empty() && !self.hostname.empty())
+        {
+            if (record.hostname != self.hostname)
+                return ContextLocality::Foreign;
+            sawIdentity = true;
+        }
+
+        if (record.id == id)
+        {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found)
+        return ContextLocality::Unknown;
+
+    // Nothing on the ancestry claimed an identity, so nothing proved this is the same machine. Unknown
+    // rather than Local, deliberately: nothing emits a `remote` context for ssh today, so a remote
+    // shell's own sequences look entirely local and a remote path may well exist here too.
+    return sawIdentity ? ContextLocality::Local : ContextLocality::Unknown;
+}
+
+optional<EffectiveWorkingDirectory> ContextStack::effectiveWorkingDirectory(
+    LocalIdentity const& self) const noexcept
+{
+    for (auto index = _chain.size(); index-- > 0;)
+    {
+        auto const& record = *_chain[index].record;
+        // The present-bit, not the string: a context that said `cwd=` and meant it stops the walk, and
+        // one that never mentioned a cwd is skipped so a `type=command` context inherits the shell's.
+        if (!(record.present & ContextField::WorkingDirectory).any())
+            continue;
+        if (record.workingDirectory.empty())
+            continue;
+        return EffectiveWorkingDirectory { .path = record.workingDirectory,
+                                           .owner = record.id,
+                                           .locality = localityOf(record.id, self) };
+    }
+    return std::nullopt;
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/core/TerminalContext.hpp
+++ b/src/vtbackend/core/TerminalContext.hpp
@@ -621,6 +621,13 @@ class ContextStack
     /// Ids naming records this stack does not hold are skipped.
     void setChain(std::span<ContextId const> ids);
 
+    /// Mints an id no record in this stack currently holds, for a mirror adopting a record whose
+    /// sender-side id means nothing here.
+    ///
+    /// The two id spaces are separate on purpose: the sender's is a uint16_t that wraps and reuses,
+    /// and a line stamped before a reuse legitimately points at the OLD record.
+    [[nodiscard]] ContextId nextAdoptedId() noexcept;
+
     /// Drops the entire ancestry and every retained record.
     ///
     /// NOT reachable from any escape sequence, deliberately. RIS and DECSTR must not clear the stack: a

--- a/src/vtbackend/core/TerminalContext.hpp
+++ b/src/vtbackend/core/TerminalContext.hpp
@@ -136,6 +136,32 @@ inline constexpr size_t ContextTypeCount = ContextTypeList.size() + 1;
     }
 }
 
+/// Which context types a color scheme's tint map is allowed to paint.
+///
+/// Two independent gates guard the tint, and this is the first: the scheme decides WHICH colour, the
+/// configuration decides WHETHER that colour applies at all. Both are closed by default -- no shipped
+/// scheme sets a tint -- because a background that changes on upgrade reads as a rendering fault, and
+/// because a tint is a security-adjacent signal any program on the tty can trigger.
+enum class ContextTintScope : uint8_t
+{
+    Off = 0,    ///< Ignore every tint slot.
+    Boundaries, ///< Honour only the types isBoundaryContext() names. The default.
+    All,        ///< Honour every slot the scheme sets, including shell and command.
+};
+
+/// Whether the terminal reads OSC 3008 at all.
+///
+/// ONE gate, checked where the sequence enters (@see Screen::processHierarchicalContext), rather than
+/// a flag conjoined into each consumer at the configuration boundary. With the ancestry never
+/// populated, the breadcrumb, the page tint, the derived semantic marks and the daemon's replication
+/// are all empty BY CONSTRUCTION -- so a consumer added tomorrow cannot forget to consult it, which is
+/// exactly how two of the first four came to be ungated.
+enum class ContextSignalling : uint8_t
+{
+    Disabled = 0,
+    Enabled = 1,
+};
+
 /// How a context ended, as `end=`'s `exit=` reports it.
 enum class ContextExit : uint8_t
 {
@@ -721,3 +747,20 @@ class ContextStack
 // }}}
 
 } // namespace vtbackend
+
+/// Spelled as the configuration spells it, which is what `contour generate config` writes back.
+template <>
+struct std::formatter<vtbackend::ContextTintScope>: formatter<std::string_view>
+{
+    auto format(vtbackend::ContextTintScope value, auto& ctx) const
+    {
+        string_view name;
+        switch (value)
+        {
+            case vtbackend::ContextTintScope::Off: name = "off"; break;
+            case vtbackend::ContextTintScope::Boundaries: name = "boundaries"; break;
+            case vtbackend::ContextTintScope::All: name = "all"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};

--- a/src/vtbackend/core/TerminalContext.hpp
+++ b/src/vtbackend/core/TerminalContext.hpp
@@ -1,0 +1,723 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/core/ContextId.hpp>
+
+#include <crispy/Flags.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <format>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace vtbackend
+{
+
+// {{{ vocabulary
+
+/// Whether a context type is entered by crossing onto a different host, kernel or filesystem.
+///
+/// Not decoration: it is what lets a frontend decide that a `cwd=` inherited from above a boundary
+/// does not name a path on THIS machine. @see ContextStack::localityOf.
+enum class HostBoundary : uint8_t
+{
+    Same = 0,
+    Crossed = 1,
+};
+
+/// The single source for every `type=` the protocol names: one row each, giving the enumerator, the
+/// wire spelling, and whether entering it crosses a host boundary.
+///
+/// The enumeration, the two name lookups and @ref contextTypeCrossesHost are all generated from this
+/// table, so **adding a type is adding one row here**. Mirrors VTBACKEND_LINE_FLAGS in LineFlags.hpp,
+/// which exists for the same reason.
+#define VTBACKEND_CONTEXT_TYPES(_)      \
+    _(Service, "service", Same)         \
+    _(Session, "session", Same)         \
+    _(Shell, "shell", Same)             \
+    _(Command, "command", Same)         \
+    _(Vm, "vm", Crossed)                \
+    _(Container, "container", Crossed)  \
+    _(Elevate, "elevate", Same)         \
+    _(ChangePrivileges, "chpriv", Same) \
+    _(Subcontext, "subcontext", Same)   \
+    _(Remote, "remote", Crossed)        \
+    _(Boot, "boot", Crossed)            \
+    _(App, "app", Same)
+
+/// What kind of thing took control of the terminal.
+/// @see VTBACKEND_CONTEXT_TYPES for the table this is generated from.
+enum class ContextType : uint8_t
+{
+    None = 0, ///< No `type=` was given, or one this terminal does not know.
+
+#define VTBACKEND_CONTEXT_TYPE_ENUMERATOR(Name, Spelling, Boundary) Name,
+    VTBACKEND_CONTEXT_TYPES(VTBACKEND_CONTEXT_TYPE_ENUMERATOR)
+#undef VTBACKEND_CONTEXT_TYPE_ENUMERATOR
+};
+
+/// Every ContextType, in declaration order, excluding None.
+///
+/// Anything that must visit every type reads this rather than writing the list out again -- the
+/// colour-scheme tint map and the breadcrumb's segment table both do.
+inline constexpr auto ContextTypeList = std::array {
+#define VTBACKEND_CONTEXT_TYPE_ROW(Name, Spelling, Boundary) ContextType::Name,
+    VTBACKEND_CONTEXT_TYPES(VTBACKEND_CONTEXT_TYPE_ROW)
+#undef VTBACKEND_CONTEXT_TYPE_ROW
+};
+
+/// One past the largest ContextType value, so an array indexed by type is sized from the table.
+inline constexpr size_t ContextTypeCount = ContextTypeList.size() + 1;
+
+/// The wire spelling of @p type, or an empty view for @ref ContextType::None.
+[[nodiscard]] constexpr std::string_view contextTypeName(ContextType type) noexcept
+{
+    switch (type)
+    {
+#define VTBACKEND_CONTEXT_TYPE_NAME(Name, Spelling, Boundary) \
+    case ContextType::Name: return Spelling;
+        VTBACKEND_CONTEXT_TYPES(VTBACKEND_CONTEXT_TYPE_NAME)
+#undef VTBACKEND_CONTEXT_TYPE_NAME
+        case ContextType::None: break;
+    }
+    return {};
+}
+
+/// The type @p name spells, or @ref ContextType::None when it spells none.
+[[nodiscard]] constexpr ContextType contextTypeFrom(std::string_view name) noexcept
+{
+#define VTBACKEND_CONTEXT_TYPE_FROM(Name, Spelling, Boundary) \
+    if (name == (Spelling))                                   \
+        return ContextType::Name;
+    VTBACKEND_CONTEXT_TYPES(VTBACKEND_CONTEXT_TYPE_FROM)
+#undef VTBACKEND_CONTEXT_TYPE_FROM
+    return ContextType::None;
+}
+
+/// Whether entering @p type means leaving this machine's process tree and filesystem.
+[[nodiscard]] constexpr HostBoundary contextTypeCrossesHost(ContextType type) noexcept
+{
+    switch (type)
+    {
+#define VTBACKEND_CONTEXT_TYPE_BOUNDARY(Name, Spelling, Boundary) \
+    case ContextType::Name: return HostBoundary::Boundary;
+        VTBACKEND_CONTEXT_TYPES(VTBACKEND_CONTEXT_TYPE_BOUNDARY)
+#undef VTBACKEND_CONTEXT_TYPE_BOUNDARY
+        case ContextType::None: break;
+    }
+    return HostBoundary::Same;
+}
+
+/// Whether @p type names a PRIVILEGE or MACHINE boundary -- a change in who you are, or in which kernel
+/// you are talking to.
+///
+/// These five are what a `boundaries`-scoped tint honours and what the breadcrumb shows at its default
+/// verbosity: their absence from the screen is what is genuinely costly to a reader. `shell` and
+/// `command` are not news; `session`, `boot`, `service`, `app` and `subcontext` are structure, not
+/// identity.
+[[nodiscard]] constexpr bool isBoundaryContext(ContextType type) noexcept
+{
+    switch (type)
+    {
+        case ContextType::Elevate:
+        case ContextType::ChangePrivileges:
+        case ContextType::Container:
+        case ContextType::Vm:
+        case ContextType::Remote: return true;
+        default: return false;
+    }
+}
+
+/// How a context ended, as `end=`'s `exit=` reports it.
+enum class ContextExit : uint8_t
+{
+    Unknown = 0,  ///< No `exit=` was given, or the context was terminated implicitly.
+    Success = 1,  ///< `exit=success`.
+    Failure = 2,  ///< `exit=failure`; `status=` names the code.
+    Crash = 3,    ///< `exit=crash`; `signal=` names the signal.
+    Interrupt = 4 ///< `exit=interrupt`.
+};
+
+/// The wire spelling of @p exit, or an empty view for @ref ContextExit::Unknown.
+[[nodiscard]] constexpr std::string_view contextExitName(ContextExit exit) noexcept
+{
+    switch (exit)
+    {
+        case ContextExit::Success: return "success";
+        case ContextExit::Failure: return "failure";
+        case ContextExit::Crash: return "crash";
+        case ContextExit::Interrupt: return "interrupt";
+        case ContextExit::Unknown: break;
+    }
+    return {};
+}
+
+/// The exit kind @p name spells, or @ref ContextExit::Unknown when it spells none.
+[[nodiscard]] constexpr ContextExit contextExitFrom(std::string_view name) noexcept
+{
+    if (name == "success")
+        return ContextExit::Success;
+    if (name == "failure")
+        return ContextExit::Failure;
+    if (name == "crash")
+        return ContextExit::Crash;
+    if (name == "interrupt")
+        return ContextExit::Interrupt;
+    return ContextExit::Unknown;
+}
+
+/// Every signal `signal=` may name, with the number Linux gives it.
+///
+/// The numbers are Linux's, hard-coded rather than taken from <signal.h>, and that is deliberate: a
+/// context may describe a process on ANOTHER machine (`type=remote`, `type=vm`), so `SIGSEGV` has to
+/// mean 11 regardless of the platform Contour itself was built for. Including the host's header would
+/// make the same sequence decode differently on Windows.
+#define VTBACKEND_CONTEXT_SIGNALS(_) \
+    _(Hup, "SIGHUP", 1)              \
+    _(Int, "SIGINT", 2)              \
+    _(Quit, "SIGQUIT", 3)            \
+    _(Ill, "SIGILL", 4)              \
+    _(Trap, "SIGTRAP", 5)            \
+    _(Abrt, "SIGABRT", 6)            \
+    _(Bus, "SIGBUS", 7)              \
+    _(Fpe, "SIGFPE", 8)              \
+    _(Kill, "SIGKILL", 9)            \
+    _(Usr1, "SIGUSR1", 10)           \
+    _(Segv, "SIGSEGV", 11)           \
+    _(Usr2, "SIGUSR2", 12)           \
+    _(Pipe, "SIGPIPE", 13)           \
+    _(Alrm, "SIGALRM", 14)           \
+    _(Term, "SIGTERM", 15)           \
+    _(Xcpu, "SIGXCPU", 24)           \
+    _(Xfsz, "SIGXFSZ", 25)           \
+    _(Sys, "SIGSYS", 31)
+
+/// The signal a crashed context died of. @see VTBACKEND_CONTEXT_SIGNALS.
+enum class ContextSignal : uint8_t
+{
+    None = 0, ///< No `signal=` was given, or its symbolic name is not one we know.
+
+#define VTBACKEND_CONTEXT_SIGNAL_ENUMERATOR(Name, Spelling, Number) Name = (Number),
+    VTBACKEND_CONTEXT_SIGNALS(VTBACKEND_CONTEXT_SIGNAL_ENUMERATOR)
+#undef VTBACKEND_CONTEXT_SIGNAL_ENUMERATOR
+};
+
+/// The symbolic name of @p signal, or an empty view for @ref ContextSignal::None.
+[[nodiscard]] constexpr std::string_view contextSignalName(ContextSignal signal) noexcept
+{
+    switch (signal)
+    {
+#define VTBACKEND_CONTEXT_SIGNAL_NAME(Name, Spelling, Number) \
+    case ContextSignal::Name: return Spelling;
+        VTBACKEND_CONTEXT_SIGNALS(VTBACKEND_CONTEXT_SIGNAL_NAME)
+#undef VTBACKEND_CONTEXT_SIGNAL_NAME
+        case ContextSignal::None: break;
+    }
+    return {};
+}
+
+/// The signal @p name spells, or @ref ContextSignal::None when it spells none.
+[[nodiscard]] constexpr ContextSignal contextSignalFrom(std::string_view name) noexcept
+{
+#define VTBACKEND_CONTEXT_SIGNAL_FROM(Name, Spelling, Number) \
+    if (name == (Spelling))                                   \
+        return ContextSignal::Name;
+    VTBACKEND_CONTEXT_SIGNALS(VTBACKEND_CONTEXT_SIGNAL_FROM)
+#undef VTBACKEND_CONTEXT_SIGNAL_FROM
+    return ContextSignal::None;
+}
+
+/// Whether @p value is a signal number this terminal knows, so a byte off the wire can be validated
+/// rather than cast.
+[[nodiscard]] constexpr bool isKnownContextSignal(uint8_t value) noexcept
+{
+    if (value == 0)
+        return true;
+#define VTBACKEND_CONTEXT_SIGNAL_KNOWN(Name, Spelling, Number) \
+    if (value == (Number))                                     \
+        return true;
+    VTBACKEND_CONTEXT_SIGNALS(VTBACKEND_CONTEXT_SIGNAL_KNOWN)
+#undef VTBACKEND_CONTEXT_SIGNAL_KNOWN
+    return false;
+}
+
+/// The single source for every STARTFIELD: one row each, giving the enumerator, its bit, the wire
+/// spelling, the member of @ref TerminalContext it fills, the validator it needs and the decoded length
+/// the ABNF allows.
+///
+/// The bit enumeration, the parser's key dispatch, the flush-to-defaults pass a re-`start=` performs
+/// and the length validation are all generated from this table, so **adding a field is adding one row
+/// here**. Without it, a sixteenth field would be four edits in three files.
+///
+/// `Kind` selects the validator: Text is `1*255SAFE`, OptionalText is `*255SAFE` (may be empty), Id128
+/// is `32*36(HEX / "-")`, Uint64 is `1*20DECIMAL`, Enum is a fixed vocabulary.
+#define VTBACKEND_CONTEXT_FIELDS(_)                                                  \
+    /*   Name             bit  spelling       member            kind          max */ \
+    _(Type, 0, "type", type, Enum, 0)                                                \
+    _(User, 1, "user", user, Text, 255)                                              \
+    _(Hostname, 2, "hostname", hostname, Text, 255)                                  \
+    _(MachineId, 3, "machineid", machineId, Id128, 36)                               \
+    _(BootId, 4, "bootid", bootId, Id128, 36)                                        \
+    _(Pid, 5, "pid", pid, Uint64, 20)                                                \
+    _(PidFdId, 6, "pidfdid", pidFdId, Uint64, 20)                                    \
+    _(Comm, 7, "comm", comm, Text, 255)                                              \
+    _(WorkingDirectory, 8, "cwd", workingDirectory, Text, 255)                       \
+    _(CommandLine, 9, "cmdline", commandLine, OptionalText, 255)                     \
+    _(Vm, 10, "vm", vm, Text, 255)                                                   \
+    _(Container, 11, "container", container, Text, 255)                              \
+    _(TargetUser, 12, "targetuser", targetUser, Text, 255)                           \
+    _(TargetHost, 13, "targethost", targetHost, Text, 255)                           \
+    _(SessionId, 14, "sessionid", sessionId, Text, 255)
+
+/// Which STARTFIELDs a `start=` payload carried. @see VTBACKEND_CONTEXT_FIELDS.
+enum class ContextField : uint16_t
+{
+    None = 0,
+
+#define VTBACKEND_CONTEXT_FIELD_ENUMERATOR(Name, Bit, Spelling, Member, Kind, Max) Name = (1U << (Bit)),
+    VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_ENUMERATOR)
+#undef VTBACKEND_CONTEXT_FIELD_ENUMERATOR
+};
+
+using ContextFields = crispy::Flags<ContextField>;
+
+/// Every ContextField, in declaration order, excluding None.
+inline constexpr auto ContextFieldList = std::array {
+#define VTBACKEND_CONTEXT_FIELD_ROW(Name, Bit, Spelling, Member, Kind, Max) ContextField::Name,
+    VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_ROW)
+#undef VTBACKEND_CONTEXT_FIELD_ROW
+};
+
+/// The bits VTBACKEND_CONTEXT_FIELDS actually assigns, so a peer-supplied mask can be validated rather
+/// than trusted.
+inline constexpr uint16_t ContextFieldMask = [] {
+    auto bits = uint16_t {};
+#define VTBACKEND_CONTEXT_FIELD_BIT(Name, Bit, Spelling, Member, Kind, Max) \
+    bits = static_cast<uint16_t>(bits | (1U << (Bit)));
+    VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_BIT)
+#undef VTBACKEND_CONTEXT_FIELD_BIT
+    return bits;
+}();
+
+/// How a context ended.
+struct ContextOutcome
+{
+    ContextExit exit = ContextExit::Unknown;
+    ContextSignal signal = ContextSignal::None;
+
+    /// The `status=` code. Meaningful for @ref ContextExit::Failure; zero otherwise.
+    uint64_t status = 0;
+
+    bool operator==(ContextOutcome const&) const = default;
+
+    /// The exit code a shell would have reported for this outcome, in the encoding OSC 133;D uses --
+    /// so a session driven by OSC 3008 alone still feeds the command-block machinery.
+    ///
+    /// success is 0, failure is `status`, a signal is 128+n as every POSIX shell spells it, and a bare
+    /// interrupt is 130 (128+SIGINT) because that is the code the shell itself would have had.
+    [[nodiscard]] constexpr int asShellExitCode() const noexcept
+    {
+        if (signal != ContextSignal::None)
+            return 128 + static_cast<int>(signal);
+        switch (exit)
+        {
+            case ContextExit::Success: return 0;
+            case ContextExit::Failure: return static_cast<int>(status & 0xFF);
+            case ContextExit::Crash: return 128 + static_cast<int>(ContextSignal::Segv);
+            case ContextExit::Interrupt: return 128 + static_cast<int>(ContextSignal::Int);
+            case ContextExit::Unknown: break;
+        }
+        return 0;
+    }
+};
+
+/// One hierarchical context: what the application told us about a level of its own nesting.
+///
+/// Every text field holds the bytes the application sent, unescaped but NOT transcoded and NOT
+/// validated as UTF-8 -- a `cwd=` on Linux is an arbitrary byte string, and rejecting one that is not
+/// valid UTF-8 would discard a legitimate path. A frontend that puts one on screen transcodes with
+/// replacement; nothing here may assume the bytes are printable.
+///
+/// METADATA DRIFT, which a reader of these fields must know about: a `start=` naming a context that is
+/// already active reinitialises it IN PLACE, keeping its ContextId (@see ContextStack::apply). systemd
+/// re-announces the shell context on every prompt, so a scrollback line stamped with a shell context
+/// reports TODAY's cwd, not the one in effect when it was written. Per-command metadata is not affected
+/// -- `type=command` contexts are never updated -- so present this as current state, never as history.
+struct TerminalContext
+{
+    ContextId id {};     ///< This terminal's handle. Never zero for a stored record.
+    ContextId parent {}; ///< The context this one was pushed under; zero for the outermost.
+
+    /// The application's own CTXID, unescaped. What `start=` and `end=` name a context by.
+    std::string identifier;
+
+    ContextType type = ContextType::None;
+
+    std::string user;
+    std::string hostname;
+    std::string machineId;
+    std::string bootId;
+    std::string comm;
+    std::string workingDirectory;
+    std::string commandLine;
+    std::string vm;
+    std::string container;
+    std::string targetUser;
+    std::string targetHost;
+    std::string sessionId;
+
+    uint64_t pid = 0;
+    uint64_t pidFdId = 0;
+
+    /// Which fields the most recent `start=` actually carried.
+    ///
+    /// Not the same question as "is the string empty": an application may legitimately send `cmdline=`,
+    /// and telling that apart from "no cmdline was mentioned" is what lets the nearest-`cwd=` walk in
+    /// @ref ContextStack::effectiveWorkingDirectory skip a context rather than stop at it with an empty
+    /// answer.
+    ContextFields present {};
+
+    /// How it ended, once it has. All-default while it is still live.
+    ContextOutcome outcome {};
+
+    bool operator==(TerminalContext const&) const = default;
+};
+
+// }}}
+// {{{ the decoded command
+
+/// Which of the protocol's two verbs a payload carries.
+enum class ContextVerb : uint8_t
+{
+    Start = 0, ///< `start=`: initiates, updates, or returns to a context.
+    End = 1,   ///< `end=`: terminates a context.
+};
+
+/// One decoded OSC 3008 payload.
+///
+/// Every string is a VIEW -- into the sequence buffer, or into the scratch buffer the decoder was
+/// handed -- and both die when the sequence does. Nothing here may outlive @ref ContextStack::apply.
+///
+/// Views rather than strings because of what the traffic looks like: systemd re-announces the shell
+/// context on EVERY prompt, with six fields byte-identical to what is already stored. Decoding into
+/// owning strings would allocate on every prompt to store what we already have; @ref ContextStack::apply
+/// instead assigns view-to-string field by field, which reuses the destination's capacity and so
+/// allocates nothing after the first prompt.
+struct ContextCommand
+{
+    ContextVerb verb = ContextVerb::Start;
+
+    /// The CTXID, unescaped.
+    std::string_view identifier;
+
+    /// Which STARTFIELDs were present AND valid. A field the payload carried but that failed validation
+    /// is absent here -- the protocol is lenient, so an invalid field is dropped and the rest stands.
+    ContextFields present {};
+
+    ContextType type = ContextType::None;
+
+    std::string_view user;
+    std::string_view hostname;
+    std::string_view machineId;
+    std::string_view bootId;
+    std::string_view comm;
+    std::string_view workingDirectory;
+    std::string_view commandLine;
+    std::string_view vm;
+    std::string_view container;
+    std::string_view targetUser;
+    std::string_view targetHost;
+    std::string_view sessionId;
+
+    uint64_t pid = 0;
+    uint64_t pidFdId = 0;
+
+    /// Filled from the ENDFIELDs; all-default for a `start=`.
+    ContextOutcome outcome {};
+};
+
+// }}}
+// {{{ the stack
+
+/// What @ref ContextStack::apply did with a command.
+enum class ContextTransitionKind : uint8_t
+{
+    Ignored = 0,   ///< Nothing happened. An `end=` naming a context that is not in the ancestry.
+    Pushed,        ///< A context the ancestry did not hold was created beneath the active one.
+    Updated,       ///< The ACTIVE context was re-announced and reinitialised from the payload.
+    ReturnedTo,    ///< An ANCESTOR was re-announced; everything below it was implicitly terminated.
+    Ended,         ///< A context was terminated by `end=`.
+    DepthExceeded, ///< A push was refused because the ancestry is already at its limit.
+};
+
+/// Whether a command changed anything a frontend can see.
+enum class ContextChange : uint8_t
+{
+    None = 0, ///< The record is byte-for-byte what it already was; nothing needs redrawing.
+    Yes = 1,  ///< Metadata, the ancestry, or both moved.
+};
+
+/// The outcome of one command, and everything a caller needs to react to it.
+struct ContextTransition
+{
+    ContextTransitionKind kind = ContextTransitionKind::Ignored;
+
+    /// The context the command named. Zero when @ref kind is Ignored or DepthExceeded.
+    ContextId subject {};
+
+    /// @ref subject's type, so a caller can consult its mark table without a second lookup.
+    ContextType subjectType = ContextType::None;
+
+    /// Whether anything observable moved.
+    ///
+    /// Separate from @ref kind because the systemd hot path -- a shell context re-announced on every
+    /// prompt -- is an Updated transition that usually changes NOTHING, and re-notifying a frontend of
+    /// an unchanged value is work for no change.
+    ContextChange change = ContextChange::None;
+
+    /// How many descendants this command terminated implicitly (a return-to, or an `end=` of an
+    /// ancestor). Zero for every other transition.
+    ///
+    /// Wide enough for @ref ContextStackLimits::maxDepth, which the configuration lets a user raise to
+    /// 256: a uint8_t counter silently wrapped to zero at exactly that limit, and the `end=` arm's
+    /// `retired - 1` then reported 255 descendants for a stack that had just been emptied.
+    uint16_t implicitlyEnded = 0;
+};
+
+/// How deep the ancestry may go and how much history is kept.
+///
+/// A struct rather than two parameters because a third limit would then be a field rather than a
+/// signature change, and because @ref ContextStack takes its limits at construction and never after.
+struct ContextStackLimits
+{
+    /// The deepest ancestry the terminal will track. A push beyond it is REFUSED -- the spec's "keep
+    /// the earlier contexts, discard the newer".
+    ///
+    /// Note this is the OPPOSITE of MaxSavedTitles, where a push onto a full stack discards the oldest
+    /// entry. Same shape, inverted rule; confusing the two would be an easy and invisible bug.
+    size_t maxDepth = 16;
+
+    /// How many context records are kept for lines that reference them. Must be >= maxDepth, so a
+    /// context that is still an ancestor can never be evicted.
+    size_t maxRetained = 256;
+
+    bool operator==(ContextStackLimits const&) const = default;
+};
+
+/// This machine's identity, for deciding whether a context describes it.
+///
+/// Injected rather than read here, exactly as @ref vtbackend::isLocalHost takes the local host name
+/// rather than calling gethostname(2): reading /etc/machine-id is an ambient resource, and a terminal
+/// engine that reaches for one stops being testable. The session supplies it.
+struct LocalIdentity
+{
+    std::string_view machineId;
+    std::string_view hostname;
+};
+
+/// Whether a path named by a context can be opened on this machine.
+enum class ContextLocality : uint8_t
+{
+    Unknown = 0, ///< Nothing on the ancestry says either way.
+    Local = 1,   ///< This machine, this boot: the path is openable.
+    Foreign = 2, ///< Behind a container, VM, remote or different-machine boundary.
+};
+
+/// A working directory and where it came from.
+struct EffectiveWorkingDirectory
+{
+    /// The `cwd=` value. A view into the owning record; valid while the stack is not mutated.
+    std::string_view path;
+
+    /// Which context supplied it -- not necessarily the active one.
+    ContextId owner;
+
+    /// Whether @ref path names a file on the machine Contour runs on.
+    ContextLocality locality = ContextLocality::Unknown;
+};
+
+/// The terminal's model of the application's own nesting: OSC 3008's ancestry, and the records that
+/// scrolled-back lines still point at.
+///
+/// Deliberately free of Screen, Terminal and the grid: given a decoded command it produces the next
+/// state and says what changed, so every one of the protocol's transitions is exercised without a
+/// terminal. core/WindowSizeStack.hpp is the model.
+///
+/// Exactly one context is active -- the innermost of @ref chain() -- and its ancestors stay valid. The
+/// ancestry may be EMPTY: before the first `start=`, and after the last context is ended. There is no
+/// terminal-owned bottom entry, because unlike a pointer shape there is nothing the terminal could
+/// truthfully say about the application's process tree on its own.
+class ContextStack
+{
+  public:
+    /// One level of the ancestry.
+    struct Entry
+    {
+        /// A strong reference, so a context that is still an ancestor outlives eviction from the
+        /// retained store. The same reason HyperlinkStorage hands out shared_ptr.
+        std::shared_ptr<TerminalContext> record;
+    };
+
+    /// @param limits How deep the ancestry may go and how much history is kept. Fixed for the object's
+    ///        lifetime: a session configured differently is a different session. Requires
+    ///        `limits.maxRetained >= limits.maxDepth`.
+    explicit ContextStack(ContextStackLimits limits = {}) noexcept;
+
+    // -- mutation ---------------------------------------------------------------------------------
+
+    /// Applies one decoded command.
+    ///
+    /// Total, not fallible: the protocol is lenient, so "the command named a context I do not have" is
+    /// a defined OUTCOME (@ref ContextTransitionKind::Ignored), not an error. Malformed PAYLOADS never
+    /// reach here -- the decoder rejects those with std::expected.
+    ///
+    /// @param command The decoded payload. Its views are read, never retained.
+    /// @return What happened, and whether anything observable changed.
+    ContextTransition apply(ContextCommand const& command);
+
+    /// Adopts a whole record, for a mirror being brought in line with a host that already has one.
+    ///
+    /// The daemon replicates records rather than the sequences that produced them, so a client needs a
+    /// way in that is not `apply`. Not reachable from any escape sequence.
+    ///
+    /// @param record The record to store, whose @ref TerminalContext::id must be non-zero.
+    void adopt(TerminalContext record);
+
+    /// Replaces the ancestry with the given ids, for the same mirroring reason as @ref adopt.
+    /// Ids naming records this stack does not hold are skipped.
+    void setChain(std::span<ContextId const> ids);
+
+    /// Drops the entire ancestry and every retained record.
+    ///
+    /// NOT reachable from any escape sequence, deliberately. RIS and DECSTR must not clear the stack: a
+    /// program down the ancestry must not be able to erase context established above it. This exists
+    /// for session teardown only. @see Terminal::hardReset.
+    void clear() noexcept;
+
+    // -- the ancestry -----------------------------------------------------------------------------
+
+    /// The ancestry, outermost first; empty when no context has been announced.
+    [[nodiscard]] std::span<Entry const> chain() const noexcept { return _chain; }
+
+    /// The innermost context's id, or zero when the ancestry is empty.
+    [[nodiscard]] ContextId activeId() const noexcept
+    {
+        return _chain.empty() ? ContextId {} : _chain.back().record->id;
+    }
+
+    /// The innermost context, or nullptr when the ancestry is empty.
+    [[nodiscard]] TerminalContext const* active() const noexcept
+    {
+        return _chain.empty() ? nullptr : _chain.back().record.get();
+    }
+
+    /// @return The record @p id names, or nullptr if it was never created or has been evicted.
+    ///         A line whose context has aged out of the store resolves to nullptr; that is the defined
+    ///         answer, not an error. @see HyperlinkStorage::hyperlinkById.
+    [[nodiscard]] TerminalContext const* find(ContextId id) const noexcept;
+
+    /// As @ref find, but keeps the record alive for as long as the caller holds the result.
+    [[nodiscard]] std::shared_ptr<TerminalContext const> retain(ContextId id) const noexcept;
+
+    /// Every retained record, oldest first -- what a daemon host replicates.
+    ///
+    /// A VISITOR rather than a returned container, because the caller that matters runs once per
+    /// daemon flush (every 20ms, per session) and reads two fields per record before dropping the lot:
+    /// handing back a std::vector<TerminalContext> deep-copied the whole pool -- up to maxRetained
+    /// records of a dozen strings each -- to answer a question that copies nothing.
+    template <typename Fn>
+    void forEachRecord(Fn const& fn) const
+    {
+        // Cast rather than as_const: shared_ptr::operator* yields T& however const the shared_ptr is,
+        // so without this a visitor could mutate a record the stack believes it owns.
+        for (auto const id: _creationOrder)
+            if (auto const it = _byId.find(id); it != _byId.end())
+                fn(static_cast<TerminalContext const&>(*it->second));
+    }
+
+    /// Every retained record, oldest first, as owned copies. Prefer @ref forEachRecord where the
+    /// records are only read; this exists for a caller that needs them to outlive the stack.
+    [[nodiscard]] std::vector<TerminalContext> records() const;
+
+    // -- derived questions ------------------------------------------------------------------------
+
+    /// The working directory in effect: the nearest `cwd=` walking UP from the active context.
+    ///
+    /// Walking up rather than reading the active context alone is what makes a `type=command` context
+    /// -- which systemd sends without a `cwd=` when nothing changed -- inherit the shell's. Returns
+    /// nullopt when no context on the ancestry carried one; the caller then falls back to OSC 7.
+    ///
+    /// @param self This machine's identity, for the locality verdict.
+    [[nodiscard]] std::optional<EffectiveWorkingDirectory> effectiveWorkingDirectory(
+        LocalIdentity const& self) const noexcept;
+
+    /// Whether @p id sits behind a host boundary, i.e. whether a path it names exists here.
+    ///
+    /// Three questions, in order of strength:
+    ///   1. Is any context from the outermost down to @p id a VM, container, remote or boot context?
+    ///      Then the path names another filesystem, whatever it looks like. A boundary is never
+    ///      escaped by a deeper context.
+    ///   2. Does `machineid=` match this machine's? This is the strong one and it is free: systemd's
+    ///      shim emits it. It catches ssh-to-a-similar-host -- where NOTHING emits a `remote` context
+    ///      and the remote shell's own sequences look entirely local -- plus containers sharing a
+    ///      hostname and VMs, all with no heuristics.
+    ///   3. Does `hostname=` name this machine?
+    ///
+    /// An ANONYMOUS context -- no boundary, no machineid, no hostname -- is Unknown, NOT Local. That is
+    /// the conservative answer and it degrades to exactly the behaviour before OSC 3008 existed.
+    [[nodiscard]] ContextLocality localityOf(ContextId id, LocalIdentity const& self) const noexcept;
+
+    // -- diagnostics ------------------------------------------------------------------------------
+
+    /// Bumped by every transition that changed something. A frontend caching a derived view keys on it,
+    /// exactly as the fold caches key on Terminal::_semanticMarkRevision.
+    [[nodiscard]] uint64_t revision() const noexcept { return _revision; }
+
+    [[nodiscard]] size_t depth() const noexcept { return _chain.size(); }
+    [[nodiscard]] size_t retainedCount() const noexcept { return _byId.size(); }
+
+    /// How many pushes the depth limit refused. Non-zero means the ancestry on screen is a prefix of
+    /// the truth; worth surfacing in the inspector, and what a depth-overflow test asserts.
+    [[nodiscard]] size_t droppedPushes() const noexcept { return _droppedPushes; }
+
+    [[nodiscard]] ContextStackLimits const& limits() const noexcept { return _limits; }
+
+  private:
+    /// Finds @p identifier in the ANCESTRY only, never in the retained store.
+    ///
+    /// That restriction is the protocol's stated safety property in code: an `end=` that could reach a
+    /// context outside the ancestry would let a program guess an identifier and terminate a context
+    /// established above it, which is exactly what "RIS must not clear the stack" exists to prevent.
+    [[nodiscard]] std::optional<size_t> indexOf(std::string_view identifier) const noexcept;
+
+    /// Retires the ancestry entries from @p firstIndex to the innermost, innermost first.
+    /// @return How many were retired. Counted in the chain's own index type, so it cannot wrap at a
+    ///         depth the configuration allows.
+    uint16_t popFrom(size_t firstIndex);
+
+    /// Whether @p id is currently an ancestor, and so must not be evicted.
+    [[nodiscard]] bool isOnChain(ContextId id) const noexcept;
+
+    /// Stores @p record, evicting the oldest retained record if that would exceed the bound.
+    void store(std::shared_ptr<TerminalContext> record);
+
+    ContextStackLimits _limits;
+    std::vector<Entry> _chain;
+    std::unordered_map<ContextId, std::shared_ptr<TerminalContext>> _byId;
+    std::deque<ContextId> _creationOrder; ///< Eviction order; oldest at the front.
+    ContextId _nextId { 1 };              ///< Monotonic; zero is reserved for "no context".
+    uint64_t _revision = 0;
+    size_t _droppedPushes = 0;
+};
+
+// }}}
+
+} // namespace vtbackend

--- a/src/vtbackend/core/TerminalContext_test.cpp
+++ b/src/vtbackend/core/TerminalContext_test.cpp
@@ -1,0 +1,910 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/core/TerminalContext.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vtbackend;
+using namespace std::string_view_literals;
+
+namespace
+{
+
+/// A `start=` naming @p id and carrying @p type, plus whatever else the caller sets afterwards.
+ContextCommand startOf(std::string_view id, ContextType type = ContextType::None)
+{
+    auto command = ContextCommand {};
+    command.verb = ContextVerb::Start;
+    command.identifier = id;
+    if (type != ContextType::None)
+    {
+        command.type = type;
+        command.present.enable(ContextField::Type);
+    }
+    return command;
+}
+
+/// A fully-specified outcome, so no designated initializer leaves a field unnamed.
+ContextOutcome makeOutcome(ContextExit exit, ContextSignal signal = ContextSignal::None, uint64_t status = 0)
+{
+    return ContextOutcome { .exit = exit, .signal = signal, .status = status };
+}
+
+/// An `end=` naming @p id with no outcome fields.
+ContextCommand endOf(std::string_view id)
+{
+    auto command = ContextCommand {};
+    command.verb = ContextVerb::End;
+    command.identifier = id;
+    return command;
+}
+
+/// Adds `cwd=` to @p command, which is what makes the nearest-cwd walk stop at it.
+ContextCommand& withCwd(ContextCommand& command, std::string_view cwd)
+{
+    command.workingDirectory = cwd;
+    command.present.enable(ContextField::WorkingDirectory);
+    return command;
+}
+
+/// Adds `machineid=` to @p command.
+ContextCommand& withMachineId(ContextCommand& command, std::string_view machineId)
+{
+    command.machineId = machineId;
+    command.present.enable(ContextField::MachineId);
+    return command;
+}
+
+/// Adds `hostname=` to @p command.
+ContextCommand& withHostname(ContextCommand& command, std::string_view hostname)
+{
+    command.hostname = hostname;
+    command.present.enable(ContextField::Hostname);
+    return command;
+}
+
+constexpr auto ThisMachine =
+    LocalIdentity { .machineId = "3deb5353d3ba43d08201c136a47ead7b", .hostname = "zeta" };
+
+} // namespace
+
+// {{{ vocabulary tables
+
+TEST_CASE("ContextType.every type round-trips through its wire spelling", "[context]")
+{
+    for (auto const type: ContextTypeList)
+    {
+        auto const name = contextTypeName(type);
+        CHECK(!name.empty());
+        CHECK(contextTypeFrom(name) == type);
+    }
+    CHECK(contextTypeName(ContextType::None).empty());
+    CHECK(contextTypeFrom("nonesuch") == ContextType::None);
+    CHECK(contextTypeFrom("") == ContextType::None);
+}
+
+TEST_CASE("ContextType.only vm, container, remote and boot cross a host boundary", "[context]")
+{
+    CHECK(contextTypeCrossesHost(ContextType::Vm) == HostBoundary::Crossed);
+    CHECK(contextTypeCrossesHost(ContextType::Container) == HostBoundary::Crossed);
+    CHECK(contextTypeCrossesHost(ContextType::Remote) == HostBoundary::Crossed);
+    CHECK(contextTypeCrossesHost(ContextType::Boot) == HostBoundary::Crossed);
+
+    CHECK(contextTypeCrossesHost(ContextType::Shell) == HostBoundary::Same);
+    CHECK(contextTypeCrossesHost(ContextType::Command) == HostBoundary::Same);
+    CHECK(contextTypeCrossesHost(ContextType::Elevate) == HostBoundary::Same);
+    CHECK(contextTypeCrossesHost(ContextType::None) == HostBoundary::Same);
+}
+
+TEST_CASE("ContextType.a boundary context is a privilege or machine change", "[context]")
+{
+    CHECK(isBoundaryContext(ContextType::Elevate));
+    CHECK(isBoundaryContext(ContextType::ChangePrivileges));
+    CHECK(isBoundaryContext(ContextType::Container));
+    CHECK(isBoundaryContext(ContextType::Vm));
+    CHECK(isBoundaryContext(ContextType::Remote));
+
+    CHECK(!isBoundaryContext(ContextType::Shell));
+    CHECK(!isBoundaryContext(ContextType::Command));
+    CHECK(!isBoundaryContext(ContextType::Session));
+    CHECK(!isBoundaryContext(ContextType::None));
+}
+
+TEST_CASE("ContextExit.every exit kind round-trips through its wire spelling", "[context]")
+{
+    for (auto const exit:
+         { ContextExit::Success, ContextExit::Failure, ContextExit::Crash, ContextExit::Interrupt })
+    {
+        auto const name = contextExitName(exit);
+        CHECK(!name.empty());
+        CHECK(contextExitFrom(name) == exit);
+    }
+    CHECK(contextExitName(ContextExit::Unknown).empty());
+    CHECK(contextExitFrom("nonesuch") == ContextExit::Unknown);
+}
+
+TEST_CASE("ContextSignal.symbolic names decode to the numbers Linux gives them", "[context]")
+{
+    // Hard-coded rather than taken from <signal.h>: a context may describe a process on another
+    // machine, so SIGSEGV must decode to 11 even on a platform that numbers it differently.
+    CHECK(contextSignalFrom("SIGSEGV") == ContextSignal::Segv);
+    CHECK(static_cast<int>(ContextSignal::Segv) == 11);
+    CHECK(contextSignalFrom("SIGINT") == ContextSignal::Int);
+    CHECK(static_cast<int>(ContextSignal::Int) == 2);
+    CHECK(contextSignalFrom("SIGKILL") == ContextSignal::Kill);
+    CHECK(static_cast<int>(ContextSignal::Kill) == 9);
+
+    CHECK(contextSignalFrom("SIGNOSUCH") == ContextSignal::None);
+    CHECK(contextSignalFrom("") == ContextSignal::None);
+    CHECK(contextSignalName(ContextSignal::None).empty());
+    CHECK(contextSignalName(ContextSignal::Segv) == "SIGSEGV");
+}
+
+TEST_CASE("ContextSignal.a peer-supplied number is validated, not cast", "[context]")
+{
+    CHECK(isKnownContextSignal(0));
+    CHECK(isKnownContextSignal(11));
+    CHECK(isKnownContextSignal(31));
+    CHECK(!isKnownContextSignal(200));
+    CHECK(!isKnownContextSignal(16));
+}
+
+TEST_CASE("ContextField.the mask names exactly the assigned bits", "[context]")
+{
+    auto expected = uint16_t {};
+    for (auto const field: ContextFieldList)
+        expected = static_cast<uint16_t>(expected | static_cast<uint16_t>(field));
+    CHECK(ContextFieldMask == expected);
+    CHECK(ContextFieldList.size() == 15);
+}
+
+TEST_CASE("ContextOutcome.exit codes map the way a shell would report them", "[context]")
+{
+    CHECK(makeOutcome(ContextExit::Success).asShellExitCode() == 0);
+    CHECK(makeOutcome(ContextExit::Failure, ContextSignal::None, 1).asShellExitCode() == 1);
+    CHECK(makeOutcome(ContextExit::Failure, ContextSignal::None, 42).asShellExitCode() == 42);
+    // 128+n, as every POSIX shell spells a signal death.
+    CHECK(makeOutcome(ContextExit::Failure, ContextSignal::Segv).asShellExitCode() == 139);
+    CHECK(makeOutcome(ContextExit::Interrupt).asShellExitCode() == 130);
+    CHECK(ContextOutcome {}.asShellExitCode() == 0);
+}
+
+// }}}
+// {{{ the transitions
+
+TEST_CASE("ContextStack.a fresh stack has no active context", "[context]")
+{
+    auto stack = ContextStack {};
+    CHECK(stack.depth() == 0);
+    CHECK(!stack.activeId());
+    CHECK(stack.active() == nullptr);
+    CHECK(stack.retainedCount() == 0);
+    CHECK(stack.find(ContextId { 1 }) == nullptr);
+}
+
+TEST_CASE("ContextStack.start of an unknown id pushes", "[context]")
+{
+    auto stack = ContextStack {};
+    auto const transition = stack.apply(startOf("shell-a", ContextType::Shell));
+
+    CHECK(transition.kind == ContextTransitionKind::Pushed);
+    CHECK(transition.change == ContextChange::Yes);
+    CHECK(transition.subjectType == ContextType::Shell);
+    CHECK(stack.depth() == 1);
+    CHECK(stack.activeId() == transition.subject);
+    REQUIRE(stack.active() != nullptr);
+    CHECK(stack.active()->identifier == "shell-a");
+    CHECK(!stack.active()->parent); // the outermost context has no parent
+}
+
+TEST_CASE("ContextStack.a push records its parent", "[context]")
+{
+    auto stack = ContextStack {};
+    auto const shell = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+    auto const command = stack.apply(startOf("cmd-1", ContextType::Command)).subject;
+
+    CHECK(stack.depth() == 2);
+    REQUIRE(stack.find(command) != nullptr);
+    CHECK(stack.find(command)->parent == shell);
+}
+
+TEST_CASE("ContextStack.start of the active id updates in place and keeps the id", "[context]")
+{
+    // Load-bearing: systemd re-announces the shell context on EVERY prompt. Minting a fresh id would
+    // exhaust the 16-bit space in ~32k prompts and point every scrollback line at a distinct record.
+    auto stack = ContextStack {};
+    auto const first = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+
+    auto update = startOf("shell-a", ContextType::Shell);
+    withCwd(update, "/home/user");
+    auto const transition = stack.apply(update);
+
+    CHECK(transition.kind == ContextTransitionKind::Updated);
+    CHECK(transition.subject == first);
+    CHECK(stack.depth() == 1);
+    CHECK(stack.retainedCount() == 1);
+    CHECK(stack.active()->workingDirectory == "/home/user");
+}
+
+TEST_CASE("ContextStack.an update flushes omitted fields to defaults", "[context]")
+{
+    auto stack = ContextStack {};
+    auto first = startOf("shell-a", ContextType::Shell);
+    withCwd(first, "/home/user");
+    withHostname(first, "zeta");
+    stack.apply(first);
+    REQUIRE(stack.active()->workingDirectory == "/home/user");
+
+    // The spec: "any previously set metadata fields are flushed out, reset to their defaults, and then
+    // reinitialized from the newly supplied data".
+    stack.apply(startOf("shell-a", ContextType::Shell));
+
+    CHECK(stack.active()->workingDirectory.empty());
+    CHECK(stack.active()->hostname.empty());
+    CHECK(!(stack.active()->present & ContextField::WorkingDirectory).any());
+}
+
+TEST_CASE("ContextStack.an update that changes nothing reports no change", "[context]")
+{
+    // The systemd hot path: a shell context re-announced every prompt with byte-identical metadata.
+    // Reporting a change here would redraw the frontend once per prompt for nothing.
+    auto stack = ContextStack {};
+    auto command = startOf("shell-a", ContextType::Shell);
+    withCwd(command, "/home/user");
+    withMachineId(command, ThisMachine.machineId);
+    stack.apply(command);
+
+    auto const before = stack.revision();
+    auto const transition = stack.apply(command);
+
+    CHECK(transition.kind == ContextTransitionKind::Updated);
+    CHECK(transition.change == ContextChange::None);
+    CHECK(stack.revision() == before);
+}
+
+TEST_CASE("ContextStack.an update clears an outcome recorded from a previous life", "[context]")
+{
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell-a", ContextType::Shell));
+    auto cmd = startOf("cmd-1", ContextType::Command);
+    stack.apply(cmd);
+
+    auto finish = endOf("cmd-1");
+    finish.outcome = makeOutcome(ContextExit::Failure, ContextSignal::None, 1);
+    stack.apply(finish);
+
+    // The same identifier starts again -- as a fresh push, since it left the ancestry.
+    auto const reborn = stack.apply(startOf("cmd-1", ContextType::Command)).subject;
+    CHECK(stack.find(reborn)->outcome == ContextOutcome {});
+}
+
+TEST_CASE("ContextStack.start of an ancestor returns to it and terminates subcontexts", "[context]")
+{
+    auto stack = ContextStack {};
+    auto const shell = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+    stack.apply(startOf("cmd-1", ContextType::Command));
+    stack.apply(startOf("cmd-2", ContextType::Command));
+    REQUIRE(stack.depth() == 3);
+
+    auto const transition = stack.apply(startOf("shell-a", ContextType::Shell));
+
+    CHECK(transition.kind == ContextTransitionKind::ReturnedTo);
+    CHECK(transition.subject == shell);
+    CHECK(transition.implicitlyEnded == 2);
+    CHECK(transition.change == ContextChange::Yes);
+    CHECK(stack.depth() == 1);
+    CHECK(stack.activeId() == shell);
+}
+
+TEST_CASE("ContextStack.start of an ended id pushes a new context rather than resurrecting", "[context]")
+{
+    // Minting a new id keeps every line's stamp meaning what it meant when it was written: a scrollback
+    // line pointing at the old record must not silently acquire the new context's metadata.
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell-a", ContextType::Shell));
+    auto const firstCommand = stack.apply(startOf("cmd-1", ContextType::Command)).subject;
+    stack.apply(endOf("cmd-1"));
+
+    auto const transition = stack.apply(startOf("cmd-1", ContextType::Command));
+
+    CHECK(transition.kind == ContextTransitionKind::Pushed);
+    CHECK(transition.subject != firstCommand);
+    CHECK(stack.find(firstCommand) != nullptr); // the old record is still resolvable
+}
+
+TEST_CASE("ContextStack.end of the active id pops", "[context]")
+{
+    auto stack = ContextStack {};
+    auto const shell = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+    auto const command = stack.apply(startOf("cmd-1", ContextType::Command)).subject;
+
+    auto finish = endOf("cmd-1");
+    finish.outcome = makeOutcome(ContextExit::Failure, ContextSignal::Segv, 139);
+    auto const transition = stack.apply(finish);
+
+    CHECK(transition.kind == ContextTransitionKind::Ended);
+    CHECK(transition.subject == command);
+    CHECK(transition.implicitlyEnded == 0);
+    CHECK(stack.activeId() == shell);
+    REQUIRE(stack.find(command) != nullptr);
+    CHECK(stack.find(command)->outcome.signal == ContextSignal::Segv);
+}
+
+TEST_CASE("ContextStack.end of an ancestor pops it and everything below", "[context]")
+{
+    // The spec is silent here. Ignoring it would leave a TERMINATED context in the ancestry, which
+    // makes the chain a lie; popping the ancestor and its descendants is the only reading that keeps a
+    // stack a stack.
+    auto stack = ContextStack {};
+    stack.apply(startOf("outer", ContextType::Container));
+    auto const shell = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+    stack.apply(startOf("cmd-1", ContextType::Command));
+    REQUIRE(stack.depth() == 3);
+
+    auto const transition = stack.apply(endOf("shell-a"));
+
+    CHECK(transition.kind == ContextTransitionKind::Ended);
+    CHECK(transition.subject == shell);
+    CHECK(transition.implicitlyEnded == 1);
+    CHECK(stack.depth() == 1);
+    CHECK(stack.active()->identifier == "outer");
+}
+
+TEST_CASE("ContextStack.end of an unknown id does nothing", "[context]")
+{
+    // The protocol's stated safety property in code: if an unknown end could pop, a program could
+    // terminate the context established above it by guessing an identifier.
+    auto stack = ContextStack {};
+    auto const shell = stack.apply(startOf("shell-a", ContextType::Shell)).subject;
+    auto const before = stack.revision();
+
+    auto const transition = stack.apply(endOf("nonesuch"));
+
+    CHECK(transition.kind == ContextTransitionKind::Ignored);
+    CHECK(transition.change == ContextChange::None);
+    CHECK(!transition.subject);
+    CHECK(stack.activeId() == shell);
+    CHECK(stack.revision() == before);
+}
+
+TEST_CASE("ContextStack.end of a retired id does nothing", "[context]")
+{
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell-a", ContextType::Shell));
+    stack.apply(startOf("cmd-1", ContextType::Command));
+    stack.apply(endOf("cmd-1"));
+    REQUIRE(stack.depth() == 1);
+
+    CHECK(stack.apply(endOf("cmd-1")).kind == ContextTransitionKind::Ignored);
+    CHECK(stack.depth() == 1);
+}
+
+TEST_CASE("ContextStack.end of the last context leaves the ancestry empty", "[context]")
+{
+    // Empty is also the state at session start, so allowing it means one state fewer, not one more.
+    // There is no terminal-owned bottom entry: unlike a pointer shape, the terminal knows nothing about
+    // the application's process tree that it could truthfully name.
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell-a", ContextType::Shell));
+
+    CHECK(stack.apply(endOf("shell-a")).kind == ContextTransitionKind::Ended);
+    CHECK(stack.depth() == 0);
+    CHECK(!stack.activeId());
+    CHECK(stack.active() == nullptr);
+}
+
+TEST_CASE("ContextStack.a push at the depth limit keeps the earlier and discards the newer", "[context]")
+{
+    // The spec's rule, which is the OPPOSITE of MaxSavedTitles': a program deep in the ancestry must
+    // not be able to evict the elevate context above it.
+    auto stack = ContextStack { { .maxDepth = 3, .maxRetained = 64 } };
+    stack.apply(startOf("a", ContextType::Elevate));
+    stack.apply(startOf("b", ContextType::Shell));
+    stack.apply(startOf("c", ContextType::Command));
+    REQUIRE(stack.depth() == 3);
+
+    auto const transition = stack.apply(startOf("d", ContextType::Command));
+
+    CHECK(transition.kind == ContextTransitionKind::DepthExceeded);
+    CHECK(transition.change == ContextChange::None);
+    CHECK(!transition.subject);
+    CHECK(stack.depth() == 3);
+    CHECK(stack.droppedPushes() == 1);
+    CHECK(stack.chain().front().record->identifier == "a"); // the earliest survived
+    CHECK(stack.activeId() == stack.chain().back().record->id);
+}
+
+TEST_CASE("ContextStack.a refused push does not let its end pop the parent", "[context]")
+{
+    // A push refused for depth is unknown to the ancestry, so its later `end=` falls through the
+    // unknown-identifier arm. That is why that arm has to be evaluated first.
+    auto stack = ContextStack { { .maxDepth = 2, .maxRetained = 64 } };
+    stack.apply(startOf("a", ContextType::Shell));
+    auto const b = stack.apply(startOf("b", ContextType::Command)).subject;
+    stack.apply(startOf("c", ContextType::Command));
+    REQUIRE(stack.depth() == 2);
+
+    CHECK(stack.apply(endOf("c")).kind == ContextTransitionKind::Ignored);
+    CHECK(stack.depth() == 2);
+    CHECK(stack.activeId() == b);
+}
+
+TEST_CASE("ContextStack.an update still works at the depth limit", "[context]")
+{
+    auto stack = ContextStack { { .maxDepth = 2, .maxRetained = 64 } };
+    stack.apply(startOf("a", ContextType::Shell));
+    stack.apply(startOf("b", ContextType::Command));
+
+    auto update = startOf("b", ContextType::Command);
+    withCwd(update, "/tmp");
+    auto const transition = stack.apply(update);
+
+    CHECK(transition.kind == ContextTransitionKind::Updated);
+    CHECK(stack.active()->workingDirectory == "/tmp");
+    CHECK(stack.droppedPushes() == 0);
+}
+
+TEST_CASE("ContextStack.a start with a different type is still an update", "[context]")
+{
+    // The identifier is the identity; the type is metadata like any other field.
+    auto stack = ContextStack {};
+    auto const id = stack.apply(startOf("x", ContextType::Shell)).subject;
+
+    auto const transition = stack.apply(startOf("x", ContextType::App));
+
+    CHECK(transition.kind == ContextTransitionKind::Updated);
+    CHECK(transition.subject == id);
+    CHECK(stack.active()->type == ContextType::App);
+}
+
+// }}}
+// {{{ store and lifetime
+
+TEST_CASE("ContextStack.a retired record stays findable by id", "[context]")
+{
+    // A scrolled-back line keeps its id after the context closed, so the record has to outlive `end=`.
+    // If it did not, the tint would vanish retroactively the moment a command exits.
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell-a", ContextType::Shell));
+    auto const command = stack.apply(startOf("cmd-1", ContextType::Command)).subject;
+    stack.apply(endOf("cmd-1"));
+
+    REQUIRE(stack.find(command) != nullptr);
+    CHECK(stack.find(command)->identifier == "cmd-1");
+}
+
+TEST_CASE("ContextStack.the oldest record is evicted first", "[context]")
+{
+    // FIFO rather than LRU: scrollback eviction is itself FIFO, so the oldest context is the one whose
+    // lines are most likely already gone -- and LRU would mean mutating the cache on the render path.
+    auto stack = ContextStack { { .maxDepth = 2, .maxRetained = 4 } };
+    stack.apply(startOf("shell", ContextType::Shell));
+
+    auto ids = std::vector<ContextId> {};
+    for (auto const name: { "c1"sv, "c2"sv, "c3"sv, "c4"sv, "c5"sv })
+    {
+        ids.push_back(stack.apply(startOf(name, ContextType::Command)).subject);
+        stack.apply(endOf(name));
+    }
+
+    CHECK(stack.retainedCount() <= 4);
+    CHECK(stack.find(ids.front()) == nullptr); // c1 aged out
+    CHECK(stack.find(ids.back()) != nullptr);  // c5 is still here
+}
+
+TEST_CASE("ContextStack.a context that is still an ancestor is never evicted", "[context]")
+{
+    auto stack = ContextStack { { .maxDepth = 2, .maxRetained = 2 } };
+    auto const shell = stack.apply(startOf("shell", ContextType::Shell)).subject;
+
+    for (auto const name: { "c1"sv, "c2"sv, "c3"sv, "c4"sv })
+    {
+        stack.apply(startOf(name, ContextType::Command));
+        stack.apply(endOf(name));
+    }
+
+    // The ancestry holds a strong reference, so the shell survives every eviction pass.
+    REQUIRE(stack.find(shell) != nullptr);
+    CHECK(stack.find(shell)->identifier == "shell");
+}
+
+TEST_CASE("ContextStack.an evicted id resolves to nothing rather than failing", "[context]")
+{
+    // The defined answer, not an error -- exactly the contract HyperlinkStorage::hyperlinkById has.
+    auto stack = ContextStack {};
+    CHECK(stack.find(ContextId { 9999 }) == nullptr);
+    CHECK(stack.retain(ContextId { 9999 }) == nullptr);
+    CHECK(stack.find(ContextId {}) == nullptr);
+}
+
+TEST_CASE("ContextStack.retain keeps a record alive past eviction", "[context]")
+{
+    auto stack = ContextStack { { .maxDepth = 2, .maxRetained = 2 } };
+    stack.apply(startOf("shell", ContextType::Shell));
+    auto const doomed = stack.apply(startOf("c1", ContextType::Command)).subject;
+    stack.apply(endOf("c1"));
+
+    auto const held = stack.retain(doomed);
+    REQUIRE(held != nullptr);
+
+    for (auto const name: { "c2"sv, "c3"sv, "c4"sv })
+    {
+        stack.apply(startOf(name, ContextType::Command));
+        stack.apply(endOf(name));
+    }
+
+    CHECK(held->identifier == "c1"); // the caller's handle still resolves
+}
+
+TEST_CASE("ContextStack.clear drops the ancestry and every record", "[context]")
+{
+    // Reachable from session teardown only -- never from an escape sequence. RIS and DECSTR must not
+    // clear the stack.
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell", ContextType::Shell));
+    auto const id = stack.apply(startOf("cmd", ContextType::Command)).subject;
+
+    stack.clear();
+
+    CHECK(stack.depth() == 0);
+    CHECK(stack.retainedCount() == 0);
+    CHECK(stack.find(id) == nullptr);
+    CHECK(!stack.activeId());
+}
+
+TEST_CASE("ContextStack.the revision advances only on an observable change", "[context]")
+{
+    auto stack = ContextStack {};
+    CHECK(stack.revision() == 0);
+
+    stack.apply(startOf("a", ContextType::Shell));
+    auto const afterPush = stack.revision();
+    CHECK(afterPush > 0);
+
+    stack.apply(startOf("a", ContextType::Shell)); // identical re-announce
+    CHECK(stack.revision() == afterPush);
+
+    stack.apply(endOf("nonesuch")); // ignored
+    CHECK(stack.revision() == afterPush);
+
+    stack.apply(endOf("a"));
+    CHECK(stack.revision() > afterPush);
+}
+
+// }}}
+// {{{ derived questions
+
+TEST_CASE("ContextStack.the effective cwd is the nearest one walking up", "[context]")
+{
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/user");
+    withMachineId(shell, ThisMachine.machineId);
+    stack.apply(shell);
+
+    auto command = startOf("cmd", ContextType::Command);
+    withCwd(command, "/home/user/project");
+    withMachineId(command, ThisMachine.machineId);
+    stack.apply(command);
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->path == "/home/user/project");
+    CHECK(cwd->locality == ContextLocality::Local);
+}
+
+TEST_CASE("ContextStack.a context that sent no cwd is skipped by the walk", "[context]")
+{
+    // systemd sends `type=command` without a cwd when nothing changed, and the command must then
+    // inherit the shell's.
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/user");
+    stack.apply(shell);
+    stack.apply(startOf("cmd", ContextType::Command));
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->path == "/home/user");
+}
+
+TEST_CASE("ContextStack.no cwd anywhere on the ancestry reports nothing", "[context]")
+{
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell", ContextType::Shell));
+    stack.apply(startOf("cmd", ContextType::Command));
+
+    CHECK(!stack.effectiveWorkingDirectory(ThisMachine).has_value());
+}
+
+TEST_CASE("ContextStack.an empty ancestry reports no cwd", "[context]")
+{
+    auto stack = ContextStack {};
+    CHECK(!stack.effectiveWorkingDirectory(ThisMachine).has_value());
+}
+
+TEST_CASE("ContextStack.a container ancestor makes the active context foreign", "[context]")
+{
+    // A boundary crossed above is never escaped by a deeper context: a shell inside a container is
+    // still inside it.
+    auto stack = ContextStack {};
+    auto container = startOf("box", ContextType::Container);
+    withMachineId(container, ThisMachine.machineId); // even claiming OUR machine id
+    stack.apply(container);
+
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/app");
+    withHostname(shell, ThisMachine.hostname); // and OUR hostname
+    stack.apply(shell);
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->path == "/app");
+    CHECK(cwd->locality == ContextLocality::Foreign);
+}
+
+TEST_CASE("ContextStack.a differing machine id makes the context foreign", "[context]")
+{
+    // The strong test, and the one that catches ssh: NOTHING emits a `remote` context today, so a
+    // remote shell's own sequences look entirely local and its /home/bob may well exist here too.
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/bob");
+    withMachineId(shell, "ffffffffffffffffffffffffffffffff");
+    withHostname(shell, ThisMachine.hostname); // a similarly-named host does not save it
+    stack.apply(shell);
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->locality == ContextLocality::Foreign);
+}
+
+TEST_CASE("ContextStack.a differing hostname makes the context foreign when no machine id is given",
+          "[context]")
+{
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/bob");
+    withHostname(shell, "elsewhere");
+    stack.apply(shell);
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->locality == ContextLocality::Foreign);
+}
+
+TEST_CASE("ContextStack.an anonymous cwd is Unknown, not Local", "[context]")
+{
+    // The conservative answer, and it degrades to exactly the pre-OSC-3008 behaviour. Treating it as
+    // Local would let an ssh session seed a local tab with a remote path that happens to exist.
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/bob");
+    stack.apply(shell);
+
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->path == "/home/bob");
+    CHECK(cwd->locality == ContextLocality::Unknown);
+}
+
+TEST_CASE("ContextStack.a plain shell on this machine is local", "[context]")
+{
+    auto stack = ContextStack {};
+    auto shell = startOf("shell", ContextType::Shell);
+    withCwd(shell, "/home/user");
+    withMachineId(shell, ThisMachine.machineId);
+    stack.apply(shell);
+
+    CHECK(stack.localityOf(stack.activeId(), ThisMachine) == ContextLocality::Local);
+}
+
+TEST_CASE("ContextStack.localityOf an unknown id is Unknown", "[context]")
+{
+    auto stack = ContextStack {};
+    CHECK(stack.localityOf(ContextId {}, ThisMachine) == ContextLocality::Unknown);
+    CHECK(stack.localityOf(ContextId { 42 }, ThisMachine) == ContextLocality::Unknown);
+}
+
+TEST_CASE("ContextStack.localityOf a retired id is Unknown", "[context]")
+{
+    // It is off the ancestry, so nothing on the chain can speak to where it was.
+    auto stack = ContextStack {};
+    stack.apply(startOf("shell", ContextType::Shell));
+    auto const cmd = stack.apply(startOf("cmd", ContextType::Command)).subject;
+    stack.apply(endOf("cmd"));
+
+    CHECK(stack.localityOf(cmd, ThisMachine) == ContextLocality::Unknown);
+}
+
+// }}}
+// {{{ mirroring
+
+TEST_CASE("ContextStack.adopt stores a record a mirror was handed", "[context]")
+{
+    auto stack = ContextStack {};
+    auto record = TerminalContext {};
+    record.id = ContextId { 7 };
+    record.type = ContextType::Container;
+    record.identifier = "box";
+    record.container = "foobar";
+
+    stack.adopt(record);
+
+    REQUIRE(stack.find(ContextId { 7 }) != nullptr);
+    CHECK(stack.find(ContextId { 7 })->container == "foobar");
+}
+
+TEST_CASE("ContextStack.adopting the same id twice updates in place", "[context]")
+{
+    // In place, so the ancestry's shared_ptr and every line already stamped with this id keep resolving
+    // to the record they named.
+    auto stack = ContextStack {};
+    auto record = TerminalContext {};
+    record.id = ContextId { 7 };
+    record.type = ContextType::Shell;
+    record.identifier = "s";
+    stack.adopt(record);
+    auto const* first = stack.find(ContextId { 7 });
+
+    record.workingDirectory = "/tmp";
+    stack.adopt(record);
+
+    CHECK(stack.find(ContextId { 7 }) == first); // same object
+    CHECK(stack.find(ContextId { 7 })->workingDirectory == "/tmp");
+    CHECK(stack.retainedCount() == 1);
+}
+
+TEST_CASE("ContextStack.a locally created id never collides with an adopted one", "[context]")
+{
+    auto stack = ContextStack {};
+    auto record = TerminalContext {};
+    record.id = ContextId { 5 };
+    record.type = ContextType::Shell;
+    record.identifier = "adopted";
+    stack.adopt(record);
+
+    auto const minted = stack.apply(startOf("local", ContextType::Command)).subject;
+
+    CHECK(minted != ContextId { 5 });
+    CHECK(stack.find(ContextId { 5 })->identifier == "adopted");
+}
+
+TEST_CASE("ContextStack.setChain rebuilds the ancestry from ids", "[context]")
+{
+    auto stack = ContextStack {};
+    auto outer = TerminalContext {};
+    outer.id = ContextId { 1 };
+    outer.type = ContextType::Container;
+    outer.identifier = "box";
+    auto inner = TerminalContext {};
+    inner.id = ContextId { 2 };
+    inner.parent = ContextId { 1 };
+    inner.identifier = "sh";
+    inner.type = ContextType::Shell;
+    stack.adopt(outer);
+    stack.adopt(inner);
+
+    auto const ids = std::array { ContextId { 1 }, ContextId { 2 } };
+    stack.setChain(ids);
+
+    CHECK(stack.depth() == 2);
+    CHECK(stack.activeId() == ContextId { 2 });
+    CHECK(stack.chain().front().record->identifier == "box");
+}
+
+TEST_CASE("ContextStack.setChain skips ids it does not hold", "[context]")
+{
+    auto stack = ContextStack {};
+    auto record = TerminalContext {};
+    record.id = ContextId { 1 };
+    record.type = ContextType::Shell;
+    record.identifier = "sh";
+    stack.adopt(record);
+
+    auto const ids = std::array { ContextId { 1 }, ContextId { 99 } };
+    stack.setChain(ids);
+
+    CHECK(stack.depth() == 1);
+}
+
+TEST_CASE("ContextStack.setChain to what is already there reports no change", "[context]")
+{
+    auto stack = ContextStack {};
+    auto record = TerminalContext {};
+    record.id = ContextId { 1 };
+    record.type = ContextType::Shell;
+    record.identifier = "sh";
+    stack.adopt(record);
+    auto const ids = std::array { ContextId { 1 } };
+    stack.setChain(ids);
+
+    auto const before = stack.revision();
+    stack.setChain(ids);
+
+    CHECK(stack.revision() == before);
+}
+
+TEST_CASE("ContextStack.records reports every retained record oldest first", "[context]")
+{
+    auto stack = ContextStack {};
+    stack.apply(startOf("a", ContextType::Shell));
+    stack.apply(startOf("b", ContextType::Command));
+
+    auto const records = stack.records();
+
+    REQUIRE(records.size() == 2);
+    CHECK(records[0].identifier == "a");
+    CHECK(records[1].identifier == "b");
+}
+
+// }}}
+// {{{ the real traffic
+
+TEST_CASE("ContextStack.the systemd prompt cycle keeps one shell and one command per command", "[context]")
+{
+    // What /etc/profile.d/80-systemd-osc-context.sh actually emits, three commands deep. The shell
+    // context is announced once and UPDATED every prompt; it is never ended.
+    auto stack = ContextStack {};
+
+    auto shellUpdate = [&](std::string_view cwd) {
+        auto command = startOf("shell-uuid", ContextType::Shell);
+        withCwd(command, cwd);
+        withMachineId(command, ThisMachine.machineId);
+        withHostname(command, ThisMachine.hostname);
+        return command;
+    };
+
+    auto shellId = ContextId {};
+    for (auto const& [index, name]:
+         std::vector<std::pair<int, std::string_view>> { { 0, "cmd-1" }, { 1, "cmd-2" }, { 2, "cmd-3" } })
+    {
+        (void) index;
+        // 1. PROMPT_COMMAND updates the shell context (a push the very first time).
+        auto const shell = stack.apply(shellUpdate("/home/user"));
+        if (!shellId)
+            shellId = shell.subject;
+        CHECK(shell.subject == shellId); // the same record every prompt, forever
+
+        // 2. PS0 pushes the command context beneath it.
+        auto commandStart = startOf(name, ContextType::Command);
+        withCwd(commandStart, "/home/user");
+        withMachineId(commandStart, ThisMachine.machineId);
+        CHECK(stack.apply(commandStart).kind == ContextTransitionKind::Pushed);
+        CHECK(stack.depth() == 2);
+
+        // 3. the next PROMPT_COMMAND closes it.
+        auto finish = endOf(name);
+        finish.outcome = makeOutcome(ContextExit::Success);
+        CHECK(stack.apply(finish).kind == ContextTransitionKind::Ended);
+        CHECK(stack.depth() == 1);
+    }
+
+    CHECK(stack.activeId() == shellId);
+    CHECK(stack.retainedCount() == 4); // one shell + three commands
+}
+
+TEST_CASE("ContextStack.a nested run0 inside a container reads as foreign and elevated", "[context]")
+{
+    auto stack = ContextStack {};
+    auto container = startOf("box", ContextType::Container);
+    container.container = "foobar";
+    container.present.enable(ContextField::Container);
+    stack.apply(container);
+
+    auto elevate = startOf("root", ContextType::Elevate);
+    elevate.targetUser = "root";
+    elevate.present.enable(ContextField::TargetUser);
+    stack.apply(elevate);
+
+    auto shell = startOf("sh", ContextType::Shell);
+    withCwd(shell, "/app");
+    stack.apply(shell);
+
+    CHECK(stack.depth() == 3);
+    auto const cwd = stack.effectiveWorkingDirectory(ThisMachine);
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->locality == ContextLocality::Foreign);
+    CHECK(stack.chain().front().record->type == ContextType::Container);
+}
+
+// }}}

--- a/src/vtbackend/core/WorkingDirectory.cpp
+++ b/src/vtbackend/core/WorkingDirectory.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/core/WorkingDirectory.hpp>
+
+#include <vtbackend/core/FileUrl.hpp>
+
+using std::optional;
+using std::string;
+
+namespace vtbackend
+{
+
+namespace
+{
+    /// Whether @p purpose will actually open or chdir into the path, and therefore needs it to be on
+    /// this machine.
+    [[nodiscard]] constexpr bool needsLocalPath(CwdPurpose purpose) noexcept
+    {
+        return purpose != CwdPurpose::Display;
+    }
+} // namespace
+
+optional<ResolvedWorkingDirectory> resolveWorkingDirectory(ContextStack const& contexts,
+                                                           string const& osc7Url,
+                                                           LocalIdentity const& self,
+                                                           CwdPurpose purpose)
+{
+    // 1. The OSC 3008 ancestry, which is the only source that carries enough identity to say whether
+    //    the path it names is on this machine.
+    if (auto const context = contexts.effectiveWorkingDirectory(self))
+    {
+        auto const usable = !needsLocalPath(purpose) || context->locality == ContextLocality::Local;
+        if (usable)
+            return ResolvedWorkingDirectory { .path = string { context->path },
+                                              .source = CwdSource::ContextSignal,
+                                              .locality = context->locality };
+        // Not usable for THIS purpose, but the fall-through below is not a second chance at the same
+        // question: OSC 7 is a different source with its own host authority to test.
+    }
+
+    // 2. OSC 7. Its authority is the only locality evidence it carries, which is exactly why an OSC
+    //    3008 `cwd=` -- a bare path with no authority at all -- must not be run through the same test:
+    //    isLocalHost() accepts an empty authority, so every container path would pass it.
+    if (osc7Url.empty())
+        return std::nullopt;
+
+    // Asked ONCE, and the answer carries both halves: localWorkingDirectory() already extracts the path
+    // on its way to the verdict, so testing locality and then extracting again would parse the same URL
+    // twice and throw one of the two strings away.
+    if (auto local = localWorkingDirectory(osc7Url, self.hostname))
+        return ResolvedWorkingDirectory { .path = std::move(*local),
+                                          .source = CwdSource::Osc7,
+                                          .locality = ContextLocality::Local };
+
+    if (needsLocalPath(purpose))
+        return std::nullopt;
+
+    auto path = extractPathFromFileUrl(osc7Url);
+    if (path.empty())
+        return std::nullopt;
+    return ResolvedWorkingDirectory { .path = std::move(path),
+                                      .source = CwdSource::Osc7,
+                                      .locality = ContextLocality::Foreign };
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/core/WorkingDirectory.hpp
+++ b/src/vtbackend/core/WorkingDirectory.hpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/core/TerminalContext.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace vtbackend
+{
+
+/// What a caller wants a working directory FOR.
+///
+/// The three questions have three different right answers, and conflating them is what makes a
+/// container's `/app` end up handed to a host fork+exec:
+///
+///   - "Where should a new tab on this machine start?"  -> a path this process can chdir into.
+///   - "What should I show the user?"                   -> where they believe they are, boundary or not.
+///   - "Open this folder in the host file manager?"     -> refuse unless it is provably local.
+///
+/// A table rather than three near-copies of the precedence, so a fourth question is a row.
+enum class CwdPurpose : uint8_t
+{
+    /// Spawning a child on THIS machine. Refuses anything not provably local.
+    Spawn = 0,
+
+    /// Showing the user where they are. A container or remote path is the RIGHT answer here -- it is
+    /// what the user is looking at -- so no locality filter applies.
+    Display,
+
+    /// Opening the path with a host tool (a file manager). Refuses on the same terms as Spawn; the
+    /// caller greys the affordance out rather than opening the host's directory of the same name.
+    OpenLocally,
+};
+
+/// Where a resolved working directory came from.
+enum class CwdSource : uint8_t
+{
+    None = 0,      ///< Nothing had anything to say.
+    ContextSignal, ///< The nearest `cwd=` on the OSC 3008 ancestry.
+    Osc7,          ///< The OSC 7 working-directory URL.
+};
+
+/// A working directory, where it came from, and whether it is this machine's.
+struct ResolvedWorkingDirectory
+{
+    std::string path;
+    CwdSource source = CwdSource::None;
+    ContextLocality locality = ContextLocality::Unknown;
+
+    bool operator==(ResolvedWorkingDirectory const&) const = default;
+};
+
+/// Resolves the working directory for @p purpose from the two sources a terminal has.
+///
+/// The order is the same for every purpose -- the OSC 3008 ancestry first, then OSC 7 -- and only the
+/// FILTER differs. That is deliberate: "where does a new tab start" and "what does the tooltip say"
+/// must never disagree about precedence, only about how strict they are.
+///
+/// Note what this deliberately does NOT do: it never claims a path is local without evidence. An OSC
+/// 3008 `cwd=` with no boundary, no machineid and no hostname resolves Unknown, and Spawn/OpenLocally
+/// reject it -- because nothing emits a `remote` context for ssh today, so a remote shell's sequences
+/// look entirely local and its `/home/bob` may well exist here too. The caller's own fallback (on
+/// POSIX, the pty child's /proc cwd) is a better answer than a guess.
+///
+/// @param contexts  The OSC 3008 ancestry.
+/// @param osc7Url   The OSC 7 working-directory URL, or empty when none was reported.
+/// @param self      This machine's identity, injected. @see LocalIdentity.
+/// @param purpose   What the answer is wanted for.
+/// @return The resolved directory, or nullopt when no source could answer for this purpose.
+[[nodiscard]] std::optional<ResolvedWorkingDirectory> resolveWorkingDirectory(ContextStack const& contexts,
+                                                                              std::string const& osc7Url,
+                                                                              LocalIdentity const& self,
+                                                                              CwdPurpose purpose);
+
+} // namespace vtbackend

--- a/src/vtbackend/core/WorkingDirectory_test.cpp
+++ b/src/vtbackend/core/WorkingDirectory_test.cpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/core/WorkingDirectory.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+
+using namespace vtbackend;
+
+namespace
+{
+
+constexpr auto ThisMachine =
+    LocalIdentity { .machineId = "3deb5353d3ba43d08201c136a47ead7b", .hostname = "zeta" };
+
+/// Pushes one context carrying the given fields onto @p stack.
+void push(ContextStack& stack,
+          std::string_view id,
+          ContextType type,
+          std::string_view cwd = {},
+          std::string_view machineId = {},
+          std::string_view hostname = {})
+{
+    auto command = ContextCommand {};
+    command.verb = ContextVerb::Start;
+    command.identifier = id;
+    if (type != ContextType::None)
+    {
+        command.type = type;
+        command.present.enable(ContextField::Type);
+    }
+    if (!cwd.empty())
+    {
+        command.workingDirectory = cwd;
+        command.present.enable(ContextField::WorkingDirectory);
+    }
+    if (!machineId.empty())
+    {
+        command.machineId = machineId;
+        command.present.enable(ContextField::MachineId);
+    }
+    if (!hostname.empty())
+    {
+        command.hostname = hostname;
+        command.present.enable(ContextField::Hostname);
+    }
+    stack.apply(command);
+}
+
+} // namespace
+
+TEST_CASE("WorkingDirectory.nothing anywhere resolves to nothing", "[cwd]")
+{
+    auto const stack = ContextStack {};
+    for (auto const purpose: { CwdPurpose::Spawn, CwdPurpose::Display, CwdPurpose::OpenLocally })
+        CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, purpose).has_value());
+}
+
+TEST_CASE("WorkingDirectory.a local context cwd wins over OSC 7 for every purpose", "[cwd]")
+{
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell, "/home/user/project", ThisMachine.machineId);
+
+    for (auto const purpose: { CwdPurpose::Spawn, CwdPurpose::Display, CwdPurpose::OpenLocally })
+    {
+        auto const resolved = resolveWorkingDirectory(stack, "file://zeta/home/user", ThisMachine, purpose);
+        REQUIRE(resolved.has_value());
+        CHECK(resolved->path == "/home/user/project");
+        CHECK(resolved->source == CwdSource::ContextSignal);
+    }
+}
+
+TEST_CASE("WorkingDirectory.OSC 7 answers when no context carries a cwd", "[cwd]")
+{
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell); // no cwd= at all
+
+    auto const resolved =
+        resolveWorkingDirectory(stack, "file://zeta/home/user", ThisMachine, CwdPurpose::Spawn);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved->path == "/home/user");
+    CHECK(resolved->source == CwdSource::Osc7);
+}
+
+TEST_CASE("WorkingDirectory.an anonymous context cwd is refused for spawning", "[cwd]")
+{
+    // The ssh case: nothing emits a `remote` context today, so the REMOTE host's shim sends contexts
+    // that look entirely local -- and its /home/bob may well exist here too. Unknown is not Local.
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell, "/home/bob"); // no machineid, no hostname
+
+    CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Spawn).has_value());
+    CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::OpenLocally).has_value());
+}
+
+TEST_CASE("WorkingDirectory.an anonymous context cwd is still shown to the user", "[cwd]")
+{
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell, "/home/bob");
+
+    auto const resolved = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Display);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved->path == "/home/bob");
+    CHECK(resolved->locality == ContextLocality::Unknown);
+}
+
+TEST_CASE("WorkingDirectory.a container cwd is displayed but never spawned into", "[cwd]")
+{
+    // The concrete hazard: a container path carries NO host authority, so running it through
+    // isLocalHost() -- which accepts an empty authority -- would call it local and open the HOST's
+    // directory of the same name.
+    auto stack = ContextStack {};
+    push(stack, "box", ContextType::Container, {}, ThisMachine.machineId, ThisMachine.hostname);
+    push(stack, "shell", ContextType::Shell, "/app");
+
+    auto const shown = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Display);
+    REQUIRE(shown.has_value());
+    CHECK(shown->path == "/app");
+    CHECK(shown->locality == ContextLocality::Foreign);
+
+    CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Spawn).has_value());
+    CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::OpenLocally).has_value());
+}
+
+TEST_CASE("WorkingDirectory.a foreign machine id is refused for spawning", "[cwd]")
+{
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell, "/home/bob", "ffffffffffffffffffffffffffffffff", "zeta");
+
+    CHECK(!resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Spawn).has_value());
+
+    auto const shown = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Display);
+    REQUIRE(shown.has_value());
+    CHECK(shown->locality == ContextLocality::Foreign);
+}
+
+TEST_CASE("WorkingDirectory.a foreign context falls through to OSC 7 for spawning", "[cwd]")
+{
+    // The fall-through is not a second chance at the same question: OSC 7 is a different source, with
+    // its own host authority to test.
+    auto stack = ContextStack {};
+    push(stack, "box", ContextType::Container, "/app");
+
+    auto const resolved =
+        resolveWorkingDirectory(stack, "file://zeta/home/user", ThisMachine, CwdPurpose::Spawn);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved->path == "/home/user");
+    CHECK(resolved->source == CwdSource::Osc7);
+}
+
+TEST_CASE("WorkingDirectory.a remote OSC 7 url is refused for spawning but shown", "[cwd]")
+{
+    auto const stack = ContextStack {};
+
+    CHECK(!resolveWorkingDirectory(stack, "file://elsewhere/home/bob", ThisMachine, CwdPurpose::Spawn)
+               .has_value());
+
+    auto const shown =
+        resolveWorkingDirectory(stack, "file://elsewhere/home/bob", ThisMachine, CwdPurpose::Display);
+    REQUIRE(shown.has_value());
+    CHECK(shown->path == "/home/bob");
+    CHECK(shown->locality == ContextLocality::Foreign);
+}
+
+TEST_CASE("WorkingDirectory.the walk skips a context that never mentioned a cwd", "[cwd]")
+{
+    // systemd sends type=command without a cwd when nothing changed, so the command inherits the
+    // shell's.
+    auto stack = ContextStack {};
+    push(stack, "shell", ContextType::Shell, "/home/user", ThisMachine.machineId);
+    push(stack, "cmd", ContextType::Command);
+
+    auto const resolved = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Spawn);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved->path == "/home/user");
+}
+
+TEST_CASE("WorkingDirectory.spawn and openLocally always agree", "[cwd]")
+{
+    // The menu row's enablement and the action behind it go through this one function, so they cannot
+    // disagree about whether a directory is openable.
+    auto const cases = std::array {
+        std::pair { std::string_view { "/home/user" }, ThisMachine.machineId },
+        std::pair { std::string_view { "/app" }, std::string_view {} },
+        std::pair { std::string_view { "/home/bob" },
+                    std::string_view { "ffffffffffffffffffffffffffffffff" } },
+    };
+
+    for (auto const& [cwd, machineId]: cases)
+    {
+        auto stack = ContextStack {};
+        push(stack, "shell", ContextType::Shell, cwd, machineId);
+        auto const spawn = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::Spawn);
+        auto const open = resolveWorkingDirectory(stack, "", ThisMachine, CwdPurpose::OpenLocally);
+        CHECK(spawn.has_value() == open.has_value());
+        if (spawn && open)
+            CHECK(spawn->path == open->path);
+    }
+}

--- a/src/vtbackend/grid/Grid.cpp
+++ b/src/vtbackend/grid/Grid.cpp
@@ -43,20 +43,44 @@ namespace detail
         return lines;
     }
 
+    /// Internal linkage, matching the `static` helpers around it: this is reflow's own vocabulary and
+    /// nothing outside this translation unit names it.
+    namespace
+    {
+        /// Everything a logical line carries that survives being re-chopped into physical rows.
+        ///
+        /// One parameter rather than four, and one local rather than four kept in step by hand: reflow
+        /// assigns these together, captures them together and passes them together, so a fifth attribute is
+        /// a member here instead of an edit at six sites. It also un-swaps the two ColumnOffsets, which as
+        /// adjacent parameters of one type could be exchanged at any call site without a diagnostic.
+        struct LogicalLineAttributes
+        {
+            LineFlags flags = LineFlag::None;
+
+            /// An offset into the LOGICAL line, carried by its head alone: re-chopping the line into
+            /// different physical pieces leaves it untouched.
+            ColumnOffset commandEndOffset {};
+
+            /// Likewise head-only. @see commandEndOffset.
+            ColumnOffset promptEndOffset {};
+
+            /// NOT head-only, unlike the two above: those name a border WITHIN the logical line, while this
+            /// names who WROTE it, and a wrap does not change the author of a continuation.
+            ContextId contextId {};
+        };
+    } // namespace
+
     /// Splits a logical line (stored as a LineSoA) into fixed-width Line objects.
-    /// @param baseFlags The logical line's flags; only its head keeps the semantic marks among them.
-    /// @param commandEndOffset The logical line's command-end offset, likewise carried by the head alone.
-    /// @param promptEndOffset The logical line's prompt-end offset, likewise carried by the head alone.
+    /// @param attributes What the logical line carries; only its head keeps the head-only members.
     /// @returns number of inserted lines.
     static LineCount addNewWrappedLines(Lines& targetLines,
                                         ColumnCount newColumnCount,
                                         LineSoA const& logicalLineBuffer,
                                         size_t usedColumns,
-                                        LineFlags baseFlags,
-                                        ColumnOffset commandEndOffset,
-                                        ColumnOffset promptEndOffset,
+                                        LogicalLineAttributes const& attributes,
                                         bool initialNoWrap)
     {
+        auto const& baseFlags = attributes.flags;
         auto const newCols = unbox<size_t>(newColumnCount);
         int i = 0;
         size_t offset = 0;
@@ -75,9 +99,11 @@ namespace detail
                                      newColumnCount);
             if (isHead)
             {
-                targetLines.back().setCommandEndOffset(commandEndOffset);
-                targetLines.back().setPromptEndOffset(promptEndOffset);
+                targetLines.back().setCommandEndOffset(attributes.commandEndOffset);
+                targetLines.back().setPromptEndOffset(attributes.promptEndOffset);
             }
+            // EVERY chunk, head or not. @see LogicalLineAttributes::contextId.
+            targetLines.back().adoptContext(attributes.contextId);
             ++i;
         };
 
@@ -766,9 +792,7 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
             LineSoA logicalLineBuffer;
             initializeLineSoA(logicalLineBuffer, ColumnCount(0));
             size_t logicalLineUsed = 0;
-            LineFlags logicalLineFlags = LineFlag::None;
-            ColumnOffset logicalLineCommandEndOffset {};
-            ColumnOffset logicalLinePromptEndOffset {};
+            auto logicalLineAttributes = detail::LogicalLineAttributes {};
 
             auto const appendToLogicalLine = [&logicalLineBuffer, &logicalLineUsed](Line const& line) {
                 auto const cols = unbox<size_t>(line.size());
@@ -786,18 +810,14 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
                                            &grownLines,
                                            &logicalLineBuffer,
                                            &logicalLineUsed,
-                                           &logicalLineFlags,
-                                           &logicalLineCommandEndOffset,
-                                           &logicalLinePromptEndOffset]() {
+                                           &logicalLineAttributes]() {
                 if (logicalLineUsed > 0)
                 {
                     detail::addNewWrappedLines(grownLines,
                                                newColumnCount,
                                                logicalLineBuffer,
                                                logicalLineUsed,
-                                               logicalLineFlags,
-                                               logicalLineCommandEndOffset,
-                                               logicalLinePromptEndOffset,
+                                               logicalLineAttributes,
                                                true);
                     initializeLineSoA(logicalLineBuffer, ColumnCount(0));
                     logicalLineUsed = 0;
@@ -824,9 +844,12 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
                     else
                     {
                         appendToLogicalLine(line);
-                        logicalLineFlags = line.flags().without(LineFlag::Wrapped);
-                        logicalLineCommandEndOffset = line.commandEndOffset();
-                        logicalLinePromptEndOffset = line.promptEndOffset();
+                        logicalLineAttributes = {
+                            .flags = line.flags().without(LineFlag::Wrapped),
+                            .commandEndOffset = line.commandEndOffset(),
+                            .promptEndOffset = line.promptEndOffset(),
+                            .contextId = line.contextId(),
+                        };
                     }
                 }
             }
@@ -878,7 +901,13 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
             LineSoA wrappedColumns;
             initializeLineSoA(wrappedColumns, ColumnCount(0));
             size_t wrappedUsed = 0;
-            LineFlags previousFlags = _lines.front().inheritableFlags();
+            // A run of physical rows being rejoined into one logical line was all written by one
+            // context, so the chunks that run is re-split into all belong to it -- which is why the
+            // context travels beside the flags rather than being defaulted per chunk. The two offsets
+            // stay at zero here: a shrink emits only continuations, which carry neither.
+            auto previousAttributes =
+                detail::LogicalLineAttributes { .flags = _lines.front().inheritableFlags(),
+                                                .contextId = _lines.front().contextId() };
 
             auto const totalLineCount = unbox<size_t>(_pageSize.lines + maxHistoryLineCount());
             shrunkLines.reserve(totalLineCount);
@@ -891,7 +920,7 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
 
                 if (wrappedUsed > 0)
                 {
-                    if (line.wrapped() && line.inheritableFlags() == previousFlags)
+                    if (line.wrapped() && line.inheritableFlags() == previousAttributes.flags)
                     {
                         // Prepend wrapped columns to this line using SoA copyColumns
                         auto const cols = unbox<size_t>(line.size());
@@ -907,7 +936,13 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
                         // is guarded on it), so it carries no command-end offset to lose — but say so out
                         // loud rather than let the constructor's default quietly stand in for the reason.
                         Require(line.commandEndOffset() == ColumnOffset(0));
+                        // Carried across the rebuild explicitly. Unlike the offsets above, the context
+                        // is NOT default-correct here: this line and the columns being prepended to it
+                        // are two physical pieces of ONE logical line, so they share an author, and a
+                        // fresh Line would silently report none.
+                        auto const carriedContext = line.contextId();
                         line = Line(line.flags(), std::move(merged), ColumnCount::cast_from(totalCols));
+                        line.adoptContext(carriedContext);
                     }
                     else
                     {
@@ -917,12 +952,11 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
                                                                                  newColumnCount,
                                                                                  wrappedColumns,
                                                                                  wrappedUsed,
-                                                                                 previousFlags,
-                                                                                 ColumnOffset(0),
-                                                                                 ColumnOffset(0),
+                                                                                 previousAttributes,
                                                                                  false);
                         numLinesWritten += numLinesInserted;
-                        previousFlags = line.inheritableFlags();
+                        previousAttributes = { .flags = line.inheritableFlags(),
+                                               .contextId = line.contextId() };
                     }
                     wrappedUsed = 0;
                     initializeLineSoA(wrappedColumns, ColumnCount(0));
@@ -930,7 +964,7 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
                 else
                 {
                     line.setWrappable(true);
-                    previousFlags = line.inheritableFlags();
+                    previousAttributes = { .flags = line.inheritableFlags(), .contextId = line.contextId() };
                 }
 
                 auto overflow = line.reflow(newColumnCount);
@@ -947,14 +981,8 @@ CellLocation Grid::resize(PageSize newSize, CellLocation currentCursorPos, bool 
             }
             if (wrappedUsed > 0)
             {
-                numLinesWritten += detail::addNewWrappedLines(shrunkLines,
-                                                              newColumnCount,
-                                                              wrappedColumns,
-                                                              wrappedUsed,
-                                                              previousFlags,
-                                                              ColumnOffset(0),
-                                                              ColumnOffset(0),
-                                                              false);
+                numLinesWritten += detail::addNewWrappedLines(
+                    shrunkLines, newColumnCount, wrappedColumns, wrappedUsed, previousAttributes, false);
             }
             Require(unbox<size_t>(numLinesWritten) == shrunkLines.size());
             Require(numLinesWritten >= _pageSize.lines);

--- a/src/vtbackend/grid/Grid.hpp
+++ b/src/vtbackend/grid/Grid.hpp
@@ -1195,7 +1195,7 @@ template <typename RendererT>
             auto const cellFlags = tb.textAttributes.flags;
             hints.containsBlinkingCells = hints.containsBlinkingCells || (cellFlags & CellFlag::Blinking)
                                           || (cellFlags & CellFlag::RapidBlinking);
-            render.renderTrivialLine(tb, y, line.flags(), trivialText);
+            render.renderTrivialLine(tb, y, line.flags(), line.contextId(), trivialText);
         }
         else
         {
@@ -1204,7 +1204,7 @@ template <typename RendererT>
             auto const& storage = line.storage();
             auto const cols = unbox<size_t>(line.size());
 
-            render.startLine(y, line.flags());
+            render.startLine(y, line.flags(), line.contextId());
             for (size_t col = 0; col < cols; ++col)
             {
                 auto const proxy = ConstCellProxy(storage, col);

--- a/src/vtbackend/grid/Grid_test.cpp
+++ b/src/vtbackend/grid/Grid_test.cpp
@@ -980,7 +980,7 @@ struct MockGridRenderer
     size_t trivialCount = 0;
     size_t perCellCount = 0;
 
-    void startLine(LineOffset y, [[maybe_unused]] LineFlags flags)
+    void startLine(LineOffset y, [[maybe_unused]] LineFlags flags, [[maybe_unused]] ContextId contextId)
     {
         renderedLines.push_back(y);
         ++perCellCount;
@@ -997,6 +997,7 @@ struct MockGridRenderer
     void renderTrivialLine([[maybe_unused]] TrivialLineBuffer const& lineBuffer,
                            LineOffset y,
                            [[maybe_unused]] LineFlags flags,
+                           [[maybe_unused]] ContextId contextId,
                            std::u32string_view textOverride = {})
     {
         renderedLines.push_back(y);

--- a/src/vtbackend/grid/Line.hpp
+++ b/src/vtbackend/grid/Line.hpp
@@ -400,12 +400,20 @@ class Line
 
     /// Records that this line was produced under @p id, if it was not already.
     ///
+    /// A ZERO id is ignored, and that is load-bearing in two places. A line's author is set when the
+    /// line is written and cleared when the line is REUSED (@see reset), so "no context is active
+    /// right now" is an absence of information rather than a claim that this line had no author --
+    /// the cursor merely returning to a line after its context ended must not erase what wrote it.
+    /// And on a daemon mirror, whose ancestry is replicated rather than parsed, the local active
+    /// context is routinely zero while the ids arriving on the wire are not; clearing here would wipe
+    /// every replicated stamp the moment the cursor moved.
+    ///
     /// Deliberately does NOT mark the line dirty. The id is derived state -- a frontend resolves it
     /// through the context stack -- and nothing about the line's CONTENT changed, so dirtying it would
     /// push a delta for a row that did not visually change, twice per command, forever.
     void adoptContext(ContextId id) noexcept
     {
-        if (_contextId != id)
+        if (!!id)
             _contextId = id;
     }
 

--- a/src/vtbackend/grid/Line.hpp
+++ b/src/vtbackend/grid/Line.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <vtbackend/core/ContextId.hpp>
 #include <vtbackend/core/GraphicsAttributes.hpp>
 #include <vtbackend/core/Hyperlink.hpp>
 #include <vtbackend/core/LineFlags.hpp>
@@ -119,6 +120,7 @@ class Line
         _storage = other._storage;
         _columns = other._columns;
         _flags = other._flags;
+        _contextId = other._contextId;
         _commandEndOffset = other._commandEndOffset;
         _promptEndOffset = other._promptEndOffset;
         _revision = other._revision;
@@ -133,6 +135,7 @@ class Line
         _storage = std::move(other._storage);
         _columns = other._columns;
         _flags = other._flags;
+        _contextId = other._contextId;
         _commandEndOffset = other._commandEndOffset;
         _promptEndOffset = other._promptEndOffset;
         _revision = other._revision;
@@ -176,6 +179,7 @@ class Line
     {
         _dirty = true;
         _flags = flags;
+        _contextId = {};
         _commandEndOffset = {};
         _promptEndOffset = {};
         if (isBlankWithFillAttrs(attributes))
@@ -187,6 +191,7 @@ class Line
     {
         _dirty = true;
         _flags = flags;
+        _contextId = {};
         _commandEndOffset = {};
         _promptEndOffset = {};
         _columns = count;
@@ -203,6 +208,7 @@ class Line
     {
         _dirty = true;
         _flags = flags;
+        _contextId = {};
         _commandEndOffset = {};
         _promptEndOffset = {};
         if (codepoint == 0)
@@ -388,6 +394,21 @@ class Line
     /// re-chops a logical line into different physical pieces but never changes its content, so a
     /// logical column does not move when the window is resized.
     [[nodiscard]] ColumnOffset promptEndOffset() const noexcept { return _promptEndOffset; }
+
+    /// The context that wrote this line, or zero when none was in effect.
+    [[nodiscard]] ContextId contextId() const noexcept { return _contextId; }
+
+    /// Records that this line was produced under @p id, if it was not already.
+    ///
+    /// Deliberately does NOT mark the line dirty. The id is derived state -- a frontend resolves it
+    /// through the context stack -- and nothing about the line's CONTENT changed, so dirtying it would
+    /// push a delta for a row that did not visually change, twice per command, forever.
+    void adoptContext(ContextId id) noexcept
+    {
+        if (_contextId != id)
+            _contextId = id;
+    }
+
     void setPromptEndOffset(ColumnOffset offset) noexcept
     {
         _dirty = true;
@@ -607,6 +628,20 @@ class Line
     LineSoA _storage;
     ColumnCount _columns {};
     LineFlags _flags {};
+
+    /// The OSC 3008 context that wrote this line, or zero for none.
+    ///
+    /// Placed HERE on purpose: _columns is 4-aligned and _commandEndOffset must be too, so there was a
+    /// two-byte padding hole right at this offset. Associating every line with the context that
+    /// produced it therefore costs nothing per line -- which is what makes it affordable across a
+    /// whole scrollback. The static_assert below is what turns a future field reordering that breaks
+    /// that into a build error rather than a silent +8 bytes on every line in the grid.
+    ///
+    /// Unlike _commandEndOffset and _promptEndOffset, this is NOT head-only: those name a border
+    /// WITHIN a logical line, so only its head can carry them, while this names who WROTE the line --
+    /// and a wrap does not change the author of the continuation. @see detail::addNewWrappedLines.
+    ContextId _contextId {};
+
     ColumnOffset _commandEndOffset {};
     ColumnOffset _promptEndOffset {};
     uint64_t _revision = 0; ///< Batch seqno of the last change (see revision()).
@@ -616,6 +651,22 @@ class Line
                             ///< years, so wrap is not handled in the comparison.
     bool _dirty = true;     ///< Fresh lines are pending: bootstrap self-heals.
 };
+
+/// Line's size is a fact about the whole scrollback, so it is pinned rather than left to drift.
+///
+/// _contextId was placed in the padding hole between _flags and _commandEndOffset precisely so that
+/// associating every line with the context that wrote it costs nothing. A reordering that pushes it
+/// out of that hole costs eight bytes on every line the grid holds -- tens of thousands of them -- and
+/// would otherwise do so silently. If this fires, do not simply update the number: put the field back
+/// where it fits, or accept the cost deliberately.
+///
+/// Expressed RELATIVE to LineSoA rather than as an absolute byte count, because an absolute count is
+/// not portable: LineSoA holds a std::vector and a std::optional<std::unordered_map>, whose sizes
+/// differ between libstdc++, libc++ and the MSVC STL, so a pinned literal would be a build break on
+/// macOS and Windows rather than a statement about Line's own tail. What matters here is exactly that
+/// tail -- the scalars after the storage -- and it is the same 32 bytes everywhere.
+static_assert(sizeof(Line) == sizeof(LineSoA) + 32,
+              "Line's scalar tail grew. See the comment on Line::_contextId before changing this.");
 
 } // namespace vtbackend
 

--- a/src/vtbackend/screen/RenderBufferBuilder.cpp
+++ b/src/vtbackend/screen/RenderBufferBuilder.cpp
@@ -62,7 +62,8 @@ namespace
                             bool isCursorLine,
                             bool isHighlighted,
                             float blink,
-                            float rapidBlink) noexcept
+                            float rapidBlink,
+                            std::optional<RGBColor> contextTint) noexcept
     {
         auto sgrColors = CellUtil::makeColors(colorPalette,
                                               colorLookupTable,
@@ -72,6 +73,22 @@ namespace
                                               backgroundColor,
                                               blink,
                                               rapidBlink);
+
+        // The OSC 3008 context tint stands in for the PAGE background and for nothing else.
+        //
+        // Compared against the RESOLVED background rather than against the SGR parameter, which gets
+        // reverse video (DECSCNM) and the Inverse attribute right for free: in both, the resolved
+        // background comes from the FOREGROUND colour, does not equal the page background, and is
+        // therefore left alone. A cell the application coloured itself keeps that colour -- otherwise
+        // `ls --color` inside a container comes out repainted, and a hint about who is running would
+        // cost the user the output they ran it for.
+        //
+        // Lowest of all the layers below, deliberately. Every one of them is a TRANSIENT answer to
+        // something the user is doing right now -- moving the cursor, dragging a selection, searching
+        // -- and a persistent, ambient property of the line must never win over one of those, or the
+        // user loses the ability to see what they just selected.
+        if (contextTint && sgrColors.background == colorPalette.defaultBackground)
+            sgrColors.background = *contextTint;
 
         if (isCursorLine)
             sgrColors = makeRGBColorPair(sgrColors, colorPalette.normalModeCursorline);
@@ -130,12 +147,30 @@ RenderBufferBuilder::RenderBufferBuilder(Terminal const& terminal,
     _colorLookupTable { colorLookupTable },
     _highlightSearchMatches { highlightSearchMatches },
     _inputMethodData { std::move(inputMethodData) },
-    _includeSelection { includeSelection }
+    _includeSelection { includeSelection },
+    // Once per pass, not once per line: three facts that cannot change while a buffer is being built.
+    _contextTintingPossible { terminal.settings().contextTintScope != ContextTintScope::Off
+                              && terminal.colorPalette().hasContextTints()
+                              && &screen == &terminal.primaryScreen() }
 {
     output.frameID = terminal.lastFrameID();
 
     if (_cursorPosition)
         output.cursor = renderCursor();
+}
+
+std::optional<RGBColor> RenderBufferBuilder::tintFor(ContextId id) const noexcept
+{
+    if (!_contextTintingPossible)
+        return std::nullopt;
+
+    auto const* const record = _terminal->contexts().find(id);
+    // A line whose context has aged out of the retained pool renders untinted, which is the same
+    // degradation a cell whose hyperlink was evicted already has. A missing context tints nothing;
+    // it never tints wrongly.
+    return record
+               ? _terminal->colorPalette().contextTint(record->type, _terminal->settings().contextTintScope)
+               : std::nullopt;
 }
 
 optional<RenderCursor> RenderBufferBuilder::renderCursor() const
@@ -328,7 +363,8 @@ RGBColorPair RenderBufferBuilder::makeColorsForCell(CellLocation gridPosition,
                       _useCursorlineColoring,
                       highlighted,
                       blink,
-                      rapidBlink);
+                      rapidBlink,
+                      _currentContextTint);
 }
 
 RenderAttributes RenderBufferBuilder::createRenderAttributes(
@@ -397,6 +433,7 @@ bool RenderBufferBuilder::gridLineContainsCursor(LineOffset screenRow) const
 void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                                             LineOffset lineOffset,
                                             LineFlags flags,
+                                            ContextId contextId,
                                             std::u32string_view textOverride)
 {
     // if (lineBuffer.text.size())
@@ -414,6 +451,7 @@ void RenderBufferBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
     // hard-coding it to false (the old invariant "cursor lines are always inflated") dropped the
     // current-line highlight on plain-text lines.
     _useCursorlineColoring = isCursorLine(lineOffset);
+    _currentContextTint = tintFor(contextId);
     _currentLineFlags = flags;
 
     // Same reason, and the same job startLine() does for a per-cell line: makeColorsForCell reads
@@ -577,7 +615,7 @@ void RenderBufferBuilder::matchSearchPattern(T const& cellText)
     _searchPatternOffset = 0;
 }
 
-void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags)
+void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags, ContextId contextId)
 {
     _lineNr = line;
     _currentLineFlags = flags;
@@ -585,6 +623,7 @@ void RenderBufferBuilder::startLine(LineOffset line, LineFlags flags)
     _prevHasCursor = false;
 
     _useCursorlineColoring = isCursorLine(line);
+    _currentContextTint = tintFor(contextId);
 }
 
 bool RenderBufferBuilder::isCursorLine(LineOffset line) const

--- a/src/vtbackend/screen/RenderBufferBuilder.hpp
+++ b/src/vtbackend/screen/RenderBufferBuilder.hpp
@@ -47,7 +47,7 @@ class RenderBufferBuilder
     void renderCell(ConstCellProxy cell, LineOffset line, ColumnOffset column);
     /// Not noexcept: the cursor-line decision it makes goes through the viewport's coordinate
     /// translation, which builds the fold projection lazily and therefore allocates.
-    void startLine(LineOffset line, LineFlags flags);
+    void startLine(LineOffset line, LineFlags flags, ContextId contextId);
     void endLine() noexcept;
 
     /// Renders a trivial line.
@@ -61,6 +61,7 @@ class RenderBufferBuilder
     void renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                            LineOffset lineOffset,
                            LineFlags flags,
+                           ContextId contextId,
                            std::u32string_view textOverride = {});
 
     /// This call is guaranteed to be invoked when the the full page has been rendered.
@@ -71,6 +72,11 @@ class RenderBufferBuilder
     [[nodiscard]] bool isCursorLine(LineOffset line) const;
 
     [[nodiscard]] std::optional<RenderCursor> renderCursor() const;
+
+    /// The tint for @p id, resolved once per LINE -- not per cell, and only when @ref
+    /// _contextTintingPossible said a tint could apply at all, which is what keeps the ordinary
+    /// session (no scheme sets a tint) at one bool test per line.
+    [[nodiscard]] std::optional<RGBColor> tintFor(ContextId id) const noexcept;
 
     [[nodiscard]] static RenderCell makeRenderCellExplicit(ColorPalette const& colorPalette,
                                                            std::u32string graphemeCluster,
@@ -182,6 +188,20 @@ class RenderBufferBuilder
     bool _prevHasCursor = false;
     LineOffset _lineNr = LineOffset(0);
     bool _useCursorlineColoring = false;
+
+    /// The OSC 3008 tint in force on the line currently being rendered, resolved once per line.
+    std::optional<RGBColor> _currentContextTint {};
+
+    /// Whether any tint could apply at all -- the scheme sets one, the configuration allows it, and
+    /// this is the primary screen. Decided once per pass so the per-line path is a single branch.
+    ///
+    /// The alternate screen is excluded on purpose. The equality guard in makeColors() would make the
+    /// tint PATCHY there rather than uniform -- a full-screen application paints most of its canvas
+    /// with its own background, so only the cells it left at default would tint, and a striped vim
+    /// reads as a rendering fault. The application's background IS the application; the information is
+    /// constant for the whole buffer anyway, so there is nothing per-line to convey; and the status
+    /// line is the better channel for it, being already immune to an application's own colours.
+    bool _contextTintingPossible = false;
 
     // Offset into the search pattern that has been already matched.
     size_t _searchPatternOffset = 0;

--- a/src/vtbackend/screen/Screen.cpp
+++ b/src/vtbackend/screen/Screen.cpp
@@ -6070,6 +6070,21 @@ void Screen::setLogicalLineFlags(LineOffset line, LineFlags flags, bool enable) 
         _terminal->invalidateFoldRanges();
 }
 
+void Screen::markLogicalLineAtCursorWithColumn(ColumnMark mark) noexcept
+{
+    auto const cursorPosition = cursor().position;
+    auto const flag = mark == ColumnMark::PromptEnd ? LineFlag::PromptEnd : LineFlag::CommandEnd;
+    auto const column = _grid.logicalColumnOf(cursorPosition);
+
+    setLogicalLineFlags(cursorPosition.line, flag, true);
+
+    auto& head = _grid.changingLineAt(_grid.logicalLineHead(cursorPosition.line));
+    if (mark == ColumnMark::PromptEnd)
+        head.setPromptEndOffset(column);
+    else
+        head.setCommandEndOffset(column);
+}
+
 void Screen::setMark()
 {
     markLogicalLineAtCursor(LineFlag::Marked);
@@ -6130,10 +6145,7 @@ void Screen::processShellIntegration(Sequence const& seq)
             // accessibility client — or anything else asking about the LIVE prompt — where the prompt
             // area ends, and it cannot be recovered afterwards: once the user types, the two are the same
             // run of cells.
-            auto const cursorPosition = cursor().position;
-            auto& head = _grid.changingLineAt(_grid.logicalLineHead(cursorPosition.line));
-            head.setFlag(LineFlag::PromptEnd, true);
-            head.setPromptEndOffset(_grid.logicalColumnOf(cursorPosition));
+            markLogicalLineAtCursorWithColumn(ColumnMark::PromptEnd);
 
             _terminal->shellIntegration().promptEnd();
             break;
@@ -6164,10 +6176,7 @@ void Screen::processShellIntegration(Sequence const& seq)
             // output did not end in a newline, the prompt about to be printed lands on the very same line.
             // Remembering the column is what later tells the two apart; without it a copy of the command's
             // output either swallows the next prompt or loses its own last line.
-            auto const cursorPosition = cursor().position;
-            auto& head = _grid.changingLineAt(_grid.logicalLineHead(cursorPosition.line));
-            head.setFlag(LineFlag::CommandEnd, true);
-            head.setCommandEndOffset(_grid.logicalColumnOf(cursorPosition));
+            markLogicalLineAtCursorWithColumn(ColumnMark::CommandEnd);
 
             auto const exitCode =
                 (cmd.size() > 2 && cmd[1] == ';') ? crispy::toInteger<10, int>(cmd.substr(2)).value_or(0) : 0;

--- a/src/vtbackend/screen/Screen.cpp
+++ b/src/vtbackend/screen/Screen.cpp
@@ -13,6 +13,7 @@
 #include <vtbackend/screen/Terminal.hpp>
 #include <vtbackend/vt/ControlCode.hpp>
 #include <vtbackend/vt/DesktopNotification.hpp>
+#include <vtbackend/vt/HierarchicalContext.hpp>
 #include <vtbackend/vt/ModifyKeys.hpp>
 #include <vtbackend/vt/RectangularAreaChecksum.hpp>
 #include <vtbackend/vt/SgrWriter.hpp>
@@ -6074,6 +6075,21 @@ void Screen::setMark()
     markLogicalLineAtCursor(LineFlag::Marked);
 }
 
+ApplyResult Screen::processHierarchicalContext(std::string_view payload)
+{
+    auto const command = parseContextSequence(payload, _contextScratch);
+    if (!command)
+    {
+        errorLog()("Ignoring malformed OSC 3008 sequence: {}", toString(command.error()));
+        return ApplyResult::Invalid;
+    }
+
+    // The stack is terminal-global rather than per-screen: the ancestry describes the APPLICATION's
+    // process tree, which an alternate-screen switch or a page change does not touch.
+    (void) _terminal->applyContextCommand(*command);
+    return ApplyResult::Ok;
+}
+
 void Screen::processShellIntegration(Sequence const& seq)
 {
     auto const& cmd = seq.intermediateCharacters();
@@ -7067,6 +7083,7 @@ ApplyResult Screen::apply(Function const& function, Sequence const& seq)
         case TEXTSIZING: return processTextSizing(seq.intermediateCharacters());
         case KITTYCLIPBOARD: return processKittyClipboard(seq.intermediateCharacters());
         case POINTERSHAPE: return processPointerShape(seq.intermediateCharacters());
+        case HIERCONTEXT: return processHierarchicalContext(seq.intermediateCharacters());
         case DESKTOPNOTIFY: return impl::DESKTOPNOTIFY(seq, *_terminal);
         case DUMPSTATE: inspect(); break;
         case SEMA: processShellIntegration(seq); break;

--- a/src/vtbackend/screen/Screen.cpp
+++ b/src/vtbackend/screen/Screen.cpp
@@ -6101,8 +6101,91 @@ ApplyResult Screen::processHierarchicalContext(std::string_view payload)
 
     // The stack is terminal-global rather than per-screen: the ancestry describes the APPLICATION's
     // process tree, which an alternate-screen switch or a page change does not touch.
-    (void) _terminal->applyContextCommand(*command);
+    auto const transition = _terminal->applyContextCommand(*command);
+    synthesizeSemanticMarks(transition, *command);
     return ApplyResult::Ok;
+}
+
+void Screen::synthesizeSemanticMarks(ContextTransition const& transition, ContextCommand const& command)
+{
+    // Only the shell/command cycle carries a positional guarantee. run0's `elevate` and
+    // systemd-nspawn's `container` contexts are announced wherever the cursor happens to be, so a mark
+    // derived from one would land on an arbitrary line.
+    if (transition.subjectType != ContextType::Shell && transition.subjectType != ContextType::Command)
+        return;
+
+    auto& arbiter = _terminal->markArbiter();
+    if (transition.subjectType == ContextType::Command)
+    {
+        if (command.verb == ContextVerb::Start)
+            arbiter.observedContextCommandStart();
+        else
+            arbiter.observedContextCommandEnd();
+    }
+
+    if (!arbiter.contextMayMark())
+        return;
+
+    // Which OSC 133 mark each transition stands in for, and why it lands where it does. The positions
+    // are not a guess: they are where systemd's own PROMPT_COMMAND/PS0 hooks put these sequences.
+    //
+    //   type=shell, UPDATE   -> 133;A   emitted from PROMPT_COMMAND, before the prompt is painted, so
+    //                                   the cursor is where the prompt is about to begin.
+    //   type=command, start  -> 133;C   emitted from PS0, after the user pressed Enter, so the cursor
+    //                                   is at the start of the output area.
+    //   type=command, end    -> 133;D   emitted from PROMPT_COMMAND, so the cursor is still standing
+    //                                   where the output left it -- which is why the column is
+    //                                   recoverable here and worth recording.
+    //
+    // There is deliberately NO 133;B equivalent: OSC 3008 has no event at the prompt/input border, so
+    // PromptRegion::inputBegin stays nullopt -- a state PromptRegion documents as supported for shells
+    // that emit only ;A.
+    //
+    // A type=shell PUSH marks nothing: systemd opens that context when profile.d is sourced, which can
+    // be arbitrarily far above the first prompt, and a mark there would land on the motd.
+    auto const notify = arbiter.contextMayNotify();
+    switch (transition.subjectType)
+    {
+        case ContextType::Shell:
+            if (transition.kind != ContextTransitionKind::Updated
+                && transition.kind != ContextTransitionKind::ReturnedTo)
+                return;
+            setMark();
+            if (notify)
+            {
+                _terminal->shellIntegration().promptStart();
+                _terminal->semanticBlockTracker().promptStart();
+                _terminal->autoCollapseOnNewPrompt();
+            }
+            return;
+        case ContextType::Command:
+            if (command.verb == ContextVerb::Start)
+            {
+                // No DepthExceeded guard here: a refused push carries no subject, so its transition
+                // reports ContextType::None and the type test at the top of this function has already
+                // returned. Restating it read as a second gate and was dead code.
+                markLogicalLineAtCursor(LineFlag::OutputStart);
+                if (notify)
+                {
+                    // No cmdline: the systemd shim sends none, and 3008 may FILL a command line but
+                    // never overwrite one OSC 133;C already supplied.
+                    _terminal->shellIntegration().commandOutputStart(std::nullopt);
+                    _terminal->semanticBlockTracker().commandOutputStart(std::nullopt);
+                }
+            }
+            else if (transition.kind == ContextTransitionKind::Ended)
+            {
+                markLogicalLineAtCursorWithColumn(ColumnMark::CommandEnd);
+                if (notify)
+                {
+                    auto const exitCode = command.outcome.asShellExitCode();
+                    _terminal->shellIntegration().commandFinished(exitCode);
+                    _terminal->semanticBlockTracker().commandFinished(exitCode);
+                }
+            }
+            return;
+        default: return;
+    }
 }
 
 void Screen::processShellIntegration(Sequence const& seq)
@@ -6110,6 +6193,11 @@ void Screen::processShellIntegration(Sequence const& seq)
     auto const& cmd = seq.intermediateCharacters();
     if (cmd.empty())
         return;
+
+    // The shell speaks OSC 133 itself, so it owns this session's marks from here on and OSC 3008
+    // contributes metadata only. Recorded before the switch, so every one of the four sub-commands
+    // counts -- a shell integration that emits only ;A still settles the question.
+    _terminal->markArbiter().observedShellIntegration();
 
     auto const forEachKeyValue = []<typename Callback>(std::string_view text, Callback&& callback) {
         crispy::forEachKeyValue(

--- a/src/vtbackend/screen/Screen.cpp
+++ b/src/vtbackend/screen/Screen.cpp
@@ -6092,6 +6092,12 @@ void Screen::setMark()
 
 ApplyResult Screen::processHierarchicalContext(std::string_view payload)
 {
+    // The single gate. Unsupported rather than Invalid: the payload may well be perfectly formed, the
+    // terminal has simply been told not to read it. Refusing HERE is what makes the feature genuinely
+    // off -- the ancestry stays empty, and every consumer of it is empty in consequence.
+    if (_settings->contextSignalling == ContextSignalling::Disabled)
+        return ApplyResult::Unsupported;
+
     auto const command = parseContextSequence(payload, _contextScratch);
     if (!command)
     {

--- a/src/vtbackend/screen/Screen.hpp
+++ b/src/vtbackend/screen/Screen.hpp
@@ -669,7 +669,65 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
         return useCellAt(_lastCursorPosition.line, _lastCursorPosition.column);
     }
 
-    void updateCursorIterator() noexcept { _currentLine = &_grid.lineAt(_cursor.position.line); }
+    /// Re-points _currentLine at the row the cursor is on, and stamps that row with the context in
+    /// effect.
+    ///
+    /// The stamp lives HERE because this is the tree's single "the cursor is now on this line" funnel
+    /// -- fifteen call sites, and provably exhaustive, because _currentLine would already be stale if
+    /// any path skipped it. Stamping per CODEPOINT instead would be the obvious design and the wrong
+    /// one: this runs once per cursor line change, so the per-character write path is untouched.
+    void updateCursorIterator() noexcept
+    {
+        _currentLine = &_grid.lineAt(_cursor.position.line);
+        _currentLine->adoptContext(_activeContextId);
+    }
+
+    /// The OSC 3008 context freshly written lines are stamped with.
+    ///
+    /// A mirror of Terminal's ancestry rather than a read through it: Terminal fans the active id out
+    /// to all 18 screens whenever it moves (@see Terminal::applyContextCommand), which costs two stores
+    /// per command and keeps this funnel free of the two pointer chases a lookup would add. It also
+    /// keeps Screen drivable in a test without a populated stack behind it.
+    void setActiveContextId(ContextId id) noexcept
+    {
+        _activeContextId = id;
+        // The line the cursor is ALREADY on, not just the ones it moves to next. A context is
+        // announced before the output it describes is written, and typically at column 0 of a line the
+        // cursor is already sitting on -- so waiting for the next cursor-line change would attribute
+        // that whole first line to the previous context. Re-stamping a line that already holds output
+        // is last-writer-wins, which is the only defensible answer when one line spans two contexts.
+        if (_currentLine && !!id && _currentLine->contextId() != id)
+        {
+            _currentLine->adoptContext(id);
+            // Dirtied HERE, unlike the updateCursorIterator() funnel, which deliberately is not.
+            // There the stamp always precedes the write that dirties the row anyway; here the row may
+            // already be clean and already replicated, and a daemon mirror's delta scan only revisits
+            // dirty rows -- so without this the mirror keeps a row's old context id forever, which
+            // GridParity reports as a real difference. At most one row per context transition.
+            _currentLine->markDirty();
+        }
+    }
+
+    /// The context that wrote the line at @p line, walking UP through blank lines.
+    ///
+    /// A line the cursor never moved onto -- one cleared by ED while the cursor stayed put -- carries
+    /// no stamp of its own, and a run of blank lines below some output reads to a user as belonging to
+    /// that output. Bounded by the page height so the walk cannot run away into a scrollback of blank
+    /// lines; this is a query-time cost only, paid at most once per visible row.
+    [[nodiscard]] ContextId contextIdAt(LineOffset line) const noexcept
+    {
+        auto const limit = unbox<int>(pageSize().lines);
+        auto const topMost = boxed_cast<LineOffset>(-_grid.historyLineCount());
+        for (auto steps = 0; steps < limit; ++steps)
+        {
+            auto const probe = line - steps;
+            if (probe < topMost)
+                break;
+            if (auto const id = _grid.lineAt(probe).contextId(); !!id)
+                return id;
+        }
+        return {};
+    }
 
     [[nodiscard]] Line& currentLine() noexcept { return *_currentLine; }
 
@@ -1021,6 +1079,9 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
 
     Cursor _cursor {};
     Cursor _savedCursor {};
+
+    /// The OSC 3008 context freshly written lines are stamped with. @see setActiveContextId.
+    ContextId _activeContextId {};
 
     /// Scratch for the OSC 3008 decoder, owned here so the per-prompt hot path allocates once per
     /// session rather than once per sequence. @see parseContextSequence.

--- a/src/vtbackend/screen/Screen.hpp
+++ b/src/vtbackend/screen/Screen.hpp
@@ -4,6 +4,7 @@
 #include <vtbackend/core/Color.hpp>
 #include <vtbackend/core/Hyperlink.hpp>
 #include <vtbackend/core/Image.hpp>
+#include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/graphics/KittyGraphics.hpp>
 #include <vtbackend/graphics/MessageParser.hpp>
 #include <vtbackend/grid/CellUtil.hpp>
@@ -248,6 +249,10 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
 
     /// Applies one `OSC 3008` (hierarchical context signalling) sequence.
     [[nodiscard]] ApplyResult processHierarchicalContext(std::string_view payload);
+
+    /// Stamps the OSC-133-equivalent marks an OSC 3008 transition stands in for, when the arbiter says
+    /// this session's marks are OSC 3008's to stamp. @see MarkArbiter.
+    void synthesizeSemanticMarks(ContextTransition const& transition, ContextCommand const& command);
 
     /// Erases the whole multi-cell block that @p position belongs to, however many rows and columns
     /// it covers, and wherever within it @p position happens to be.

--- a/src/vtbackend/screen/Screen.hpp
+++ b/src/vtbackend/screen/Screen.hpp
@@ -246,6 +246,9 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
     /// Lays out one `OSC 66` (kitty text sizing) request.
     [[nodiscard]] ApplyResult processTextSizing(std::string_view payload);
 
+    /// Applies one `OSC 3008` (hierarchical context signalling) sequence.
+    [[nodiscard]] ApplyResult processHierarchicalContext(std::string_view payload);
+
     /// Erases the whole multi-cell block that @p position belongs to, however many rows and columns
     /// it covers, and wherever within it @p position happens to be.
     void eraseMulticellBlockAt(CellLocation position);
@@ -998,6 +1001,10 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
 
     Cursor _cursor {};
     Cursor _savedCursor {};
+
+    /// Scratch for the OSC 3008 decoder, owned here so the per-prompt hot path allocates once per
+    /// session rather than once per sequence. @see parseContextSequence.
+    std::string _contextScratch {};
 
     /// Payload accumulated across a chunked kitty graphics transmission (`m=1`), plus the command
     /// that opened it -- the continuation chunks carry no control data of their own.

--- a/src/vtbackend/screen/Screen.hpp
+++ b/src/vtbackend/screen/Screen.hpp
@@ -823,6 +823,26 @@ class Screen final: public SequenceHandler, public capabilities::StaticDatabase
     /// derived from them have to be invalidated when one lands.
     void setLogicalLineFlags(LineOffset line, LineFlags flags, bool enable) noexcept;
 
+    /// Which of the two column-carrying semantic marks a @ref markLogicalLineAtCursorWithColumn call
+    /// is recording.
+    ///
+    /// OSC 133's ;B and ;D each remember a COLUMN as well as a flag -- where the prompt handed the
+    /// line over, and where the command's output stopped -- and both are meaningless without it. An
+    /// enum rather than two functions because the two differ only in which pair they write, and
+    /// because a third such mark would be an enumerator rather than a third near-copy.
+    enum class ColumnMark : uint8_t
+    {
+        PromptEnd = 0, ///< OSC 133;B: the border between what the shell wrote and what the user types.
+        CommandEnd,    ///< OSC 133;D: where the command's output actually stopped.
+    };
+
+    /// Stamps @p mark onto the head of the logical line the cursor is on, together with the cursor's
+    /// LOGICAL column.
+    ///
+    /// Goes through the same funnel setLogicalLineFlags() does, and for the same reason: both marks
+    /// are in HeadOnlyLineFlags, so both have to invalidate the fold ranges derived from them.
+    void markLogicalLineAtCursorWithColumn(ColumnMark mark) noexcept;
+
     /// Whether the LOGICAL line that @p line belongs to carries all of @p flags.
     [[nodiscard]] bool isLogicalLineFlagEnabled(LineOffset line, LineFlags flags) const noexcept
     {

--- a/src/vtbackend/screen/ScreenTestFixtures.cpp
+++ b/src/vtbackend/screen/ScreenTestFixtures.cpp
@@ -23,7 +23,7 @@ Image::Data const& white10x10()
     return data;
 }
 
-void TextRenderBuilder::startLine(LineOffset lineOffset, LineFlags /*flags*/)
+void TextRenderBuilder::startLine(LineOffset lineOffset, LineFlags /*flags*/, ContextId /*contextId*/)
 {
     if (!*lineOffset)
         text.clear();
@@ -42,6 +42,7 @@ void TextRenderBuilder::endLine()
 void TextRenderBuilder::renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                                           LineOffset lineOffset,
                                           LineFlags /*flags*/,
+                                          ContextId /*contextId*/,
                                           std::u32string_view textOverride)
 {
     if (!*lineOffset)

--- a/src/vtbackend/screen/ScreenTestFixtures.hpp
+++ b/src/vtbackend/screen/ScreenTestFixtures.hpp
@@ -46,12 +46,13 @@ struct TextRenderBuilder
 {
     std::string text;
 
-    void startLine(LineOffset lineOffset, LineFlags flags);
+    void startLine(LineOffset lineOffset, LineFlags flags, ContextId contextId);
     void renderCell(ConstCellProxy cell, LineOffset lineOffset, ColumnOffset columnOffset);
     void endLine();
     void renderTrivialLine(TrivialLineBuffer const& lineBuffer,
                            LineOffset lineOffset,
                            LineFlags flags,
+                           ContextId contextId,
                            std::u32string_view textOverride = {});
     void finish();
 };

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -634,3 +634,137 @@ TEST_CASE("Screen.osc3008 is not read at all when signalling is disabled", "[con
 }
 
 // }}}
+
+// {{{ background tinting
+
+namespace
+{
+
+/// Gives @p mock a scheme that tints containers and commands, with the scope the configuration would
+/// supply. Not a factory, because MockTerm holds a Terminal and is therefore not movable.
+void tintContainers(MockTerm<>& mock, ContextTintScope scope = ContextTintScope::Boundaries)
+{
+    mock.terminal.settings().contextTintScope = scope;
+    auto& palette = mock.terminal.colorPalette();
+    palette.contextTints[static_cast<size_t>(ContextType::Container)] = RGBColor { 0x16, 0x1c, 0x26 };
+    palette.contextTints[static_cast<size_t>(ContextType::Command)] = RGBColor { 0x14, 0x14, 0x14 };
+}
+
+/// The background the renderer actually paints at @p line, column 0.
+RGBColor backgroundAt(MockTerm<>& mock, int line)
+{
+    mock.terminal.refreshRenderBuffer(true);
+    auto const buffer = mock.terminal.renderBuffer();
+    for (auto const& cell: buffer.get().cells)
+        if (cell.position.line == LineOffset(line) && cell.position.column == ColumnOffset(0))
+            return cell.attributes.backgroundColor;
+    for (auto const& row: buffer.get().lines)
+        if (row.lineOffset == LineOffset(line))
+            return row.fillAttributes.backgroundColor;
+    return {};
+}
+
+} // namespace
+
+TEST_CASE("Screen.osc3008 a line under a tinted context takes the tint", "[context]")
+{
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock);
+    auto const plain = mock.terminal.colorPalette().defaultBackground;
+
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("inside\r\n");
+
+    CHECK(backgroundAt(mock, 0) == RGBColor { 0x16, 0x1c, 0x26 });
+    CHECK(backgroundAt(mock, 0) != plain);
+}
+
+TEST_CASE("Screen.osc3008 a cell the application coloured itself is left alone", "[context]")
+{
+    // Otherwise `ls --color` inside a container comes out repainted, and a hint about who is running
+    // costs the user the output they ran it for.
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock);
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("\033[41mred\033[m\r\n");
+
+    // The scheme's own red, untouched: the tint stands in for the PAGE background and nothing else.
+    CHECK(backgroundAt(mock, 0) == mock.terminal.colorPalette().normalColor(1));
+}
+
+TEST_CASE("Screen.osc3008 tinting off silences a scheme that sets every slot", "[context]")
+{
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock, ContextTintScope::Off);
+    auto const plain = mock.terminal.colorPalette().defaultBackground;
+
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("inside\r\n");
+
+    CHECK(backgroundAt(mock, 0) == plain);
+}
+
+TEST_CASE("Screen.osc3008 the boundaries scope ignores a command tint", "[context]")
+{
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock, ContextTintScope::Boundaries);
+    auto const plain = mock.terminal.colorPalette().defaultBackground;
+
+    mock.writeToScreen(osc3008("start=cmd;type=command"));
+    mock.writeToScreen("ordinary\r\n");
+    CHECK(backgroundAt(mock, 0) == plain);
+
+    // The same scheme, the same slot, but a scope that admits it.
+    auto all = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(all, ContextTintScope::All);
+    all.writeToScreen(osc3008("start=cmd;type=command"));
+    all.writeToScreen("ordinary\r\n");
+    CHECK(backgroundAt(all, 0) == RGBColor { 0x14, 0x14, 0x14 });
+}
+
+TEST_CASE("Screen.osc3008 the alternate screen is never tinted", "[context]")
+{
+    // The equality guard would make it PATCHY there rather than uniform: a full-screen application
+    // paints most of its canvas with its own background, so only the cells it left at default would
+    // tint, and a striped vim reads as a rendering fault.
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock);
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("\033[?1049h");
+    mock.writeToScreen("full screen app\r\n");
+
+    CHECK(backgroundAt(mock, 0) != RGBColor { 0x16, 0x1c, 0x26 });
+}
+
+TEST_CASE("Screen.osc3008 a tinted line stays on the batched render path", "[context]")
+{
+    // The performance guard. A tint is uniform over a line, so it rides RenderLine::fillAttributes;
+    // demoting a trivial line to per-cell rendering because of one would be a serious regression.
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    tintContainers(mock);
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("plain text\r\n");
+    mock.terminal.refreshRenderBuffer(true);
+
+    auto const buffer = mock.terminal.renderBuffer();
+    CHECK(!buffer.get().lines.empty());
+    auto const tinted = std::ranges::any_of(buffer.get().lines, [](auto const& row) {
+        return row.fillAttributes.backgroundColor == RGBColor { 0x16, 0x1c, 0x26 };
+    });
+    CHECK(tinted);
+}
+
+TEST_CASE("Screen.osc3008 a scheme with no tints costs the render path nothing", "[context]")
+{
+    // hasContextTints() is false, so the per-line lookup is skipped for the overwhelmingly common case
+    // of a scheme that never opted in.
+    auto mock = MockTerm { PageSize { LineCount(4), ColumnCount(10) } };
+    CHECK(!mock.terminal.colorPalette().hasContextTints());
+
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("inside\r\n");
+    mock.terminal.refreshRenderBuffer(true);
+    CHECK(!mock.terminal.renderBuffer().get().lines.empty());
+}
+
+// }}}

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -261,3 +261,155 @@ TEST_CASE("Screen.osc3008 the effective working directory walks up the ancestry"
 }
 
 // }}}
+
+// {{{ line association
+
+TEST_CASE("Screen.osc3008 lines carry the context that wrote them", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    auto const first = mock.terminal.contexts().activeId();
+    mock.writeToScreen("first\r\n");
+
+    mock.writeToScreen(osc3008("end=one;exit=success"));
+    mock.writeToScreen(osc3008("start=two;type=command"));
+    auto const second = mock.terminal.contexts().activeId();
+    mock.writeToScreen("second\r\n");
+
+    auto const& screen = mock.terminal.primaryScreen();
+    CHECK(screen.contextIdAt(LineOffset(0)) == first);
+    CHECK(screen.contextIdAt(LineOffset(1)) == second);
+    CHECK(first != second);
+}
+
+TEST_CASE("Screen.osc3008 a line written before any context carries none", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen("before\r\n");
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    mock.writeToScreen("after\r\n");
+
+    auto const& screen = mock.terminal.primaryScreen();
+    CHECK(!screen.contextIdAt(LineOffset(0)));
+    CHECK(!!screen.contextIdAt(LineOffset(1)));
+}
+
+TEST_CASE("Screen.osc3008 a blank line inherits from the output above it", "[context]")
+{
+    // A run of blank lines below some output reads to a user as belonging to that output, and a line
+    // the cursor never moved onto carries no stamp of its own.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    auto const id = mock.terminal.contexts().activeId();
+    mock.writeToScreen("output\r\n");
+
+    auto const& screen = mock.terminal.primaryScreen();
+    CHECK(screen.contextIdAt(LineOffset(0)) == id);
+    CHECK(screen.contextIdAt(LineOffset(2)) == id); // never written to
+}
+
+TEST_CASE("Screen.osc3008 the stamp survives a scroll into history", "[context]")
+{
+    auto mock = MockTerm { PageSize { LineCount(3), ColumnCount(20) }, LineCount(10) };
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    auto const id = mock.terminal.contexts().activeId();
+    mock.writeToScreen("scrolled\r\n");
+    mock.writeToScreen("a\r\nb\r\nc\r\nd\r\n");
+
+    REQUIRE(mock.terminal.primaryScreen().historyLineCount() > LineCount(0));
+    CHECK(mock.terminal.primaryScreen().grid().lineAt(LineOffset(-3)).contextId() == id);
+}
+
+TEST_CASE("Screen.osc3008 a retired context still resolves for the lines it wrote", "[context]")
+{
+    // The record has to outlive end=, or the tint would vanish retroactively the moment a command
+    // exits.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=one;type=command;cwd=/tmp"));
+    auto const id = mock.terminal.contexts().activeId();
+    mock.writeToScreen("output\r\n");
+    mock.writeToScreen(osc3008("end=one;exit=success"));
+
+    REQUIRE(mock.terminal.contexts().depth() == 0);
+    auto const* const record = mock.terminal.contexts().find(id);
+    REQUIRE(record != nullptr);
+    CHECK(record->workingDirectory == "/tmp");
+    CHECK(record->outcome.exit == ContextExit::Success);
+}
+
+TEST_CASE("Screen.osc3008 line association survives a reflow", "[context]")
+{
+    // Unlike the two column offsets, the context is NOT head-only: it names who WROTE the line, and
+    // re-chopping a logical line into different physical pieces does not change the author of any
+    // piece. So every physical row of a wrapped logical line must still resolve after a resize.
+    auto mock = MockTerm { PageSize { LineCount(6), ColumnCount(10) }, LineCount(20) };
+    mock.terminal.setMode(DECMode::TextReflow, true);
+
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    auto const id = mock.terminal.contexts().activeId();
+    mock.writeToScreen("aaaaaaaaaabbbbbbbbbbcccccccccc"); // three physical rows at 10 columns
+
+    // Only rows holding part of the logical line: the row the cursor sits on is stamped too, and the
+    // property under test is that no PIECE of the wrapped line loses its author.
+    auto physicalRowsCarrying = [&](ContextId wanted) {
+        auto count = 0;
+        auto const& grid = mock.terminal.primaryScreen().grid();
+        auto const top = -unbox<int>(grid.historyLineCount());
+        for (auto i = top; i < unbox<int>(mock.terminal.pageSize().lines); ++i)
+        {
+            if (grid.lineText(LineOffset(i)).find_first_of("abc") == std::string::npos)
+                continue;
+            CHECK(grid.lineAt(LineOffset(i)).contextId() == wanted);
+            ++count;
+        }
+        return count;
+    };
+    REQUIRE(physicalRowsCarrying(id) == 3);
+
+    // Narrower: the logical line is re-split into more physical rows, all still that context's.
+    mock.terminal.resizeScreen(PageSize { LineCount(6), ColumnCount(5) });
+    CHECK(physicalRowsCarrying(id) == 6);
+
+    // Wider again: rejoined and re-split, and still that context's.
+    mock.terminal.resizeScreen(PageSize { LineCount(6), ColumnCount(15) });
+    CHECK(physicalRowsCarrying(id) == 2);
+}
+
+TEST_CASE("Screen.osc3008 a reflow keeps two contexts apart", "[context]")
+{
+    auto mock = MockTerm { PageSize { LineCount(8), ColumnCount(10) }, LineCount(20) };
+    mock.terminal.setMode(DECMode::TextReflow, true);
+
+    mock.writeToScreen(osc3008("start=one;type=command"));
+    auto const first = mock.terminal.contexts().activeId();
+    mock.writeToScreen("aaaaaaaaaaaaaaa\r\n");
+    mock.writeToScreen(osc3008("end=one;exit=success"));
+    mock.writeToScreen(osc3008("start=two;type=command"));
+    auto const second = mock.terminal.contexts().activeId();
+    mock.writeToScreen("bbbbbbbbbbbbbbb\r\n");
+
+    mock.terminal.resizeScreen(PageSize { LineCount(8), ColumnCount(5) });
+
+    // Counting only rows that hold content: the cursor's landing row is stamped too -- correctly, since
+    // it is where the next output goes -- and that is not what this case is about.
+    auto const& grid = mock.terminal.primaryScreen().grid();
+    auto seenFirst = 0;
+    auto seenSecond = 0;
+    auto const top = -unbox<int>(grid.historyLineCount());
+    for (auto i = top; i < unbox<int>(mock.terminal.pageSize().lines); ++i)
+    {
+        auto const text = grid.lineText(LineOffset(i));
+        if (text.find_first_of("ab") == std::string::npos)
+            continue;
+        auto const id = grid.lineAt(LineOffset(i)).contextId();
+        CHECK(id == (text.front() == 'a' ? first : second));
+        if (id == first)
+            ++seenFirst;
+        else if (id == second)
+            ++seenSecond;
+    }
+    CHECK(seenFirst == 3);
+    CHECK(seenSecond == 3);
+}
+
+// }}}

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/core/TerminalContext.hpp>
+#include <vtbackend/screen/Screen.hpp>
+#include <vtbackend/testing/MockTerm.hpp>
+#include <vtbackend/vt/Functions.hpp>
+
+#include <libunicode/convert.h>
+#include <libunicode/width.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+using namespace vtbackend;
+using namespace std::string_view_literals;
+
+namespace
+{
+
+/// Wraps @p body in `OSC 3008 ; ... ST`, exactly as an application would emit it.
+std::string osc3008(std::string_view body)
+{
+    return "\033]3008;" + std::string { body } + "\033\\";
+}
+
+/// A MockTerm with a page big enough for the traffic these cases push through it.
+MockTerm<> makeTerm()
+{
+    return MockTerm { PageSize { LineCount(6), ColumnCount(40) } };
+}
+
+} // namespace
+
+// {{{ registration
+
+TEST_CASE("Functions.OSC3008", "[context]")
+{
+    auto const availableSequences = SupportedSequences {};
+    auto const* const function = selectOSCommand(3008, availableSequences.activeSequences());
+    REQUIRE(function != nullptr);
+    CHECK(*function == HIERCONTEXT);
+    CHECK(function->documentation.mnemonic == "HIERCONTEXT");
+}
+
+// }}}
+// {{{ dispatch
+
+TEST_CASE("Screen.osc3008 start establishes an active context", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell;cwd=/home/user"));
+
+    auto const& contexts = mock.terminal.contexts();
+    REQUIRE(contexts.active() != nullptr);
+    CHECK(contexts.active()->identifier == "shell-a");
+    CHECK(contexts.active()->type == ContextType::Shell);
+    CHECK(contexts.active()->workingDirectory == "/home/user");
+    CHECK(contexts.depth() == 1);
+}
+
+TEST_CASE("Screen.osc3008 end pops the context", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell"));
+    mock.writeToScreen(osc3008("start=cmd-1;type=command"));
+    REQUIRE(mock.terminal.contexts().depth() == 2);
+
+    mock.writeToScreen(osc3008("end=cmd-1;exit=failure;status=139;signal=SIGSEGV"));
+
+    auto const& contexts = mock.terminal.contexts();
+    CHECK(contexts.depth() == 1);
+    CHECK(contexts.active()->identifier == "shell-a");
+}
+
+TEST_CASE("Screen.osc3008 a malformed payload leaves the stack untouched", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell"));
+    auto const before = mock.terminal.contexts().revision();
+
+    mock.writeToScreen(osc3008("garbage"));
+    mock.writeToScreen(osc3008("start="));
+    mock.writeToScreen(osc3008("start=" + std::string(65, 'x')));
+
+    CHECK(mock.terminal.contexts().revision() == before);
+    CHECK(mock.terminal.contexts().depth() == 1);
+}
+
+TEST_CASE("Screen.osc3008 replies nothing", "[context]")
+{
+    // The protocol has no query form. A stray reply would be written to the shell's stdin as if the
+    // user had typed it.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell;cwd=/tmp"));
+    mock.writeToScreen(osc3008("end=shell-a;exit=success"));
+    mock.writeToScreen(osc3008("nonsense"));
+
+    CHECK(mock.terminal.peekInput().empty());
+}
+
+TEST_CASE("Screen.osc3008 an empty payload is rejected without disturbing the stack", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell"));
+
+    mock.writeToScreen("\033]3008\033\\");
+
+    CHECK(mock.terminal.contexts().depth() == 1);
+}
+
+// }}}
+// {{{ reset immunity -- the property most likely to break silently
+
+TEST_CASE("Screen.osc3008 survives a hard reset", "[context]")
+{
+    // UAPI.15 makes this a SAFETY property, not a convenience: "the usual terminal reset sequences
+    // should not affect the stack of contexts ... a program down the stack should not be able to
+    // affect the stack further up, possibly hiding relevant information".
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container;container=foobar"));
+    mock.writeToScreen(osc3008("start=shell-a;type=shell"));
+    REQUIRE(mock.terminal.contexts().depth() == 2);
+
+    mock.writeToScreen("\033c"); // RIS
+
+    auto const& contexts = mock.terminal.contexts();
+    CHECK(contexts.depth() == 2);
+    CHECK(contexts.chain().front().record->type == ContextType::Container);
+    CHECK(contexts.active()->identifier == "shell-a");
+}
+
+TEST_CASE("Screen.osc3008 survives a soft reset", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    REQUIRE(mock.terminal.contexts().depth() == 1);
+
+    mock.writeToScreen("\033[!p"); // DECSTR
+
+    CHECK(mock.terminal.contexts().depth() == 1);
+    CHECK(mock.terminal.contexts().active()->type == ContextType::Container);
+}
+
+TEST_CASE("Screen.osc3008 a hard reset clears the grid but not the ancestry", "[context]")
+{
+    // Pinning both halves together, because the bug this guards against is a future "tidy" of
+    // hardReset() that adds the stack to the list of things it clears.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen("some output");
+    REQUIRE(mock.terminal.primaryScreen().grid().lineText(LineOffset(0)).starts_with("some output"));
+
+    mock.writeToScreen("\033c");
+
+    CHECK(!mock.terminal.primaryScreen().grid().lineText(LineOffset(0)).starts_with("some output"));
+    CHECK(mock.terminal.contexts().depth() == 1);
+}
+
+// }}}
+// {{{ screen and page independence
+
+TEST_CASE("Screen.osc3008 survives a screen switch", "[context]")
+{
+    // The ancestry describes the APPLICATION's process tree: vim running in a container is still in
+    // that container while the alternate screen is up.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container"));
+
+    mock.writeToScreen("\033[?1049h"); // to the alternate screen
+    CHECK(mock.terminal.contexts().depth() == 1);
+
+    mock.writeToScreen("\033[?1049l"); // and back
+    CHECK(mock.terminal.contexts().depth() == 1);
+    CHECK(mock.terminal.contexts().active()->type == ContextType::Container);
+}
+
+TEST_CASE("Screen.osc3008 a context started on the alternate screen is still there afterwards", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen("\033[?1049h");
+    mock.writeToScreen(osc3008("start=app;type=app"));
+    mock.writeToScreen("\033[?1049l");
+
+    CHECK(mock.terminal.contexts().depth() == 1);
+    CHECK(mock.terminal.contexts().active()->type == ContextType::App);
+}
+
+// }}}
+// {{{ notification gating
+
+TEST_CASE("Screen.osc3008 a context change notifies once", "[context]")
+{
+    auto mock = makeTerm();
+    auto const announcement = "start=shell-a;type=shell;cwd=/home/user;pid=1234"sv;
+
+    mock.writeToScreen(osc3008(announcement));
+    auto const afterFirst = mock.terminal.contexts().revision();
+
+    // systemd re-announces the shell context on EVERY prompt with byte-identical metadata. Reporting a
+    // change for that would redraw the frontend once per prompt for nothing.
+    for (auto i = 0; i < 10; ++i)
+        mock.writeToScreen(osc3008(announcement));
+
+    CHECK(mock.terminal.contexts().revision() == afterFirst);
+    CHECK(mock.terminal.contexts().depth() == 1);
+    CHECK(mock.terminal.contexts().retainedCount() == 1);
+}
+
+// }}}
+// {{{ the real traffic
+
+TEST_CASE("Screen.osc3008 the systemd prompt cycle replays", "[context]")
+{
+    // Three commands through the cycle /etc/profile.d/80-systemd-osc-context.sh actually emits, with
+    // real output in between, driven through the real parser.
+    auto mock = makeTerm();
+    auto const common = ";machineid=3deb5353d3ba43d08201c136a47ead7b;user=lennart;hostname=zeta"
+                        ";bootid=d4a3d0fdf2e24fdea6d971ce73f4fbf2;pid=1062862;cwd=/home/lennart"sv;
+
+    for (auto const& [index, command]:
+         std::vector<std::pair<int, std::string_view>> { { 0, "cmd-1" }, { 1, "cmd-2" }, { 2, "cmd-3" } })
+    {
+        (void) index;
+        // PROMPT_COMMAND: announce (or re-announce) the shell context.
+        mock.writeToScreen(osc3008("start=shell-uuid;type=shell" + std::string { common }));
+        mock.writeToScreen("$ ");
+
+        // PS0: push the command context.
+        mock.writeToScreen(
+            osc3008("start=" + std::string { command } + ";type=command" + std::string { common }));
+        CHECK(mock.terminal.contexts().depth() == 2);
+        mock.writeToScreen("output\r\n");
+
+        // The next PROMPT_COMMAND closes it.
+        mock.writeToScreen(osc3008("end=" + std::string { command } + ";exit=success"));
+        CHECK(mock.terminal.contexts().depth() == 1);
+    }
+
+    auto const& contexts = mock.terminal.contexts();
+    CHECK(contexts.active()->identifier == "shell-uuid");
+    CHECK(contexts.retainedCount() == 4); // one shell + three commands
+    CHECK(mock.terminal.peekInput().empty());
+}
+
+TEST_CASE("Screen.osc3008 the effective working directory walks up the ancestry", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-a;type=shell;cwd=/home/user"
+                               ";machineid=3deb5353d3ba43d08201c136a47ead7b"));
+    // A command context with no cwd= of its own, which is what systemd sends when nothing changed.
+    mock.writeToScreen(osc3008("start=cmd-1;type=command"));
+
+    auto const self = LocalIdentity { .machineId = "3deb5353d3ba43d08201c136a47ead7b", .hostname = "zeta" };
+    auto const cwd = mock.terminal.contexts().effectiveWorkingDirectory(self);
+
+    REQUIRE(cwd.has_value());
+    CHECK(cwd->path == "/home/user");
+    CHECK(cwd->locality == ContextLocality::Local);
+}
+
+// }}}

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -611,3 +611,26 @@ TEST_CASE("Screen.osc3008 fires no callbacks during its first, undecided cycle",
 }
 
 // }}}
+
+// {{{ the enabled gate
+
+TEST_CASE("Screen.osc3008 is not read at all when signalling is disabled", "[context]")
+{
+    // The single gate, and what it is worth: it is checked where the sequence ENTERS, so the ancestry
+    // stays empty -- and with it the breadcrumb, the page tint, the derived marks and what a daemon
+    // replicates, none of which needs a flag of its own. The configuration's `enabled: false`
+    // promises exactly this ("nothing is tracked, nothing is derived and nothing is tinted").
+    auto mock = makeTerm();
+    mock.terminal.settings().contextSignalling = ContextSignalling::Disabled;
+
+    mock.writeToScreen("\033]3008;start=abc;type=container;container=foobar\033\\");
+
+    CHECK(mock.terminal.contexts().depth() == 0);
+    CHECK(!mock.terminal.contexts().activeId());
+    CHECK(mock.terminal.contexts().active() == nullptr);
+
+    // And with nothing on the ancestry the breadcrumb collapses, rather than being separately silenced.
+    CHECK(mock.terminal.contexts().chain().empty());
+}
+
+// }}}

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/screen/Screen.hpp>
+#include <vtbackend/screen/StatusLineBuilder.hpp>
 #include <vtbackend/testing/MockTerm.hpp>
 #include <vtbackend/vt/Functions.hpp>
 
@@ -765,6 +766,181 @@ TEST_CASE("Screen.osc3008 a scheme with no tints costs the render path nothing",
     mock.writeToScreen("inside\r\n");
     mock.terminal.refreshRenderBuffer(true);
     CHECK(!mock.terminal.renderBuffer().get().lines.empty());
+}
+
+// }}}
+
+// {{{ the breadcrumb
+
+namespace
+{
+
+/// The `{Context}` segment as it would be written into the indicator status line.
+std::string breadcrumb(
+    MockTerm<>& mock,
+    StatusLineDefinitions::ContextVerbosity verbosity = StatusLineDefinitions::ContextVerbosity::Boundaries,
+    ColumnCount maxWidth = ColumnCount(32))
+{
+    auto item = StatusLineDefinitions::Context {};
+    item.verbosity = verbosity;
+    item.maxWidth = maxWidth;
+    auto const segment = StatusLineSegment { item };
+    return serializeToVT(mock.terminal, segment, StatusLineStyling::Disabled);
+}
+
+} // namespace
+
+TEST_CASE("Screen.osc3008 an empty ancestry renders no breadcrumb", "[context]")
+{
+    auto mock = makeTerm();
+    CHECK(breadcrumb(mock).empty());
+}
+
+TEST_CASE("Screen.osc3008 a shell-and-command-only session renders no breadcrumb", "[context]")
+{
+    // The property that lets this ship in the DEFAULT status line: on a stock systemd install the
+    // shim emits only session/shell/command, so an ordinary session pays nothing for the segment.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=session-1;type=session"));
+    mock.writeToScreen(osc3008("start=shell-1;type=shell;comm=bash"));
+    mock.writeToScreen(osc3008("start=cmd-1;type=command;comm=ls"));
+
+    CHECK(breadcrumb(mock).empty());
+}
+
+TEST_CASE("Screen.osc3008 a container renders with its type prefix", "[context]")
+{
+    // A bare name reads like a hostname, so the type goes in front -- while a hostname and a user are
+    // self-describing in position and take none.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container;container=foobar"));
+
+    CHECK(breadcrumb(mock) == "container:foobar");
+}
+
+TEST_CASE("Screen.osc3008 an elevate renders its target user without a prefix", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=root;type=elevate;targetuser=root"));
+
+    CHECK(breadcrumb(mock) == "root");
+}
+
+TEST_CASE("Screen.osc3008 an elevate to the session's own user renders nothing", "[context]")
+{
+    // run0 while already root is not news -- and suppressing it removes the commonest honest false
+    // positive, so a SPOOFED one has to actually differ before it appears at all.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=outer;type=session;user=root"));
+    mock.writeToScreen(osc3008("start=elev;type=elevate;targetuser=root"));
+
+    CHECK(breadcrumb(mock).empty());
+}
+
+TEST_CASE("Screen.osc3008 a full ancestry reads root-first", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=s;type=session;user=lennart;hostname=zeta"));
+    mock.writeToScreen(osc3008("start=box;type=container;container=foobar"));
+    mock.writeToScreen(osc3008("start=root;type=elevate;targetuser=root"));
+    mock.writeToScreen(osc3008("start=app;type=app;comm=vim"));
+
+    CHECK(breadcrumb(mock, StatusLineDefinitions::ContextVerbosity::Full, ColumnCount(80))
+          == "zeta › container:foobar › root › vim");
+}
+
+TEST_CASE("Screen.osc3008 the Active verbosity shows the innermost context alone", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container;container=foobar"));
+    mock.writeToScreen(osc3008("start=app;type=app;comm=vim"));
+
+    CHECK(breadcrumb(mock, StatusLineDefinitions::ContextVerbosity::Active, ColumnCount(80)) == "vim");
+}
+
+TEST_CASE("Screen.osc3008 an over-long breadcrumb elides its middle and keeps both ends", "[context]")
+{
+    // The first segment answers *where* and the last answers *who*; the ones between are the least
+    // costly to lose.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=s;type=session;hostname=zeta"));
+    mock.writeToScreen(osc3008("start=box;type=container;container=a-rather-long-container-name"));
+    mock.writeToScreen(osc3008("start=root;type=elevate;targetuser=root"));
+
+    auto const text = breadcrumb(mock, StatusLineDefinitions::ContextVerbosity::Full, ColumnCount(20));
+    CHECK(text.starts_with("zeta"));
+    CHECK(text.ends_with("root"));
+    CHECK(text.contains("…"));
+}
+
+TEST_CASE("Screen.osc3008 a single over-long segment is cut on a codepoint boundary", "[context]")
+{
+    // The last resort of the elision: the innermost segment alone, cut at its own START. Cutting one
+    // BYTE at a time left the result beginning on a UTF-8 continuation byte -- mojibake on screen, and
+    // an invalid sequence handed to writeToScreenInternal(), which parses it.
+    auto mock = makeTerm();
+    // Eight double-width CJK codepoints: 24 bytes, 16 columns, and no byte boundary that is also a
+    // codepoint boundary except every third one.
+    mock.writeToScreen(osc3008("start=box;type=container;container=容器容器容器容器"));
+
+    auto const text = breadcrumb(mock, StatusLineDefinitions::ContextVerbosity::Full, ColumnCount(8));
+
+    // Every byte of the result decodes: a lone continuation byte would round-trip to U+FFFD.
+    auto const decoded = unicode::convert_to<char32_t>(std::string_view { text });
+    CHECK(std::ranges::none_of(decoded, [](char32_t cp) { return cp == U'�'; }));
+    CHECK(text.starts_with("…"));
+    CHECK(text.ends_with("器")); // the TAIL survives: it is the part that identifies the context
+
+    // And the ellipsis is BUDGETED for rather than added on top, so the whole thing fits.
+    auto columns = 0;
+    for (auto const codepoint: decoded)
+        columns += static_cast<int>(unicode::width(codepoint));
+    CHECK(columns <= 8);
+}
+
+TEST_CASE("Screen.osc3008 control bytes in a context field never reach the status screen", "[context]")
+{
+    // Defence in depth: this string is handed to writeToScreenInternal(), which PARSES it. The
+    // decoder already rejects control bytes, so one arriving here would mean a parser bug -- and
+    // without the strip, that bug would be an injection able to clear the status screen from a field
+    // any program on the tty can write.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container;container=safe"));
+
+    // Reach past the sequence decoder, as a parser bug would.
+    auto record = *mock.terminal.contexts().active();
+    record.container = "ev\033[2Jil";
+    mock.terminal.adoptContext(record);
+
+    // The ESC is what makes the rest a SEQUENCE; strip it and "[2J" is inert text on the status line.
+    auto const text = breadcrumb(mock);
+    CHECK(!text.contains('\033'));
+    CHECK(text == "container:ev[2Jil");
+}
+
+TEST_CASE("Screen.osc3008 the breadcrumb round-trips through the status-line serializer", "[context]")
+{
+    auto item = StatusLineDefinitions::Context {};
+    item.verbosity = StatusLineDefinitions::ContextVerbosity::Full;
+    item.separator = " | ";
+    item.maxWidth = ColumnCount(40);
+
+    auto const written = serializeStatusLineSegment(StatusLineSegment { item });
+    auto const parsed = parseStatusLineSegment(written);
+
+    REQUIRE(parsed.size() == 1);
+    auto const* const back = std::get_if<StatusLineDefinitions::Context>(&parsed.front());
+    REQUIRE(back != nullptr);
+    CHECK(back->verbosity == StatusLineDefinitions::ContextVerbosity::Full);
+    CHECK(back->separator == " | ");
+    CHECK(back->maxWidth == ColumnCount(40));
+}
+
+TEST_CASE("Screen.osc3008 a default breadcrumb writes no redundant attributes", "[context]")
+{
+    // A config Contour wrote must not gain noise when it writes it again.
+    auto const written = serializeStatusLineSegment(StatusLineSegment { StatusLineDefinitions::Context {} });
+    CHECK(written == "{Context}");
 }
 
 // }}}

--- a/src/vtbackend/screen/Screen_context_test.cpp
+++ b/src/vtbackend/screen/Screen_context_test.cpp
@@ -413,3 +413,201 @@ TEST_CASE("Screen.osc3008 a reflow keeps two contexts apart", "[context]")
 }
 
 // }}}
+
+// {{{ synthesised semantic marks
+
+namespace
+{
+
+/// The systemd prompt cycle for one command, as PROMPT_COMMAND and PS0 actually emit it.
+void systemdCycle(MockTerm<>& mock, std::string_view commandId, std::string_view previousCommandId = {})
+{
+    // The real order, which is what makes the synthesised marks land where OSC 133's would:
+    //   PROMPT_COMMAND closes the previous command, then re-announces the shell context (before the
+    //   prompt is painted), the prompt is painted, the user's command line and its Enter are echoed,
+    //   and only THEN does PS0 fire -- with the cursor already at the start of the output area.
+    if (!previousCommandId.empty())
+        mock.writeToScreen(osc3008("end=" + std::string { previousCommandId } + ";exit=success"));
+    mock.writeToScreen(osc3008("start=shell-uuid;type=shell;cwd=/home/user"));
+    mock.writeToScreen("$ ls\r\n");
+    mock.writeToScreen(osc3008("start=" + std::string { commandId } + ";type=command;cwd=/home/user"));
+    mock.writeToScreen("output\r\n");
+}
+
+/// Whether the logical line at @p line carries @p flag.
+bool lineHas(MockTerm<>& mock, int line, LineFlag flag)
+{
+    return mock.terminal.primaryScreen().isLogicalLineFlagEnabled(LineOffset(line), flag);
+}
+
+} // namespace
+
+TEST_CASE("Screen.osc3008 synthesises the OSC 133 marks when 133 is silent", "[context]")
+{
+    auto mock = makeTerm();
+
+    // The FIRST cycle pushes the shell context, and a push marks nothing: systemd opens it when
+    // profile.d is sourced, which can be arbitrarily far above the prompt. So the prompt mark appears
+    // from the second cycle on, where the shell context is UPDATED.
+    systemdCycle(mock, "cmd-1");
+    // Line 0 is the prompt+command line; line 1 is where output begins.
+    CHECK(lineHas(mock, 1, LineFlag::OutputStart)); // type=command start stands in for 133;C
+    CHECK(!lineHas(mock, 0, LineFlag::Marked));     // the shell context was PUSHED, not updated
+
+    mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+    CHECK(lineHas(mock, 2, LineFlag::CommandEnd)); // where the output left the cursor -> 133;D
+
+    // Second cycle: the shell context is re-announced, which IS the prompt boundary -> 133;A.
+    systemdCycle(mock, "cmd-2");
+    CHECK(lineHas(mock, 2, LineFlag::Marked));
+    CHECK(lineHas(mock, 3, LineFlag::OutputStart));
+}
+
+TEST_CASE("Screen.osc3008 never synthesises PromptEnd", "[context]")
+{
+    // OSC 3008 has no event at the prompt/input border: its type=command context is announced from
+    // PS0, after the user pressed Enter, by which time the cursor has left the prompt line. Guessing
+    // would put the mark on the wrong line AND the wrong column.
+    auto mock = makeTerm();
+    systemdCycle(mock, "cmd-1");
+    mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+    systemdCycle(mock, "cmd-2");
+
+    for (auto line = 0; line < 5; ++line)
+        CHECK(!lineHas(mock, line, LineFlag::PromptEnd));
+}
+
+TEST_CASE("Screen.osc3008 stamps nothing once OSC 133 has spoken", "[context]")
+{
+    auto mock = makeTerm();
+    mock.writeToScreen("\033]133;A\033\\"); // a shell integration is installed
+    mock.writeToScreen("$ ");
+    mock.writeToScreen("\033]133;B\033\\");
+    mock.writeToScreen("\r\n");
+
+    // Now the systemd stream arrives too, on a fresh line that 133 has not marked.
+    mock.writeToScreen(osc3008("start=shell-uuid;type=shell"));
+    mock.writeToScreen(osc3008("start=cmd-1;type=command"));
+
+    CHECK(!lineHas(mock, 1, LineFlag::Marked));
+    CHECK(!lineHas(mock, 1, LineFlag::OutputStart));
+    CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+}
+
+TEST_CASE("Screen.osc3008 the initial shell context push marks nothing", "[context]")
+{
+    // systemd opens the shell context when profile.d is sourced, which can be arbitrarily far above
+    // the first prompt -- above the motd. A mark there would land on it.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=shell-uuid;type=shell"));
+
+    CHECK(!lineHas(mock, 0, LineFlag::Marked));
+}
+
+TEST_CASE("Screen.osc3008 a boundary context never synthesises a mark", "[context]")
+{
+    // run0's elevate and systemd-nspawn's container contexts are announced wherever the cursor happens
+    // to be, so they carry no positional guarantee at all.
+    auto mock = makeTerm();
+    mock.writeToScreen(osc3008("start=box;type=container"));
+    mock.writeToScreen(osc3008("start=root;type=elevate"));
+    mock.writeToScreen(osc3008("start=ssh;type=remote"));
+
+    CHECK(!lineHas(mock, 0, LineFlag::Marked));
+    CHECK(!lineHas(mock, 0, LineFlag::OutputStart));
+    CHECK(!lineHas(mock, 0, LineFlag::CommandEnd));
+}
+
+TEST_CASE("Screen.osc3008 the arbiter survives RIS and DECSTR", "[context]")
+{
+    // Like the ancestry, it describes the shells attached to the pty rather than the screen: a program
+    // emitting RIS must not be able to flip which protocol owns the user's markers.
+    auto mock = makeTerm();
+    mock.writeToScreen("\033]133;A\033\\");
+    REQUIRE(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+
+    mock.writeToScreen("\033c");
+    CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+
+    mock.writeToScreen("\033[!p");
+    CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+}
+
+TEST_CASE("Screen.osc3008 the first prompt race resolves to shell integration either way", "[context]")
+{
+    SECTION("133 first, then 3008 -- the shipped Fedora ordering")
+    {
+        auto mock = makeTerm();
+        mock.writeToScreen("\033]133;A\033\\");
+        mock.writeToScreen(osc3008("start=shell-uuid;type=shell"));
+        mock.writeToScreen(osc3008("start=cmd-1;type=command"));
+        mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+
+        CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+    }
+
+    SECTION("3008 first, then 133 -- a user integration appended after systemd's")
+    {
+        auto mock = makeTerm();
+        mock.writeToScreen(osc3008("start=shell-uuid;type=shell"));
+        mock.writeToScreen(osc3008("start=cmd-1;type=command"));
+        mock.writeToScreen("\033]133;A\033\\");
+        mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+
+        // 3008 stamped a flag or two before 133 spoke, which is harmless -- both land on the same
+        // logical line head, and a flag is an idempotent bit. What matters is that 133 owns it now.
+        CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ShellIntegration);
+    }
+}
+
+TEST_CASE("Screen.osc3008 synthesised marks drive folding", "[context]")
+{
+    // The payoff: a Fedora user with no shell integration installed gets fold ranges, mark navigation
+    // and "copy last command output" for free. computeFoldRanges reads exactly the three flags OSC
+    // 3008 can supply and never touches PromptEnd, so folding is fully correct on synthesised marks.
+    auto mock = MockTerm { PageSize { LineCount(12), ColumnCount(40) } };
+    systemdCycle(mock, "cmd-1");
+    mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+    systemdCycle(mock, "cmd-2");
+    mock.writeToScreen(osc3008("end=cmd-2;exit=success"));
+    systemdCycle(mock, "cmd-3");
+
+    CHECK(!mock.terminal.foldRanges().empty());
+}
+
+TEST_CASE("Screen.osc3008 drives the semantic block tracker once it owns the session", "[context]")
+{
+    auto mock = makeTerm();
+    mock.terminal.semanticBlockTracker().setEnabled(true);
+
+    systemdCycle(mock, "cmd-1");
+    mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+    // The first cycle only DECIDES; the callbacks start with the second.
+    systemdCycle(mock, "cmd-2");
+    mock.writeToScreen(osc3008("end=cmd-2;exit=failure;status=139;signal=SIGSEGV"));
+
+    // commandFinished() marks the CURRENT block; it moves to completedBlocks on the next prompt.
+    auto const& current = mock.terminal.semanticBlockTracker().currentBlock();
+    REQUIRE(current.has_value());
+    CHECK(current->finished);
+    // 128+11, as every POSIX shell spells a SIGSEGV death -- which OSC 133;D, carrying only a numeric
+    // exit code, cannot distinguish from a command that merely returned 139.
+    CHECK(current->exitCode == 139);
+}
+
+TEST_CASE("Screen.osc3008 fires no callbacks during its first, undecided cycle", "[context]")
+{
+    // The cost of deferring, stated plainly: with no OSC 133 anywhere, the session's FIRST command
+    // block gets line flags but no tracker entry. One block, once, in a protocol that is off by
+    // default -- cheaper than letting a cmdline-less 3008 command clobber a good cmdline_url.
+    auto mock = makeTerm();
+    mock.terminal.semanticBlockTracker().setEnabled(true);
+
+    systemdCycle(mock, "cmd-1");
+    mock.writeToScreen(osc3008("end=cmd-1;exit=success"));
+
+    CHECK(mock.terminal.semanticBlockTracker().completedBlocks().empty());
+    CHECK(mock.terminal.markArbiter().owner() == MarkOwner::ContextSignalling);
+}
+
+// }}}

--- a/src/vtbackend/screen/Settings.hpp
+++ b/src/vtbackend/screen/Settings.hpp
@@ -2,8 +2,10 @@
 
 #include <vtbackend/core/ColorPalette.hpp>
 #include <vtbackend/core/Primitives.hpp>
+#include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/input/InputGenerator.hpp> // Modifier
 #include <vtbackend/shell/Folding.hpp>        // FoldJumpBehavior
+#include <vtbackend/shell/MarkArbiter.hpp>
 #include <vtbackend/vt/Charset.hpp>
 #include <vtbackend/vt/RectangularAreaChecksum.hpp>
 #include <vtbackend/vt/VTType.hpp>
@@ -123,6 +125,16 @@ struct Settings
     /// space available to cells, so a page fitted with one and a renderer drawing without it (or vice
     /// versa) put the grid in two different places.
     bool foldMarkers = false;
+
+    /// OSC 3008 hierarchical context signalling.
+    ///
+    /// Whether the sequence is read at all is ONE flag, honoured at the point the sequence enters the
+    /// emulation; the two below then describe only what to do with an ancestry that exists. @see
+    /// ContextSignalling for why the gate is here rather than folded into each of them.
+    ContextSignalling contextSignalling = ContextSignalling::Enabled;
+    ContextStackLimits contextLimits {};
+    ContextMarkPolicy contextMarkPolicy = ContextMarkPolicy::WhenAlone;
+    ContextTintScope contextTintScope = ContextTintScope::Boundaries;
 
     /// Whether a finished command's output is folded away as soon as the next prompt starts, so
     /// that only the command running now is shown in full. Off by default: folding output the user

--- a/src/vtbackend/screen/Settings.hpp
+++ b/src/vtbackend/screen/Settings.hpp
@@ -68,7 +68,9 @@ struct Settings
     struct
     {
         std::string left { "{VTType} │ {InputMode:Bold,Color=#C0C030}{SearchPrompt:Left= │ }"
-                           "{TraceMode:Bold,Color=#FFFF00,Left= │ }{ProtectedMode:Bold,Left= │ }" };
+                           "{TraceMode:Bold,Color=#FFFF00,Left= │ }{ProtectedMode:Bold,Left= │ }"
+                           // Collapses to nothing without a privilege or machine boundary.
+                           "{Context:Left= │ }" };
         std::string middle { "{Title:Left= « ,Right= » ,Color=#20c0c0}" };
         std::string right { "{HistoryLineCount:Faint,Color=#c0c0c0} │ {Clock:Bold} " };
     } indicatorStatusLine;

--- a/src/vtbackend/screen/StatusLineBuilder.cpp
+++ b/src/vtbackend/screen/StatusLineBuilder.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <ctime>
 #include <format>
+#include <iterator>
 #include <optional>
 #include <ranges>
 #include <system_error>
@@ -89,6 +90,18 @@ static std::optional<StatusLineDefinitions::Item> makeItemOfType(
         return StatusLineDefinitions::Text {
             styles, tryParseStringAttribute(interpolation, "text").value_or(std::string {})
         };
+    }
+    else if constexpr (std::same_as<T, StatusLineDefinitions::Context>)
+    {
+        auto item = StatusLineDefinitions::Context {};
+        static_cast<StatusLineDefinitions::Styles&>(item) = styles;
+        if (auto const verbosity = tryParseStringAttribute(interpolation, "Verbosity"))
+            item.verbosity = StatusLineDefinitions::contextVerbosityFrom(*verbosity);
+        item.separator = tryParseStringAttribute(interpolation, "Separator");
+        if (auto const width = tryParseStringAttribute(interpolation, "MaxWidth"))
+            if (auto const columns = crispy::toInteger<10, int>(*width); columns && *columns > 0)
+                item.maxWidth = ColumnCount(*columns);
+        return item;
     }
     else if constexpr (std::same_as<T, StatusLineDefinitions::Tabs>)
     {
@@ -462,6 +475,229 @@ namespace
             return std::format("{}", vt.operatingLevel());
         }
 
+        /// How one context type reads in a breadcrumb.
+        ///
+        /// A TABLE rather than a switch chain, and the prefix column is why: `container:foobar` needs
+        /// its type in front because a bare name reads like a hostname, while `zeta` and `root` are
+        /// self-describing in position. That rule lives here, one row per type, rather than being
+        /// re-decided at each call site.
+        struct SegmentRule
+        {
+            ContextType type;
+            std::string_view prefix; ///< "" for none.
+            /// Fields tried in order; the first non-empty one is shown.
+            std::array<ContextField, 2> fields;
+        };
+
+        /// Which field to show for each type. WHETHER a type is shown at the default verbosity is not
+        /// a column here: that is isBoundaryContext(), and stating it twice is how the tint and the
+        /// breadcrumb would come to disagree about what a boundary is.
+        static constexpr auto SegmentRules = std::array {
+            SegmentRule { ContextType::Remote, "", { ContextField::TargetHost, ContextField::Hostname } },
+            SegmentRule {
+                ContextType::Container, "container:", { ContextField::Container, ContextField::Comm } },
+            SegmentRule { ContextType::Vm, "vm:", { ContextField::Vm, ContextField::Comm } },
+            SegmentRule { ContextType::Elevate, "", { ContextField::TargetUser, ContextField::User } },
+            SegmentRule {
+                ContextType::ChangePrivileges, "", { ContextField::TargetUser, ContextField::User } },
+            // A session names WHERE, which is why the issue's example reads "zeta > container:foobar
+            // > root > vim": the hostname comes from the outermost context.
+            SegmentRule { ContextType::Session, "", { ContextField::Hostname, ContextField::User } },
+            SegmentRule { ContextType::Boot, "", { ContextField::Hostname, ContextField::Comm } },
+            SegmentRule { ContextType::Service, "", { ContextField::Comm, ContextField::User } },
+            SegmentRule { ContextType::Shell, "", { ContextField::Comm, ContextField::User } },
+            SegmentRule { ContextType::Command, "", { ContextField::Comm, ContextField::CommandLine } },
+            SegmentRule { ContextType::App, "", { ContextField::Comm, ContextField::User } },
+            SegmentRule { ContextType::Subcontext, "", { ContextField::TargetUser, ContextField::User } },
+        };
+
+        static_assert(SegmentRules.size() == ContextTypeList.size(),
+                      "A ContextType was added or removed. Give it a SegmentRule row, or the breadcrumb "
+                      "falls back to comm= for it without anything saying so.");
+
+        /// The value @p field names on @p record, or empty when it was not supplied.
+        ///
+        /// Generated from VTBACKEND_CONTEXT_FIELDS, so a sixteenth textual field is reachable from a
+        /// SegmentRule the moment it exists. Written out by hand, a row naming a field the switch had
+        /// forgotten yielded a silently empty segment.
+        [[nodiscard]] static std::string_view fieldOf(TerminalContext const& record, ContextField field)
+        {
+            if (!(record.present & field).any())
+                return {};
+            switch (field)
+            {
+// Only the textual kinds have a std::string to view; Enum and Uint64 fall to the default below.
+#define VTBACKEND_CONTEXT_FIELD_OF_Text(Name, Member) \
+    case ContextField::Name: return record.Member;
+#define VTBACKEND_CONTEXT_FIELD_OF_OptionalText(Name, Member) \
+    case ContextField::Name: return record.Member;
+#define VTBACKEND_CONTEXT_FIELD_OF_Id128(Name, Member) \
+    case ContextField::Name: return record.Member;
+#define VTBACKEND_CONTEXT_FIELD_OF_Uint64(Name, Member)
+#define VTBACKEND_CONTEXT_FIELD_OF_Enum(Name, Member)
+#define VTBACKEND_CONTEXT_FIELD_OF(Name, Bit, Spelling, Member, Kind, Max) \
+    VTBACKEND_CONTEXT_FIELD_OF_##Kind(Name, Member)
+                VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_OF)
+#undef VTBACKEND_CONTEXT_FIELD_OF
+#undef VTBACKEND_CONTEXT_FIELD_OF_Enum
+#undef VTBACKEND_CONTEXT_FIELD_OF_Uint64
+#undef VTBACKEND_CONTEXT_FIELD_OF_Id128
+#undef VTBACKEND_CONTEXT_FIELD_OF_OptionalText
+#undef VTBACKEND_CONTEXT_FIELD_OF_Text
+                default: return {};
+            }
+        }
+
+        /// Strips anything a terminal would INTERPRET.
+        ///
+        /// Defence in depth, and not theoretical: this string is handed to writeToScreenInternal(),
+        /// which parses it. The sequence decoder already rejects control bytes, so one arriving here
+        /// means a parser bug -- and without this, that bug would be an injection able to clear the
+        /// status screen from a field any program on the tty can write.
+        [[nodiscard]] static std::string sanitized(std::string_view text)
+        {
+            auto out = std::string {};
+            out.reserve(text.size());
+            for (auto const ch: text)
+                if (static_cast<unsigned char>(ch) >= 0x20 && static_cast<unsigned char>(ch) != 0x7f)
+                    out.push_back(ch);
+            return out;
+        }
+
+        /// How @p record reads in a breadcrumb at @p verbosity, or empty when it says nothing worth
+        /// showing.
+        [[nodiscard]] static std::string segmentFor(TerminalContext const& record,
+                                                    TerminalContext const* outermost,
+                                                    StatusLineDefinitions::ContextVerbosity verbosity)
+        {
+            // Plain `auto`, never `auto const*`: std::array's const_iterator is a raw pointer only in
+            // libstdc++. The MSVC STL wraps it in a class, so the pointer form fails to deduce there --
+            // which is exactly why .clang-tidy disables readability-qualified-auto.
+            auto const rule = std::ranges::find_if(
+                SegmentRules, [&](SegmentRule const& r) { return r.type == record.type; });
+            auto const known = rule != SegmentRules.end();
+
+            // The same predicate the background tint consults, so the two can never disagree about what
+            // a boundary is. An untyped context is not one, which is what the old `known &&` said.
+            if (verbosity == StatusLineDefinitions::ContextVerbosity::Boundaries
+                && !isBoundaryContext(record.type))
+                return {};
+
+            // run0 while already root, or an elevate to yourself, is not news -- and suppressing it
+            // removes the commonest honest false positive, so a SPOOFED one has to actually differ
+            // before it appears at all.
+            if (known && (record.type == ContextType::Elevate || record.type == ContextType::ChangePrivileges)
+                && outermost != nullptr && !record.targetUser.empty() && record.targetUser == outermost->user)
+                return {};
+
+            auto value = std::string_view {};
+            if (known)
+            {
+                for (auto const field: rule->fields)
+                    if (value = fieldOf(record, field); !value.empty())
+                        break;
+            }
+            else
+                value = fieldOf(record, ContextField::Comm);
+
+            if (value.empty())
+                return {};
+            return (known ? std::string { rule->prefix } : std::string {}) + sanitized(value);
+        }
+
+        /// Joins @p segments, eliding the MIDDLE when the result would exceed @p maxWidth columns.
+        [[nodiscard]] static std::string elide(std::vector<std::string> const& segments,
+                                               std::string const& separator,
+                                               ColumnCount maxWidth)
+        {
+            auto const widthOf = [](std::string_view text) {
+                // Counted in COLUMNS, not bytes: a CJK container name is two columns per codepoint and
+                // three bytes, and measuring bytes would elide text that fits.
+                auto columns = 0;
+                for (auto const codepoint: unicode::convert_to<char32_t>(text))
+                    columns += static_cast<int>(unicode::width(codepoint));
+                return columns;
+            };
+
+            auto const join = [&](std::vector<std::string> const& parts) {
+                return crispy::joinWith(parts, separator);
+            };
+
+            auto candidate = join(segments);
+            if (widthOf(candidate) <= unbox<int>(maxWidth))
+                return candidate;
+
+            // Keep both ends: the first answers *where*, the last answers *who*.
+            if (segments.size() > 2)
+            {
+                auto elided = std::vector<std::string> { segments.front(), "…", segments.back() };
+                candidate = join(elided);
+                if (widthOf(candidate) <= unbox<int>(maxWidth))
+                    return candidate;
+            }
+
+            // Still too wide: the innermost alone, cut at its own START so its tail -- the part that
+            // identifies it -- survives.
+            //
+            // Cut by CODEPOINT, never by byte: a container name is UTF-8, and erasing one byte at a
+            // time leaves the string starting on a continuation byte, which is mojibake on screen and
+            // an invalid sequence handed to writeToScreenInternal(). The ellipsis is budgeted for
+            // rather than added afterwards, because prepending it to a string already at maxWidth
+            // overflows the width by exactly the column the caller allotted.
+            auto const codepoints = unicode::convert_to<char32_t>(std::string_view { segments.back() });
+            auto const budget = unbox<int>(maxWidth) - 1; // one column for the leading '…'
+            if (budget <= 0)
+                return {};
+
+            auto kept = size_t {};
+            auto columns = 0;
+            for (auto index = codepoints.size(); index-- > 0;)
+            {
+                columns += static_cast<int>(unicode::width(codepoints[index]));
+                if (columns > budget)
+                    break;
+                kept = codepoints.size() - index;
+            }
+            if (kept == 0)
+                return {};
+
+            auto tail = std::string { "…" };
+            unicode::convert_to<char>(std::u32string_view { codepoints }.substr(codepoints.size() - kept),
+                                      std::back_inserter(tail));
+            return tail;
+        }
+
+        std::string visit(StatusLineDefinitions::Context const& item)
+        {
+            auto const& stack = vt.contexts();
+            auto const chain = stack.chain();
+            if (chain.empty())
+                return {};
+
+            auto const* const outermost = chain.front().record.get();
+            auto segments = std::vector<std::string> {};
+
+            if (item.verbosity == StatusLineDefinitions::ContextVerbosity::Active)
+            {
+                if (auto text = segmentFor(
+                        *chain.back().record, outermost, StatusLineDefinitions::ContextVerbosity::Full);
+                    !text.empty())
+                    segments.push_back(std::move(text));
+            }
+            else
+                for (auto const& entry: chain)
+                    if (auto text = segmentFor(*entry.record, outermost, item.verbosity); !text.empty())
+                        segments.push_back(std::move(text));
+
+            // Nothing to say, so the segment COLLAPSES -- and operator() drops textLeft/textRight with
+            // it, so no orphan divider is left behind. That is what keeps this affordable in the
+            // default status line: an ordinary session pays nothing for it.
+            if (segments.empty())
+                return {};
+
+            return elide(segments, item.separator.value_or(" › "), item.maxWidth);
+        }
+
         std::string visit(StatusLineDefinitions::Tabs const& tabs)
         {
             auto const tabsInfo = vt.guiTabsInfoForStatusLine();
@@ -614,6 +850,20 @@ std::string serializeStatusLineSegment(StatusLineSegment const& segment)
                     attributes.add("Program", v.command);
 
                 appendStyles(attributes, v);
+
+                if constexpr (std::same_as<T, StatusLineDefinitions::Context>)
+                {
+                    // Only what is NOT the default: a config Contour writes must be one Contour reads
+                    // back, and one it wrote must not gain noise. The default is read off a
+                    // default-constructed item rather than restated, so it cannot drift from the header.
+                    if (auto const name = StatusLineDefinitions::contextVerbosityName(v.verbosity);
+                        !name.empty())
+                        attributes.add("Verbosity", std::string { name });
+                    if (v.separator)
+                        attributes.add("Separator", *v.separator);
+                    if (v.maxWidth != StatusLineDefinitions::Context {}.maxWidth)
+                        attributes.add("MaxWidth", std::to_string(unbox(v.maxWidth)));
+                }
 
                 if constexpr (std::same_as<T, StatusLineDefinitions::Tabs>)
                 {

--- a/src/vtbackend/screen/StatusLineBuilder.hpp
+++ b/src/vtbackend/screen/StatusLineBuilder.hpp
@@ -3,9 +3,12 @@
 
 #include <vtbackend/core/CellFlags.hpp>
 #include <vtbackend/core/Color.hpp>
+#include <vtbackend/core/Primitives.hpp>
+#include <vtbackend/core/TerminalContext.hpp>
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -45,6 +48,65 @@ namespace StatusLineDefinitions
     struct TraceMode: Styles {};
     struct VTType: Styles {};
 
+    /// What a `{Context}` breadcrumb shows of the OSC 3008 ancestry.
+    enum class ContextVerbosity : uint8_t
+    {
+        /// Only the contexts that name a privilege or machine boundary, and NOTHING at all when there
+        /// is none -- the same collapse ProtectedMode and TraceMode use. That is what lets this ship
+        /// in the default indicator line: on a stock systemd install the shim emits only
+        /// session/shell/command, so the segment costs an ordinary session nothing until the user
+        /// runs run0, ssh, or enters a container.
+        Boundaries = 0,
+        Full,   ///< The whole ancestry, root-first: "zeta > container:foobar > root > vim".
+        Active, ///< The innermost context alone.
+    };
+
+    /// The attribute spelling of @p verbosity, or an empty view for the default.
+    ///
+    /// Paired with @ref contextVerbosityFrom rather than left as two if-chains in the parser and the
+    /// serializer: those face in opposite directions, and a spelling that disagreed between them was a
+    /// silent round-trip failure that lost the whole placeholder. Same shape as contextTypeName /
+    /// contextTypeFrom.
+    [[nodiscard]] constexpr std::string_view contextVerbosityName(ContextVerbosity verbosity) noexcept
+    {
+        switch (verbosity)
+        {
+            case ContextVerbosity::Full: return "Full";
+            case ContextVerbosity::Active: return "Active";
+            case ContextVerbosity::Boundaries: break;
+        }
+        return {};
+    }
+
+    /// The verbosity @p name spells, or @ref ContextVerbosity::Boundaries when it spells none.
+    ///
+    /// An unrecognised spelling keeps the DEFAULT rather than making the whole placeholder unknown: a
+    /// typo in one attribute must not silently delete the segment.
+    [[nodiscard]] constexpr ContextVerbosity contextVerbosityFrom(std::string_view name) noexcept
+    {
+        if (name == contextVerbosityName(ContextVerbosity::Full))
+            return ContextVerbosity::Full;
+        if (name == contextVerbosityName(ContextVerbosity::Active))
+            return ContextVerbosity::Active;
+        return ContextVerbosity::Boundaries;
+    }
+
+    struct Context: Styles
+    {
+        ContextVerbosity verbosity = ContextVerbosity::Boundaries;
+
+        /// Defaulted explicitly, unlike Tabs::separator: the settings editor builds every item it does
+        /// not special-case as `T { styles }`, and a member without an initializer makes that a
+        /// -Wmissing-field-initializers error under -Werror.
+        std::optional<std::string> separator {};
+
+        /// Widest the breadcrumb may draw, in COLUMNS -- not bytes, because a container name is UTF-8
+        /// and may be double-width. Beyond it the MIDDLE is elided and both ends kept: the first
+        /// segment answers *where* and the last answers *who*, and the ones between are the least
+        /// costly to lose.
+        ColumnCount maxWidth { 32 };
+    };
+
     struct Tabs: Styles
     {
         std::optional<RGBColor> activeColor;
@@ -69,7 +131,8 @@ namespace StatusLineDefinitions
         Title,
         TraceMode,
         VTType,
-        Tabs
+        Tabs,
+        Context
     >;
     // clang-format on
 
@@ -157,6 +220,9 @@ namespace StatusLineDefinitions
 
     template <> struct ItemTraits<Tabs>
     { static constexpr std::string_view Name = "Tabs", Label = "Tab strip", Sample = "1 2 3"; };
+
+    template <> struct ItemTraits<Context>
+    { static constexpr std::string_view Name = "Context", Label = "Context breadcrumb", Sample = "container:build \u203a root"; };
 
     template <> struct ItemTraits<Text>
     { static constexpr std::string_view Name = "Text", Label = "Static text", Sample = "text"; };

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -3680,6 +3680,36 @@ void Terminal::setProgress(Progress progress)
     _eventListener.progressChanged(progress);
 }
 
+ContextTransition Terminal::applyContextCommand(ContextCommand const& command)
+{
+    auto const transition = _contexts.apply(command);
+
+    // Only when something a frontend can SEE moved. The systemd hot path -- a shell context
+    // re-announced on every prompt with byte-identical metadata -- is an Updated transition that
+    // usually changes nothing, and notifying for it would be a redraw per prompt.
+    if (transition.change == ContextChange::Yes)
+    {
+        // Lock-free for the same reason setProgress() above is: the OSC 3008 dispatch in Screen reaches
+        // this from inside writeToScreen()'s _stateMutex hold, and _stateMutex is not recursive.
+        _eventListener.contextChanged(_contexts.activeId());
+    }
+
+    return transition;
+}
+
+void Terminal::adoptContext(TerminalContext record)
+{
+    _contexts.adopt(std::move(record));
+}
+
+void Terminal::setContextChain(std::span<ContextId const> ids)
+{
+    auto const before = _contexts.activeId();
+    _contexts.setChain(ids);
+    if (_contexts.activeId() != before)
+        _eventListener.contextChanged(_contexts.activeId());
+}
+
 Progress Terminal::resolvedProgress() const
 {
     auto const l = std::lock_guard { _stateMutex };
@@ -4117,6 +4147,7 @@ void Terminal::moveCursorTo(LineOffset line, ColumnOffset column)
 void Terminal::softReset()
 {
     // https://vt100.net/docs/vt510-rm/DECSTR.html
+    // NB: the OSC 3008 context ancestry is deliberately left alone here; hardReset() below says why.
     setMode(DECMode::BatchedRendering, false);
     setMode(DECMode::TextReflow, _settings.primaryScreen.allowReflowOnResize);
     setGraphicsRendition(GraphicsRendition::Reset); // SGR
@@ -4301,6 +4332,18 @@ void Terminal::hardReset()
     // holding a hand cursor must not leave the user with one. The stack keeps its bottom entry -- the
     // terminal's own default -- exactly as popPointerShape does.
     resetPointerShape();
+    // The OSC 3008 context ancestry is deliberately NOT reset here, and neither does softReset() touch
+    // it. UAPI.15 makes that a safety property rather than a convenience: a program running down the
+    // ancestry must not be able to erase the context a program above it established, and RIS is
+    // something any program can send. A shell that has announced "you are inside container X" must
+    // still be able to say so after a program inside that container resets the terminal.
+    //
+    // The full reset the specification DOES name is vhangup(), which has no equivalent here: closing
+    // the PTY destroys the TerminalSession and this Terminal with it, so the ancestry dies with the
+    // object and needs no mechanism. ContextStack::clear() exists for that teardown alone and is
+    // reachable from no escape sequence.
+    //
+    // @see Screen_context_test.cpp, "osc3008 survives a hard reset".
 
     resetColorPalette();
 

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -3689,12 +3689,27 @@ ContextTransition Terminal::applyContextCommand(ContextCommand const& command)
     // usually changes nothing, and notifying for it would be a redraw per prompt.
     if (transition.change == ContextChange::Yes)
     {
+        publishActiveContext();
+
         // Lock-free for the same reason setProgress() above is: the OSC 3008 dispatch in Screen reaches
         // this from inside writeToScreen()'s _stateMutex hold, and _stateMutex is not recursive.
         _eventListener.contextChanged(_contexts.activeId());
     }
 
     return transition;
+}
+
+void Terminal::publishActiveContext() noexcept
+{
+    // Every screen, not just the current one: an application may switch screens or flip pages between
+    // one context announcement and the next, and a line written on whichever screen is current then has
+    // to be stamped with the context that is actually in effect. The same shape hardReset() uses when
+    // it walks _pages.
+    auto const id = _contexts.activeId();
+    for (auto& page: _pages)
+        page->setActiveContextId(id);
+    _hostWritableStatusLineScreen.setActiveContextId(id);
+    _indicatorStatusScreen.setActiveContextId(id);
 }
 
 void Terminal::adoptContext(TerminalContext record)
@@ -3707,7 +3722,10 @@ void Terminal::setContextChain(std::span<ContextId const> ids)
     auto const before = _contexts.activeId();
     _contexts.setChain(ids);
     if (_contexts.activeId() != before)
+    {
+        publishActiveContext();
         _eventListener.contextChanged(_contexts.activeId());
+    }
 }
 
 Progress Terminal::resolvedProgress() const

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -1331,6 +1331,9 @@ class Terminal
     /// Replaces the ancestry with @p ids, for the same mirroring reason as @ref adoptContext.
     void setContextChain(std::span<ContextId const> ids);
 
+    /// Mirrors the active context id into every screen, so lines written next carry it.
+    void publishActiveContext() noexcept;
+
     [[nodiscard]] SemanticBlockTracker& semanticBlockTracker() noexcept { return _semanticBlockTracker; }
     [[nodiscard]] SemanticBlockTracker const& semanticBlockTracker() const noexcept
     {

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -1322,6 +1322,10 @@ class Terminal
     /// Mutated only through applyContextCommand().
     [[nodiscard]] ContextStack const& contexts() const noexcept { return _contexts; }
 
+    /// Mutable access, for a daemon mirror adopting records the host already holds.
+    /// Every other caller reads: the ancestry moves through applyContextCommand().
+    [[nodiscard]] ContextStack& contexts() noexcept { return _contexts; }
+
     /// Applies one decoded OSC 3008 command: updates the ancestry, mirrors the new active id into
     /// every screen so freshly written lines are stamped with it, and announces an observable change.
     ContextTransition applyContextCommand(ContextCommand const& command);

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -2745,12 +2745,12 @@ class Terminal
     /// session, so there is no setter.
     ///
     /// Deliberately NOT reset by RIS or DECSTR. @see hardReset().
-    ContextStack _contexts;
+    ContextStack _contexts { _settings.contextLimits };
 
     /// Which of OSC 133 and OSC 3008 owns this session's semantic marks. Like the ancestry itself,
     /// deliberately NOT reset by RIS or DECSTR: it describes the shells attached to the pty, not the
     /// screen, and a program that emits RIS must not be able to flip it.
-    MarkArbiter _markArbiter;
+    MarkArbiter _markArbiter { _settings.contextMarkPolicy };
 
     // {{{ Output folding
     mutable FoldState _foldState;

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -19,6 +19,7 @@
 #include <vtbackend/screen/StatusLineBuilder.hpp>
 #include <vtbackend/screen/Viewport.hpp>
 #include <vtbackend/shell/Folding.hpp>
+#include <vtbackend/shell/MarkArbiter.hpp>
 #include <vtbackend/shell/SemanticBlockTracker.hpp>
 #include <vtbackend/shell/ShellIntegration.hpp>
 #include <vtbackend/vt/DesktopNotification.hpp>
@@ -1333,6 +1334,10 @@ class Terminal
 
     /// Mirrors the active context id into every screen, so lines written next carry it.
     void publishActiveContext() noexcept;
+
+    /// Decides whether OSC 3008 may synthesise OSC-133-equivalent marks in this session.
+    [[nodiscard]] MarkArbiter& markArbiter() noexcept { return _markArbiter; }
+    [[nodiscard]] MarkArbiter const& markArbiter() const noexcept { return _markArbiter; }
 
     [[nodiscard]] SemanticBlockTracker& semanticBlockTracker() noexcept { return _semanticBlockTracker; }
     [[nodiscard]] SemanticBlockTracker const& semanticBlockTracker() const noexcept
@@ -2741,6 +2746,11 @@ class Terminal
     ///
     /// Deliberately NOT reset by RIS or DECSTR. @see hardReset().
     ContextStack _contexts;
+
+    /// Which of OSC 133 and OSC 3008 owns this session's semantic marks. Like the ancestry itself,
+    /// deliberately NOT reset by RIS or DECSTR: it describes the shells attached to the pty, not the
+    /// screen, and a program that emits RIS must not be able to flip it.
+    MarkArbiter _markArbiter;
 
     // {{{ Output folding
     mutable FoldState _foldState;

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -5,6 +5,7 @@
 #include <vtbackend/core/ColorPalette.hpp>
 #include <vtbackend/core/Hyperlink.hpp>
 #include <vtbackend/core/Primitives.hpp>
+#include <vtbackend/core/TerminalContext.hpp>
 #include <vtbackend/grid/Grid.hpp>
 #include <vtbackend/input/InputGenerator.hpp>
 #include <vtbackend/input/InputHandler.hpp>
@@ -310,6 +311,18 @@ class Terminal
         /// nor synchronously re-enter code that does. Defer to the GUI thread instead.
         /// @param progress The state now in effect; ProgressState::Inactive means "show nothing".
         virtual void progressChanged(Progress /*progress*/) {}
+
+        /// The application's hierarchical context ancestry changed (`OSC 3008`).
+        ///
+        /// Raised on the parser thread with Terminal::_stateMutex ALREADY HELD, with the same
+        /// consequence progressChanged() above documents: do not read terminal state here, and do not
+        /// synchronously re-enter code that does.
+        ///
+        /// Raised only when something a frontend can SEE moved. systemd re-announces the shell context
+        /// on every prompt with byte-identical metadata, and notifying for that would be a redraw per
+        /// prompt for no change.
+        /// @param activeContext The context now in effect; a zero id means the ancestry is empty.
+        virtual void contextChanged(ContextId /*activeContext*/) {}
         virtual void focusTerminalWindow() {}
         virtual void onClosed() {}
         virtual void pasteFromClipboard(unsigned /*count*/, bool /*strip*/) {}
@@ -386,6 +399,7 @@ class Terminal
         void showDesktopNotification(DesktopNotification const& /*notification*/) override {}
         void discardDesktopNotification(std::string_view /*identifier*/) override {}
         void progressChanged(Progress /*progress*/) override {}
+        void contextChanged(ContextId /*activeContext*/) override {}
         void focusTerminalWindow() override {}
         void onClosed() override {}
         void pasteFromClipboard(unsigned /*count*/, bool /*strip*/) override {}
@@ -1302,6 +1316,20 @@ class Terminal
     {
         _shellIntegration = std::move(newShellIntegration);
     }
+
+    /// The application's hierarchical context ancestry (OSC 3008), for reading.
+    /// Mutated only through applyContextCommand().
+    [[nodiscard]] ContextStack const& contexts() const noexcept { return _contexts; }
+
+    /// Applies one decoded OSC 3008 command: updates the ancestry, mirrors the new active id into
+    /// every screen so freshly written lines are stamped with it, and announces an observable change.
+    ContextTransition applyContextCommand(ContextCommand const& command);
+
+    /// Adopts a context record replicated from a daemon host. @see ContextStack::adopt.
+    void adoptContext(TerminalContext record);
+
+    /// Replaces the ancestry with @p ids, for the same mirroring reason as @ref adoptContext.
+    void setContextChain(std::span<ContextId const> ids);
 
     [[nodiscard]] SemanticBlockTracker& semanticBlockTracker() noexcept { return _semanticBlockTracker; }
     [[nodiscard]] SemanticBlockTracker const& semanticBlockTracker() const noexcept
@@ -2703,6 +2731,13 @@ class Terminal
 
     std::unique_ptr<ShellIntegration> _shellIntegration;
     SemanticBlockTracker _semanticBlockTracker;
+
+    /// The application's hierarchical context ancestry (OSC 3008), and the records the scrollback still
+    /// points at. Limits are fixed at construction; a session configured differently is a different
+    /// session, so there is no setter.
+    ///
+    /// Deliberately NOT reset by RIS or DECSTR. @see hardReset().
+    ContextStack _contexts;
 
     // {{{ Output folding
     mutable FoldState _foldState;

--- a/src/vtbackend/shell/MarkArbiter.hpp
+++ b/src/vtbackend/shell/MarkArbiter.hpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <format>
+#include <string_view>
+
+namespace vtbackend
+{
+
+/// Whether OSC 3008 may stand in for a shell integration that is not there.
+///
+/// A configuration policy, fixed at construction: two differently-configured terminals are two
+/// different terminals, not one terminal in two states.
+enum class ContextMarkPolicy : uint8_t
+{
+    Never = 0, ///< OSC 3008 never stamps a mark. Restores the behaviour from before it was consumed.
+    WhenAlone, ///< OSC 3008 stamps marks only while OSC 133 has not spoken. The default.
+};
+
+/// Which of the two shell-boundary protocols owns the semantic line marks in this session.
+///
+/// Two independent streams describe the same prompt cycle: OSC 133, which a user opted into by
+/// installing a shell integration, and OSC 3008, which systemd 258+ emits from /etc/profile.d with no
+/// user action at all. Both would otherwise stamp LineFlag::Marked / OutputStart / CommandEnd and both
+/// would drive the ShellIntegration callbacks, so exactly one of them is the source of record.
+///
+/// The order is one-way. OSC 133 is the richer protocol -- it alone marks the prompt/input border
+/// (;B) -- and it is the one the user asked for, so its first sequence wins the session for good.
+/// OSC 3008 can take the marks only in its absence, and can never take them back. That asymmetry IS
+/// the hysteresis: without it a session would flap between marker sources depending on which stream
+/// happened to be quiet.
+enum class MarkOwner : uint8_t
+{
+    /// Nothing has claimed the session yet, or OSC 3008 has claimed it for less than one full prompt
+    /// cycle.
+    ///
+    /// OSC 3008 STAMPS FLAGS in this state -- they are terminal memory, they are idempotent bits on a
+    /// logical line head, and they cost nothing if OSC 133 turns up and stamps the same heads -- but
+    /// fires NO callbacks, because those are not idempotent.
+    Undecided = 0,
+
+    /// OSC 133 has been seen. It stamps every mark and drives every callback; OSC 3008 contributes
+    /// metadata only -- cwd, exit=crash|interrupt, signal=, identity -- and never a mark.
+    ShellIntegration,
+
+    /// One complete OSC 3008 command cycle passed with no OSC 133 in sight. OSC 3008 stamps the marks
+    /// and drives the callbacks, until and unless OSC 133 speaks.
+    ContextSignalling,
+};
+
+/// How many complete OSC 3008 command cycles must pass before OSC 3008 may drive the callbacks.
+///
+/// One: by the end of the first cycle a shell integration that exists has certainly spoken, since
+/// OSC 133;C lands in the same cycle, immediately after the PS0 that opens the 3008 command context.
+/// A constant rather than a literal so raising the bar is a one-line change and not a hunt through the
+/// logic.
+constexpr inline uint8_t ContextMarkDecisionCycles = 1;
+
+/// Decides, per session, which boundary protocol may stamp semantic marks and fire shell-integration
+/// callbacks. @see MarkOwner.
+///
+/// Deliberately dependency-free: this is the one decision in the OSC 3008 feature that has to be
+/// exercised in isolation -- every interleaving of the two streams, and a shell integration sourced
+/// halfway through a session -- with no Grid, no Screen and no Terminal behind it.
+///
+/// NOT reset by RIS or DECSTR. The OSC 3008 ancestry is reset-immune by specification, and this is a
+/// property of the shells attached to the pty rather than of the screen; a program that emits RIS must
+/// not be able to flip which protocol owns the user's markers. A vhangup -- a new pty, and so a new
+/// Terminal -- starts a fresh arbiter, which is the only reset there is.
+class MarkArbiter
+{
+  public:
+    /// @param policy Whether OSC 3008 may stand in for OSC 133 at all.
+    explicit constexpr MarkArbiter(ContextMarkPolicy policy = ContextMarkPolicy::WhenAlone) noexcept:
+        _policy { policy }
+    {
+    }
+
+    /// Who owns the marks right now.
+    [[nodiscard]] constexpr MarkOwner owner() const noexcept { return _owner; }
+
+    /// Records that an OSC 133 sequence was seen. Terminal: this settles the session for good.
+    constexpr void observedShellIntegration() noexcept { _owner = MarkOwner::ShellIntegration; }
+
+    /// Records that an OSC 3008 `type=command` context was pushed.
+    constexpr void observedContextCommandStart() noexcept
+    {
+        if (_owner == MarkOwner::Undecided)
+            _hasOpenCommand = true;
+    }
+
+    /// Records that an OSC 3008 `type=command` context was closed.
+    ///
+    /// The decision point. A cycle that both began and ended without OSC 133 hands OSC 3008 the
+    /// session. Counted at the END rather than the start so the arbiter decides on a cycle BOUNDARY
+    /// and not on an arbitrary sequence in the middle of one, where the two streams interleave -- and
+    /// "first completed cycle" is a stable property of the session where "first sequence seen" is a
+    /// coin flip on hook-install order.
+    constexpr void observedContextCommandEnd() noexcept
+    {
+        if (_owner != MarkOwner::Undecided || !_hasOpenCommand)
+            return;
+        _hasOpenCommand = false;
+        if (++_completedCycles >= ContextMarkDecisionCycles)
+            _owner = MarkOwner::ContextSignalling;
+    }
+
+    /// Whether OSC 3008 may stamp LineFlags right now.
+    [[nodiscard]] constexpr bool contextMayMark() const noexcept
+    {
+        return _policy != ContextMarkPolicy::Never && _owner != MarkOwner::ShellIntegration;
+    }
+
+    /// Whether OSC 3008 may drive the ShellIntegration callbacks and the SemanticBlockTracker.
+    ///
+    /// Strictly narrower than @ref contextMayMark: a flag stamped twice is one bit, but promptStart()
+    /// delivered twice is two notifications -- and SemanticBlockTracker::commandOutputStart() assigns
+    /// its command line unconditionally, so a 3008 command context, which carries no cmdline= at all
+    /// under systemd, would otherwise clobber a good cmdline_url from OSC 133;C.
+    [[nodiscard]] constexpr bool contextMayNotify() const noexcept
+    {
+        return _policy != ContextMarkPolicy::Never && _owner == MarkOwner::ContextSignalling;
+    }
+
+  private:
+    ContextMarkPolicy _policy;
+    MarkOwner _owner = MarkOwner::Undecided;
+    uint8_t _completedCycles = 0;
+    bool _hasOpenCommand = false; ///< Predicate: is a `type=command` context open right now?
+};
+
+} // namespace vtbackend
+
+/// Spelled as the configuration spells it, which is what `contour generate config` writes back.
+template <>
+struct std::formatter<vtbackend::ContextMarkPolicy>: formatter<std::string_view>
+{
+    auto format(vtbackend::ContextMarkPolicy value, auto& ctx) const
+    {
+        string_view name;
+        switch (value)
+        {
+            case vtbackend::ContextMarkPolicy::Never: name = "never"; break;
+            case vtbackend::ContextMarkPolicy::WhenAlone: name = "when_alone"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};

--- a/src/vtbackend/shell/MarkArbiter_test.cpp
+++ b/src/vtbackend/shell/MarkArbiter_test.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/shell/MarkArbiter.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vtbackend;
+
+TEST_CASE("MarkArbiter.a fresh session lets OSC 3008 mark but not notify", "[markarbiter]")
+{
+    // Flags are idempotent bits on a logical line head, so stamping one that OSC 133 may also stamp
+    // costs nothing. Callbacks are not idempotent, so they wait for the decision.
+    auto const arbiter = MarkArbiter {};
+    CHECK(arbiter.owner() == MarkOwner::Undecided);
+    CHECK(arbiter.contextMayMark());
+    CHECK(!arbiter.contextMayNotify());
+}
+
+TEST_CASE("MarkArbiter.the first OSC 133 sequence settles the session", "[markarbiter]")
+{
+    auto arbiter = MarkArbiter {};
+    arbiter.observedShellIntegration();
+
+    CHECK(arbiter.owner() == MarkOwner::ShellIntegration);
+    CHECK(!arbiter.contextMayMark());
+    CHECK(!arbiter.contextMayNotify());
+}
+
+TEST_CASE("MarkArbiter.one completed 3008 command cycle hands over the session", "[markarbiter]")
+{
+    auto arbiter = MarkArbiter {};
+    arbiter.observedContextCommandStart();
+    CHECK(arbiter.owner() == MarkOwner::Undecided);
+    CHECK(!arbiter.contextMayNotify()); // still mid-cycle: OSC 133 could yet appear
+
+    arbiter.observedContextCommandEnd();
+
+    CHECK(arbiter.owner() == MarkOwner::ContextSignalling);
+    CHECK(arbiter.contextMayMark());
+    CHECK(arbiter.contextMayNotify());
+}
+
+TEST_CASE("MarkArbiter.an end without a matching start does not complete a cycle", "[markarbiter]")
+{
+    // The decision is on a cycle BOUNDARY, so a stray end -- one whose start was refused by the depth
+    // limit, say -- must not stand in for a whole cycle.
+    auto arbiter = MarkArbiter {};
+    arbiter.observedContextCommandEnd();
+
+    CHECK(arbiter.owner() == MarkOwner::Undecided);
+    CHECK(!arbiter.contextMayNotify());
+}
+
+TEST_CASE("MarkArbiter.OSC 133 arriving mid-cycle still wins", "[markarbiter]")
+{
+    auto arbiter = MarkArbiter {};
+    arbiter.observedContextCommandStart();
+    arbiter.observedShellIntegration();
+    arbiter.observedContextCommandEnd();
+
+    CHECK(arbiter.owner() == MarkOwner::ShellIntegration);
+    CHECK(!arbiter.contextMayMark());
+}
+
+TEST_CASE("MarkArbiter.OSC 133 sourced mid-session supersedes context signalling", "[markarbiter]")
+{
+    // A user may `source` a shell integration halfway through a session. That has to take effect.
+    auto arbiter = MarkArbiter {};
+    arbiter.observedContextCommandStart();
+    arbiter.observedContextCommandEnd();
+    REQUIRE(arbiter.owner() == MarkOwner::ContextSignalling);
+
+    arbiter.observedShellIntegration();
+
+    CHECK(arbiter.owner() == MarkOwner::ShellIntegration);
+    CHECK(!arbiter.contextMayMark());
+}
+
+TEST_CASE("MarkArbiter.context signalling never takes the marks back", "[markarbiter]")
+{
+    // The whole hysteresis. Without it a session would flap between marker sources depending on which
+    // stream happened to be quiet.
+    auto arbiter = MarkArbiter {};
+    arbiter.observedShellIntegration();
+
+    for (auto i = 0; i < 5; ++i)
+    {
+        arbiter.observedContextCommandStart();
+        arbiter.observedContextCommandEnd();
+        CHECK(arbiter.owner() == MarkOwner::ShellIntegration);
+        CHECK(!arbiter.contextMayMark());
+    }
+}
+
+TEST_CASE("MarkArbiter.ContextMarkPolicy::Never silences OSC 3008 entirely", "[markarbiter]")
+{
+    auto arbiter = MarkArbiter { ContextMarkPolicy::Never };
+    arbiter.observedContextCommandStart();
+    arbiter.observedContextCommandEnd();
+
+    // The owner still moves -- the policy gates the ACT, not the observation -- but nothing is stamped.
+    CHECK(!arbiter.contextMayMark());
+    CHECK(!arbiter.contextMayNotify());
+}
+
+TEST_CASE("MarkArbiter.repeated cycles keep the session with context signalling", "[markarbiter]")
+{
+    auto arbiter = MarkArbiter {};
+    for (auto i = 0; i < 5; ++i)
+    {
+        arbiter.observedContextCommandStart();
+        arbiter.observedContextCommandEnd();
+    }
+    CHECK(arbiter.owner() == MarkOwner::ContextSignalling);
+    CHECK(arbiter.contextMayNotify());
+}

--- a/src/vtbackend/shell/ShellIntegration_test.cpp
+++ b/src/vtbackend/shell/ShellIntegration_test.cpp
@@ -904,3 +904,32 @@ TEST_CASE("ShellIntegration.livePromptSpan is silent on the alternate screen")
 }
 
 // }}}
+
+TEST_CASE("ShellIntegration.OSC 133;D invalidates the fold ranges it changes")
+{
+    // A regression guard for a real defect: the ;B and ;D handlers used to stamp their flag directly on
+    // the line head, bypassing Screen::setLogicalLineFlags() and therefore never calling
+    // Terminal::invalidateFoldRanges(). Both flags are in HeadOnlyLineFlags, and Terminal::foldRanges()
+    // caches on {generation, stableBase, markRevision} -- so a ;D landing on a page that has not
+    // scrolled left the cached ranges reporting the state from before the command finished.
+    //
+    // It was masked only by the ;A of the NEXT prompt invalidating one sequence later, i.e. by an
+    // accident of shell-script ordering rather than by design. This case closes the window: it reads
+    // the ranges between the ;D and that ;A, which is exactly where the stale answer lived.
+    auto mock = MockTerm { PageSize { LineCount(6), ColumnCount(20) } };
+
+    mock.writeToScreen("\033]133;A\033\\");
+    mock.writeToScreen("$ ");
+    mock.writeToScreen("\033]133;B\033\\");
+    mock.writeToScreen("ls\r\n");
+    mock.writeToScreen("\033]133;C\033\\");
+    mock.writeToScreen("one\r\ntwo\r\n");
+
+    // Warm the cache while the command is still open: no block has finished, so there is no range yet.
+    REQUIRE(mock.terminal.foldRanges().empty());
+
+    mock.writeToScreen("\033]133;D;0\033\\");
+
+    // Without the invalidation this still reports the warmed, empty answer.
+    CHECK(!mock.terminal.foldRanges().empty());
+}

--- a/src/vtbackend/vt/Functions.hpp
+++ b/src/vtbackend/vt/Functions.hpp
@@ -239,6 +239,7 @@ constexpr inline auto ITERM2 = FunctionDocumentation { .mnemonic = "ITERM2", .co
 constexpr inline auto TEXTSIZING = FunctionDocumentation { .mnemonic = "TEXTSIZING", .comment = "Kitty text sizing protocol: sized/scaled text.", .parameters = "metadata ; text" };
 constexpr inline auto KITTYCLIPBOARD = FunctionDocumentation { .mnemonic = "KITTYCLIPBOARD", .comment = "Kitty clipboard protocol: chunked, MIME-typed clipboard read/write.", .parameters = "metadata ; base64" };
 constexpr inline auto POINTERSHAPE = FunctionDocumentation { .mnemonic = "POINTERSHAPE", .comment = "Kitty pointer shape protocol: set, push, pop or query the mouse pointer shape.", .parameters = "=|>|<|? name[,name...]" };
+constexpr inline auto HIERCONTEXT = FunctionDocumentation { .mnemonic = "HIERCONTEXT", .comment = "Hierarchical context signalling (UAPI.15): the nesting a shell, run0, ssh or a container runtime opens around what runs inside it.", .parameters = "start=CTXID|end=CTXID [; field=value ...]", .description = "Maintains a stack of contexts, each carrying metadata about the component in control of the terminal. `start=` initiates, updates or returns to a context; `end=` terminates one. Ordinary reset sequences deliberately do NOT clear the stack.", .examples = "OSC 3008 ; start=bed86fab ; type=container ; container=foobar ST\nOSC 3008 ; end=bed86fab ; exit=success ST" };
 
 // DEC Multi-Page Navigation (VT420)
 constexpr inline auto NP = FunctionDocumentation { .mnemonic = "NP", .comment = "Next Page", .parameters = "Pn", .description = "Moves the cursor to the home position on one of the following pages in page memory." };
@@ -886,6 +887,7 @@ constexpr inline auto ITERM2           = detail::OSC(1337, VTExtension::Unknown,
 constexpr inline auto TEXTSIZING       = detail::OSC(66, VTExtension::Unknown, documentation::TEXTSIZING);
 constexpr inline auto KITTYCLIPBOARD   = detail::OSC(5522, VTExtension::Unknown, documentation::KITTYCLIPBOARD);
 constexpr inline auto POINTERSHAPE     = detail::OSC(22, VTExtension::Unknown, documentation::POINTERSHAPE);
+constexpr inline auto HIERCONTEXT      = detail::OSC(3008, VTExtension::Unknown, documentation::HIERCONTEXT);
 
 // NOLINTEND(readability-identifier-naming)
 // clang-format on
@@ -1151,6 +1153,7 @@ constexpr static auto allFunctionsArray() noexcept
         TEXTSIZING,
         KITTYCLIPBOARD,
         POINTERSHAPE,
+        HIERCONTEXT,
         DUMPSTATE,
     };
     return funcs;

--- a/src/vtbackend/vt/HierarchicalContext.cpp
+++ b/src/vtbackend/vt/HierarchicalContext.cpp
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/vt/HierarchicalContext.hpp>
+
+#include <crispy/Utils.hpp>
+
+#include <algorithm>
+#include <optional>
+
+using std::string;
+using std::string_view;
+
+namespace vtbackend
+{
+
+namespace
+{
+    /// Whether @p ch is a byte SAFE admits directly, i.e. without an escape.
+    ///
+    /// `SAFE = %x20-3a / %x3c-5b / %x5d-7e / ESCSEMICOLON / ESCBACKSLASH` -- so `;` (0x3b) and `\`
+    /// (0x5c) are excluded, being spelled by the two escapes instead. Bytes above 0x7e are admitted
+    /// here although the ABNF's own production does not name them: the specification's prose overrides
+    /// it, allowing "the ASCII byte range > 0x7f" so that UTF-8 values survive. 0x7f itself is a
+    /// control character and is not allowed -- and it is reachable, because vtparser's OSC range ends
+    /// at 0x7f rather than 0x7e.
+    [[nodiscard]] constexpr bool isSafeByte(unsigned char ch) noexcept
+    {
+        if (ch < 0x20 || ch == 0x7f)
+            return false;
+        return ch != ';' && ch != '\\';
+    }
+
+    /// Whether @p ch is the hex digit @p lower, in either case.
+    [[nodiscard]] constexpr bool matchesHexDigit(char ch, char lower) noexcept
+    {
+        return ch == lower || ch == static_cast<char>(lower - ('a' - 'A'));
+    }
+
+    /// The byte the four characters at @p raw[index] escape, if they are one of the two escapes.
+    ///
+    /// ABNF quoted strings are case-insensitive (RFC 5234 section 2.3), so `\x3b`, `\x3B`, `\X3b` and
+    /// `\X3B` all spell ESCSEMICOLON -- and likewise for ESCBACKSLASH.
+    [[nodiscard]] constexpr std::optional<char> escapedByteAt(string_view raw, size_t index) noexcept
+    {
+        if (index + 4 > raw.size())
+            return std::nullopt;
+        if (!matchesHexDigit(raw[index + 1], 'x'))
+            return std::nullopt;
+        if (raw[index + 2] == '3' && matchesHexDigit(raw[index + 3], 'b'))
+            return ';';
+        if (raw[index + 2] == '5' && matchesHexDigit(raw[index + 3], 'c'))
+            return '\\';
+        return std::nullopt;
+    }
+
+    /// One key=value entry of the payload, still escaped.
+    struct RawField
+    {
+        string_view key;
+        string_view value;
+    };
+
+    /// Splits @p entry at its first `=`.
+    /// @return The field, or nullopt when @p entry carries no `=` at all.
+    [[nodiscard]] constexpr std::optional<RawField> splitField(string_view entry) noexcept
+    {
+        auto const separator = entry.find('=');
+        if (separator == string_view::npos)
+            return std::nullopt;
+        return RawField { .key = entry.substr(0, separator), .value = entry.substr(separator + 1) };
+    }
+
+    /// Whether @p value is `ID128 = 32*36(HEX / "-")`.
+    [[nodiscard]] constexpr bool isId128(string_view value) noexcept
+    {
+        if (value.size() < 32 || value.size() > 36)
+            return false;
+        return std::ranges::all_of(value, [](char ch) {
+            return ch == '-' || (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f')
+                   || (ch >= 'A' && ch <= 'F');
+        });
+    }
+
+    /// Parses `UINT64 = 1*20DECIMAL`.
+    ///
+    /// The length bound is the GRAMMAR's, not an overflow guard: crispy::toInteger range-checks every
+    /// digit against the target type and returns nullopt on overflow, so a 21-digit run would be
+    /// rejected anyway. Stating the ABNF here keeps `1*20DECIMAL` enforced where it is written.
+    [[nodiscard]] constexpr std::optional<uint64_t> parseUint64(string_view value) noexcept
+    {
+        if (value.empty() || value.size() > 20)
+            return std::nullopt;
+        if (!std::ranges::all_of(value, [](char ch) { return ch >= '0' && ch <= '9'; }))
+            return std::nullopt;
+        return crispy::toInteger<10, uint64_t>(value);
+    }
+
+    /// Appends @p raw's decoded bytes to @p scratch and returns a view of them.
+    ///
+    /// The view is into @p scratch, which the caller reserved up front so it never reallocates and the
+    /// views handed back never dangle.
+    /// @return The decoded value, or nullopt when @p raw is not a valid run of SAFE elements.
+    [[nodiscard]] std::optional<string_view> decodeInto(string& scratch, string_view raw)
+    {
+        auto const begin = scratch.size();
+        if (!unescapeContextValue(raw, scratch))
+        {
+            scratch.resize(begin);
+            return std::nullopt;
+        }
+        return string_view { scratch }.substr(begin, scratch.size() - begin);
+    }
+
+    /// Records one decoded STARTFIELD on @p command, or drops it when it fails its validator.
+    void applyStartField(ContextCommand& command, string_view key, string_view value)
+    {
+        // Generated from VTBACKEND_CONTEXT_FIELDS so a sixteenth field is one row there, not an edit
+        // here. Each arm validates before recording: a field that fails is simply absent, and the
+        // present-bit is what later tells "sent empty" apart from "never mentioned".
+#define VTBACKEND_CONTEXT_FIELD_APPLY(Name, Bit, Spelling, Member, Kind, Max) \
+    if (key == (Spelling))                                                    \
+    {                                                                         \
+        applyField##Kind(command, ContextField::Name, command.Member, value); \
+        return;                                                               \
+    }
+
+        // The five validators, as local lambdas so the table above reads as a table.
+        auto const applyFieldText =
+            [](ContextCommand& cmd, ContextField field, string_view& member, string_view value) {
+                // `1*255SAFE`: empty is not a value, and an over-long one is DISCARDED rather than
+                // truncated -- a truncated path names a real directory that is not the one meant, and
+                // something will eventually open it. An absent field is honestly absent.
+                if (value.empty() || value.size() > MaxContextFieldLength)
+                    return;
+                member = value;
+                cmd.present.enable(field);
+            };
+        auto const applyFieldOptionalText =
+            [](ContextCommand& cmd, ContextField field, string_view& member, string_view value) {
+                // `*255SAFE`: cmdline= alone may legitimately be empty, so honour that difference.
+                if (value.size() > MaxContextFieldLength)
+                    return;
+                member = value;
+                cmd.present.enable(field);
+            };
+        auto const applyFieldId128 =
+            [](ContextCommand& cmd, ContextField field, string_view& member, string_view value) {
+                if (!isId128(value))
+                    return;
+                member = value;
+                cmd.present.enable(field);
+            };
+        auto const applyFieldUint64 =
+            [](ContextCommand& cmd, ContextField field, uint64_t& member, string_view value) {
+                auto const parsed = parseUint64(value);
+                if (!parsed)
+                    return;
+                member = *parsed;
+                cmd.present.enable(field);
+            };
+        auto const applyFieldEnum =
+            [](ContextCommand& cmd, ContextField field, ContextType& member, string_view value) {
+                auto const type = contextTypeFrom(value);
+                if (type == ContextType::None)
+                    return; // an unknown type is an unknown field: ignored, rest of the sequence stands
+                member = type;
+                cmd.present.enable(field);
+            };
+
+        VTBACKEND_CONTEXT_FIELDS(VTBACKEND_CONTEXT_FIELD_APPLY)
+#undef VTBACKEND_CONTEXT_FIELD_APPLY
+    }
+
+    /// Records one decoded ENDFIELD on @p command's outcome, or drops it.
+    void applyEndField(ContextCommand& command, string_view key, string_view value)
+    {
+        if (key == "exit")
+        {
+            if (auto const exit = contextExitFrom(value); exit != ContextExit::Unknown)
+                command.outcome.exit = exit;
+            return;
+        }
+        if (key == "status")
+        {
+            if (auto const status = parseUint64(value))
+                command.outcome.status = *status;
+            return;
+        }
+        if (key == "signal")
+        {
+            if (auto const signal = contextSignalFrom(value); signal != ContextSignal::None)
+                command.outcome.signal = signal;
+            return;
+        }
+        // Anything else is an unknown field: ignored, and the rest of the sequence still stands.
+    }
+} // namespace
+
+bool unescapeContextValue(string_view raw, string& out)
+{
+    for (auto index = size_t {}; index < raw.size();)
+    {
+        auto const ch = raw[index];
+        if (ch == '\\')
+        {
+            auto const escaped = escapedByteAt(raw, index);
+            if (!escaped)
+                return false; // a bare 0x5c, which SAFE does not admit in any position
+            out.push_back(*escaped);
+            index += 4;
+            continue;
+        }
+        if (!isSafeByte(static_cast<unsigned char>(ch)))
+            return false;
+        out.push_back(ch);
+        ++index;
+    }
+    return true;
+}
+
+std::expected<ContextCommand, ContextParseError> parseContextSequence(string_view payload, string& scratch)
+{
+    if (payload.size() > MaxContextPayloadLength)
+        return std::unexpected(ContextParseError::PayloadTooLong);
+
+    auto command = ContextCommand {};
+    if (payload.starts_with("start="))
+    {
+        command.verb = ContextVerb::Start;
+        payload.remove_prefix(6);
+    }
+    else if (payload.starts_with("end="))
+    {
+        command.verb = ContextVerb::End;
+        payload.remove_prefix(4);
+    }
+    else
+        return std::unexpected(ContextParseError::MissingVerb);
+
+    // Reserved once, to what any decoding of this payload can need: an escape only ever shrinks, so
+    // the decoded total can never exceed the raw total. That is what lets every view handed back point
+    // into this buffer safely.
+    scratch.clear();
+    scratch.reserve(payload.size());
+
+    auto const firstSeparator = payload.find(';');
+    auto const rawIdentifier = payload.substr(0, firstSeparator);
+    if (rawIdentifier.empty())
+        return std::unexpected(ContextParseError::EmptyIdentifier);
+
+    auto const identifier = decodeInto(scratch, rawIdentifier);
+    if (!identifier)
+        return std::unexpected(ContextParseError::MalformedIdentifier);
+    // Measured on the DECODED value, because SAFE counts elements and ESCSEMICOLON is ONE of them
+    // spelled with four characters. Validating the raw length instead would reject a legal id.
+    if (identifier->size() > MaxContextIdentifierLength)
+        return std::unexpected(ContextParseError::IdentifierTooLong);
+    command.identifier = *identifier;
+
+    if (firstSeparator == string_view::npos)
+        return command; // a bare `start=ID`, which the ABNF admits: `*(";" STARTFIELD)`
+
+    // The field order is undefined -- `type=` may appear last, or in the middle -- so each entry is
+    // dispatched independently against the field table and nothing is read until the payload is done.
+    crispy::split(payload.substr(firstSeparator + 1), ';', [&](string_view entry) {
+        auto const field = splitField(entry);
+        if (!field)
+            return true; // a bare token with no `=` is not a field; ignore it and keep going
+
+        auto const value = decodeInto(scratch, field->value);
+        if (!value)
+            return true; // an invalid field is dropped; the rest of the sequence still stands
+
+        if (command.verb == ContextVerb::Start)
+            applyStartField(command, field->key, *value);
+        else
+            applyEndField(command, field->key, *value);
+        return true;
+    });
+
+    return command;
+}
+
+} // namespace vtbackend

--- a/src/vtbackend/vt/HierarchicalContext.hpp
+++ b/src/vtbackend/vt/HierarchicalContext.hpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vtbackend/core/TerminalContext.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <string_view>
+
+namespace vtbackend
+{
+
+/// The longest CTXID the ABNF admits: `CTXID = 1*64SAFE`, counted in DECODED bytes.
+inline constexpr size_t MaxContextIdentifierLength = 64;
+
+/// The longest decoded value any metadata field may carry: every text field is `*255SAFE`.
+inline constexpr size_t MaxContextFieldLength = 255;
+
+/// The longest payload the decoder will look at.
+///
+/// Derived, not guessed: the ABNF's largest legal payload is one 64-byte CTXID plus fifteen fields of
+/// at most 255 decoded bytes, and a decoded byte costs at most four raw characters (`\x5c`), so no
+/// conforming sequence exceeds ~16 kB. Being under Sequence::MaxOscLength (50 kB) is the point: a
+/// legal sequence can therefore never have been truncated by the time we see it, so the decoder never
+/// has to guess whether a short last field was sent short or cut off.
+inline constexpr size_t MaxContextPayloadLength = 16384;
+
+/// Why an OSC 3008 payload could not be decoded at all.
+///
+/// Only failures of the SEQUENCE are errors. A malformed FIELD is not: the protocol is lenient, so an
+/// invalid or unknown field is dropped and the rest of the sequence stands. What cannot be recovered
+/// from is a broken identifier -- the subject of the sequence, not one of its fields.
+enum class ContextParseError : uint8_t
+{
+    MissingVerb = 0,     ///< The payload begins with neither `start=` nor `end=`.
+    EmptyIdentifier,     ///< The CTXID was empty; the ABNF requires at least one SAFE.
+    IdentifierTooLong,   ///< The CTXID exceeded @ref MaxContextIdentifierLength decoded bytes.
+    MalformedIdentifier, ///< The CTXID held a byte SAFE does not admit, or a broken escape.
+    PayloadTooLong,      ///< The payload exceeded @ref MaxContextPayloadLength.
+};
+
+/// Names a decode failure for diagnostics.
+///
+/// A switch rather than a table, so that -Wswitch makes adding an enumerator without its name a build
+/// break -- the same reason proto::toString(DecodeError) is one.
+[[nodiscard]] constexpr std::string_view toString(ContextParseError error) noexcept
+{
+    switch (error)
+    {
+        case ContextParseError::MissingVerb: return "MissingVerb";
+        case ContextParseError::EmptyIdentifier: return "EmptyIdentifier";
+        case ContextParseError::IdentifierTooLong: return "IdentifierTooLong";
+        case ContextParseError::MalformedIdentifier: return "MalformedIdentifier";
+        case ContextParseError::PayloadTooLong: return "PayloadTooLong";
+    }
+    return "Unknown";
+}
+
+/// Resolves the two escapes the ABNF defines.
+///
+/// `ESCSEMICOLON` and `ESCBACKSLASH` are the LITERAL four-character sequences `\x3b` and `\x5c` -- not
+/// C escapes, and not a general `\xNN` scheme: no other hex pair is an escape, and a bare backslash is
+/// not a SAFE element at all (SAFE resumes at %x5d, one past it). ABNF quoted strings are
+/// case-insensitive per RFC 5234 section 2.3, so all four spellings of each are accepted.
+///
+/// Anything else carrying a backslash is therefore a value the grammar does not admit, and the caller
+/// drops that FIELD while keeping the rest of the sequence -- which is what the specification means by
+/// processing "in a lenient, graceful fashion".
+///
+/// Bytes above 0x7f pass through verbatim: the specification deliberately departs from ECMA-48 to
+/// allow them. Control bytes do not -- and 0x7f in particular is reachable, because the parser's OSC
+/// range ends at it.
+///
+/// @param raw The field's text as it arrived.
+/// @param out Receives the decoded bytes, APPENDED. The caller reserves once and reuses.
+/// @return Whether @p raw was a valid sequence of SAFE elements. On false @p out is left with whatever
+///         was appended before the fault; the caller drops the field.
+[[nodiscard]] bool unescapeContextValue(std::string_view raw, std::string& out);
+
+/// Decodes one OSC 3008 payload.
+///
+/// @param payload The OSC body with the code and its following `;` already removed, i.e.
+///        `start=ID;type=shell` -- @see SequenceBuilder::dispatchOSC, which erases exactly that.
+/// @param scratch A buffer the decoder owns for the duration of the call. Cleared and reserved on
+///        entry to what any decoding of @p payload can need (an escape only ever SHRINKS), so it never
+///        reallocates mid-decode and the returned views never dangle. Injected rather than static: a
+///        hidden buffer is shared mutable state, and a member of the caller costs one allocation per
+///        session rather than one per prompt.
+/// @return The decoded command, whose views point into @p payload and @p scratch, or why the sequence
+///         as a whole was rejected.
+[[nodiscard]] std::expected<ContextCommand, ContextParseError> parseContextSequence(std::string_view payload,
+                                                                                    std::string& scratch);
+
+} // namespace vtbackend

--- a/src/vtbackend/vt/HierarchicalContext_test.cpp
+++ b/src/vtbackend/vt/HierarchicalContext_test.cpp
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <vtbackend/vt/HierarchicalContext.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <optional>
+#include <string>
+
+using namespace vtbackend;
+using namespace std::string_view_literals;
+
+namespace
+{
+
+/// Decodes @p payload, requiring success, and keeps the scratch alive for the caller's views.
+struct Decoded
+{
+    std::string scratch;
+    ContextCommand command;
+
+    explicit Decoded(std::string_view payload)
+    {
+        auto result = parseContextSequence(payload, scratch);
+        REQUIRE(result.has_value());
+        command = *result;
+    }
+};
+
+/// The error @p payload is rejected with.
+ContextParseError errorOf(std::string_view payload)
+{
+    auto scratch = std::string {};
+    auto const result = parseContextSequence(payload, scratch);
+    REQUIRE(!result.has_value());
+    return result.error();
+}
+
+/// One unescaped value, or nullopt when the raw text is not a valid run of SAFE elements.
+std::optional<std::string> unescaped(std::string_view raw)
+{
+    auto out = std::string {};
+    if (!unescapeContextValue(raw, out))
+        return std::nullopt;
+    return out;
+}
+
+} // namespace
+
+// {{{ the unescaper
+
+TEST_CASE("HierarchicalContext.an escaped semicolon decodes", "[context]")
+{
+    CHECK(unescaped("a\\x3bb") == "a;b");
+}
+
+TEST_CASE("HierarchicalContext.an escaped backslash decodes", "[context]")
+{
+    CHECK(unescaped("a\\x5cb") == "a\\b");
+}
+
+TEST_CASE("HierarchicalContext.escapes are case-insensitive, as ABNF quoted strings are", "[context]")
+{
+    // RFC 5234 section 2.3. This is the grammar, not a lenience we invented.
+    CHECK(unescaped("\\x3b") == ";");
+    CHECK(unescaped("\\x3B") == ";");
+    CHECK(unescaped("\\X3b") == ";");
+    CHECK(unescaped("\\X3B") == ";");
+
+    CHECK(unescaped("\\x5c") == "\\");
+    CHECK(unescaped("\\x5C") == "\\");
+    CHECK(unescaped("\\X5c") == "\\");
+    CHECK(unescaped("\\X5C") == "\\");
+}
+
+TEST_CASE("HierarchicalContext.a stray backslash is rejected", "[context]")
+{
+    // A bare 0x5c is not a SAFE element in any position -- SAFE resumes at %x5d, one past it.
+    CHECK(!unescaped("a\\b").has_value());
+    CHECK(!unescaped("\\").has_value());
+    CHECK(!unescaped("trailing\\").has_value());
+}
+
+TEST_CASE("HierarchicalContext.an unknown hex escape is rejected", "[context]")
+{
+    // Not a general \\xNN scheme: only the two the ABNF names are escapes.
+    CHECK(!unescaped("\\x41").has_value());
+    CHECK(!unescaped("\\x00").has_value());
+    CHECK(!unescaped("\\y3b").has_value());
+}
+
+TEST_CASE("HierarchicalContext.a truncated escape at the end is rejected", "[context]")
+{
+    CHECK(!unescaped("\\x3").has_value());
+    CHECK(!unescaped("\\x").has_value());
+    CHECK(!unescaped("ok\\x5").has_value());
+}
+
+TEST_CASE("HierarchicalContext.bytes above 0x7f are kept verbatim", "[context]")
+{
+    // The specification deliberately departs from ECMA-48 to allow them, so a UTF-8 path survives.
+    auto const utf8 = "/home/\xc3\xbcser/\xe6\x97\xa5\xe6\x9c\xac"sv;
+    CHECK(unescaped(utf8) == std::string { utf8 });
+}
+
+TEST_CASE("HierarchicalContext.invalid UTF-8 is kept verbatim and not validated", "[context]")
+{
+    // The backend stores bytes: a Linux cwd is an arbitrary byte string, and rejecting one that is not
+    // valid UTF-8 would discard a legitimate path. Transcoding is the frontend's job.
+    auto const invalid = "\xff\xfe"sv;
+    CHECK(unescaped(invalid) == std::string { invalid });
+}
+
+TEST_CASE("HierarchicalContext.control bytes are rejected", "[context]")
+{
+    CHECK(!unescaped("a\x01"
+                     "b")
+               .has_value());
+    CHECK(!unescaped("a\x1f").has_value());
+    // 0x7f in particular is REACHABLE: vtparser's OSC range ends at 0x7f, not 0x7e, so DEL is handed
+    // to us even though the specification forbids it.
+    CHECK(!unescaped("a\x7f").has_value());
+}
+
+TEST_CASE("HierarchicalContext.an empty value decodes to empty", "[context]")
+{
+    CHECK(unescaped("") == "");
+}
+
+// }}}
+// {{{ ABNF acceptance
+
+TEST_CASE("HierarchicalContext.a bare start is accepted", "[context]")
+{
+    // `STARTSEQ = OSC "3008;start=" CTXID *(";" STARTFIELD) ST` -- zero fields is legal.
+    auto const decoded = Decoded { "start=abc" };
+    CHECK(decoded.command.verb == ContextVerb::Start);
+    CHECK(decoded.command.identifier == "abc");
+    CHECK(decoded.command.present == ContextFields {});
+}
+
+TEST_CASE("HierarchicalContext.a bare end is accepted", "[context]")
+{
+    auto const decoded = Decoded { "end=abc" };
+    CHECK(decoded.command.verb == ContextVerb::End);
+    CHECK(decoded.command.identifier == "abc");
+    CHECK(decoded.command.outcome == ContextOutcome {});
+}
+
+TEST_CASE("HierarchicalContext.every start field decodes", "[context]")
+{
+    auto const decoded =
+        Decoded { "start=id;type=container;user=lennart;hostname=zeta;"
+                  "machineid=3deb5353d3ba43d08201c136a47ead7b;bootid=d4a3d0fdf2e24fdea6d971ce73f4fbf2;"
+                  "pid=1062862;pidfdid=1063162;comm=systemd-nspawn;cwd=/app;cmdline=ls -l;vm=myvm;"
+                  "container=foobar;targetuser=root;targethost=example.com;sessionid=42" };
+    auto const& command = decoded.command;
+
+    CHECK(command.type == ContextType::Container);
+    CHECK(command.user == "lennart");
+    CHECK(command.hostname == "zeta");
+    CHECK(command.machineId == "3deb5353d3ba43d08201c136a47ead7b");
+    CHECK(command.bootId == "d4a3d0fdf2e24fdea6d971ce73f4fbf2");
+    CHECK(command.pid == 1062862);
+    CHECK(command.pidFdId == 1063162);
+    CHECK(command.comm == "systemd-nspawn");
+    CHECK(command.workingDirectory == "/app");
+    CHECK(command.commandLine == "ls -l");
+    CHECK(command.vm == "myvm");
+    CHECK(command.container == "foobar");
+    CHECK(command.targetUser == "root");
+    CHECK(command.targetHost == "example.com");
+    CHECK(command.sessionId == "42");
+
+    // Every field the table names was recorded.
+    for (auto const field: ContextFieldList)
+        CHECK((command.present & field).any());
+}
+
+TEST_CASE("HierarchicalContext.every type enum decodes", "[context]")
+{
+    for (auto const type: ContextTypeList)
+    {
+        auto const payload = std::string { "start=id;type=" } + std::string { contextTypeName(type) };
+        auto const decoded = Decoded { payload };
+        CHECK(decoded.command.type == type);
+    }
+}
+
+TEST_CASE("HierarchicalContext.every exit enum decodes", "[context]")
+{
+    for (auto const exit:
+         { ContextExit::Success, ContextExit::Failure, ContextExit::Crash, ContextExit::Interrupt })
+    {
+        auto const payload = std::string { "end=id;exit=" } + std::string { contextExitName(exit) };
+        auto const decoded = Decoded { payload };
+        CHECK(decoded.command.outcome.exit == exit);
+    }
+}
+
+TEST_CASE("HierarchicalContext.a symbolic signal decodes to its Linux number", "[context]")
+{
+    auto const decoded = Decoded { "end=id;exit=failure;status=139;signal=SIGSEGV" };
+    CHECK(decoded.command.outcome.exit == ContextExit::Failure);
+    CHECK(decoded.command.outcome.status == 139);
+    CHECK(decoded.command.outcome.signal == ContextSignal::Segv);
+    CHECK(decoded.command.outcome.asShellExitCode() == 139);
+}
+
+TEST_CASE("HierarchicalContext.field order is undefined so type may come last", "[context]")
+{
+    // The specification says so outright: "including that type= is specified at the very end or in the
+    // middle".
+    auto const decoded = Decoded { "start=id;cwd=/tmp;user=bob;type=shell" };
+    CHECK(decoded.command.type == ContextType::Shell);
+    CHECK(decoded.command.workingDirectory == "/tmp");
+    CHECK(decoded.command.user == "bob");
+}
+
+TEST_CASE("HierarchicalContext.an escaped value round-trips through a field", "[context]")
+{
+    auto const decoded = Decoded { "start=id;cwd=/home/a\\x3bb\\x5cc" };
+    CHECK(decoded.command.workingDirectory == "/home/a;b\\c");
+}
+
+TEST_CASE("HierarchicalContext.an escaped identifier decodes", "[context]")
+{
+    auto const decoded = Decoded { "start=a\\x3bb;type=shell" };
+    CHECK(decoded.command.identifier == "a;b");
+    CHECK(decoded.command.type == ContextType::Shell);
+}
+
+// }}}
+// {{{ ABNF rejection and leniency
+
+TEST_CASE("HierarchicalContext.a payload without a verb is rejected", "[context]")
+{
+    CHECK(errorOf("") == ContextParseError::MissingVerb);
+    CHECK(errorOf("begin=abc") == ContextParseError::MissingVerb);
+    CHECK(errorOf("abc") == ContextParseError::MissingVerb);
+    CHECK(errorOf("START=abc") == ContextParseError::MissingVerb); // the verb itself is not ABNF-quoted
+}
+
+TEST_CASE("HierarchicalContext.an empty identifier is rejected", "[context]")
+{
+    // `CTXID = 1*64SAFE` -- at least one.
+    CHECK(errorOf("start=") == ContextParseError::EmptyIdentifier);
+    CHECK(errorOf("end=") == ContextParseError::EmptyIdentifier);
+    CHECK(errorOf("start=;type=shell") == ContextParseError::EmptyIdentifier);
+}
+
+TEST_CASE("HierarchicalContext.an identifier over 64 bytes is rejected", "[context]")
+{
+    // The identifier is the SUBJECT of the sequence, not one of its fields, so the leniency clause
+    // does not reach it: acting on a truncated key would attach metadata to the wrong context.
+    CHECK(errorOf("start=" + std::string(65, 'a')) == ContextParseError::IdentifierTooLong);
+    auto scratch = std::string {};
+    CHECK(parseContextSequence("start=" + std::string(64, 'a'), scratch).has_value());
+}
+
+TEST_CASE("HierarchicalContext.identifier length is measured after unescaping", "[context]")
+{
+    // SAFE counts ELEMENTS, and ESCSEMICOLON is one of them spelled with four characters. Validating
+    // the raw length would reject a legal id.
+    auto scratch = std::string {};
+    auto const sixtyFourSemicolons = std::string { "start=" };
+    auto payload = sixtyFourSemicolons;
+    for (auto i = 0; i < 64; ++i)
+        payload += "\\x3b";
+    auto const result = parseContextSequence(payload, scratch);
+    REQUIRE(result.has_value());
+    CHECK(result->identifier.size() == 64);
+
+    payload += "\\x3b"; // one element too many
+    CHECK(errorOf(payload) == ContextParseError::IdentifierTooLong);
+}
+
+TEST_CASE("HierarchicalContext.a malformed identifier is rejected", "[context]")
+{
+    CHECK(errorOf("start=a\\b") == ContextParseError::MalformedIdentifier);
+    CHECK(errorOf("start=a\x7f") == ContextParseError::MalformedIdentifier);
+}
+
+TEST_CASE("HierarchicalContext.an oversized payload is rejected", "[context]")
+{
+    CHECK(errorOf("start=id;cwd=" + std::string(MaxContextPayloadLength, 'a'))
+          == ContextParseError::PayloadTooLong);
+}
+
+TEST_CASE("HierarchicalContext.an unknown field is ignored and the rest survives", "[context]")
+{
+    // The specification: "if a sequence contains invalid fields, those fields should be ignored, but
+    // the rest of the fields should still be used. In particular, unknown fields should be ignored."
+    auto const decoded = Decoded { "start=id;nosuchfield=x;type=shell;alsonot=y;cwd=/tmp" };
+    CHECK(decoded.command.type == ContextType::Shell);
+    CHECK(decoded.command.workingDirectory == "/tmp");
+}
+
+TEST_CASE("HierarchicalContext.a bare token with no equals is ignored", "[context]")
+{
+    auto const decoded = Decoded { "start=id;justatoken;type=shell" };
+    CHECK(decoded.command.type == ContextType::Shell);
+}
+
+TEST_CASE("HierarchicalContext.a field with a broken escape is dropped, not the sequence", "[context]")
+{
+    auto const decoded = Decoded { "start=id;cwd=/bad\\path;type=shell" };
+    CHECK(decoded.command.type == ContextType::Shell);
+    CHECK(!(decoded.command.present & ContextField::WorkingDirectory).any());
+}
+
+TEST_CASE("HierarchicalContext.an oversized field is discarded, not truncated", "[context]")
+{
+    // A truncated path names a REAL directory that is not the one meant, and something will eventually
+    // open it. An absent field is honestly absent.
+    auto const decoded =
+        Decoded { "start=id;cwd=/" + std::string(MaxContextFieldLength, 'a') + ";type=shell" };
+    CHECK(decoded.command.type == ContextType::Shell);
+    CHECK(!(decoded.command.present & ContextField::WorkingDirectory).any());
+    CHECK(decoded.command.workingDirectory.empty());
+}
+
+TEST_CASE("HierarchicalContext.a field of exactly the maximum length is accepted", "[context]")
+{
+    auto const decoded = Decoded { "start=id;cwd=" + std::string(MaxContextFieldLength, 'a') };
+    CHECK((decoded.command.present & ContextField::WorkingDirectory).any());
+    CHECK(decoded.command.workingDirectory.size() == MaxContextFieldLength);
+}
+
+TEST_CASE("HierarchicalContext.field length is measured after unescaping", "[context]")
+{
+    auto payload = std::string { "start=id;cwd=" };
+    for (auto i = size_t {}; i < MaxContextFieldLength; ++i)
+        payload += "\\x3b";
+    auto const decoded = Decoded { payload };
+    CHECK((decoded.command.present & ContextField::WorkingDirectory).any());
+    CHECK(decoded.command.workingDirectory.size() == MaxContextFieldLength);
+}
+
+TEST_CASE("HierarchicalContext.an empty text field is discarded", "[context]")
+{
+    // `1*255SAFE`: empty is not a value.
+    auto const decoded = Decoded { "start=id;user=;type=shell" };
+    CHECK(!(decoded.command.present & ContextField::User).any());
+    CHECK(decoded.command.type == ContextType::Shell);
+}
+
+TEST_CASE("HierarchicalContext.an empty cmdline is accepted because the ABNF allows it", "[context]")
+{
+    // `CMDLINE = "cmdline=" *255SAFE` -- deliberately different from every other text field, so honour
+    // the difference. It is what tells "ran an empty command line" apart from "did not say".
+    auto const decoded = Decoded { "start=id;cmdline=" };
+    CHECK((decoded.command.present & ContextField::CommandLine).any());
+    CHECK(decoded.command.commandLine.empty());
+}
+
+TEST_CASE("HierarchicalContext.a malformed ID128 is discarded", "[context]")
+{
+    CHECK(!(Decoded { "start=id;machineid=tooshort" }.command.present & ContextField::MachineId).any());
+    CHECK(
+        !(Decoded { "start=id;machineid=" + std::string(37, 'a') }.command.present & ContextField::MachineId)
+             .any());
+    CHECK(
+        !(Decoded { "start=id;machineid=" + std::string(32, 'z') }.command.present & ContextField::MachineId)
+             .any());
+    CHECK(
+        (Decoded { "start=id;bootid=" + std::string(32, 'a') }.command.present & ContextField::BootId).any());
+    CHECK(
+        (Decoded { "start=id;bootid=" + std::string(36, 'F') }.command.present & ContextField::BootId).any());
+}
+
+TEST_CASE("HierarchicalContext.a 21-digit pid is discarded", "[context]")
+{
+    // `UINT64 = 1*20DECIMAL`. Bounded BEFORE the digits are accumulated, or an absurdly long run would
+    // wrap and land back on a value the caller accepts.
+    CHECK(!(Decoded { "start=id;pid=" + std::string(21, '9') }.command.present & ContextField::Pid).any());
+    CHECK((Decoded { "start=id;pid=" + std::string(20, '1') }.command.present & ContextField::Pid).any());
+    CHECK(!(Decoded { "start=id;pid=12a" }.command.present & ContextField::Pid).any());
+    CHECK(!(Decoded { "start=id;pid=-1" }.command.present & ContextField::Pid).any());
+    CHECK(!(Decoded { "start=id;pid=" }.command.present & ContextField::Pid).any());
+}
+
+TEST_CASE("HierarchicalContext.an unknown type is ignored like any unknown field", "[context]")
+{
+    auto const decoded = Decoded { "start=id;type=nosuchtype;cwd=/tmp" };
+    CHECK(decoded.command.type == ContextType::None);
+    CHECK(!(decoded.command.present & ContextField::Type).any());
+    CHECK(decoded.command.workingDirectory == "/tmp");
+}
+
+TEST_CASE("HierarchicalContext.a duplicate field takes the last value", "[context]")
+{
+    // Spec-silent; matches crispy::splitKeyValuePairs and the OSC 99 metadata loop, both last-wins.
+    auto const decoded = Decoded { "start=id;user=first;user=second" };
+    CHECK(decoded.command.user == "second");
+}
+
+TEST_CASE("HierarchicalContext.an unknown signal name is discarded", "[context]")
+{
+    auto const decoded = Decoded { "end=id;exit=crash;signal=SIGNOSUCH" };
+    CHECK(decoded.command.outcome.exit == ContextExit::Crash);
+    CHECK(decoded.command.outcome.signal == ContextSignal::None);
+}
+
+TEST_CASE("HierarchicalContext.a second verb later in the payload is ignored", "[context]")
+{
+    // The grammar puts the verb first; anything later is not a STARTFIELD.
+    auto const decoded = Decoded { "start=id;type=shell;start=other" };
+    CHECK(decoded.command.identifier == "id");
+    CHECK(decoded.command.type == ContextType::Shell);
+}
+
+TEST_CASE("HierarchicalContext.start fields on an end sequence are ignored", "[context]")
+{
+    auto const decoded = Decoded { "end=id;cwd=/tmp;exit=success" };
+    CHECK(decoded.command.outcome.exit == ContextExit::Success);
+    CHECK(decoded.command.present == ContextFields {});
+}
+
+TEST_CASE("HierarchicalContext.end fields on a start sequence are ignored", "[context]")
+{
+    auto const decoded = Decoded { "start=id;exit=success;type=shell" };
+    CHECK(decoded.command.outcome == ContextOutcome {});
+    CHECK(decoded.command.type == ContextType::Shell);
+}
+
+// }}}
+// {{{ the real traffic
+
+TEST_CASE("HierarchicalContext.the systemd shell announcement decodes", "[context]")
+{
+    // Byte for byte what /etc/profile.d/80-systemd-osc-context.sh emits from PROMPT_COMMAND, including
+    // the escaped cwd its __systemd_osc_context_escape produces.
+    auto const decoded =
+        Decoded { "start=8c1ba9a4-8b2f-4a1e-9c3d-2f5e7a9b1c4d;type=shell;"
+                  "machineid=3deb5353d3ba43d08201c136a47ead7b;user=lennart;hostname=zeta;"
+                  "bootid=d4a3d0fdf2e24fdea6d971ce73f4fbf2;pid=1062862;cwd=/home/lennart/pro\\x3bject" };
+
+    CHECK(decoded.command.verb == ContextVerb::Start);
+    CHECK(decoded.command.type == ContextType::Shell);
+    CHECK(decoded.command.user == "lennart");
+    CHECK(decoded.command.pid == 1062862);
+    CHECK(decoded.command.workingDirectory == "/home/lennart/pro;ject");
+    // No cmdline= at all: the systemd shim does not send one, so every 3008-derived block has none.
+    CHECK(!(decoded.command.present & ContextField::CommandLine).any());
+}
+
+TEST_CASE("HierarchicalContext.the systemd failure report decodes", "[context]")
+{
+    auto const decoded = Decoded { "end=8c1ba9a4-8b2f-4a1e-9c3d-2f5e7a9b1c4d;exit=failure;status=139;"
+                                   "signal=SIGSEGV" };
+    CHECK(decoded.command.verb == ContextVerb::End);
+    CHECK(decoded.command.outcome.exit == ContextExit::Failure);
+    CHECK(decoded.command.outcome.signal == ContextSignal::Segv);
+}
+
+TEST_CASE("HierarchicalContext.the specification's container example decodes", "[context]")
+{
+    auto const decoded = Decoded { "start=bed86fab93af4328bbed0a1224af6d40;type=container;user=lennart;"
+                                   "hostname=zeta;machineid=3deb5353d3ba43d08201c136a47ead7b;"
+                                   "bootid=d4a3d0fdf2e24fdea6d971ce73f4fbf2;pid=1062862;pidfdid=1063162;"
+                                   "comm=systemd-nspawn;container=foobar" };
+    CHECK(decoded.command.type == ContextType::Container);
+    CHECK(decoded.command.container == "foobar");
+    CHECK(decoded.command.pidFdId == 1063162);
+}
+
+// }}}
+// {{{ allocation discipline
+
+TEST_CASE("HierarchicalContext.repeated decoding reuses the scratch buffer", "[context]")
+{
+    // The systemd hot path: the shell context is re-announced on EVERY prompt. Decoding must not
+    // allocate once per prompt to store what we already have.
+    auto scratch = std::string {};
+    auto const payload = "start=shell-uuid;type=shell;machineid=3deb5353d3ba43d08201c136a47ead7b;"
+                         "user=lennart;hostname=zeta;pid=1062862;cwd=/home/lennart"sv;
+
+    REQUIRE(parseContextSequence(payload, scratch).has_value());
+    auto const warmCapacity = scratch.capacity();
+
+    for (auto i = 0; i < 100; ++i)
+        REQUIRE(parseContextSequence(payload, scratch).has_value());
+
+    CHECK(scratch.capacity() == warmCapacity);
+}
+
+TEST_CASE("HierarchicalContext.the decoded views point into the scratch buffer", "[context]")
+{
+    // What makes reuse safe: the scratch is reserved to the raw payload size up front, and an escape
+    // only ever shrinks, so it never reallocates mid-decode and no view dangles.
+    auto scratch = std::string {};
+    auto const result = parseContextSequence("start=id;cwd=/a\\x3bb;user=bob", scratch);
+    REQUIRE(result.has_value());
+
+    auto const* const base = scratch.data();
+    auto const* const end = base + scratch.size();
+    CHECK(result->identifier.data() >= base);
+    CHECK(result->identifier.data() < end);
+    CHECK(result->workingDirectory.data() >= base);
+    CHECK(result->workingDirectory.data() < end);
+    CHECK(result->workingDirectory == "/a;b");
+    CHECK(result->user == "bob");
+}
+
+// }}}
+// {{{ diagnostics
+
+TEST_CASE("HierarchicalContext.every parse error has a distinct name", "[context]")
+{
+    auto const names = std::array { toString(ContextParseError::MissingVerb),
+                                    toString(ContextParseError::EmptyIdentifier),
+                                    toString(ContextParseError::IdentifierTooLong),
+                                    toString(ContextParseError::MalformedIdentifier),
+                                    toString(ContextParseError::PayloadTooLong) };
+    for (auto i = size_t {}; i < names.size(); ++i)
+    {
+        CHECK(!names[i].empty());
+        CHECK(names[i] != "Unknown");
+        for (auto j = i + 1; j < names.size(); ++j)
+            CHECK(names[i] != names[j]);
+    }
+}
+
+// }}}

--- a/src/vthost/ContextWire.hpp
+++ b/src/vthost/ContextWire.hpp
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// The OSC 3008 hierarchical context state as it travels on the native protocol — single-sourced so
+/// the server's capture (NativeSession) and the client's apply (ScreenMirror) cannot disagree, exactly
+/// as @ref vthost/StatusWire.hpp does for the status display and @ref vthost/MouseWire.hpp for the
+/// mouse.
+///
+/// Decoding is TOTAL, which is the whole reason this file exists. Every one of these arrives as a raw
+/// byte a peer chose, and casting one straight into its enum is how a value no enumerator has reaches
+/// a switch that assumes otherwise. Three enums and a flag mask travel here; none of them is cast.
+
+#include <vtbackend/core/TerminalContext.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include <vthost/proto/Pdu.hpp>
+
+namespace vthost
+{
+
+/// @param value A ContextType as the wire spells it.
+/// @return The type it names, or nullopt for a value no enumerator has.
+[[nodiscard]] constexpr std::optional<vtbackend::ContextType> contextTypeOf(uint8_t value) noexcept
+{
+    // The enumerators are contiguous from None, so the bound is the last row of the type table.
+    constexpr auto Last = static_cast<uint8_t>(vtbackend::ContextTypeList.back());
+    return value <= Last ? std::optional { static_cast<vtbackend::ContextType>(value) } : std::nullopt;
+}
+
+/// @param value A ContextExit as the wire spells it.
+/// @return The exit kind it names, or nullopt for a value no enumerator has.
+[[nodiscard]] constexpr std::optional<vtbackend::ContextExit> contextExitOf(uint8_t value) noexcept
+{
+    return value <= std::to_underlying(vtbackend::ContextExit::Interrupt)
+               ? std::optional { static_cast<vtbackend::ContextExit>(value) }
+               : std::nullopt;
+}
+
+/// @param value A ContextSignal as the wire spells it -- a Linux signal NUMBER, not an index.
+/// @return The signal it names, or nullopt for a number this terminal does not know.
+[[nodiscard]] constexpr std::optional<vtbackend::ContextSignal> contextSignalOf(uint8_t value) noexcept
+{
+    // Not a range check: the signal numbers are sparse (there is no 16..23), so membership is the only
+    // sound test. @see VTBACKEND_CONTEXT_SIGNALS.
+    return vtbackend::isKnownContextSignal(value)
+               ? std::optional { static_cast<vtbackend::ContextSignal>(value) }
+               : std::nullopt;
+}
+
+/// @param value A ContextFields mask as the wire spells it.
+/// @return The mask with any bit the field table does not assign cleared.
+///
+/// Masked rather than rejected: an unknown bit is an unknown FIELD, and the protocol's own rule for
+/// one of those is to ignore it and keep the rest -- so a peer built from a newer commit that gained
+/// a sixteenth field degrades to the fifteen this build understands.
+[[nodiscard]] constexpr vtbackend::ContextFields contextFieldsOf(uint16_t value) noexcept
+{
+    return vtbackend::ContextFields { static_cast<vtbackend::ContextField>(
+        static_cast<uint16_t>(value & vtbackend::ContextFieldMask)) };
+}
+
+/// Every ContextField, with the wire bit it is pinned to. @see ContextPresentMask.
+constexpr inline auto PinnedContextFieldBits = std::array {
+    std::pair { vtbackend::ContextField::Type, 0 },
+    std::pair { vtbackend::ContextField::User, 1 },
+    std::pair { vtbackend::ContextField::Hostname, 2 },
+    std::pair { vtbackend::ContextField::MachineId, 3 },
+    std::pair { vtbackend::ContextField::BootId, 4 },
+    std::pair { vtbackend::ContextField::Pid, 5 },
+    std::pair { vtbackend::ContextField::PidFdId, 6 },
+    std::pair { vtbackend::ContextField::Comm, 7 },
+    std::pair { vtbackend::ContextField::WorkingDirectory, 8 },
+    std::pair { vtbackend::ContextField::CommandLine, 9 },
+    std::pair { vtbackend::ContextField::Vm, 10 },
+    std::pair { vtbackend::ContextField::Container, 11 },
+    std::pair { vtbackend::ContextField::TargetUser, 12 },
+    std::pair { vtbackend::ContextField::TargetHost, 13 },
+    std::pair { vtbackend::ContextField::SessionId, 14 },
+};
+
+namespace detail
+{
+    [[nodiscard]] constexpr bool contextFieldBitsAreAsPinned() noexcept
+    {
+        for (auto const& [field, bit]: PinnedContextFieldBits)
+            if (std::to_underlying(field) != (1U << static_cast<unsigned>(bit)))
+                return false;
+        return true;
+    }
+} // namespace detail
+
+static_assert(detail::contextFieldBitsAreAsPinned(),
+              "A ContextField's bit value changed. Those bits travel on the native wire verbatim "
+              "inside a context record's `present`, so an older peer would read the wrong field: bump "
+              "proto::CodecVersion (or restore the bit) and update the pin above.");
+static_assert(PinnedContextFieldBits.size() == vtbackend::ContextFieldList.size(),
+              "A ContextField was added or removed. Add (or drop) its row in PinnedContextFieldBits "
+              "and in proto::ContextStringFields/ContextVarintFields, which together freeze the wire "
+              "encoding, then widen proto::ContextPresentMask.");
+static_assert(vtbackend::ContextFieldMask == proto::ContextPresentMask,
+              "vtbackend's field table and the wire's presence mask disagree about which bits exist.");
+
+/// Builds a TerminalContext from its wire form, with the two ids already translated.
+///
+/// Total, and THIS is where that is secured: the codec carries every enum-ish byte through raw -- it
+/// knows nothing of vtbackend's enumerators, deliberately -- so each one is named here through the
+/// validators above, and anything they cannot name falls to its zero value. Nothing below can produce
+/// a value no enumerator has.
+///
+/// @param wire      The record off the wire.
+/// @param localId   The id THIS terminal will hold it under.
+/// @param localParent The translated parent id, or zero when the parent is not (yet) known here.
+[[nodiscard]] inline vtbackend::TerminalContext fromWireContext(proto::WireContext const& wire,
+                                                                vtbackend::ContextId localId,
+                                                                vtbackend::ContextId localParent)
+{
+    auto record = vtbackend::TerminalContext {};
+    record.id = localId;
+    record.parent = localParent;
+    record.identifier = wire.identifier;
+    record.type = contextTypeOf(wire.type).value_or(vtbackend::ContextType::None);
+    record.present = contextFieldsOf(wire.present);
+    record.user = wire.user;
+    record.hostname = wire.hostname;
+    record.machineId = wire.machineId;
+    record.bootId = wire.bootId;
+    record.comm = wire.comm;
+    record.workingDirectory = wire.workingDirectory;
+    record.commandLine = wire.commandLine;
+    record.vm = wire.vm;
+    record.container = wire.container;
+    record.targetUser = wire.targetUser;
+    record.targetHost = wire.targetHost;
+    record.sessionId = wire.sessionId;
+    record.pid = wire.pid;
+    record.pidFdId = wire.pidFdId;
+    record.outcome.exit = contextExitOf(wire.exitKind).value_or(vtbackend::ContextExit::Unknown);
+    record.outcome.signal = contextSignalOf(wire.signal).value_or(vtbackend::ContextSignal::None);
+    record.outcome.status = wire.status;
+    return record;
+}
+
+/// Whether @p record already holds exactly what @p wire describes under @p localParent.
+///
+/// Field by field rather than `fromWireContext(...) == record`, and the difference is not cosmetic:
+/// this answers "did anything move?" once per retained record per delta -- every 20 ms on an attached
+/// pane -- and building a TerminalContext to ask would allocate a dozen strings per record per flush
+/// to usually learn that nothing did. Mirrors @ref fromWireContext line for line, deliberately: the
+/// two are read together, and a field present in one but not the other is the bug this exists to
+/// prevent.
+[[nodiscard]] inline bool matchesWireContext(vtbackend::TerminalContext const& record,
+                                             proto::WireContext const& wire,
+                                             vtbackend::ContextId localParent) noexcept
+{
+    return record.parent == localParent && record.identifier == wire.identifier
+           && record.type == contextTypeOf(wire.type).value_or(vtbackend::ContextType::None)
+           && record.present == contextFieldsOf(wire.present) && record.user == wire.user
+           && record.hostname == wire.hostname && record.machineId == wire.machineId
+           && record.bootId == wire.bootId && record.comm == wire.comm
+           && record.workingDirectory == wire.workingDirectory && record.commandLine == wire.commandLine
+           && record.vm == wire.vm && record.container == wire.container
+           && record.targetUser == wire.targetUser && record.targetHost == wire.targetHost
+           && record.sessionId == wire.sessionId && record.pid == wire.pid && record.pidFdId == wire.pidFdId
+           && record.outcome.exit == contextExitOf(wire.exitKind).value_or(vtbackend::ContextExit::Unknown)
+           && record.outcome.signal == contextSignalOf(wire.signal).value_or(vtbackend::ContextSignal::None)
+           && record.outcome.status == wire.status;
+}
+
+/// The wire form of @p record, for a host replicating it.
+[[nodiscard]] inline proto::WireContext toWireContext(vtbackend::TerminalContext const& record)
+{
+    auto wire = proto::WireContext {};
+    wire.id = record.id.value;
+    wire.parent = record.parent.value;
+    wire.identifier = record.identifier;
+    wire.type = static_cast<uint8_t>(record.type);
+    wire.present = record.present.value();
+    wire.user = record.user;
+    wire.hostname = record.hostname;
+    wire.machineId = record.machineId;
+    wire.bootId = record.bootId;
+    wire.comm = record.comm;
+    wire.workingDirectory = record.workingDirectory;
+    wire.commandLine = record.commandLine;
+    wire.vm = record.vm;
+    wire.container = record.container;
+    wire.targetUser = record.targetUser;
+    wire.targetHost = record.targetHost;
+    wire.sessionId = record.sessionId;
+    wire.pid = record.pid;
+    wire.pidFdId = record.pidFdId;
+    wire.exitKind = static_cast<uint8_t>(record.outcome.exit);
+    wire.signal = static_cast<uint8_t>(record.outcome.signal);
+    wire.status = record.outcome.status;
+    return wire;
+}
+
+} // namespace vthost

--- a/src/vthost/GridWire.cpp
+++ b/src/vthost/GridWire.cpp
@@ -171,7 +171,8 @@ void applyWireCell(vtbackend::LineSoA& soa,
 
 void applyWireLine(vtbackend::Line& line,
                    proto::WireLine const& wire,
-                   std::unordered_map<uint16_t, vtbackend::HyperlinkId> const& hyperlinks)
+                   std::unordered_map<uint16_t, vtbackend::HyperlinkId> const& hyperlinks,
+                   ContextIdMap const& contexts)
 {
     auto const flags = vtbackend::LineFlags::fromValue(wire.flags);
     // The clear does three jobs at once: it drops stale content, it gives the omitted trailing
@@ -181,6 +182,13 @@ void applyWireLine(vtbackend::Line& line,
     // After the reset, never before: Line::reset() clears both offsets.
     line.setPromptEndOffset(vtbackend::ColumnOffset(wire.promptEndOffset));
     line.setCommandEndOffset(vtbackend::ColumnOffset(wire.commandEndOffset));
+    // Translated, never copied: the id is the SENDER's, and this terminal mints its own. An id with
+    // no mapping resolves to none, exactly as an unmapped hyperlink id does. The zero test first,
+    // because a session that never sees OSC 3008 stamps every line with it and would otherwise pay a
+    // hash lookup per line per delta to learn nothing.
+    if (wire.contextId != 0)
+        if (auto const it = contexts.find(wire.contextId); it != contexts.end())
+            line.adoptContext(it->second.local);
     if (wire.cells.empty())
         return;
 
@@ -213,6 +221,7 @@ proto::WireLine toWireLine(vtbackend::Grid const& grid,
     auto wire = proto::WireLine {};
     wire.stableId = grid.stableLineIdOf(offset);
     wire.flags = static_cast<uint16_t>(line.flags().value());
+    wire.contextId = unbox<uint16_t>(line.contextId());
     wire.promptEndOffset = unbox<int32_t>(line.promptEndOffset());
     wire.commandEndOffset = unbox<int32_t>(line.commandEndOffset());
     wire.columns = unbox<uint32_t>(line.size());

--- a/src/vthost/GridWire.hpp
+++ b/src/vthost/GridWire.hpp
@@ -117,6 +117,25 @@ void applyWireCell(vtbackend::LineSoA& soa,
                    proto::WireCell const& cell,
                    vtbackend::HyperlinkId hyperlink);
 
+/// What a mirror made of one wire context id.
+///
+/// The local id and the identifier it was adopted under travel together because they are always
+/// written together and always read together: keeping them in two maps keyed alike was two lookups,
+/// two insertions, and an invariant nothing enforced.
+struct MirroredContext
+{
+    /// The id THIS terminal holds the record under. Wire ids are the sender's counter, which wraps and
+    /// reuses, so a line stamped before a reuse legitimately points at the OLD record.
+    vtbackend::ContextId local;
+
+    /// The identifier last adopted under @ref local. It distinguishes a REUSED wire id — which must
+    /// get a fresh local id — from the same context being re-announced, which keeps its own.
+    std::string identifier;
+};
+
+/// Wire context id → what the mirror adopted for it.
+using ContextIdMap = std::unordered_map<uint16_t, MirroredContext>;
+
 /// Brings @p line to exactly what @p wire describes — the inverse of @ref toWireLine.
 ///
 /// Clears the row to its fill first, which is both how stale content goes and how the omitted
@@ -127,9 +146,11 @@ void applyWireCell(vtbackend::LineSoA& soa,
 /// @param wire What it should hold.
 /// @param hyperlinks Wire hyperlink id → this terminal's own id. Ids are per-terminal counters, so
 ///        a cell's id is meaningless until translated; an unmapped id becomes "no hyperlink".
+/// @param contexts Wire context id → what the mirror adopted for it. @see MirroredContext.
 void applyWireLine(vtbackend::Line& line,
                    proto::WireLine const& wire,
-                   std::unordered_map<uint16_t, vtbackend::HyperlinkId> const& hyperlinks);
+                   std::unordered_map<uint16_t, vtbackend::HyperlinkId> const& hyperlinks,
+                   ContextIdMap const& contexts);
 
 /// Restores every column of @p line, undoing the trailing-fill omission.
 ///

--- a/src/vthost/NativeSession.cpp
+++ b/src/vthost/NativeSession.cpp
@@ -17,6 +17,7 @@
 
 #include <net/Sockets.hpp>
 #include <net/Tls.hpp>
+#include <vthost/ContextWire.hpp>
 #include <vthost/CursorStyle.hpp>
 #include <vthost/GridWire.hpp>
 #include <vthost/Logging.hpp>
@@ -249,6 +250,56 @@ coro::Task<void> NativeSession::flushSoon()
         pushDelta(SessionId { session }, /*forceSnapshot=*/false);
 }
 
+void NativeSession::collectContextState(vtbackend::Terminal& terminal,
+                                        FollowState& follow,
+                                        proto::Delta& delta,
+                                        bool snapshot)
+{
+    // The ACTIVE id is pull+diff like the cwd is, and the records it and its ancestors need travel as
+    // a side table in the same "sent once per connection on first reference" shape the hyperlink pool
+    // uses -- so a client already told about a context is not told again on every command.
+    auto const& contexts = terminal.contexts();
+    auto const active = static_cast<int>(contexts.activeId().value);
+    if (active != follow.lastActiveContext)
+    {
+        if (!snapshot)
+        {
+            delta.contextChanged = 1;
+            delta.activeContext = contexts.activeId().value;
+        }
+        follow.lastActiveContext = active;
+    }
+
+    // Every record the ancestry needs, plus any whose metadata moved. Compared as the WHOLE wire
+    // record, not by identifier alone: a re-`start=` reinitialises a context IN PLACE under the same
+    // id and the same identifier, and `end=` records an outcome on one, so an identifier-keyed gate
+    // would replicate a shell context's first `cwd=` and then never again -- leaving an attached pane
+    // resolving a directory the session left long ago, and never learning how a command ended.
+    //
+    // Gated on the stack's revision, which is what that counter is for: this runs per flush (20ms, per
+    // session) and the pool holds up to maxRetained records, so walking it unconditionally spent the
+    // common case -- a session where nothing about the ancestry moved -- on a scan that can have
+    // nothing to say. @see ContextStack::revision.
+    if (follow.contextRevisionKnown && contexts.revision() == follow.lastContextRevision)
+        return;
+
+    follow.lastContextRevision = contexts.revision();
+    follow.contextRevisionKnown = true;
+    // Rebuilt rather than merged into, so the table tracks the sender's own retention bound instead of
+    // accumulating one entry per context the session ever created.
+    auto refreshed = decltype(follow.sentContexts) {};
+    contexts.forEachRecord([&](vtbackend::TerminalContext const& record) {
+        auto wire = toWireContext(record);
+        auto const id = record.id.value;
+        auto const known = follow.sentContexts.find(id);
+        auto const unchanged = known != follow.sentContexts.end() && known->second == wire;
+        if (!unchanged && !snapshot)
+            delta.contexts.push_back(wire);
+        refreshed.insert_or_assign(id, std::move(wire));
+    });
+    follow.sentContexts = std::move(refreshed);
+}
+
 void NativeSession::collectLiveState(vtbackend::Terminal& terminal,
                                      FollowState& follow,
                                      proto::Delta& delta,
@@ -301,6 +352,8 @@ void NativeSession::collectLiveState(vtbackend::Terminal& terminal,
         follow.lastCwd = cwd;
         follow.cwdKnown = true;
     }
+
+    collectContextState(terminal, follow, delta, snapshot);
 
     // Live default fg/bg (OSC 10/11): pull+diff; the snapshot carries them in
     // SessionState below.
@@ -428,6 +481,14 @@ void NativeSession::collectLiveState(vtbackend::Terminal& terminal,
         snap.title = terminal.windowTitle();
         snap.cursorShape = cursorPs;
         snap.cwd = terminal.currentWorkingDirectory();
+        // Stated outright, including when EMPTY: a snapshot routes this through SessionState rather
+        // than through a delta's changed-gate, so an ancestry that emptied would otherwise never be
+        // delivered -- and the server, having recorded it as sent, would never re-send it.
+        terminal.contexts().forEachRecord([&](vtbackend::TerminalContext const& record) {
+            snap.contexts.push_back(toWireContext(record));
+        });
+        for (auto const& entry: terminal.contexts().chain())
+            snap.contextChain.push_back(entry.record->id.value);
         snap.defaultForeground = colors.defaultForeground.value();
         snap.defaultBackground = colors.defaultBackground.value();
         snap.statusDisplayType = static_cast<uint8_t>(statusType);
@@ -528,7 +589,15 @@ void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
             // Conditional because clearing costs a full URI re-send, and with an empty backlog
             // — the overwhelmingly common case — nothing was dropped and nothing is stale.
             if (_writer.dropTagged(session.value) != 0)
+            {
                 follow.sentHyperlinks.clear();
+                // Same reasoning, same fix: a context record whose only mention was in a dropped
+                // delta would leave the client with lines pointing at a record it never received.
+                follow.sentContexts.clear();
+                // And the revision gate with it: the pool has not moved, so without this the re-send
+                // the clear exists to force would be skipped and the records never sent again.
+                follow.contextRevisionKnown = false;
+            }
         }
         delta.snapshot = snapshot ? 1 : 0;
         delta.generation = grid.generation();

--- a/src/vthost/NativeSession.hpp
+++ b/src/vthost/NativeSession.hpp
@@ -163,6 +163,22 @@ class NativeSession final: public SessionStreamEvents
         /// "never sent" from "sent empty".
         std::string lastCwd;
         bool cwdKnown = false;
+        /// The OSC 3008 context records this peer has been told about, keyed by id and remembering
+        /// the WHOLE record. A map for the reason `sentHyperlinks` is: the id space is a uint16_t
+        /// that wraps, so a REUSED id has to be recognised as a new context rather than silently
+        /// re-pointing every line already stamped with it. The whole record rather than its
+        /// identifier alone because a context is also reinitialised IN PLACE -- a re-`start=` on
+        /// every prompt, an `end=` recording an outcome -- and those carry news too.
+        std::unordered_map<uint16_t, proto::WireContext> sentContexts;
+        /// The ContextStack revision `sentContexts` was last brought in line with, so the per-flush
+        /// walk over the retained pool is skipped entirely while the ancestry has not moved. Reset to
+        /// its sentinel wherever `sentContexts` is cleared, or the re-send that clearing exists to
+        /// force would be gated away.
+        uint64_t lastContextRevision = 0;
+        bool contextRevisionKnown = false;
+        /// The active context last sent (-1 until the first snapshot), so a change carries -- and
+        /// forces -- a delta only when the ancestry actually moved.
+        int lastActiveContext = -1;
         /// The default fg/bg (0xRRGGBB) last sent (-1 until the first snapshot),
         /// so an OSC 10/11 change carries (and forces) a delta only on change.
         int lastDefaultForeground = -1;
@@ -246,6 +262,17 @@ class NativeSession final: public SessionStreamEvents
                                  vtworkspace::SessionId session,
                                  uint8_t screenTypeValue,
                                  bool snapshot);
+
+    /// Captures the live OSC 3008 ancestry into @p delta, or — on a snapshot, which carries the records
+    /// through SessionState instead — only brings @p follow up to date.
+    ///
+    /// Split out of collectLiveState for the same reason that one is split out of pushDelta: it is a
+    /// self-contained pull+diff over its own state, and inline it pushed collectLiveState past the
+    /// cognitive-complexity budget. Static: it reads only its arguments.
+    static void collectContextState(vtbackend::Terminal& terminal,
+                                    FollowState& follow,
+                                    proto::Delta& delta,
+                                    bool snapshot);
 
     /// What every session THIS connection creates is spawned with.
     ///

--- a/src/vthost/client/NativeClient.cpp
+++ b/src/vthost/client/NativeClient.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iterator>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -51,6 +52,12 @@ void RemoteScreen::apply(proto::SessionState const& state)
     mouse = state.mouse;
     progressState = state.progressState;
     progressPercentage = state.progressPercentage;
+
+    // Stated outright, and the ancestry REPLACED rather than merged: a snapshot is the whole truth
+    // about the session, so an ancestry that emptied since the last one has to arrive as empty.
+    for (auto const& context: state.contexts)
+        contexts.insert_or_assign(context.id, context);
+    contextChain = state.contextChain;
 }
 
 void RemoteScreen::apply(proto::Delta const& delta)
@@ -115,6 +122,31 @@ void RemoteScreen::apply(proto::Delta const& delta)
         imageCells[entry.stableId][entry.column] = entry;
     for (auto const& entry: delta.hyperlinks)
         hyperlinks.insert_or_assign(entry.id, entry.uri);
+
+    for (auto const& context: delta.contexts)
+        contexts.insert_or_assign(context.id, context);
+    if (delta.contextChanged != 0)
+    {
+        // The delta carries only the ACTIVE id; the ancestry above it is rebuilt from the records'
+        // parent links, which every record carries. Cheaper than resending the whole chain on every
+        // command, and it cannot disagree with the records, being derived from them.
+        contextChain.clear();
+        // Every id is visited at most once, which is what makes the walk TOTAL. A self-reference is
+        // not the only cycle a peer can present: the sender's id space is a uint16_t that wraps and
+        // reuses, so a long-lived session can legitimately end up with A.parent == B and B.parent == A
+        // in this accumulated table, and a bare "stop when parent == id" would then spin forever
+        // appending to contextChain until the process ran out of memory.
+        auto visited = std::unordered_set<uint16_t> {};
+        for (auto id = delta.activeContext; id != 0 && visited.insert(id).second;)
+        {
+            contextChain.push_back(id);
+            auto const it = contexts.find(id);
+            if (it == contexts.end())
+                break; // unknown parent: the chain is as much of the ancestry as this mirror has
+            id = it->second.parent;
+        }
+        std::ranges::reverse(contextChain); // outermost first, as SessionState spells it
+    }
 
     // Trim client-side scrollback. The server's floor is authoritative — a
     // `clear`/CSI 3 J jumps it up with no line changes, so honoring it is what

--- a/src/vthost/client/NativeClient.hpp
+++ b/src/vthost/client/NativeClient.hpp
@@ -79,6 +79,14 @@ struct RemoteScreen
     std::map<int64_t, proto::WireLine> rows;
     /// Hyperlink id → URI, merged from the deltas' side tables.
     std::unordered_map<uint16_t, std::string> hyperlinks;
+
+    /// OSC 3008 context records, keyed by the SENDER's id, accumulated the way `hyperlinks` is: sent
+    /// once on first reference and kept here so a later fullReplay can re-assert them.
+    std::unordered_map<uint16_t, proto::WireContext> contexts;
+
+    /// The ancestry, outermost first, in the sender's id space. Empty when there is none -- and that
+    /// emptiness is itself asserted, so a stack that emptied is not mistaken for one never sent.
+    std::vector<uint16_t> contextChain;
     /// The mirrored DEC private modes currently SET remotely (by number).
     std::vector<uint32_t> setModes;
     /// The mirrored ANSI modes currently SET remotely (by number) — a separate

--- a/src/vthost/client/ScreenMirror.cpp
+++ b/src/vthost/client/ScreenMirror.cpp
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include <vthost/ContextWire.hpp>
 #include <vthost/CursorStyle.hpp>
 #include <vthost/GridWire.hpp>
 #include <vthost/ImageWire.hpp>
@@ -127,6 +128,55 @@ void ScreenMirror::syncHyperlinks(RemoteScreen const& screen)
     }
 }
 
+void ScreenMirror::syncContexts(RemoteScreen const& screen)
+{
+    auto& contexts = _terminal->contexts();
+    for (auto const& [wireId, wire]: screen.contexts)
+    {
+        if (wire.id == 0)
+            continue;
+
+        auto localParent = vtbackend::ContextId {};
+        if (auto const parent = _contextIds.find(wire.parent); parent != _contextIds.end())
+            localParent = parent->second.local;
+
+        auto const known = _contextIds.find(wire.id);
+        if (known != _contextIds.end() && known->second.identifier == wire.identifier)
+        {
+            // The SAME context, so it keeps the local id every line already stamped with it points
+            // at -- but not necessarily the same metadata: a re-`start=` reinitialises a context in
+            // place under the same identifier, and `end=` records an outcome on it. Skipping on the
+            // identifier alone left an attached pane resolving the cwd of the session's first prompt
+            // forever. Compared without building the record, because this loop runs over the whole
+            // accumulated pool on every delta. @see vthost::matchesWireContext.
+            auto const* const current = contexts.find(known->second.local);
+            if (current != nullptr && matchesWireContext(*current, wire, localParent))
+                continue;
+            _terminal->adoptContext(vthost::fromWireContext(wire, known->second.local, localParent));
+            continue;
+        }
+
+        // A FRESH local id when the sender reuses a wire id for a different context, rather than
+        // rewriting the record behind the old one: lines written before the reuse legitimately point
+        // at the OLD context, and mutating it in place would retroactively re-attribute every one of
+        // them. Exactly the rule syncHyperlinks() follows, and for exactly the same reason.
+        auto const localId = contexts.nextAdoptedId();
+        _terminal->adoptContext(vthost::fromWireContext(wire, localId, localParent));
+        _contextIds.insert_or_assign(
+            wire.id, vthost::MirroredContext { .local = localId, .identifier = wire.identifier });
+    }
+
+    // The ancestry, translated through the same map. Asserted even when EMPTY: a snapshot routes it
+    // through SessionState rather than a changed-gate, so a value that returned to its default would
+    // otherwise never be delivered -- which is how a Kitty-keyboard reset used to get lost.
+    auto chain = std::vector<vtbackend::ContextId> {};
+    chain.reserve(screen.contextChain.size());
+    for (auto const wireId: screen.contextChain)
+        if (auto const it = _contextIds.find(wireId); it != _contextIds.end())
+            chain.push_back(it->second.local);
+    _terminal->setContextChain(chain);
+}
+
 void ScreenMirror::writeRow(vtbackend::Screen& page,
                             RemoteScreen const& screen,
                             int64_t stableId,
@@ -145,14 +195,14 @@ void ScreenMirror::writeRow(vtbackend::Screen& page,
         // the server merely stopped naming would destroy history rather than refresh it.
         if (row == nullptr || offset < -vtbackend::LineOffset::cast_from(page.grid().historyLineCount()))
             return;
-        applyWireLine(page.grid().changingLineAt(offset), *row, _linkIds);
+        applyWireLine(page.grid().changingLineAt(offset), *row, _linkIds, _contextIds);
         return;
     }
     if (offset >= vtbackend::LineOffset::cast_from(page.pageSize().lines))
         return; // the server's page is taller than ours; the extra rows have nowhere to go
     auto& line = page.grid().lineAt(offset);
     if (row != nullptr)
-        applyWireLine(line, *row, _linkIds);
+        applyWireLine(line, *row, _linkIds, _contextIds);
     else
         // A row the mirror has no data for is cleared rather than left holding whatever was
         // there before: stale content is worse than a blank line, because it looks correct.
@@ -231,6 +281,7 @@ void ScreenMirror::apply(RemoteScreen const& screen, proto::Delta const& delta)
     {
         auto const guard = std::lock_guard { *_terminal };
         syncHyperlinks(screen); // before any row: a cell's link id is unresolvable without it
+        syncContexts(screen);   // and before any row for the same reason: so is a line's context id
         auto& page = activePage();
         auto const lines = unbox<int64_t>(page.pageSize().lines);
 
@@ -317,6 +368,7 @@ void ScreenMirror::fullReplay(RemoteScreen const& screen, LocalHistory history)
     {
         auto const guard = std::lock_guard { *_terminal };
         syncHyperlinks(screen); // before any row: a cell's link id is unresolvable without it
+        syncContexts(screen);   // and before any row for the same reason: so is a line's context id
         // The page has to be the right one BEFORE _screenType is adopted: activePage() reads it.
         auto const wantAlternate = screen.screenType == 1;
         if (_terminal->isAlternateScreen() != wantAlternate)
@@ -515,7 +567,7 @@ void ScreenMirror::applyStatusLines(RemoteScreen const& screen)
     {
         if (static_cast<std::size_t>(row) >= lines)
             break;
-        applyWireLine(page.grid().lineAt(vtbackend::LineOffset::cast_from(row)), line, _linkIds);
+        applyWireLine(page.grid().lineAt(vtbackend::LineOffset::cast_from(row)), line, _linkIds, _contextIds);
     }
 }
 

--- a/src/vthost/client/ScreenMirror.hpp
+++ b/src/vthost/client/ScreenMirror.hpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include <vthost/GridWire.hpp>
 #include <vthost/client/NativeClient.hpp>
 #include <vthost/proto/Pdu.hpp>
 
@@ -185,6 +186,13 @@ class ScreenMirror
     /// pointing at the URI they were drawn with.
     void syncHyperlinks(RemoteScreen const& screen);
 
+    /// Brings the mirror's OSC 3008 context pool and ancestry in line with the server's.
+    ///
+    /// Ahead of the rows, and for the same reason syncHyperlinks() is: a row carries only an id while
+    /// resolving it needs the record, and the record may arrive in the SAME delta as the first row
+    /// referencing it.
+    void syncContexts(RemoteScreen const& screen);
+
     /// A pointer, not a reference: a reference member would delete copy- and move-assignment, and
     /// the binding registry holds mirrors in a map. Never null.
     vtbackend::Terminal* _terminal;
@@ -213,6 +221,13 @@ class ScreenMirror
     /// cell referencing it resolves without a lookup by string. Re-pointed, never merely inserted:
     /// the sender's id space wraps, and @see syncHyperlinks for what a reused id must do.
     std::unordered_map<uint16_t, vtbackend::HyperlinkId> _linkIds;
+
+    /// Wire context id -> what this mirror adopted for it. Separate id spaces for the same reason the
+    /// hyperlink map is separate: the sender's ContextId is a uint16_t that wraps and reuses, and a
+    /// line written before a reuse legitimately points at the OLD record. The identifier rides along
+    /// so a reused wire id is recognised as new rather than silently re-pointing every line already
+    /// stamped with it. @see vthost::MirroredContext.
+    vthost::ContextIdMap _contextIds;
     /// Server image id → the local `vtbackend::Image` built from its pixels, so a placement decodes
     /// them once. Holding the reference is also what keeps the pool entry alive: `ImagePool`'s id
     /// index is weak, so an image nothing holds is collected.

--- a/src/vthost/client/ScreenMirror_test.cpp
+++ b/src/vthost/client/ScreenMirror_test.cpp
@@ -354,6 +354,223 @@ TEST_CASE("a wire hyperlink id reused for another URI re-points the mirror", "[v
     CHECK(bare.terminal->hyperlinks().nextHyperlinkId == idBefore);
 }
 
+TEST_CASE("an OSC 3008 context reaches the mirror and stamps its lines", "[vthost][mirror]")
+{
+    // The mirror drives a real vtbackend::Terminal, so a replicated context makes tinting, the
+    // breadcrumb and the cwd resolver work on an attached pane with no client-side code of their own
+    // -- provided the record and the per-line id actually arrive.
+    auto bare = BareMirror { vtbackend::LineCount(100) };
+    auto screen = vthost::client::RemoteScreen {};
+    screen.columns = 5;
+    screen.lines = 1;
+
+    auto container = proto::WireContext {};
+    container.id = 7;
+    container.identifier = "box";
+    container.type = static_cast<uint8_t>(vtbackend::ContextType::Container);
+    container.present = static_cast<uint16_t>(vtbackend::ContextField::Container)
+                        | static_cast<uint16_t>(vtbackend::ContextField::WorkingDirectory);
+    container.container = "foobar";
+    container.workingDirectory = "/app";
+
+    auto seed = proto::Delta {};
+    seed.snapshot = 1;
+    seed.stableViewportBase = 10;
+    seed.stableFloor = 10;
+    seed.contexts.push_back(container);
+    seed.contextChanged = 1;
+    seed.activeContext = 7;
+    auto row = rowAt(10, "abcde");
+    row.contextId = 7;
+    seed.lines.push_back(row);
+    screen.apply(seed);
+    bare.mirror->apply(screen, seed);
+
+    auto const& contexts = bare.terminal->contexts();
+    REQUIRE(contexts.active() != nullptr);
+    CHECK(contexts.active()->identifier == "box");
+    CHECK(contexts.active()->type == vtbackend::ContextType::Container);
+    CHECK(contexts.active()->container == "foobar");
+    CHECK(contexts.active()->workingDirectory == "/app");
+
+    // The line resolves through the MIRROR's own id space, which need not equal the sender's.
+    auto const lineContext =
+        bare.terminal->primaryScreen().grid().lineAt(vtbackend::LineOffset(0)).contextId();
+    REQUIRE(!!lineContext);
+    REQUIRE(contexts.find(lineContext) != nullptr);
+    CHECK(contexts.find(lineContext)->identifier == "box");
+}
+
+TEST_CASE("a context re-announced with new metadata updates the mirror in place", "[vthost][mirror]")
+{
+    // systemd re-announces the shell context on every prompt, and `end=` records an outcome on a
+    // command context: both reinitialise a record IN PLACE, under the same id AND the same identifier.
+    // A gate keyed on the identifier alone therefore replicated the first announcement and nothing
+    // after it, leaving an attached pane resolving a directory the session left long ago.
+    auto bare = BareMirror { vtbackend::LineCount(100) };
+    auto screen = vthost::client::RemoteScreen {};
+    screen.columns = 5;
+    screen.lines = 1;
+
+    auto shell = proto::WireContext {};
+    shell.id = 4;
+    shell.identifier = "sh";
+    shell.type = static_cast<uint8_t>(vtbackend::ContextType::Shell);
+    shell.present = static_cast<uint16_t>(vtbackend::ContextField::WorkingDirectory);
+    shell.workingDirectory = "/home/user";
+
+    auto seed = proto::Delta {};
+    seed.snapshot = 1;
+    seed.stableViewportBase = 10;
+    seed.stableFloor = 10;
+    seed.contexts.push_back(shell);
+    seed.contextChanged = 1;
+    seed.activeContext = 4;
+    seed.lines.push_back(rowAt(10, "abcde"));
+    screen.apply(seed);
+    bare.mirror->apply(screen, seed);
+
+    auto const& contexts = bare.terminal->contexts();
+    REQUIRE(contexts.active() != nullptr);
+    auto const localId = contexts.active()->id;
+    CHECK(contexts.active()->workingDirectory == "/home/user");
+
+    // The SAME context, re-announced after a `cd`. Same id, same identifier, different cwd.
+    shell.workingDirectory = "/home/user/src";
+    auto update = proto::Delta {};
+    update.stableViewportBase = 10;
+    update.stableFloor = 10;
+    update.contexts.push_back(shell);
+    screen.apply(update);
+    bare.mirror->apply(screen, update);
+
+    REQUIRE(contexts.active() != nullptr);
+    // Updated in place, so every line already stamped with this id still resolves to it.
+    CHECK(contexts.active()->id == localId);
+    CHECK(contexts.active()->workingDirectory == "/home/user/src");
+}
+
+TEST_CASE("a context ancestry whose parent links form a cycle does not spin the mirror", "[vthost][mirror]")
+{
+    // The wire's context table ACCUMULATES and the sender's id space wraps, so two records can end up
+    // naming each other as parent. RemoteScreen rebuilds the ancestry by walking those links, and a
+    // walk that only refused a SELF-reference would append to contextChain until it ran out of memory.
+    auto screen = vthost::client::RemoteScreen {};
+
+    auto makeContext = [](uint16_t id, uint16_t parent) {
+        auto context = proto::WireContext {};
+        context.id = id;
+        context.parent = parent;
+        context.identifier = std::format("ctx-{}", id);
+        return context;
+    };
+
+    auto delta = proto::Delta {};
+    delta.contexts.push_back(makeContext(1, 2));
+    delta.contexts.push_back(makeContext(2, 1));
+    delta.contextChanged = 1;
+    delta.activeContext = 1;
+    screen.apply(delta);
+
+    // Each id visited once, innermost last after the reverse.
+    CHECK(screen.contextChain == std::vector<uint16_t> { 2, 1 });
+}
+
+TEST_CASE("a wire context id reused for another context does not re-point old lines", "[vthost][mirror]")
+{
+    // The sender's ContextId is a uint16_t that wraps, exactly as HyperlinkId does. A line written
+    // before a reuse legitimately points at the OLD context, so the mirror must mint a fresh local id
+    // rather than rewriting the record behind the one it already handed out.
+    auto bare = BareMirror { vtbackend::LineCount(100) };
+    auto screen = vthost::client::RemoteScreen {};
+    screen.columns = 5;
+    screen.lines = 1;
+
+    auto makeContext = [](uint16_t id, std::string_view identifier) {
+        auto context = proto::WireContext {};
+        context.id = id;
+        context.identifier = identifier;
+        context.type = static_cast<uint8_t>(vtbackend::ContextType::Command);
+        return context;
+    };
+
+    auto first = proto::Delta {};
+    first.snapshot = 1;
+    first.stableViewportBase = 10;
+    first.stableFloor = 10;
+    first.contexts.push_back(makeContext(1, "cmd-one"));
+    auto rowOne = rowAt(10, "aaaaa");
+    rowOne.contextId = 1;
+    first.lines.push_back(rowOne);
+    screen.apply(first);
+    bare.mirror->apply(screen, first);
+
+    auto const& grid = bare.terminal->primaryScreen().grid();
+    auto const idOne = grid.lineAt(vtbackend::LineOffset(0)).contextId();
+    REQUIRE(bare.terminal->contexts().find(idOne) != nullptr);
+    CHECK(bare.terminal->contexts().find(idOne)->identifier == "cmd-one");
+
+    // The same wire id, now naming a DIFFERENT context: the counter wrapped on the server.
+    auto second = proto::Delta {};
+    second.stableViewportBase = 10;
+    second.stableFloor = 10;
+    second.contexts.push_back(makeContext(1, "cmd-two"));
+    auto rowTwo = rowAt(10, "bbbbb");
+    rowTwo.contextId = 1;
+    second.lines.push_back(rowTwo);
+    screen.apply(second);
+    bare.mirror->apply(screen, second);
+
+    auto const idTwo = grid.lineAt(vtbackend::LineOffset(0)).contextId();
+    CHECK(idTwo != idOne);
+    REQUIRE(bare.terminal->contexts().find(idTwo) != nullptr);
+    CHECK(bare.terminal->contexts().find(idTwo)->identifier == "cmd-two");
+
+    // And the record the earlier line still points at was NOT rewritten underneath it.
+    REQUIRE(bare.terminal->contexts().find(idOne) != nullptr);
+    CHECK(bare.terminal->contexts().find(idOne)->identifier == "cmd-one");
+}
+
+TEST_CASE("a snapshot asserts an EMPTY context ancestry", "[vthost][mirror]")
+{
+    // The Kitty-keyboard bug, in this feature's shape: a snapshot routes the ancestry through
+    // SessionState rather than a changed-gate, so an ancestry that emptied since the last snapshot
+    // must arrive AS empty or the mirror keeps showing a context that has ended.
+    auto bare = BareMirror { vtbackend::LineCount(100) };
+    auto screen = vthost::client::RemoteScreen {};
+    screen.columns = 5;
+    screen.lines = 1;
+
+    auto context = proto::WireContext {};
+    context.id = 3;
+    context.identifier = "box";
+    context.type = static_cast<uint8_t>(vtbackend::ContextType::Container);
+
+    auto seed = proto::Delta {};
+    seed.snapshot = 1;
+    seed.stableViewportBase = 10;
+    seed.stableFloor = 10;
+    seed.contexts.push_back(context);
+    seed.contextChanged = 1;
+    seed.activeContext = 3;
+    seed.lines.push_back(rowAt(10, "abcde"));
+    screen.apply(seed);
+    bare.mirror->apply(screen, seed);
+    REQUIRE(bare.terminal->contexts().active() != nullptr);
+
+    // A fresh snapshot whose ancestry is empty.
+    auto state = proto::SessionState {};
+    state.columns = 5;
+    state.lines = 1;
+    state.contexts.push_back(context);
+    // contextChain deliberately left empty
+    screen.apply(state);
+    bare.mirror->fullReplay(screen, vthost::client::LocalHistory::Keep);
+
+    CHECK(bare.terminal->contexts().active() == nullptr);
+    CHECK(bare.terminal->contexts().depth() == 0);
+}
+
 TEST_CASE("a peer-announced viewport jump cannot spin the mirror", "[vthost][mirror]")
 {
     // `stableViewportBase` is a wire field, and every row of the announced advance costs a

--- a/src/vthost/proto/Pdu.cpp
+++ b/src/vthost/proto/Pdu.cpp
@@ -289,6 +289,64 @@ namespace
         out.u32(pdu.imageId);
     }
 
+    /// The optional string fields of a context, in WIRE ORDER, with the presence bit each is gated on.
+    ///
+    /// ONE table, walked by both @ref encodeContext and @ref decodeContext, so the two cannot disagree
+    /// about the order. Spelled out as two hand-written sequences they agreed only by coincidence, and
+    /// a disagreement does not fail: it desynchronizes the stream mid-record and surfaces as garbage in
+    /// some later, unrelated field.
+    ///
+    /// The bit numbers are the PROTOCOL's and are pinned HERE rather than read from vtbackend, for the
+    /// reason GridWire.cpp pins LineFlag and CellFlag: they travel on the wire verbatim inside
+    /// `present`, so renumbering vtbackend's own field table -- which that table's comment actively
+    /// invites -- must not silently change what an older peer decodes. vthost/ContextWire.hpp
+    /// static_asserts that the two still agree.
+    constexpr auto ContextStringFields = std::array {
+        std::pair { uint16_t { 1 << 1 }, &WireContext::user },
+        std::pair { uint16_t { 1 << 2 }, &WireContext::hostname },
+        std::pair { uint16_t { 1 << 3 }, &WireContext::machineId },
+        std::pair { uint16_t { 1 << 4 }, &WireContext::bootId },
+        std::pair { uint16_t { 1 << 7 }, &WireContext::comm },
+        std::pair { uint16_t { 1 << 8 }, &WireContext::workingDirectory },
+        std::pair { uint16_t { 1 << 9 }, &WireContext::commandLine },
+        std::pair { uint16_t { 1 << 10 }, &WireContext::vm },
+        std::pair { uint16_t { 1 << 11 }, &WireContext::container },
+        std::pair { uint16_t { 1 << 12 }, &WireContext::targetUser },
+        std::pair { uint16_t { 1 << 13 }, &WireContext::targetHost },
+        std::pair { uint16_t { 1 << 14 }, &WireContext::sessionId },
+    };
+
+    /// The optional varint fields, same rules. @see ContextStringFields.
+    constexpr auto ContextVarintFields = std::array {
+        std::pair { uint16_t { 1 << 5 }, &WireContext::pid },
+        std::pair { uint16_t { 1 << 6 }, &WireContext::pidFdId },
+    };
+
+    /// Encodes one context record, writing only the fields its `present` mask names.
+    ///
+    /// The mask is written FIRST so the decoder knows what follows without a per-field presence byte:
+    /// a systemd `type=command` record then costs six strings on the wire rather than fifteen empty
+    /// length prefixes.
+    void encodeContext(Writer& out, WireContext const& context)
+    {
+        out.varint(context.id);
+        out.varint(context.parent);
+        out.string(context.identifier);
+        out.u8(context.type);
+        out.u16(context.present);
+
+        for (auto const& [bit, member]: ContextStringFields)
+            if (context.present & bit)
+                out.string(context.*member);
+        for (auto const& [bit, member]: ContextVarintFields)
+            if (context.present & bit)
+                out.varint(context.*member);
+
+        out.u8(context.exitKind);
+        out.u8(context.signal);
+        out.varint(context.status);
+    }
+
     void encodeBody(Writer& out, SessionState const& pdu)
     {
         out.varint(pdu.session);
@@ -313,6 +371,12 @@ namespace
         encodeMouseState(out, pdu.mouse);
         out.u8(pdu.progressState);
         out.u8(pdu.progressPercentage);
+        out.varint(pdu.contexts.size());
+        for (auto const& context: pdu.contexts)
+            encodeContext(out, context);
+        out.varint(pdu.contextChain.size());
+        for (auto const id: pdu.contextChain)
+            out.u16(id);
     }
 
     void encodeCell(Writer& out, WireCell const& cell)
@@ -335,6 +399,7 @@ namespace
     {
         out.svarint(line.stableId);
         out.u16(line.flags);
+        out.u16(line.contextId);
         out.svarint(line.promptEndOffset);
         out.svarint(line.commandEndOffset);
         out.varint(line.columns);
@@ -415,6 +480,11 @@ namespace
         out.u8(pdu.progressChanged);
         out.u8(pdu.progressState);
         out.u8(pdu.progressPercentage);
+        out.u8(pdu.contextChanged);
+        out.u16(pdu.activeContext);
+        out.varint(pdu.contexts.size());
+        for (auto const& context: pdu.contexts)
+            encodeContext(out, context);
     }
 
     void encodeBody(Writer& out, SessionBell const& pdu)
@@ -618,6 +688,41 @@ namespace
         return pdu;
     }
 
+    /// Decodes one context record, reading only the fields its `present` mask names.
+    ///
+    /// Walks the SAME tables the encoder writes, so the read order is structurally identical rather
+    /// than maintained in parallel by hand. Enum-ish bytes are carried through RAW and validated by the
+    /// consumer (@see vthost::fromWireContext), which is what keeps this codec free of vtbackend: only
+    /// the presence mask is validated here, and it has to be, because the reads below are driven by it.
+    [[nodiscard]] std::expected<WireContext, DecodeError> decodeContext(Reader& in)
+    {
+        auto context = WireContext {};
+        auto error = DecodeError {};
+        if (!assign(in.varint(), context.id, error) || !assign(in.varint(), context.parent, error)
+            || !assign(in.string(), context.identifier, error) || !assign(in.u8(), context.type, error)
+            || !assign(in.u16(), context.present, error))
+            return std::unexpected(error);
+
+        // Any bit this build does not assign is cleared, so the reads below cannot go looking for a
+        // field there is no member for and desynchronize the stream. Masked rather than rejected: an
+        // unknown bit is an unknown FIELD, and the protocol's rule for one of those is to ignore it and
+        // keep the rest, so a peer built from a newer commit degrades to the fields this build knows.
+        context.present = static_cast<uint16_t>(context.present & ContextPresentMask);
+
+        for (auto const& [bit, member]: ContextStringFields)
+            if ((context.present & bit) && !assign(in.string(), context.*member, error))
+                return std::unexpected(error);
+        for (auto const& [bit, member]: ContextVarintFields)
+            if ((context.present & bit) && !assign(in.varint(), context.*member, error))
+                return std::unexpected(error);
+
+        if (!assign(in.u8(), context.exitKind, error) || !assign(in.u8(), context.signal, error)
+            || !assign(in.varint(), context.status, error))
+            return std::unexpected(error);
+
+        return context;
+    }
+
     DecodeResult decodeSessionState(Reader& in)
     {
         auto pdu = SessionState {};
@@ -646,6 +751,12 @@ namespace
             || !decodeMouseState(in, pdu.mouse, error) || !assign(in.u8(), pdu.progressState, error)
             || !assign(in.u8(), pdu.progressPercentage, error))
             return std::unexpected(error);
+        if (auto const decoded = decodeVector(in, pdu.contexts, decodeContext); !decoded)
+            return std::unexpected(decoded.error());
+        if (auto const decoded =
+                decodeVector(in, pdu.contextChain, [](Reader& reader) { return reader.u16(); });
+            !decoded)
+            return std::unexpected(decoded.error());
         return pdu;
     }
 
@@ -676,7 +787,7 @@ namespace
         auto line = WireLine {};
         auto error = DecodeError {};
         if (!assign(in.svarint(), line.stableId, error) || !assign(in.u16(), line.flags, error)
-            || !assign(in.svarint(), line.promptEndOffset, error)
+            || !assign(in.u16(), line.contextId, error) || !assign(in.svarint(), line.promptEndOffset, error)
             || !assign(in.svarint(), line.commandEndOffset, error)
             || !assign(in.varint(), line.columns, error))
             return std::unexpected(error);
@@ -759,8 +870,11 @@ namespace
             || !assign(in.u8(), pdu.modifyOtherKeysChanged, error)
             || !assign(in.u8(), pdu.modifyOtherKeys, error) || !assign(in.u8(), pdu.mouseChanged, error)
             || !decodeMouseState(in, pdu.mouse, error) || !assign(in.u8(), pdu.progressChanged, error)
-            || !assign(in.u8(), pdu.progressState, error) || !assign(in.u8(), pdu.progressPercentage, error))
+            || !assign(in.u8(), pdu.progressState, error) || !assign(in.u8(), pdu.progressPercentage, error)
+            || !assign(in.u8(), pdu.contextChanged, error) || !assign(in.u16(), pdu.activeContext, error))
             return std::unexpected(error);
+        if (auto const decoded = decodeVector(in, pdu.contexts, decodeContext); !decoded)
+            return std::unexpected(decoded.error());
         return pdu;
     }
 

--- a/src/vthost/proto/Pdu.hpp
+++ b/src/vthost/proto/Pdu.hpp
@@ -232,6 +232,55 @@ struct MouseState
     bool operator==(MouseState const&) const = default;
 };
 
+/// The presence bits a context record's `present` field may carry, as the WIRE numbers them.
+///
+/// Proto-owned rather than taken from vtbackend, because it travels verbatim: a bit this build does
+/// not know is cleared on decode so the field reads that follow stay in step with the sender. The
+/// vtbackend side is pinned against this in vthost/ContextWire.hpp, which is where a renumbering
+/// becomes a build error instead of a silent protocol change.
+constexpr inline uint16_t ContextPresentMask = 0x7FFF; // bits 0..14: fifteen fields
+
+/// One OSC 3008 hierarchical context, as the host holds it.
+///
+/// The same id-plus-pool shape @ref HyperlinkEntry has, one level up: a grid LINE carries the 16-bit
+/// id and the record travels in a side table, sent once per connection on first reference so it is
+/// immune to the sender's own retention bound dropping it later.
+///
+/// `present` is what keeps the common record small AND what keeps it honest. Only the fields it names
+/// are encoded, so a systemd `type=command` context sends six of fifteen -- and a receiver can still
+/// tell "sent empty" from "never mentioned", which is what lets the nearest-cwd walk skip a context
+/// rather than stop at it with an empty answer.
+struct WireContext
+{
+    uint16_t id = 0;
+    uint16_t parent = 0;
+    std::string identifier; ///< The application's own CTXID, unescaped.
+    uint8_t type = 0;       ///< vtbackend::ContextType.
+    uint16_t present = 0;   ///< vtbackend::ContextFields bits; validated, never cast blindly.
+
+    /// Only the fields `present` names carry meaning; the rest are left empty by the encoder.
+    std::string user;
+    std::string hostname;
+    std::string machineId;
+    std::string bootId;
+    std::string comm;
+    std::string workingDirectory;
+    std::string commandLine;
+    std::string vm;
+    std::string container;
+    std::string targetUser;
+    std::string targetHost;
+    std::string sessionId;
+    uint64_t pid = 0;
+    uint64_t pidFdId = 0;
+
+    uint8_t exitKind = 0; ///< vtbackend::ContextExit.
+    uint8_t signal = 0;   ///< vtbackend::ContextSignal, as a Linux signal number.
+    uint64_t status = 0;
+
+    bool operator==(WireContext const&) const = default;
+};
+
 /// Everything renditional a session carries OUTSIDE its grid cells — replayed
 /// on attach and after every ResyncRequired.
 struct SessionState
@@ -265,6 +314,14 @@ struct SessionState
     /// bar an operation still in flight had drawn. @see vtbackend::ProgressState.
     uint8_t progressState = 0;      ///< vtbackend::ProgressState: 0 inactive … 4 paused.
     uint8_t progressPercentage = 0; ///< 0..100.
+    /// The OSC 3008 context pool and the ancestry, stated OUTRIGHT rather than behind a changed-gate.
+    ///
+    /// A snapshot has to assert every field including one sitting at its default, because it routes
+    /// state through here rather than through a delta's gate -- and the server, having recorded the
+    /// value as sent, never re-sends it. An EMPTY ancestry is exactly such a value, and is how a
+    /// Kitty-keyboard reset used to get lost.
+    std::vector<WireContext> contexts;
+    std::vector<uint16_t> contextChain; ///< The ancestry, outermost first; empty when there is none.
     bool operator==(SessionState const&) const = default;
 };
 
@@ -294,6 +351,10 @@ struct WireLine
     /// The bit values are frozen because they travel verbatim; `vthost/GridWire.cpp` pins them, so
     /// renumbering one is a build break rather than a silent mis-decode against an older peer.
     uint16_t flags = 0;
+    /// The OSC 3008 context that wrote this row, or 0 for none. Resolved against the context pool the
+    /// snapshot and deltas carry; an id with no record simply resolves to nothing, exactly as an
+    /// unmapped hyperlink id does.
+    uint16_t contextId = 0;
     /// Where the prompt stopped and where the previous command's output stopped, as LOGICAL columns
     /// (they may exceed @ref columns on a row whose logical line wrapped). Both are meaningful only
     /// with the matching flag — `PromptEnd`, `CommandEnd` — set in @ref flags, and both belong to
@@ -439,6 +500,15 @@ struct Delta
     uint8_t progressChanged = 0;
     uint8_t progressState = 0;      ///< vtbackend::ProgressState: 0 inactive … 4 paused.
     uint8_t progressPercentage = 0; ///< 0..100.
+    /// Set (1) when the OSC 3008 ancestry moved in this batch; `activeContext` then holds the id now
+    /// in effect, and 0 means the ancestry is empty.
+    uint8_t contextChanged = 0;
+    uint16_t activeContext = 0;
+    /// Context records first referenced in this batch, in the same "sent once per connection" shape
+    /// as @ref hyperlinks. Not gated: like the hyperlink table it is simply empty when there is
+    /// nothing new to say, so a bare `!contexts.empty()` would be a second way to spell the same
+    /// thing and hasChanges() below does not need one.
+    std::vector<WireContext> contexts;
 
     /// Whether this delta says anything about the SESSION at all — a snapshot, changed rows, or any
     /// of the gated fields above.
@@ -457,7 +527,7 @@ struct Delta
         return snapshot != 0 || !lines.empty() || titleChanged != 0 || cursorShapeChanged != 0
                || cwdChanged != 0 || colorsChanged != 0 || statusChanged != 0 || statusLinesChanged != 0
                || kittyKeyboardChanged != 0 || modifyOtherKeysChanged != 0 || mouseChanged != 0
-               || progressChanged != 0;
+               || progressChanged != 0 || contextChanged != 0 || !contexts.empty();
     }
 
     bool operator==(Delta const&) const = default;

--- a/src/vthost/proto/PduTrace.cpp
+++ b/src/vthost/proto/PduTrace.cpp
@@ -92,22 +92,31 @@ namespace
                    +[](DecodedPdu const& pdu) {
                        auto const& value = std::get<SessionState>(pdu);
                        // title/cwd are screen-derived content; their LENGTHS are the diagnostic.
-                       return std::format("session={} {}x{} screen={} title={}ch cwd={}ch progress={}/{}",
-                                          value.session,
-                                          value.columns,
-                                          value.lines,
-                                          value.screenType,
-                                          value.title.size(),
-                                          value.cwd.size(),
-                                          value.progressState,
-                                          value.progressPercentage);
+                       // Context records carry user, hostname, cwd and cmdline: a COUNT is the
+                       // diagnostic, and the fields themselves must never reach a trace log.
+                       return std::format(
+                           "session={} {}x{} screen={} title={}ch cwd={}ch progress={}/{} contexts={} "
+                           "chain={}",
+                           value.session,
+                           value.columns,
+                           value.lines,
+                           value.screenType,
+                           value.title.size(),
+                           value.cwd.size(),
+                           value.progressState,
+                           value.progressPercentage,
+                           value.contexts.size(),
+                           value.contextChain.size());
                    } },
         TraceRow { PduType::Delta,
                    "Delta",
                    +[](DecodedPdu const& pdu) {
                        auto const& value = std::get<Delta>(pdu);
+                       // Counts and the ACTIVE ID only -- never a record's fields. @see the
+                       // SessionState row above.
                        return std::format("session={} gen={} seq={} snapshot={} lines={} links={} "
-                                          "imagecells={} statuslines={} progress={}/{}",
+                                          "imagecells={} statuslines={} progress={}/{} contexts={} "
+                                          "activecontext={}",
                                           value.session,
                                           value.generation,
                                           value.seqno,
@@ -117,7 +126,9 @@ namespace
                                           value.imageCells.size(),
                                           value.statusLines.size(),
                                           value.progressChanged != 0 ? value.progressState : 0,
-                                          value.progressChanged != 0 ? value.progressPercentage : 0);
+                                          value.progressChanged != 0 ? value.progressPercentage : 0,
+                                          value.contexts.size(),
+                                          value.contextChanged != 0 ? value.activeContext : 0);
                    } },
         TraceRow { PduType::SessionBell,
                    "SessionBell",

--- a/src/vthost/proto/Pdu_test.cpp
+++ b/src/vthost/proto/Pdu_test.cpp
@@ -60,9 +60,36 @@ TEST_CASE("every catalog PDU round-trips", "[vthost][proto]")
         .underlineColor = 0x99AABBCC,
         .flags = 0xFFFFF, // all 20 CellFlags bits
     };
+    // Every field the mask can name, so the round trip proves each is written AND read back -- a
+    // record populated only in part would let a missing decoder read pass unnoticed.
+    auto const context = WireContext {
+        .id = 3,
+        .parent = 1,
+        .identifier = "bed86fab93af4328bbed0a1224af6d40",
+        .type = 6, // Container
+        .present = ContextPresentMask,
+        .user = "lennart",
+        .hostname = "zeta",
+        .machineId = "3deb5353d3ba43d08201c136a47ead7b",
+        .bootId = "d4a3d0fdf2e24fdea6d971ce73f4fbf2",
+        .comm = "systemd-nspawn",
+        .workingDirectory = "/app",
+        .commandLine = "ls -l",
+        .vm = "myvm",
+        .container = "foobar",
+        .targetUser = "root",
+        .targetHost = "example.com",
+        .sessionId = "42",
+        .pid = 1062862,
+        .pidFdId = 1063162,
+        .exitKind = 2, // Failure
+        .signal = 11,  // SIGSEGV
+        .status = 139,
+    };
     auto const line = WireLine {
         .stableId = -3, // signed: SD/unscroll push ids below the origin
         .flags = 0x01FF,
+        .contextId = 3,
         .columns = 80,
         .cells = { cell },
         .fillForeground = 1,
@@ -115,7 +142,9 @@ TEST_CASE("every catalog PDU round-trips", "[vthost][proto]")
                            .kittyKeyboardFlags = 5,
                            .modifyOtherKeys = 2,
                            .progressState = 1,
-                           .progressPercentage = 42 },
+                           .progressPercentage = 42,
+                           .contexts = { context },
+                           .contextChain = { 1, 3 } },
             Delta { .session = 9,
                     .generation = 2,
                     .seqno = 1234,
@@ -153,7 +182,10 @@ TEST_CASE("every catalog PDU round-trips", "[vthost][proto]")
                     .modifyOtherKeys = 2,
                     .progressChanged = 1,
                     .progressState = 2,
-                    .progressPercentage = 80 },
+                    .progressPercentage = 80,
+                    .contextChanged = 1,
+                    .activeContext = 3,
+                    .contexts = { context } },
         SessionBell { .session = 4 },
         SessionNotify { .session = 4, .title = "Build finished", .body = "3 warnings, 0 errors" },
         SessionClipboard { .session = 4, .selection = "c", .data = "copied text" },
@@ -424,11 +456,13 @@ TEST_CASE("an announced grid beyond MaxGridExtent is malformed", "[vthost][proto
         body.u8(0);           // modifyOtherKeys
         // Hand-built, so this list must stay in step with encodeBody(Writer&, SessionState const&) —
         // a missing field makes the decode fail here rather than anywhere informative.
-        body.u16(0); // mouseProtocol
-        body.u8(0);  // mouseTransport
-        body.u8(0);  // mouseWheelMode
-        body.u8(0);  // progressState
-        body.u8(0);  // progressPercentage
+        body.u16(0);    // mouseProtocol
+        body.u8(0);     // mouseTransport
+        body.u8(0);     // mouseWheelMode
+        body.u8(0);     // progressState
+        body.u8(0);     // progressPercentage
+        body.varint(0); // contexts
+        body.varint(0); // contextChain
         auto stream = Writer {};
         writeFrame(stream, 1, std::to_underlying(PduType::SessionState), body.view());
         return stream;

--- a/src/vthost/testing/GridParity.cpp
+++ b/src/vthost/testing/GridParity.cpp
@@ -28,6 +28,20 @@ namespace
         return info ? info->uri : std::string { "<unresolved>" };
     }
 
+    /// @return The context identifier @p id names on @p terminal, or empty for "no context".
+    ///
+    /// Compared by IDENTIFIER rather than by id, for the same reason a hyperlink is compared by URI:
+    /// the two sides mint their own ids, so equal ids would be meaningless and unequal ones a false
+    /// positive. An id whose record has aged out of the retained pool reads as "<unresolved>", which
+    /// is a real difference worth reporting if only one side lost it.
+    [[nodiscard]] std::string contextOf(vtbackend::Terminal const& terminal, uint16_t id)
+    {
+        if (id == 0)
+            return {};
+        auto const* const record = terminal.contexts().find(vtbackend::ContextId { id });
+        return record ? record->identifier : std::string { "<unresolved>" };
+    }
+
     /// Names the line flags set in @p raw, so a report says `Wrapped` rather than `0x2`.
     ///
     /// Through vtbackend's own formatter, which is generated from the same table as the
@@ -277,6 +291,13 @@ std::vector<ParityGap> compareGrids(vtbackend::Terminal const& server,
         for (auto const& field: LineFields)
             if (auto const want = field.render(expected), got = field.render(actual); want != got)
                 note(gaps, maxGaps, row, -1, std::string { field.name }, want, got);
+
+        // Outside the table, for the reason the hyperlink check below is: resolving a context id
+        // needs the TERMINAL, and the two sides mint their own ids.
+        if (auto const want = contextOf(server, expected.contextId),
+            got = contextOf(mirror, actual.contextId);
+            want != got)
+            note(gaps, maxGaps, row, -1, "context", want, got);
 
         // Expanded first: how a row is STORED (blank vs materialized) decides how much of it
         // travels, and that is not a parity difference.


### PR DESCRIPTION
systemd 258 ships a shell snippet that emits OSC 3008 (UAPI.15, hierarchical context signalling) around every interactive command, and Fedora 43 enables it by default. Contour is in the Fedora repos, so on a stock install a user's shell is already emitting these sequences today — describing the nesting a shell, `run0`, `ssh` or a container runtime opens around whatever runs inside it, with metadata for each level.

The value is not that this is more metadata. It is that it arrives with **no user configuration at all**: on such a system Contour now learns command boundaries, exit statuses and working directories with no shell integration installed. It also carries things OSC 133 structurally cannot — whether a command crashed, was interrupted, or died of a signal — plus identity and nesting OSC 133 has no concept of.

## Changes

- Parses and tracks the context ancestry, terminal-global and deliberately immune to RIS and DECSTR. The specification makes that a safety property: a program running down the ancestry must not be able to erase context a program above it established, and RIS is something any program can send.
- Associates every screen line with the context that wrote it. The field lands in padding `Line` already had, so this costs **zero bytes per line**, pinned by a `static_assert`. The association survives reflow and scrolling into history.
- Derives OSC-133-equivalent semantic marks when — and only when — no shell integration is present, so prompt navigation, output folding and "copy last command output" work with no setup. If OSC 133 speaks at any point it owns the marks for the rest of the session, and OSC 3008 can never take them back.
- Adds the global `osc_context` configuration section, with `enabled` as a single one-line kill switch.
- Adds an optional `tint:` map to colour schemes, painting the page background under an elevated, containerised or remote context. No shipped scheme sets one, deliberately — see below.
- Adds the `{Context}` indicator status-line placeholder: a breadcrumb reading `zeta › container:foobar › root › vim`. It shows only privilege and machine boundaries by default and collapses to nothing when there are none, which is what lets it ship in the default status line.
- Resolves the working directory per *purpose* — spawning, displaying, or opening locally — so the three questions can differ in strictness without ever differing in precedence.
- Replicates the whole thing to daemon clients, so a `contour attach` pane behaves exactly like a local one.

## Notes for review

**Every field is a display hint, and nothing gates behaviour on one.** Any program holding the tty can write `type=elevate` or `user=root`. Two consequences shaped the design: no scheme ships a default tint and no affordance is decorated with authority iconography, because that would teach users to trust a spoofable signal; and a `cwd=` is never used for spawning or opening unless it is provably this machine's. A context carries no host authority, so a container's `/app` would otherwise pass every locality test and open the host's directory of the same name — a false positive OSC 7 never had. An anonymous context resolves *unknown*, not *local*, which matters because nothing emits a `remote` context for `ssh` today.

**One pre-existing bug is fixed here**, in its own commit: OSC 133's `;B` and `;D` stamped their line flag without invalidating the fold ranges derived from it, so anything reading them between a command finishing and the next prompt saw stale data. It was masked only by the next prompt's `;A` — an accident of shell-script ordering rather than design.

**On POSIX, spawning still reads `/proc` first**, and that is a deliberate trade rather than an oversight: it can never hand `fork+exec` a path from another filesystem namespace, at the cost of naming the login shell rather than a subshell. The honest POSIX scope of the cwd work is the tab tooltip and "Open Current Folder".

Killing a context tree via `pidfdid=` is **not** implemented, and the docs record why: that field is a pidfd inode rather than a handle, and the protocol carries no process-group id and no cgroup path, so "and its children" is not implementable from the fields that exist.

Closes #2078