### PR TITLE
Fix daemon becoming permanently unattachable with scrollback-heavy panes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -228,6 +228,13 @@ inherited by every preset through `contour-common` (see `cmake/PedanticCompiler.
 
 First-party modules under `src/`, roughly bottom-up (later depends on earlier):
 
+- `src/coro` — the C++23 coroutine vocabulary: `Task`, `WhenAll`, `WhenAny`, `Cancellation`,
+  `UniqueCoroHandle`. **No first-party dependencies** — its headers include nothing but the
+  standard library, and that is the invariant, not an accident.
+- `src/net` — the coroutine-native reactor and transport `vthost` is built on: `EventLoop`, the
+  `EventSource` DI seam with its poll/epoll/kqueue backends, sockets, and TLS behind
+  `ITlsContext`. Built on `coro` and **deliberately not on `crispy`**, which is why it declares
+  `Threads::Threads` itself.
 - `src/crispy` — foundational utilities (`result`, ranges/format helpers, app scaffolding)
 - `src/text_shaper` — font shaping / glyph rasterization abstraction
 - `src/vtparser` — VT escape-sequence parser (state machine)
@@ -235,10 +242,21 @@ First-party modules under `src/`, roughly bottom-up (later depends on earlier):
 - `src/vtbackend` — terminal engine (grid, screen, VT semantics)
 - `src/vtrasterizer` — turns terminal cells into renderable geometry/atlases
 - `src/vtworkspace` — Qt-free tab/split-pane tree model
+- `src/vthost` — the Qt-free serving path: the daemon, session hosting, the native protocol and
+  the tmux control-mode gateway
 - `src/contour` — the application: the headless CLI, and the Qt/QML GUI frontend
 
 Respect these boundaries: lower layers must not depend on higher ones, and the GUI must not
 reach around `vtbackend`/`vtworkspace` into rendering internals.
+
+`coro` and `net` originated in [Endo](https://github.com/contour-terminal/endo) and, before that,
+fastcached — but **this copy is now the source of truth for all three**, having since gained
+`UniqueCoroHandle`, the `EventLoop`/`EventSource` split, TLS, Unix sockets and fd passing. Changes
+flow *outward*: fix here, then propagate; never re-sync *from* Endo, whose copy is a strict subset.
+Consumers pull this code in at CMake configure time rather than vendoring it. See
+[`src/coro/README.md`](src/coro/README.md) and [`src/net/README.md`](src/net/README.md), which also
+carry the invariants worth not breaking (a failed fd registration fails the awaitable rather than
+parking forever; readiness is level-triggered; I/O errors are `std::expected`, not exceptions).
 
 `src/vtbackend/` is layered too, one directory per concern, lowest first. Unlike `src/contour/`
 the namespace stays flat — everything is `vtbackend`, so the directories are about *finding* code,
@@ -265,6 +283,28 @@ not about naming it:
 The graph is acyclic — `core/ → grid/ → vt/ → render/ → screen/` — and it stays that way because
 the builders live with the engine they walk rather than with the buffer they fill. Only
 `Logging.hpp` and the two optional tools sit at the top level.
+
+`src/vthost/` is layered too, but unlike `vtbackend` **each subdirectory names a sub-namespace** —
+`vthost::proto`, `vthost::imsg`, `vthost::tmux`, `vthost::client`. The top level is the server: the
+`Daemon` entry points behind `contour daemon`/`contour client`, `ConnectionAcceptor`, `SessionHost`
+(the daemon-side owner of sessions, the second consumer `vtworkspace`'s model was designed for), and
+the `*Wire.hpp` encoders that turn `vtbackend` state into PDU payloads. Beneath it:
+
+- `proto/` — the native protocol's byte level: LEB128 varints, the PDU frame, and its trace
+  formatting. **Dependency-free** — no socket enters here, so every framing rule is table-testable.
+- `imsg/` — the rewritten-libutil imsg codec tmux ≥ 3.6 speaks between its own client and server.
+  Pure bytes-in/frames-out for the same reason.
+- `tmux/` — control mode (`tmux -CC`): the parser, the `TmuxGateway` that owns the protocol state
+  machine, and the server side that speaks it back. It deliberately knows nothing about pane
+  *contents* — consumers feed `%output` bytes into their own terminals.
+- `client/` — the native-protocol client engine, which runs **no parser**: it mirrors each remote
+  session's screen from the server's Delta stream into a `RemoteScreen` any frontend can render.
+- `testing/` — `GridParity`, which checks a mirrored screen against the grid it came from.
+
+`vthost` links no Qt, and that is the point: the whole serving path never touches the GUI stack, so
+`contour daemon` and `contour client` are thin entry points over a module that tests headlessly.
+Its suite, along with those of `coro`, `net` and `vtworkspace`, carries the `daemon` CTest label —
+`ctest -L daemon` is everything daemon mode must pass to be trusted.
 
 `src/contour/` is itself layered, one directory per concern, and **each directory names the
 namespace it holds** — `src/contour/config/` is `contour::config`, and so on for every one. Only

--- a/docs/internals/vthost.md
+++ b/docs/internals/vthost.md
@@ -260,9 +260,10 @@ directions, rather than argued.
 
 ### The send queue: what a bound may and may not conclude
 
-`net::WriteQueue`'s byte bound exists to detect a peer that stopped draining, and two rules
-keep it from firing on anything else. Both were learned the hard way — the daemon used to
-disconnect perfectly healthy clients on a window resize.
+`net::WriteQueue`'s byte bound exists to detect a peer that stopped draining, and three rules
+keep it from firing on anything else. All three were learned the hard way — the daemon used to
+disconnect perfectly healthy clients on a window resize, and later refused to let them attach
+at all.
 
 - **The bound governs the backlog, never a single frame.** A frame landing on an empty
   backlog is always accepted, however large. A full-grid snapshot of a deep scrollback is
@@ -276,8 +277,36 @@ disconnect perfectly healthy clients on a window resize.
   stacking on top of them. Without it a burst of resyncs — a window drag, or an attach
   immediately followed by the client asserting its area — queues whole grids until the
   bound trips, for frames the client's mirror would have discarded on arrival anyway.
+- **A producer that can pace itself must, and a snapshot is split so it can.** The first two
+  rules are about what the queue concludes; this one is about what a producer may hand it.
+  `enqueue` is non-suspending and the drain is *spawned* onto the loop — `EventLoop::spawn`
+  queues a handle, it does not resume one — so a producer that enqueues a burst without
+  suspending never lets the drain run, and the queue is never empty after its first frame. The
+  lone-frame exemption then protects nothing, and the whole burst has to fit the bound at once.
+  That is what made a daemon with two scrollback-heavy panes permanently unattachable: the attach
+  walked every pane pushing a whole grid each, and the second one did not fit. Snapshots
+  therefore go through `NativeSession`'s streamer, which `waitUntilBacklogBelow`s a piece's worth
+  before each PDU and splits anything past `SnapshotChunkBytes` into a `proto::SnapshotPart` run.
+  The watermark is deliberately a *low*-water mark. Pacing to `bound − piece` delivers the
+  snapshot just as well, but does it by riding the backlog just under the bound for the whole
+  run — leaving a single piece of headroom for every producer that *cannot* pace itself, and
+  refusing the first one that needs more.
 
-The complement to both lives upstream: a resync is only pushed when a grid actually moved.
+The same rule has a second shape in-tree, for a producer that *cannot* suspend: `ControlOutput::pump`
+reads `queuedBytes()` and spends a headroom-derived per-pane credit, re-arming a timer while work
+remains, rather than waiting. `NativeSession`'s own debounce re-arm does the same. Suspend where you
+can, budget-and-re-arm where you cannot — one rule, two shapes.
+
+What the third rule does **not** cover, and what is still open: the burst-in-a-non-suspending-callback
+shape is unprotected in `tmux::ControlSession`'s *reply* path (`emitGuarded` sinks one frame per
+captured row against a 256 KiB bound, bypassing the credit pacer its own `%output` path uses) and in
+`tmux::TmuxGateway` (`sendKeys`/`sendRawInput` chop a paste into many commands). Both can still
+refuse mid-burst and drop a healthy peer. The deeper fix for the
+whole class is to make the bound mean what its comment says — refuse only when over bound *and*
+the drain has made no progress for some interval — which would protect the producers that
+structurally cannot pace.
+
+The complement to the first two lives upstream: a resync is only pushed when a grid actually moved.
 `SessionHost` reports that (`SizeChange`) rather than letting callers assume a resize
 request changed something, because clients re-assert an unchanged client area on every
 attach, and each pane's grid is clamped before it is applied — so both "different request,

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -124,6 +124,7 @@
           <li>A contour attach pane gets the same context tracking, tinting and breadcrumb a local one does</li>
           <li>Fixes stale fold ranges after a command finished: OSC 133's ;B and ;D wrote their line flag without invalidating the ranges derived from it, so anything reading them between the end of a command and the next prompt saw the state from before</li>
           <li>Draws U+25BC and U+25B6 with the built-in box-drawing renderer, so they no longer depend on the font</li>
+          <li>Fixes a daemon with more than one scrollback-heavy pane becoming permanently unattachable — `contour client` was refused before any screen content arrived, and every reconnect failed the same way. Attach snapshots are now paced against the connection's send queue and split across frames, so attaching succeeds whatever the scrollback depth; a window resize could drop an already-attached client for the same reason and no longer does</li>
         </ul>
       </description>
     </release>

--- a/src/net/WriteQueue.cpp
+++ b/src/net/WriteQueue.cpp
@@ -62,6 +62,17 @@ coro::Task<void> WriteQueue::flushThenClose()
     close();
 }
 
+coro::Task<void> WriteQueue::waitUntilBacklogBelow(std::size_t watermark, std::function<bool()> callerDone)
+{
+    // The state is captured by value, so the poll survives this WriteQueue being destroyed
+    // mid-park exactly as the drain does.
+    co_await pollUntil(&_loop, [state = _state, watermark, done = std::move(callerDone)] {
+        if (done && done())
+            return true;
+        return state->closed || state->failure.has_value() || state->backlogBytes < watermark;
+    });
+}
+
 coro::Task<void> WriteQueue::drain(std::shared_ptr<State> state)
 {
     while (!state->queue.empty() && !state->failure.has_value() && !state->closed)

--- a/src/net/WriteQueue.hpp
+++ b/src/net/WriteQueue.hpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <deque>
 #include <format>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -98,6 +99,29 @@ class WriteQueue
     /// needs. The owner still closes and out-lives the SOCKET afterwards, per
     /// the lifetime note above.
     [[nodiscard]] coro::Task<void> flushThenClose();
+
+    /// Parks until the backlog falls below @p watermark, or the queue fails or closes.
+    ///
+    /// The bound above detects a peer that stopped draining, and refusing is the right answer
+    /// to that. It is the wrong answer to a producer that merely emitted faster than one loop
+    /// turn could drain — which is what a producer enqueuing a burst WITHOUT suspending does,
+    /// since the drain is spawned onto the loop and cannot run until that producer yields. Such
+    /// a producer never gives the queue the chance to empty that the bound assumes it had.
+    ///
+    /// A producer that can pace itself should therefore wait for room between frames rather
+    /// than be refused: an attach snapshot has nothing to supersede and no smaller form to fall
+    /// back to, so refusing it costs the connection for a condition the producer created.
+    ///
+    /// Returning on close/failure is what keeps a caller from parking forever against a queue
+    /// that will never drain again — the poll must not outlive the connection it paces.
+    /// @param watermark The backlog size to get below; the caller's own pacing budget.
+    /// @param callerDone Also ends the wait when it returns true; empty means "queue state only".
+    ///        A connection tearing down needs this, because closing the queue is not available to
+    ///        it as the signal: an owner that waits for its producers to let go before closing,
+    ///        and producers that wait for the close, wait for each other. The owner's own
+    ///        already-set "finished" flag breaks that cycle.
+    [[nodiscard]] coro::Task<void> waitUntilBacklogBelow(std::size_t watermark,
+                                                         std::function<bool()> callerDone = {});
 
     /// @return The write error that stopped the queue, if any. Once set, every
     ///         subsequent enqueue fails; the caller should drop the connection.

--- a/src/net/WriteQueue_test.cpp
+++ b/src/net/WriteQueue_test.cpp
@@ -89,6 +89,35 @@ class ParkingSocket: public net::ISocket
     bool _isClosed = false;
 };
 
+/// Waits for room on @p queue and records that it resumed.
+///
+/// A free coroutine taking pointers, not a capturing lambda: `spawn` outlives the expression
+/// that built it, so a closure's captures would dangle (the same reason serveNativeClient is
+/// free in vthost).
+Task<void> awaitRoom(WriteQueue* queue, std::size_t watermark, bool* resumed)
+{
+    co_await queue->waitUntilBacklogBelow(watermark);
+    *resumed = true;
+}
+
+/// Parks @p queue over a watermark of 64: one frame in flight on a socket that will not take it,
+/// and a bigger one behind it. The 16/128/64 relationship is what every waiter test depends on,
+/// so it is stated once.
+void stallOverWatermark(EventLoop& loop, WriteQueue& queue)
+{
+    REQUIRE(queue.enqueue(std::string(16, 'x')));
+    loop.blockOn(net::testing::sleepFor(&loop, 20ms));
+    REQUIRE(queue.enqueue(std::string(128, 'y')));
+    REQUIRE(queue.backlogBytes() == 128);
+}
+
+/// Waits for room, or for @p callerDone — the shape a connection tearing down needs.
+Task<void> awaitRoomOrDone(WriteQueue* queue, std::size_t watermark, bool const* callerDone, bool* resumed)
+{
+    co_await queue->waitUntilBacklogBelow(watermark, [callerDone] { return *callerDone; });
+    *resumed = true;
+}
+
 } // namespace
 
 TEST_CASE("WriteQueue drains frames in FIFO order, each frame atomically", "[net][writequeue]")
@@ -283,4 +312,97 @@ TEST_CASE("close() drops queued frames and refuses new ones", "[net][writequeue]
 
     loop.blockOn(settle(&loop)); // the spawned drain sees the closed queue and exits
     REQUIRE_FALSE(queue.draining());
+}
+
+TEST_CASE("waitUntilBacklogBelow returns without parking when there is already room", "[net][writequeue]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+
+    auto pair = net::testing::makeSocketPair(loop);
+    REQUIRE(pair.has_value());
+
+    auto queue = WriteQueue { loop, pair->first.get(), 1024 };
+
+    // The pacing wait must cost nothing in the overwhelmingly common case, or a producer that
+    // consults it between every frame pays a loop tick per frame for no reason.
+    auto resumed = false;
+    loop.blockOn(awaitRoom(&queue, 64, &resumed));
+    REQUIRE(resumed);
+}
+
+TEST_CASE("waitUntilBacklogBelow parks until the drain makes room", "[net][writequeue]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+
+    // Declared before the queue so it outlives the drain that writes to it.
+    auto socket = ParkingSocket { loop };
+    auto queue = WriteQueue { loop, &socket, 1024 };
+
+    // One frame in flight (the socket parks it) and a bigger one behind it, so the backlog
+    // sits above the watermark until the peer catches up — exactly the state a producer
+    // emitting faster than one loop turn can drain puts the queue in.
+    stallOverWatermark(loop, queue);
+
+    auto resumed = false;
+    loop.spawn(awaitRoom(&queue, 64, &resumed));
+    loop.blockOn(net::testing::sleepFor(&loop, 20ms));
+    REQUIRE_FALSE(resumed); // parked: the backlog is over the mark
+
+    // The peer catches up; the backlog drains and the waiter resumes on its own.
+    socket.release();
+    REQUIRE(loop.blockOn(net::testing::waitUntil(&loop, [&] { return resumed; })));
+    REQUIRE(queue.backlogBytes() == 0);
+}
+
+TEST_CASE("waitUntilBacklogBelow stops waiting once the queue is closed", "[net][writequeue]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+
+    auto socket = ParkingSocket { loop };
+    auto queue = WriteQueue { loop, &socket, 1024 };
+
+    stallOverWatermark(loop, queue);
+
+    auto resumed = false;
+    loop.spawn(awaitRoom(&queue, 64, &resumed));
+    loop.blockOn(net::testing::sleepFor(&loop, 20ms));
+    REQUIRE_FALSE(resumed);
+
+    // A connection being torn down must not strand its pacer: an owner that closes the queue
+    // and then polls for its producers to finish would otherwise deadlock, because a closed
+    // queue never drains again and the watermark can never be met.
+    queue.close();
+    REQUIRE(loop.blockOn(net::testing::waitUntil(&loop, [&] { return resumed; })));
+}
+
+TEST_CASE("waitUntilBacklogBelow stops waiting when the caller says it is done", "[net][writequeue]")
+{
+    auto source = net::PollEventSource {};
+    auto loop = EventLoop { source };
+
+    auto socket = ParkingSocket { loop };
+    auto queue = WriteQueue { loop, &socket, 1024 };
+
+    stallOverWatermark(loop, queue);
+
+    auto callerDone = false;
+    auto resumed = false;
+    loop.spawn(awaitRoomOrDone(&queue, 64, &callerDone, &resumed));
+    loop.blockOn(net::testing::sleepFor(&loop, 20ms));
+    REQUIRE_FALSE(resumed);
+
+    // The close() the queue-state predicate watches for is not available to a connection tearing
+    // down: it closes the queue only AFTER waiting for its producers to let go, so a producer
+    // waiting on the close would be waiting for something waiting on it. The caller's own flag is
+    // what breaks that cycle, and it must work with the backlog still stuck and the queue open.
+    callerDone = true;
+    REQUIRE(loop.blockOn(net::testing::waitUntil(&loop, [&] { return resumed; })));
+    CHECK(queue.backlogBytes() == 128); // still stuck: the caller left, the peer did not catch up
+
+    // Leave no coroutine parked on the socket at teardown.
+    socket.release();
+    REQUIRE(loop.blockOn(net::testing::waitUntil(&loop, [&] { return !queue.draining(); })));
 }

--- a/src/vthost/NativeSession.cpp
+++ b/src/vthost/NativeSession.cpp
@@ -4,13 +4,18 @@
 #include <vtbackend/core/Image.hpp>
 #include <vtbackend/grid/Line.hpp>
 
+#include <crispy/Utils.hpp>
+
 #include <algorithm>
 #include <bit>
 #include <chrono>
+#include <cstddef>
+#include <expected>
 #include <mutex>
 #include <optional>
 #include <ranges>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -125,6 +130,7 @@ namespace
             });
         }
     }
+
 } // namespace
 
 NativeSession::NativeSession(net::EventLoop& loop,
@@ -137,6 +143,23 @@ NativeSession::NativeSession(net::EventLoop& loop,
     _host(host),
     _connection(std::move(connection)),
     _writer(loop, _connection.get(), maxWriteQueueBytes),
+    // A LOW-water mark — one piece's worth — not "the bound minus a piece".
+    //
+    // Both make the enqueue that follows succeed, but the high one does it by riding the backlog
+    // just under the bound for the whole run, leaving a single piece of headroom for every OTHER
+    // producer on this queue: a LayoutState, another session's page delta, a FetchImage answer.
+    // None of those can pace itself, and any of them arriving then is refused — the connection
+    // dropped by the very mechanism added to stop dropping it. Pacing to one piece instead keeps
+    // the backlog near one piece and leaves the bound's headroom for traffic that has no choice.
+    // It also stops the size ESTIMATE being load-bearing: overshooting the budget several times
+    // over still lands far below the bound.
+    //
+    // A bound too small to hold two pieces leaves 1 — "wait until fully drained" — handing that
+    // regime to the queue's never-refuse-a-lone-frame rule. That arm is NOT a test accommodation
+    // and does not collapse into the other: a proportional watermark (bound/2, say) would park at
+    // 32 KiB under a 64 KiB bound and then have the very next piece refused for the backlog it
+    // had just permitted.
+    _snapshotWatermark(maxWriteQueueBytes >= 2 * SnapshotChunkBytes ? SnapshotChunkBytes : std::size_t { 1 }),
     _id(std::move(id)),
     _expectedToken(std::move(expectedToken))
 {
@@ -164,9 +187,15 @@ void NativeSession::send(uint64_t serial, proto::DecodedPdu const& pdu, uint64_t
         // advanced past this frame, so dropping it would leave the mirror holey
         // with no resync trigger. Closing the connection unparks the PDU pump.
         //
-        // This is now reached only by a client that genuinely stopped reading: the queue
-        // never refuses a frame for its own size, and a snapshot discards the frames it
-        // supersedes rather than stacking on top of them.
+        // Reaching this now really does mean a client that stopped reading. It did not always:
+        // the queue never refuses a frame for its own size, but that rule only ever protected
+        // the FIRST frame of a burst, because a producer that enqueues without suspending never
+        // lets the drain — which is spawned onto the loop, not resumed inline — empty the queue
+        // between frames. An attach that walked every pane pushing whole grids therefore had to
+        // fit its entire payload under the bound at once, and two scrollback-heavy panes did not.
+        // Snapshots now go through @ref streamSnapshots, which waits for room before every piece,
+        // so the only producer left on this path is the incremental one, whose frames are small
+        // by construction.
         errorLog()("{}: {}; disconnecting", _id, _writer.describeRefusal());
         _closed = true;
         _writer.close();
@@ -179,7 +208,12 @@ void NativeSession::sessionScreenUpdated(SessionId session)
     if (!_handshaken || _closed)
         return;
     _pendingSessions.insert(session.value);
-    if (_flushScheduled)
+    scheduleFlush();
+}
+
+void NativeSession::scheduleFlush()
+{
+    if (_flushScheduled || _closed)
         return;
     _flushScheduled = true;
     _loop.spawn(flushSoon());
@@ -189,16 +223,22 @@ void NativeSession::sessionClosed(SessionId session)
 {
     _followed.erase(session.value);
     _pendingSessions.erase(session.value);
+    // The snapshot bookkeeping forgets it too. The streamer would survive without this (buildPush
+    // answers NoSuchSession and it moves on), but every per-session set this connection keeps must
+    // be dropped in ONE place, or the next one added is dropped in none.
+    std::erase(_snapshotQueue, session.value);
 }
 
 void NativeSession::sessionResized(SessionId session)
 {
     // A resize destroys the grid's row identity (a rebuild bumps the generation), so the mirror
-    // cannot be brought forward by a delta — it needs the whole grid. Immediately rather than
-    // through the debounce: nothing is coalescing with, since a resize raises no screen update.
+    // cannot be brought forward by a delta — it needs the whole grid. Queued rather than pushed
+    // inline, and not through the 20ms debounce either: one client's resize re-projects every
+    // pane of every window, so this arrives once PER PANE within a single callback. Pushing each
+    // one inline is the same burst the attach walk used to be, with the same outcome.
     if (!_handshaken || _closed || !_followed.contains(session.value))
         return;
-    pushDelta(session, /*forceSnapshot=*/true);
+    requestSnapshot(session);
 }
 
 void NativeSession::sessionBell(SessionId session)
@@ -245,9 +285,21 @@ coro::Task<void> NativeSession::flushSoon()
     _flushScheduled = false;
     if (_closed)
         co_return;
-    auto pending = std::exchange(_pendingSessions, {});
-    for (auto const session: pending)
-        pushDelta(SessionId { session }, /*forceSnapshot=*/false);
+    // A session whose whole grid is about to be (or is being) re-described gets no increment: the
+    // snapshot says everything this would, and one landing BETWEEN a snapshot's pieces would have
+    // the mirror apply and repaint a grid it has only half received. Put it back rather than drop
+    // it — rows changed after the snapshot was captured are still news. The reinsert targets the
+    // member, which `exchange` just emptied, not the range being walked.
+    for (auto const session: std::exchange(_pendingSessions, {}))
+        if (snapshotPending(SessionId { session }))
+            _pendingSessions.insert(session);
+        else
+            pushDelta(SessionId { session });
+    // Something was held back and nothing else will re-arm the debounce: a session whose output
+    // has stopped raises no further screen update, so without this its last increment would wait
+    // for one that never comes.
+    if (!_pendingSessions.empty())
+        scheduleFlush();
 }
 
 void NativeSession::collectContextState(vtbackend::Terminal& terminal,
@@ -306,8 +358,9 @@ void NativeSession::collectLiveState(vtbackend::Terminal& terminal,
                                      std::optional<proto::SessionState>& state,
                                      SessionId session,
                                      uint8_t screenTypeValue,
-                                     bool snapshot)
+                                     SnapshotMode mode)
 {
+    auto const snapshot = mode == SnapshotMode::Forced;
     // Live window title (OSC 0/2): the snapshot carries it in SessionState
     // below; an incremental delta carries it only when it changed since last
     // sent, so a title-only batch still re-titles the mirror. Compare the
@@ -501,11 +554,12 @@ void NativeSession::collectLiveState(vtbackend::Terminal& terminal,
     }
 }
 
-void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
+std::expected<NativeSession::BuiltPush, NativeSession::BuildFailure> NativeSession::buildPush(
+    SessionId session, SnapshotMode mode)
 {
     auto* terminal = _host.terminal(session);
     if (terminal == nullptr)
-        return;
+        return std::unexpected(BuildFailure::NoSuchSession);
     auto& follow = _followed[session.value];
 
     auto delta = proto::Delta {};
@@ -539,8 +593,16 @@ void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
         // screenTypeFromPage then maps the displayed page to the wire's primary(0)/
         // alt-like(1) discriminator the mirror uses to toggle ?1049 and scrollback.
         auto const screenType = vtbackend::screenTypeFromPage(displayedPage);
-        auto snapshot = forceSnapshot || follow.lastDisplayedPage != displayedPage;
+        auto const pageFlipped = follow.lastDisplayedPage != displayedPage;
         follow.lastDisplayedPage = displayedPage;
+        // A page flip needs the whole grid, and the whole grid belongs on the paced path. Bail
+        // before collecting anything: only lastDisplayedPage has moved, and the Forced rebuild
+        // that follows re-derives it, so nothing this connection believes about the peer is wrong.
+        if (mode == SnapshotMode::Delta && pageFlipped)
+            return std::unexpected(BuildFailure::ResyncRequired);
+        // Past the two bails, this is exactly the mode asked for: Delta mode reached here only by
+        // not needing a snapshot, and Forced never needs anything else.
+        auto const snapshot = mode == SnapshotMode::Forced;
 
         auto const collect = [&](vtbackend::LineOffset offset, vtbackend::Line const& line) {
             delta.lines.push_back(toWireLine(grid, offset, line));
@@ -565,13 +627,15 @@ void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
             && (cursorBelowFloor
                 || grid.forEachLineChangedSince(follow.cursor, collect)
                        == vtbackend::GridDeltaResult::ResyncRequired))
-            snapshot = true;
+            // Same as the page flip above, and bailing here is equally clean: `collect` has only
+            // filled locals, and the follow state's cursor, hyperlinks and last-sent values are
+            // all still untouched. A caller told this asks for a snapshot instead.
+            return std::unexpected(BuildFailure::ResyncRequired);
         if (snapshot)
         {
-            delta.lines.clear();
-            delta.imageCells.clear();
-            hyperlinkIds.clear();
-            referencedLinks.clear();
+            // Nothing to discard first: `collect` runs only on the incremental scan above, which
+            // Forced mode short-circuits past and which Delta mode returns from rather than
+            // upgrading. Clearing here would imply otherwise.
             grid.forEachValidLine(collect);
             // The snapshot delivered the whole grid, so re-anchor the cursor to the
             // stream head directly -- forEachValidLine leaves it untouched, and a
@@ -647,11 +711,9 @@ void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
             delta.hyperlinks.push_back(proto::HyperlinkEntry { .id = id, .uri = info->uri });
         }
 
-        collectLiveState(*terminal, follow, delta, state, session, std::to_underlying(screenType), snapshot);
+        collectLiveState(*terminal, follow, delta, state, session, std::to_underlying(screenType), mode);
     }
 
-    if (state)
-        send(0, proto::DecodedPdu { *state }, session.value);
     // A pure mode flip (an app enabling mouse tracking, say) changes no cell,
     // yet clients must hear about it to encode input correctly. A pure cursor move
     // (a full-screen app repositioning with no visible cell change) likewise
@@ -670,14 +732,160 @@ void NativeSession::pushDelta(SessionId session, bool forceSnapshot)
     // history the terminal had thrown away, with `floorOutranScroll` — its detector for exactly this
     // case — waiting on a delta that never arrived.
     auto const floorMoved = delta.stableFloor != follow.lastStableFloor;
-    if (modesChanged || cursorMoved || floorMoved || delta.hasChanges())
+    if (!(modesChanged || cursorMoved || floorMoved || delta.hasChanges()))
+        return std::unexpected(BuildFailure::NothingToSay);
+
+    follow.lastModes = delta.setModes;
+    follow.lastAnsiModes = delta.setAnsiModes;
+    follow.lastCursorLine = delta.cursorLine;
+    follow.lastCursorColumn = delta.cursorColumn;
+    follow.lastStableFloor = delta.stableFloor;
+    return BuiltPush { .delta = std::move(delta), .state = std::move(state) };
+}
+
+void NativeSession::pushDelta(SessionId session)
+{
+    auto built = buildPush(session, SnapshotMode::Delta);
+    if (!built)
     {
-        follow.lastModes = delta.setModes;
-        follow.lastAnsiModes = delta.setAnsiModes;
-        follow.lastCursorLine = delta.cursorLine;
-        follow.lastCursorColumn = delta.cursorColumn;
-        follow.lastStableFloor = delta.stableFloor;
-        send(0, proto::DecodedPdu { delta }, session.value);
+        // The increment could not describe the batch. The whole grid can, and the whole grid is
+        // exactly what must not go out inline.
+        if (built.error() == BuildFailure::ResyncRequired)
+            requestSnapshot(session);
+        return;
+    }
+    // No SessionState arm: it accompanies a snapshot only, and an increment that wanted to become
+    // one reported ResyncRequired rather than building it.
+    send(0, proto::DecodedPdu { std::move(built->delta) }, session.value);
+}
+
+bool NativeSession::snapshotPending(SessionId session) const noexcept
+{
+    return _streamingSession == session.value || std::ranges::contains(_snapshotQueue, session.value);
+}
+
+void NativeSession::requestSnapshot(SessionId session)
+{
+    if (!_handshaken || _closed)
+        return;
+    // Coalesced against the QUEUE only, not against the session being streamed: a request that
+    // arrives mid-run describes state the run in flight was captured before, so it earns a fresh
+    // snapshot once that one finishes.
+    if (std::ranges::contains(_snapshotQueue, session.value))
+        return;
+    // Claimed BEFORE the spawn, not by the coroutine once it runs: `spawn` only queues the handle,
+    // so between here and its first resumption run()'s teardown poll could observe no streamer and
+    // let `this` be destroyed under a coroutine that still holds it.
+    // The queue test is belt-and-braces: past the _closed check above, a non-empty queue always
+    // has a live streamer, so !_streamingSession alone would do.
+    auto const idle = _snapshotQueue.empty() && !_streamingSession;
+    _snapshotQueue.push_back(session.value);
+    if (!idle)
+        return;
+    _streamingSession = session.value;
+    _loop.spawn(streamSnapshots());
+}
+
+coro::Task<bool> NativeSession::awaitSendRoom()
+{
+    co_await _writer.waitUntilBacklogBelow(_snapshotWatermark, [this] { return _closed; });
+    co_return !_closed;
+}
+
+coro::Task<void> NativeSession::streamSnapshots()
+{
+    // A scope guard, not an assignment at the end: run()'s teardown polls this for the streamer
+    // having let go of `this`, and a cancellation unwinding past a trailing assignment would
+    // leave it set — deadlocking the very poll that keeps `this` alive.
+    auto const finished = crispy::Finally { [this] { _streamingSession.reset(); } };
+
+    while (!_snapshotQueue.empty() && !_closed)
+    {
+        auto const session = SessionId { _snapshotQueue.front() };
+        _snapshotQueue.pop_front();
+        _streamingSession = session.value;
+
+        // Wait BEFORE building, not after: a snapshot captured and then parked behind a backlog
+        // is a snapshot of the past, and this is where a peer that fell behind gets to catch up.
+        if (!co_await awaitSendRoom())
+            co_return;
+
+        auto built = buildPush(session, SnapshotMode::Forced);
+        if (!built)
+            continue; // the host stopped hosting it while this waited its turn
+        // Always engaged on this path — a snapshot carries its session's whole state — but read as
+        // the optional it is, so the invariant lives in ONE place rather than in every consumer.
+        if (built->state)
+            send(0, proto::DecodedPdu { *std::move(built->state) }, session.value);
+        co_await sendSnapshotPieces(std::move(built->delta), session);
+    }
+}
+
+coro::Task<void> NativeSession::sendSnapshotPieces(proto::Delta delta, SessionId session)
+{
+    // The rows are the only part of a snapshot that grows without bound; everything else is one
+    // session's state. So the rows are what gets split, and the rest rides along.
+    //
+    // Non-const: the pieces move their rows out of it. Safe because each row is visited exactly
+    // once, and because the partition below is computed before anything is moved.
+    auto lines = std::exchange(delta.lines, {});
+
+    // The two side tables that are neither per-row nor scalar, held aside for the ONE piece that
+    // carries each. Copying them onto every piece and clearing them again is what it would cost
+    // to leave them in `delta`: `hyperlinks` is every URI referenced anywhere in the grid, so a
+    // 25-piece run would allocate all of them 25 times and throw 24 copies away.
+    //
+    // Hyperlinks go with the first piece: the mirror merges them into a map that outlives the
+    // run, and a row cannot resolve a link id it has not seen. Status lines go with the last,
+    // alongside the rest of the state the run must land on.
+    auto hyperlinks = std::exchange(delta.hyperlinks, {});
+    auto statusLines = std::exchange(delta.statusLines, {});
+    auto const statusLinesChanged = std::exchange(delta.statusLinesChanged, uint8_t { 0 });
+
+    // Index the image cells by the row they sit on. The mirror clears a row's image cells when it
+    // takes the row and refills them from the same PDU's side table, so an entry that travelled in
+    // a different piece than its row would be dropped on arrival.
+    // ImageCellEntry is trivially copyable, so these are copies however they are spelled; only the
+    // grouping matters.
+    auto imagesByRow = std::unordered_map<int64_t, std::vector<proto::ImageCellEntry>> {};
+    for (auto const& entry: std::exchange(delta.imageCells, {}))
+        imagesByRow[entry.stableId].push_back(entry);
+
+    for (auto const& part: proto::partitionSnapshotRows(lines, SnapshotChunkBytes))
+    {
+        // The scalar state rides on every piece. Repeating it costs a few dozen bytes and buys
+        // the receiver statelessness: each piece stands on its own, and applying the same title
+        // or cursor position twice is applying it once.
+        auto piece = delta;
+        piece.snapshotPart = std::to_underlying(part.part);
+
+        // Moved, not copied: a WireLine owns a heap-allocated cell vector, so copying a 4000-row
+        // grid is 4000 allocations and megabytes of element-wise copy construction.
+        auto const rows = std::span { lines }.subspan(part.begin, part.count);
+        piece.lines.assign(std::make_move_iterator(rows.begin()), std::make_move_iterator(rows.end()));
+        for (auto const& line: piece.lines)
+            if (auto const images = imagesByRow.find(line.stableId); images != imagesByRow.end())
+                piece.imageCells.insert(piece.imageCells.end(), images->second.begin(), images->second.end());
+
+        // Handed over with `exchange` rather than `move`: the piece that takes each is decided by
+        // the SAME predicates the receiver uses, and leaving an emptied source behind means a
+        // later piece can only ever get an empty table — the correctness does not rest on the
+        // condition firing exactly once.
+        if (piece.startsSnapshot())
+            piece.hyperlinks = std::exchange(hyperlinks, {});
+        if (piece.completesSnapshot())
+        {
+            piece.statusLines = std::exchange(statusLines, {});
+            piece.statusLinesChanged = statusLinesChanged;
+        }
+
+        // Before EVERY piece, the first included: the SessionState that precedes a snapshot is
+        // already in the backlog by now, so "the streamer waited before building" does not leave
+        // the first piece the empty backlog it needs. Waiting here is what makes the enqueue
+        // below unrefusable, which is the whole point of pacing.
+        if (!co_await awaitSendRoom())
+            co_return;
+        send(0, proto::DecodedPdu { std::move(piece) }, session.value);
     }
 }
 
@@ -883,11 +1091,13 @@ bool NativeSession::completeHandshake(proto::DecodedFrame const& frame)
     // trees before the per-session content streams into them.
     pushLayout();
 
-    // The attach snapshot: every hosted session of every window, full state.
+    // The attach snapshot: every hosted session of every window, full state. QUEUED, not pushed:
+    // this runs inside the PDU pump's handler, which cannot suspend, so pushing here would put
+    // every pane's whole grid into the send queue before the drain coroutine had run once.
     _host.model().forEachTab([this](vtworkspace::Window&, vtworkspace::Tab& tab) {
         tab.rootPane()->walkTree([&](vtworkspace::Pane& pane) {
             if (pane.isLeaf())
-                pushDelta(pane.session(), /*forceSnapshot=*/true);
+                requestSnapshot(pane.session());
         });
     });
     return true;
@@ -933,7 +1143,12 @@ coro::Task<void> NativeSession::run()
     // entire poll, so this poll MUST remain the last thing run() does before
     // returning. Any refactoring that moves logic after this point opens a
     // use-after-free window on _flushScheduled.
-    co_await net::pollUntil(&_loop, [this] { return !_flushScheduled; });
+    //
+    // The snapshot streamer joins the same barrier for the same reason, and needs it more: it
+    // parks on the write queue's watermark, which is a far longer park than the flush debounce.
+    // `_closed` was set just above, which is what unparks it — waitUntilBacklogBelow returns on
+    // a closed queue, and the streamer's loops all test _closed — so this poll is bounded.
+    co_await net::pollUntil(&_loop, [this] { return !_flushScheduled && !_streamingSession; });
     co_await _writer.flushThenClose();
     _connection->close();
 }

--- a/src/vthost/NativeSession.hpp
+++ b/src/vthost/NativeSession.hpp
@@ -8,6 +8,15 @@
 /// version handshake the session pushes a full snapshot (SessionState + a
 /// snapshot Delta per hosted session), then per-line deltas driven by the
 /// host's screen-updated signal, debounced so bursts coalesce into one Delta.
+///
+/// Snapshots and increments travel differently, and the difference is the point. An increment is
+/// small by construction — the rows that changed in one 20ms window. A snapshot is the whole
+/// grid INCLUDING all scrollback, which is legitimately megabytes and has no smaller form. So
+/// snapshots are queued per session and emitted by a single streamer coroutine that waits for
+/// room in the send queue before each piece and splits anything over `SnapshotChunkBytes`.
+/// Emitting them inline instead is what made a daemon with a couple of scrollback-heavy panes
+/// permanently unattachable: the burst never yielded, so the drain never ran, so the whole attach
+/// payload had to fit the send-queue bound at once — and past two panes it did not.
 /// Grid rows are addressed by stable id; a generation change triggers one
 /// resync snapshot. Hyperlink URIs ship once per connection on first
 /// reference; image pixels only on FetchImage.
@@ -16,6 +25,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
+#include <expected>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -43,6 +54,15 @@ class NativeSession final: public SessionStreamEvents
   public:
     /// The default send-queue bound (see the constructor).
     static constexpr std::size_t DefaultWriteQueueBytes = std::size_t { 4 } * 1024 * 1024;
+
+    /// The largest snapshot payload one PDU carries; a grid bigger than this travels as several.
+    ///
+    /// Two cliffs make a lone unbounded frame wrong, and this clears both. It sits far below the
+    /// send-queue bound, so the streamer can always wait for room for a whole piece — and a piece
+    /// that lands on a drained backlog is never refused, whatever its size. And it sits orders of
+    /// magnitude below @ref proto::MaxFrameSize, so no scrollback depth can build a frame the
+    /// peer's own decoder rejects as FrameTooLarge.
+    static constexpr std::size_t SnapshotChunkBytes = std::size_t { 256 } * 1024;
 
     /// @param loop The event loop everything runs on.
     /// @param host The session host (not owned; outlives this).
@@ -241,18 +261,93 @@ class NativeSession final: public SessionStreamEvents
     /// (serial 0), once the handshake completed — on attach and on every change.
     void pushLayout();
 
-    /// Validates the peer's ClientHello, answers, and pushes the attach
+    /// Validates the peer's ClientHello, answers, and queues the attach
     /// snapshot (spawning the first session on an empty daemon).
     /// @return False when the hello was missing or version-mismatched.
     [[nodiscard]] bool completeHandshake(proto::DecodedFrame const& frame);
 
-    /// Sends SessionState + a snapshot/delta for @p session (under its lock).
-    void pushDelta(vtworkspace::SessionId session, bool forceSnapshot);
+    /// Whether a push re-describes the whole grid or reports only what changed since this
+    /// connection's delta cursor.
+    enum class SnapshotMode : uint8_t
+    {
+        Delta = 0,  ///< Report the rows changed since @c FollowState::cursor.
+        Forced = 1, ///< Re-describe the whole grid: attach, resize, page flip or a lost cursor.
+    };
+
+    /// One session's push, built under the terminal's lock and emitted after it is released.
+    ///
+    /// Building and emitting are separate steps because the two emission policies differ and
+    /// neither may hold the lock while it waits: an increment goes out at once, a snapshot is
+    /// paced against the send queue and split across PDUs.
+    struct BuiltPush
+    {
+        proto::Delta delta;                       ///< The rows and state to send.
+        std::optional<proto::SessionState> state; ///< Precedes the delta, on a snapshot.
+    };
+
+    /// Why @ref buildPush produced no push.
+    enum class BuildFailure : uint8_t
+    {
+        NoSuchSession = 0, ///< The host no longer hosts it.
+        /// The increment asked for cannot describe this batch — row identity moved out from under
+        /// the delta cursor. Reported rather than silently upgraded to a snapshot, because a
+        /// snapshot is the whole grid and belongs on the paced path, not inline on the caller's.
+        /// Nothing in the follow state has been advanced when this is returned, so the caller may
+        /// simply ask for a snapshot instead.
+        ResyncRequired = 1,
+        /// The delta would tell this peer nothing it has not been told: no cell, mode, cursor or
+        /// scrollback-floor movement since the last push. Unlike the two above, the follow state
+        /// HAS been advanced when this is returned — there was simply nothing to send.
+        NothingToSay = 2,
+    };
+
+    /// Collects @p session's push under the terminal's lock, advancing this connection's follow
+    /// state to match what the returned push will say.
+    /// @param session The session to describe.
+    /// @param mode Whether to re-describe the whole grid or only what changed.
+    /// @return The built push, or why none was built.
+    [[nodiscard]] std::expected<BuiltPush, BuildFailure> buildPush(vtworkspace::SessionId session,
+                                                                   SnapshotMode mode);
+
+    /// Sends SessionState + an incremental delta for @p session, deferring to @ref requestSnapshot
+    /// when an increment turns out not to be able to describe the batch.
+    void pushDelta(vtworkspace::SessionId session);
+
+    /// Queues a full-grid snapshot of @p session and starts the streamer if it is idle.
+    ///
+    /// Queued rather than sent: a snapshot is the whole grid, several of them are asked for at
+    /// once (attach walks every pane, a resize re-projects every pane), and emitting them inline
+    /// puts the entire payload in the send queue before the drain has run even once.
+    void requestSnapshot(vtworkspace::SessionId session);
+
+    /// @return Whether @p session has a snapshot queued or in flight. An increment for such a
+    ///         session must be held back: the snapshot re-describes everything the increment
+    ///         would say, and one landing BETWEEN a snapshot's pieces would have the mirror
+    ///         repaint a grid it has only half received.
+    [[nodiscard]] bool snapshotPending(vtworkspace::SessionId session) const noexcept;
+
+    /// Parks until the send queue has room for a snapshot piece.
+    /// @return False when the connection is going away and the caller should stop.
+    [[nodiscard]] coro::Task<bool> awaitSendRoom();
+
+    /// Arms the debounced delta flush unless one is already armed or the connection is closing.
+    void scheduleFlush();
+
+    /// The single snapshot streamer: drains @ref _snapshotQueue, one session at a time, waiting
+    /// for room in the send queue before each piece. One streamer rather than one coroutine per
+    /// snapshot, so two runs for the same session can never interleave on the wire.
+    [[nodiscard]] coro::Task<void> streamSnapshots();
+
+    /// Emits @p delta as one PDU, or as a run of @ref SnapshotChunkBytes-sized ones when its rows
+    /// exceed that, waiting for room before each.
+    /// @param delta The snapshot to send (consumed).
+    /// @param session The session it describes; also the supersede tag its pieces carry.
+    [[nodiscard]] coro::Task<void> sendSnapshotPieces(proto::Delta delta, vtworkspace::SessionId session);
 
     /// Pulls the session's live renditional state (title, cursor shape, cwd,
     /// colours, status display, Kitty-keyboard flags) into @p delta as diffs and —
-    /// on a snapshot — captures the full state into @p state. Called by pushDelta
-    /// with the terminal already locked; split out to keep pushDelta within the
+    /// on a snapshot — captures the full state into @p state. Called by buildPush
+    /// with the terminal already locked; split out to keep buildPush within the
     /// cognitive-complexity budget. Static: it reads only its arguments.
     /// @param screenTypeValue The wire screen-type discriminator (std::to_underlying).
     static void collectLiveState(vtbackend::Terminal& terminal,
@@ -261,7 +356,7 @@ class NativeSession final: public SessionStreamEvents
                                  std::optional<proto::SessionState>& state,
                                  vtworkspace::SessionId session,
                                  uint8_t screenTypeValue,
-                                 bool snapshot);
+                                 SnapshotMode mode);
 
     /// Captures the live OSC 3008 ancestry into @p delta, or — on a snapshot, which carries the records
     /// through SessionState instead — only brings @p follow up to date.
@@ -289,6 +384,13 @@ class NativeSession final: public SessionStreamEvents
     SessionHost& _host;
     std::unique_ptr<net::ISocket> _connection;
     net::WriteQueue _writer;
+    /// The backlog a snapshot piece waits to get under before it is enqueued.
+    ///
+    /// Derived from the connection's own bound rather than fixed: waiting for room for a WHOLE
+    /// piece is what makes the enqueue that follows unrefusable, and a bound smaller than a piece
+    /// (what a test sets) degrades this to "wait until fully drained", where the queue's
+    /// never-refuse-a-lone-frame rule takes over.
+    std::size_t _snapshotWatermark;
     ConnectionId _id;           ///< Prefixes this connection's every log line.
     std::string _expectedToken; ///< Required ClientHello token; empty accepts any.
     /// The emulation settings this client asked the sessions IT creates to have, layered onto the
@@ -301,6 +403,14 @@ class NativeSession final: public SessionStreamEvents
     LayoutObserver _layoutObserver;
     std::unordered_map<uint64_t, FollowState> _followed;
     std::unordered_set<uint64_t> _pendingSessions;
+    /// Sessions awaiting a full-grid snapshot, in the order they were asked for.
+    std::deque<uint64_t> _snapshotQueue;
+    /// The session @ref streamSnapshots is emitting right now; engaged exactly while a streamer
+    /// coroutine is live, which is also how @ref run knows it may let `this` go.
+    ///
+    /// Distinct from the queue because a session is popped before its pieces go out, and an
+    /// increment for it must stay held back for the whole run, not just while it waits its turn.
+    std::optional<uint64_t> _streamingSession;
     bool _flushScheduled = false;
     bool _handshaken = false;
     bool _closed = false;

--- a/src/vthost/NativeSession_test.cpp
+++ b/src/vthost/NativeSession_test.cpp
@@ -11,9 +11,13 @@
 #include <chrono>
 #include <cstddef>
 #include <format>
+#include <functional>
+#include <map>
 #include <memory>
 #include <ranges>
+#include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -45,13 +49,21 @@ Task<void> feedBytes(net::ISocket* client, std::vector<std::byte> const* bytes)
     std::ignore = co_await client->write(std::span<std::byte const> { bytes->data(), bytes->size() });
 }
 
-/// Decodes server PDUs until @p expected arrived (or the stream ended), then
-/// closes the client end — the session's read loop sees EOF and finishes.
-Task<void> collectPdus(net::ISocket* client, std::size_t expected, std::vector<proto::DecodedFrame>* out)
+/// Decodes server PDUs until @p done says to stop (or the stream ends), then closes the client
+/// end — the session's read loop sees EOF and finishes.
+///
+/// The bound is a predicate rather than a count because the two things tests wait for are shaped
+/// differently: a fixed number of PDUs, or a marker one of them carries. How many pieces a
+/// snapshot run takes depends on how its rows happen to partition, which is exactly what a test
+/// of the partitioning must not hardcode.
+/// @param done Consulted after each decoded frame; the collector stops when it returns true.
+Task<void> collectUntil(net::ISocket* client,
+                        std::function<bool(std::vector<proto::DecodedFrame> const&)> done,
+                        std::vector<proto::DecodedFrame>* out)
 {
     auto buffer = std::vector<std::byte> {};
     auto scratch = std::array<std::byte, 4096> {};
-    while (out->size() < expected)
+    while (!done(*out))
     {
         auto decoded = proto::decodePdu(buffer);
         if (decoded)
@@ -68,6 +80,44 @@ Task<void> collectPdus(net::ISocket* client, std::size_t expected, std::vector<p
         buffer.insert(buffer.end(), scratch.begin(), scratch.begin() + static_cast<long>(*n));
     }
     client->close();
+}
+
+/// Collects exactly @p expected PDUs.
+Task<void> collectPdus(net::ISocket* client, std::size_t expected, std::vector<proto::DecodedFrame>* out)
+{
+    co_await collectUntil(client, [expected](auto const& got) { return got.size() >= expected; }, out);
+}
+
+/// @return Whether @p frame terminates a snapshot run.
+bool endsSnapshotRun(proto::DecodedFrame const& frame)
+{
+    auto const* delta = std::get_if<proto::Delta>(&frame.pdu);
+    return delta != nullptr && delta->snapshot != 0 && delta->completesSnapshot();
+}
+
+/// Collects a whole snapshot run, plus @p extra PDUs after it.
+Task<void> collectSnapshotRun(net::ISocket* client,
+                              std::vector<proto::DecodedFrame>* out,
+                              std::size_t extra = 0)
+{
+    co_await collectUntil(
+        client,
+        [extra](std::vector<proto::DecodedFrame> const& got) {
+            auto const end = std::ranges::find_if(got, endsSnapshotRun);
+            return end != got.end() && std::cmp_greater(std::distance(end, got.end()), extra);
+        },
+        out);
+}
+
+/// driveExchange, but bounded by a snapshot run's completion instead of a PDU count.
+Task<void> driveSnapshotRun(NativeSession* session,
+                            net::ISocket* client,
+                            std::vector<std::byte> const* request,
+                            std::vector<proto::DecodedFrame>* out,
+                            std::size_t extra = 0)
+{
+    co_await coro::whenAll(
+        session->run(), feedBytes(client, request), collectSnapshotRun(client, out, extra));
 }
 
 Task<void> driveExchange(NativeSession* session,
@@ -172,6 +222,17 @@ Task<void> appendThenUpdate(NativeHarness* h, vtworkspace::SessionId id)
     co_await h->loop.delay(5ms);
     h->host.terminal(id)->writeToScreen("more");
     h->session->sessionScreenUpdated(id);
+}
+
+/// Writes @p rows lines of wide, tagged text into @p session, so its snapshot is a real multiple
+/// of a send-queue bound rather than a handful of trimmed lines.
+/// @param tag Prefixes each row, so a test can tell one pane's rows from another's.
+void fillRows(NativeHarness& h, vtworkspace::SessionId session, int rows, std::string_view tag)
+{
+    auto lines = std::string {};
+    for (auto const row: std::views::iota(0, rows))
+        lines += std::format("{}-{}{}\r\n", tag, row, std::string(60, 'x'));
+    h.host.terminal(session)->writeToScreen(lines);
 }
 
 /// Once the attach snapshot has landed: repositions ONLY the cursor (writing no
@@ -476,14 +537,21 @@ TEST_CASE("FetchImage for an unknown id answers ImageGone", "[vthost][native]")
     auto h = NativeHarness {};
     h.host.createTab();
 
-    // ServerHello, LayoutState, SessionState, Delta (snapshot), then ImageGone.
+    // ServerHello, LayoutState, then ImageGone, and only then the attach snapshot
+    // (SessionState + Delta). The snapshot is QUEUED by the handshake and emitted by the streamer
+    // on a later loop turn, so a request the client pipelined behind its hello is answered first.
+    // Nothing depends on the old order: replies are correlated by serial, not by position — and
+    // the client asserting its client area right after the hello now RESIZES before the snapshot
+    // is captured, so the one grid it receives is already the right shape.
     auto const received =
         h.exchange({ proto::ClientHello {}, proto::DecodedPdu { proto::FetchImage { .imageId = 4242 } } }, 5);
     REQUIRE(received.size() == 5);
-    auto const* gone = std::get_if<proto::ImageGone>(&received[4].pdu);
+    auto const* gone = std::get_if<proto::ImageGone>(&received[2].pdu);
     REQUIRE(gone != nullptr);
     CHECK(gone->imageId == 4242);
-    CHECK(received[4].serial == 2); // correlated to the request's serial
+    CHECK(received[2].serial == 2); // correlated to the request's serial
+    CHECK(std::get_if<proto::SessionState>(&received[3].pdu) != nullptr);
+    CHECK(std::get_if<proto::Delta>(&received[4].pdu) != nullptr);
 }
 
 TEST_CASE("a version-mismatched hello is answered and the session ends", "[vthost][native]")
@@ -797,6 +865,154 @@ TEST_CASE("a client that overflows the write queue is disconnected", "[vthost][n
 
     CHECK(!watchdogFired); // the SESSION closed the connection, not the watchdog
     CHECK(received.empty());
+}
+
+TEST_CASE("attaching to several scrollback-heavy panes is not refused", "[vthost][native]")
+{
+    // THE regression this whole pacing mechanism exists for. A daemon holding a couple of panes
+    // with real scrollback became permanently unattachable: completeHandshake pushed one full-grid
+    // snapshot per leaf pane synchronously, inside the PDU pump's handler, so the drain coroutine
+    // -- which EventLoop::spawn only queues -- could not run until the burst finished. The whole
+    // attach payload therefore had to fit under the send-queue bound at once, the second pane's
+    // snapshot did not fit, and the connection was dropped before a single byte reached the client.
+    // Nothing on the daemon changed between attempts, so every reconnect reproduced it exactly.
+    auto capture = logstore::ScopedCapture {};
+
+    // A bound far smaller than the snapshots it must carry, which is the shape of the report:
+    // 4 MiB against two panes of ~1.8 MB each. The point is that the SUM exceeding the bound must
+    // no longer matter, because no two pieces are ever in the queue at the same time.
+    auto h = NativeHarness { { .writeQueueBytes = std::size_t { 64 } * 1024,
+                               .history = vtbackend::LineCount(30) } };
+
+    auto sessions = std::vector<vtworkspace::SessionId> {};
+    for (auto const tab: std::views::iota(0, 3))
+    {
+        h.host.createTab();
+        auto const id = h.host.model().window(h.host.windowId())->activeTab()->rootPane()->session();
+        sessions.push_back(id);
+        fillRows(h, id, 50, std::format("tab{}-row", tab));
+    }
+
+    // ServerHello, LayoutState, then SessionState + one snapshot Delta per pane.
+    auto const received = h.exchange({ proto::ClientHello {} }, 8);
+    REQUIRE(received.size() == 8);
+    CHECK_FALSE(capture.contains("send queue overflow"));
+
+    // Every pane arrived, and arrived whole: a snapshot that is not superseded and not truncated.
+    auto snapshots = std::map<uint64_t, proto::Delta> {};
+    for (auto const& frame: received)
+        if (auto const* delta = std::get_if<proto::Delta>(&frame.pdu))
+        {
+            CHECK(delta->snapshot == 1);
+            snapshots.emplace(delta->session, *delta);
+        }
+    REQUIRE(snapshots.size() == sessions.size());
+    for (auto const tab: std::views::iota(0, 3))
+    {
+        auto const found = snapshots.find(sessions[static_cast<std::size_t>(tab)].value);
+        REQUIRE(found != snapshots.end());
+        auto const carries = [&](std::string_view row) {
+            return std::ranges::any_of(found->second.lines,
+                                       [row](auto const& line) { return textOf(line).starts_with(row); });
+        };
+        // The oldest row is scrollback that predates the attach; the newest is on the page.
+        CHECK(carries(std::format("tab{}-row-0x", tab)));
+        CHECK(carries(std::format("tab{}-row-49x", tab)));
+    }
+}
+
+TEST_CASE("a snapshot larger than one frame travels as a marked run", "[vthost][native]")
+{
+    // The other cliff: one pane's snapshot is the whole grid INCLUDING all scrollback, built into
+    // a single PDU. Past proto::MaxFrameSize the peer's own decoder rejects it, so no amount of
+    // pacing would deliver it. It is split instead, and each piece names its place so the mirror
+    // knows which one may clear what it holds and which one completes the run.
+    auto h = NativeHarness { { .history = vtbackend::LineCount(4000) } };
+    h.host.createTab();
+    auto const sessionId = h.host.model().window(h.host.windowId())->activeTab()->rootPane()->session();
+
+    fillRows(h, sessionId, 4000, "row");
+
+    // ServerHello, LayoutState, SessionState, then however many pieces the rows partition into.
+    auto const bytes = encodeRequest({ proto::DecodedPdu { proto::ClientHello {} } });
+    auto received = std::vector<proto::DecodedFrame> {};
+    h.loop.blockOn(driveSnapshotRun(h.session.get(), h.pair.second.get(), &bytes, &received));
+
+    auto pieces = std::vector<proto::Delta> {};
+    for (auto const& frame: received)
+        if (auto const* delta = std::get_if<proto::Delta>(&frame.pdu))
+            pieces.push_back(*delta);
+    REQUIRE(pieces.size() >= 2);
+
+    // Every piece says it is a snapshot -- a piece must never be mistaken for an increment -- and
+    // the run is marked First, then Middle, then Last.
+    for (auto const& piece: pieces)
+        CHECK(piece.snapshot == 1);
+    CHECK(pieces.front().part() == proto::SnapshotPart::First);
+    CHECK(pieces.back().part() == proto::SnapshotPart::Last);
+    for (auto const& middle: pieces | std::views::drop(1) | std::views::take(pieces.size() - 2))
+        CHECK(middle.part() == proto::SnapshotPart::Middle);
+
+    // No piece is anywhere near the frame cap, and the rows are partitioned across them rather
+    // than repeated: the run delivers each row exactly once.
+    auto seen = std::set<int64_t> {};
+    auto total = std::size_t { 0 };
+    for (auto const& piece: pieces)
+    {
+        for (auto const& line: piece.lines)
+            seen.insert(line.stableId);
+        total += piece.lines.size();
+    }
+    CHECK(seen.size() == total);
+    // Every addressable row travelled exactly once: the 4000 rows written, plus the empty row the
+    // cursor sits on after the last CRLF. None is dropped at a piece boundary and none is repeated.
+    CHECK(total == 4001);
+}
+
+TEST_CASE("an increment is held back until the snapshot it would interleave with finishes",
+          "[vthost][native]")
+{
+    // A snapshot travels as a run of PDUs, and the mirror only repaints when the run completes.
+    // An incremental delta slipped BETWEEN two pieces would be published immediately, having the
+    // client repaint a grid it has only half received -- every row the run has not delivered yet
+    // rendering as absent. So a session with a snapshot queued or in flight gets no increment; it
+    // stays pending and goes out once the run is done.
+    auto h = NativeHarness { { .writeQueueBytes = std::size_t { 64 } * 1024,
+                               .history = vtbackend::LineCount(4000) } };
+    h.host.createTab();
+    auto const sessionId = h.host.model().window(h.host.windowId())->activeTab()->rootPane()->session();
+
+    fillRows(h, sessionId, 4000, "row");
+
+    // Output arriving while the attach run is still streaming: the debounce fires 20ms later,
+    // well inside a run that pauses for the write queue to drain between each of its ~25 pieces.
+    auto const bytes = encodeRequest({ proto::DecodedPdu { proto::ClientHello {} } });
+    auto received = std::vector<proto::DecodedFrame> {};
+    h.loop.blockOn(
+        net::testing::allOf(driveSnapshotRun(h.session.get(), h.pair.second.get(), &bytes, &received, 1),
+                            appendThenUpdate(&h, sessionId)));
+
+    // The run is intact: every Delta up to and including the terminating piece is a snapshot
+    // piece, with no increment wedged among them.
+    auto sawRunEnd = false;
+    auto increments = 0;
+    for (auto const& frame: received)
+    {
+        auto const* delta = std::get_if<proto::Delta>(&frame.pdu);
+        if (delta == nullptr)
+            continue;
+        if (delta->snapshot == 0)
+        {
+            CHECK(sawRunEnd); // the whole point: never before the run ended
+            ++increments;
+            continue;
+        }
+        CHECK_FALSE(sawRunEnd);
+        sawRunEnd = delta->completesSnapshot();
+    }
+    CHECK(sawRunEnd);
+    // And the increment was held, not dropped: the rows written mid-run still arrive.
+    CHECK(increments == 1);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/vthost/client/NativeClient.cpp
+++ b/src/vthost/client/NativeClient.cpp
@@ -63,9 +63,16 @@ void RemoteScreen::apply(proto::SessionState const& state)
 void RemoteScreen::apply(proto::Delta const& delta)
 {
     session = delta.session;
-    if (delta.snapshot != 0)
+    // A snapshot replaces everything the client held — but a snapshot too large for one frame
+    // arrives as several, and only its FIRST piece may clear. The piece says which it is rather
+    // than the mirror inferring it from the piece before, so a run whose tail was dropped in
+    // favour of a newer snapshot still clears when that newer run's first piece lands.
+    // Remembered for the reply PDUs that carry no marker of their own. @see snapshotInProgress.
+    // No `snapshot != 0` conjunct: completesSnapshot() already answers true for an increment.
+    snapshotInProgress = !delta.completesSnapshot();
+    if (delta.startsSnapshot())
     {
-        rows.clear(); // a snapshot replaces everything the client held
+        rows.clear();
         imageCells.clear();
         // The pixel caches stay valid: image ids are pool-scoped, not
         // generation-scoped, so a rebuild does not invalidate a fetched image.
@@ -378,7 +385,10 @@ void NativeClient::handlePdu(proto::DecodedFrame const& frame)
             screen.requestedImages.insert(entry.imageId);
             fetchImage(delta->session, entry.imageId);
         }
-        if (_onUpdate)
+        // Publish only a screen that is whole. A mid-run piece leaves the mirror holding part of
+        // a grid, and handing that to a frontend would have it repaint a snapshot it has only
+        // half received — the rows not yet delivered rendering as absent until the run finishes.
+        if (_onUpdate && !screen.snapshotInProgress)
             _onUpdate(screen, *delta);
         return;
     }
@@ -395,7 +405,9 @@ void NativeClient::handlePdu(proto::DecodedFrame const& frame)
         _pendingImages.erase(it);
         auto& screen = screenFor(session);
         screen.images.insert_or_assign(imageId, *image);
-        if (_onImage)
+        // Withheld mid-run for the same reason a snapshot piece is: the pixels are recorded either
+        // way, and the piece that completes the run places every image it holds.
+        if (_onImage && !screen.snapshotInProgress)
             _onImage(screen, imageId);
         return;
     }
@@ -411,7 +423,7 @@ void NativeClient::handlePdu(proto::DecodedFrame const& frame)
         _pendingImages.erase(it);
         auto& screen = screenFor(session);
         screen.dropImage(imageId);
-        if (_onImage)
+        if (_onImage && !screen.snapshotInProgress)
             _onImage(screen, imageId);
         return;
     }

--- a/src/vthost/client/NativeClient.hpp
+++ b/src/vthost/client/NativeClient.hpp
@@ -87,6 +87,18 @@ struct RemoteScreen
     /// The ancestry, outermost first, in the sender's id space. Empty when there is none -- and that
     /// emptiness is itself asserted, so a stack that emptied is not mistaken for one never sent.
     std::vector<uint16_t> contextChain;
+
+    /// Whether a chunked snapshot is still arriving: set by a piece that opens or continues a
+    /// run, cleared by the one that completes it.
+    ///
+    /// A frontend must never be handed a screen mid-run — it holds part of a grid, and painting
+    /// it would render the rows not yet delivered as absent. This is what every publish gate in
+    /// NativeClient asks, including the Delta one that could equally have asked the PDU: an
+    /// ImageData/ImageGone reply carries no marker and CAN land between two pieces:
+    /// the client sends a FetchImage on seeing a new image id in an early piece, and the server
+    /// answers it into the same stream the rest of the run is still using. So the screen has to
+    /// remember what its last piece said.
+    bool snapshotInProgress = false;
     /// The mirrored DEC private modes currently SET remotely (by number).
     std::vector<uint32_t> setModes;
     /// The mirrored ANSI modes currently SET remotely (by number) — a separate

--- a/src/vthost/client/NativeClient_test.cpp
+++ b/src/vthost/client/NativeClient_test.cpp
@@ -57,6 +57,15 @@ namespace
 
 /// The full server<->client pair over one in-memory socket: the REAL
 /// NativeSession serves what the REAL NativeClient mirrors.
+/// @return An empty snapshot PDU marked as @p part — the scaffolding every run test needs.
+proto::Delta snapshotPiece(proto::SnapshotPart part)
+{
+    auto delta = proto::Delta {};
+    delta.snapshot = 1;
+    delta.snapshotPart = std::to_underlying(part);
+    return delta;
+}
+
 struct EndToEndHarness
 {
     net::PollEventSource source;
@@ -174,6 +183,77 @@ TEST_CASE("RemoteScreen renders blank rows and trims trailing space", "[vthost][
     CHECK(screen.viewportText() == "hi\n\n"); // row 11 is unknown -> blank
     CHECK(screen.rowAt(0) != nullptr);
     CHECK(screen.rowAt(1) == nullptr);
+}
+
+TEST_CASE("RemoteScreen accumulates a chunked snapshot and clears only on its first piece",
+          "[vthost][attach]")
+{
+    // A snapshot too large for one frame arrives as a run. Only its FIRST piece may clear what
+    // the mirror holds -- a Middle or Last piece that cleared would throw away the rows its own
+    // run just delivered, leaving the mirror showing the tail of its own snapshot.
+    auto const rowAt = [](int64_t stableId, char32_t ch) {
+        auto line = proto::WireLine {};
+        line.stableId = stableId;
+        line.columns = 1;
+        auto cell = proto::WireCell {};
+        cell.codepoint = ch;
+        line.cells.push_back(cell);
+        return line;
+    };
+    auto const piece = [&](proto::SnapshotPart part, int64_t stableId, char32_t ch) {
+        auto delta = snapshotPiece(part);
+        delta.stableViewportBase = 0;
+        delta.lines.push_back(rowAt(stableId, ch));
+        return delta;
+    };
+
+    auto screen = RemoteScreen {};
+    screen.columns = 1;
+    screen.lines = 3;
+
+    // Something to be superseded, so "the first piece clears" is actually observable.
+    screen.apply(piece(proto::SnapshotPart::Whole, 0, U'o'));
+    REQUIRE(screen.rows.size() == 1);
+
+    screen.apply(piece(proto::SnapshotPart::First, 0, U'a'));
+    screen.apply(piece(proto::SnapshotPart::Middle, 1, U'b'));
+    screen.apply(piece(proto::SnapshotPart::Last, 2, U'c'));
+
+    // All three rows survived the run, and the row the superseded snapshot left is gone.
+    REQUIRE(screen.rows.size() == 3);
+    CHECK(screen.viewportText() == "a\nb\nc\n");
+
+    // A run whose tail was dropped in favour of a newer snapshot is what makes the marker
+    // necessary rather than merely convenient: the new run's First must still clear, even though
+    // the piece before it said more was coming.
+    screen.apply(piece(proto::SnapshotPart::First, 0, U'z'));
+    REQUIRE(screen.rows.size() == 1);
+    CHECK(screen.viewportText() == "z\n\n\n");
+}
+
+TEST_CASE("a screen knows a chunked snapshot is still arriving", "[vthost][attach]")
+{
+    // What gates the reply PDUs that carry no marker of their own. An ImageData answer lands in
+    // the same stream the run is still using — the client asked for it on seeing a new image id in
+    // an earlier piece — so without this the frontend would be handed, and would paint, a grid it
+    // has only half received.
+    auto screen = RemoteScreen {};
+    CHECK_FALSE(screen.snapshotInProgress); // nothing received yet
+
+    screen.apply(snapshotPiece(proto::SnapshotPart::First));
+    CHECK(screen.snapshotInProgress);
+    screen.apply(snapshotPiece(proto::SnapshotPart::Middle));
+    CHECK(screen.snapshotInProgress);
+    screen.apply(snapshotPiece(proto::SnapshotPart::Last));
+    CHECK_FALSE(screen.snapshotInProgress);
+
+    // An unsplit snapshot is never "in progress", and neither is an increment.
+    screen.apply(snapshotPiece(proto::SnapshotPart::Whole));
+    CHECK_FALSE(screen.snapshotInProgress);
+    screen.apply(snapshotPiece(proto::SnapshotPart::First));
+    REQUIRE(screen.snapshotInProgress);
+    screen.apply(proto::Delta {}); // a plain delta ends a run the server abandoned
+    CHECK_FALSE(screen.snapshotInProgress);
 }
 
 TEST_CASE("RemoteScreen drops history the server discarded via the floor", "[vthost][attach]")

--- a/src/vthost/proto/Pdu.cpp
+++ b/src/vthost/proto/Pdu.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <expected>
 #include <ranges>
+#include <span>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -418,6 +419,7 @@ namespace
         out.varint(pdu.generation);
         out.varint(pdu.seqno);
         out.u8(pdu.snapshot);
+        out.u8(pdu.snapshotPart);
         out.svarint(pdu.stableViewportBase);
         out.svarint(pdu.stableFloor);
         out.svarint(pdu.cursorLine);
@@ -805,6 +807,7 @@ namespace
         auto error = DecodeError {};
         if (!assign(in.varint(), pdu.session, error) || !assign(in.varint(), pdu.generation, error)
             || !assign(in.varint(), pdu.seqno, error) || !assign(in.u8(), pdu.snapshot, error)
+            || !assign(in.u8(), pdu.snapshotPart, error)
             || !assign(in.svarint(), pdu.stableViewportBase, error)
             || !assign(in.svarint(), pdu.stableFloor, error) || !assign(in.svarint(), pdu.cursorLine, error)
             || !assign(in.svarint(), pdu.cursorColumn, error))
@@ -1058,6 +1061,53 @@ namespace
     static_assert(DecodeTable.size() + 1 == std::variant_size_v<DecodedPdu>,
                   "every DecodedPdu alternative except Invalid needs a DecodeTable row");
 } // namespace
+
+std::size_t estimatedEncodedSize(WireLine const& line) noexcept
+{
+    // encodeCell writes a varint codepoint, a varint extras count, two u8, two u16 and four u32 —
+    // 22 fixed bytes plus a 1..4 byte codepoint and whatever clusterExtras adds. encodeLine's own
+    // header is two svarints, a u16, two varints and four u32. Both are rounded up to a round
+    // number rather than computed exactly: @see the header for why an estimate is the point.
+    constexpr auto BytesPerCell = std::size_t { 24 };
+    constexpr auto BytesPerRowHeader = std::size_t { 24 };
+    return BytesPerRowHeader + (line.cells.size() * BytesPerCell);
+}
+
+std::vector<SnapshotPiece> partitionSnapshotRows(std::span<WireLine const> lines, std::size_t budget)
+{
+    auto pieces = std::vector<SnapshotPiece> {};
+    auto begin = std::size_t { 0 };
+    while (begin < lines.size())
+    {
+        // The first row of a piece is taken unconditionally, which is what keeps an oversized row
+        // from producing an empty span and looping forever.
+        auto count = std::size_t { 1 };
+        auto used = estimatedEncodedSize(lines[begin]);
+        for (auto const& line: lines.subspan(begin + 1))
+        {
+            auto const cost = estimatedEncodedSize(line);
+            if (used + cost > budget)
+                break;
+            used += cost;
+            ++count;
+        }
+        pieces.push_back(SnapshotPiece { .begin = begin, .count = count });
+        begin += count;
+    }
+    if (pieces.empty())
+        pieces.push_back(SnapshotPiece {});
+
+    // Marked in a second pass: how many pieces there are is only known once the partition is done,
+    // and a lone piece must be Whole rather than a First whose Last never comes.
+    if (pieces.size() > 1)
+    {
+        for (auto& piece: pieces)
+            piece.part = SnapshotPart::Middle;
+        pieces.front().part = SnapshotPart::First;
+        pieces.back().part = SnapshotPart::Last;
+    }
+    return pieces;
+}
 
 void encodePdu(Writer& sink, uint64_t serial, DecodedPdu const& pdu)
 {

--- a/src/vthost/proto/Pdu.hpp
+++ b/src/vthost/proto/Pdu.hpp
@@ -424,6 +424,23 @@ struct ImageCellEntry
     bool operator==(ImageCellEntry const&) const = default;
 };
 
+/// Where one PDU sits in a snapshot that was too large to travel as a single frame.
+///
+/// A full-grid snapshot of a deep scrollback is legitimately megabytes, and a producer that
+/// enqueues it whole either exceeds its connection's send-queue bound or hands the peer a frame
+/// its decoder must reject. Splitting it means `snapshot != 0` alone can no longer say "clear
+/// what you hold and start over" — only the FIRST piece may say that — so each piece names its
+/// place instead of the receiver inferring it from the piece before. Inferring it is what breaks
+/// when a superseding snapshot drops the remaining pieces of the one in flight: the new run's
+/// first piece must clear, and only an explicit marker still says so.
+enum class SnapshotPart : uint8_t
+{
+    Whole = 0,  ///< The entire snapshot in one PDU. Also what a non-snapshot delta carries.
+    First = 1,  ///< The first of several: clear, then accumulate.
+    Middle = 2, ///< Accumulate.
+    Last = 3,   ///< Accumulate, then apply — this piece carries the state the run must land with.
+};
+
 /// A batch of changed rows plus the side tables they reference. `snapshot`
 /// marks a full resync (attach or generation change) rather than an increment.
 struct Delta
@@ -432,6 +449,10 @@ struct Delta
     uint64_t generation = 0;
     uint64_t seqno = 0;
     uint8_t snapshot = 0;
+    /// This PDU's place in a chunked snapshot, as a @ref SnapshotPart. Zero (`Whole`) on every
+    /// unchunked delta, so a producer that never splits says nothing and a reader that ignores
+    /// it sees exactly the unchunked protocol.
+    uint8_t snapshotPart = 0;
     /// The stable id of page row 0 at delta time — what lets the client map
     /// stable-id-addressed rows onto its viewport.
     int64_t stableViewportBase = 0;
@@ -528,6 +549,40 @@ struct Delta
                || cwdChanged != 0 || colorsChanged != 0 || statusChanged != 0 || statusLinesChanged != 0
                || kittyKeyboardChanged != 0 || modifyOtherKeysChanged != 0 || mouseChanged != 0
                || progressChanged != 0 || contextChanged != 0 || !contexts.empty();
+    }
+
+    /// @return Where this PDU sits in its snapshot, or `Whole` for anything that is not part of a
+    ///         multi-PDU run — including a value no enumerator names, which a peer built from a
+    ///         later revision could send. Treating that as `Whole` is the safe reading: the piece
+    ///         is applied on its own rather than held for a run terminator that never comes.
+    [[nodiscard]] SnapshotPart part() const noexcept
+    {
+        // A switch rather than a range check, and every enumerator named: adding a fifth then
+        // fails the build here instead of being silently folded into Whole.
+        auto const value = static_cast<SnapshotPart>(snapshotPart);
+        switch (value)
+        {
+            case SnapshotPart::Whole:
+            case SnapshotPart::First:
+            case SnapshotPart::Middle:
+            case SnapshotPart::Last: return value;
+        }
+        return SnapshotPart::Whole; // a byte no enumerator names, from a revision we do not know
+    }
+
+    /// @return Whether the receiver must discard what it holds for this session before applying
+    ///         this PDU. True for a snapshot that opens a run, or is a run of one.
+    [[nodiscard]] bool startsSnapshot() const noexcept
+    {
+        return snapshot != 0 && (part() == SnapshotPart::Whole || part() == SnapshotPart::First);
+    }
+
+    /// @return Whether the receiver holds a whole screen once this PDU is applied, and may render
+    ///         it. False only mid-run: publishing then would paint a grid half of which has not
+    ///         arrived. Every non-snapshot delta completes trivially.
+    [[nodiscard]] bool completesSnapshot() const noexcept
+    {
+        return snapshot == 0 || part() == SnapshotPart::Whole || part() == SnapshotPart::Last;
     }
 
     bool operator==(Delta const&) const = default;
@@ -709,6 +764,48 @@ using DecodedPdu = std::variant<Invalid,
 /// @param serial Request correlation; 0 = unsolicited push.
 /// @param pdu Any catalog PDU.
 void encodePdu(Writer& sink, uint64_t serial, DecodedPdu const& pdu);
+
+/// @return Roughly how many bytes @p line occupies once encoded.
+///
+/// For deciding where to split a payload that is too large to send as one frame, and for nothing
+/// else. The exact size is known only after encoding, and encoding a row twice to learn a number
+/// whose only job is to pick a split point would double the work; being within a small factor is
+/// enough for a budget whose consumer pads it anyway.
+///
+/// Lives beside the encoder it approximates for the reason `Delta::hasChanges` lives beside its
+/// gates: a field added to `encodeCell` has to be remembered here too, and nothing points across
+/// a module boundary to say so. `Pdu_test` pins the two together against a real `Writer`.
+[[nodiscard]] std::size_t estimatedEncodedSize(WireLine const& line) noexcept;
+
+/// One piece of a snapshot whose rows did not fit a single frame: an index range plus its
+/// place in the run.
+struct SnapshotPiece
+{
+    std::size_t begin = 0; ///< Index of this piece's first row.
+    std::size_t count = 0; ///< How many rows it covers; zero only for an empty input.
+    /// Where this piece sits in the run.
+    ///
+    /// Carried here rather than left to the caller so the rule with the sharp edge — a lone piece
+    /// is `Whole`, never a `First` whose `Last` never comes — has one home and one test. A caller
+    /// re-deriving it from "am I the first element, am I the last" gets that case wrong by writing
+    /// the two conditions independently, and the peer then waits forever for a terminator.
+    SnapshotPart part = SnapshotPart::Whole;
+};
+
+/// Splits @p lines into consecutive pieces, each aiming to stay within @p budget bytes.
+///
+/// Two rules make the result always usable rather than sometimes impossible:
+/// - **A row is never split.** It is the smallest thing the wire can address, so a row that alone
+///   exceeds @p budget gets a span to itself and the budget is overshot. The budget is a target,
+///   not a guarantee — its consumer must not depend on the bound.
+/// - **An empty input yields one empty span.** A payload with no rows is still a payload, and its
+///   sender still has one PDU's worth of state to deliver.
+/// @param lines The rows to partition, in order.
+/// @param budget The byte target per piece, by @ref estimatedEncodedSize.
+/// @return One entry per piece, covering @p lines exactly once, in order, each marked with its
+///         place in the run — a single piece is `Whole`, never `First` followed by nothing.
+[[nodiscard]] std::vector<SnapshotPiece> partitionSnapshotRows(std::span<WireLine const> lines,
+                                                               std::size_t budget);
 
 /// The catalog tag @p pdu carries, for diagnostics and dispatch.
 ///

--- a/src/vthost/proto/PduTrace.cpp
+++ b/src/vthost/proto/PduTrace.cpp
@@ -114,13 +114,14 @@ namespace
                        auto const& value = std::get<Delta>(pdu);
                        // Counts and the ACTIVE ID only -- never a record's fields. @see the
                        // SessionState row above.
-                       return std::format("session={} gen={} seq={} snapshot={} lines={} links={} "
+                       return std::format("session={} gen={} seq={} snapshot={}/{} lines={} links={} "
                                           "imagecells={} statuslines={} progress={}/{} contexts={} "
                                           "activecontext={}",
                                           value.session,
                                           value.generation,
                                           value.seqno,
                                           value.snapshot,
+                                          value.snapshotPart,
                                           value.lines.size(),
                                           value.hyperlinks.size(),
                                           value.imageCells.size(),

--- a/src/vthost/proto/Pdu_test.cpp
+++ b/src/vthost/proto/Pdu_test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <ranges>
@@ -683,4 +684,114 @@ TEST_CASE("Delta::hasChanges answers for every gated field", "[vthost][proto]")
     moved.cursorLine = 4;
     moved.setModes = { 1049 };
     CHECK_FALSE(moved.hasChanges());
+}
+
+TEST_CASE("a row's size estimate tracks what the encoder actually writes", "[vthost][proto]")
+{
+    // The estimate exists so a splitter need not encode a row twice. That only holds while it
+    // stays in the encoder's neighbourhood — a field added to encodeCell and forgotten here turns
+    // a byte budget into a wish. Pinned as a FACTOR, not a number: the estimate is deliberately
+    // approximate (it rounds, and it does not model varint widths), so an exact assertion would
+    // fail on every harmless encoding change while missing the drift that matters.
+    auto const rowOf = [](std::size_t cells) {
+        auto line = WireLine {};
+        line.stableId = 7;
+        line.columns = static_cast<uint32_t>(cells);
+        for (auto const column: std::views::iota(std::size_t { 0 }, cells))
+        {
+            auto cell = WireCell {};
+            cell.codepoint = U'x';
+            cell.hyperlink = static_cast<uint16_t>(column);
+            line.cells.push_back(cell);
+        }
+        return line;
+    };
+
+    for (auto const cells: { std::size_t { 0 }, std::size_t { 1 }, std::size_t { 80 }, std::size_t { 400 } })
+    {
+        auto sink = Writer {};
+        auto const line = rowOf(cells);
+        auto delta = Delta {};
+        delta.lines.push_back(line);
+        encodePdu(sink, 1, DecodedPdu { delta });
+        auto const actual = sink.view().size();
+        auto const estimate = estimatedEncodedSize(line);
+        // Never wildly under (a budget that under-counts overshoots the frame it was sizing) and
+        // never wildly over (one that over-counts splits more than it needs to).
+        CHECK(estimate * 4 >= actual);
+        CHECK(actual * 4 >= estimate);
+    }
+}
+
+TEST_CASE("partitionSnapshotRows covers every row exactly once, in order", "[vthost][proto]")
+{
+    auto lines = std::vector<WireLine> {};
+    for (auto const row: std::views::iota(0, 20))
+    {
+        auto line = WireLine {};
+        line.stableId = row;
+        line.cells.resize(10);
+        lines.push_back(line);
+    }
+    auto const perRow = estimatedEncodedSize(lines.front());
+
+    SECTION("a budget holding three rows yields pieces of three")
+    {
+        auto const spans = partitionSnapshotRows(lines, perRow * 3);
+        REQUIRE(spans.size() == 7); // 6 full pieces plus the remaining 2 rows
+        CHECK(spans.front().count == 3);
+        CHECK(spans.back().count == 2);
+
+        // The spans tile the input: consecutive, gapless, no row named twice.
+        auto next = std::size_t { 0 };
+        for (auto const& span: spans)
+        {
+            CHECK(span.begin == next);
+            next += span.count;
+        }
+        CHECK(next == lines.size());
+    }
+
+    SECTION("each piece is marked with its place in the run")
+    {
+        auto const spans = partitionSnapshotRows(lines, perRow * 3);
+        REQUIRE(spans.size() > 2);
+        CHECK(spans.front().part == SnapshotPart::First);
+        CHECK(spans.back().part == SnapshotPart::Last);
+        for (auto const& middle: spans | std::views::drop(1) | std::views::take(spans.size() - 2))
+            CHECK(middle.part == SnapshotPart::Middle);
+    }
+
+    SECTION("a run of one is Whole, never a First whose Last never comes")
+    {
+        // The marker a receiver acts on: First tells it to clear and wait, and a lone piece that
+        // said First would leave it waiting for a terminator that is never sent.
+        CHECK(partitionSnapshotRows(lines, perRow * lines.size()).front().part == SnapshotPart::Whole);
+        CHECK(partitionSnapshotRows({}, 1024).front().part == SnapshotPart::Whole);
+    }
+
+    SECTION("a row larger than the budget still travels, alone")
+    {
+        // A row is the smallest thing the wire can address, so the budget has to yield to it.
+        // Refusing instead would make a wide enough grid unsendable at any budget.
+        auto const spans = partitionSnapshotRows(lines, 1);
+        REQUIRE(spans.size() == lines.size());
+        CHECK(std::ranges::all_of(spans, [](auto const& span) { return span.count == 1; }));
+    }
+
+    SECTION("one budget-sized piece is not split")
+    {
+        auto const spans = partitionSnapshotRows(lines, perRow * lines.size());
+        REQUIRE(spans.size() == 1);
+        CHECK(spans.front().count == lines.size());
+    }
+
+    SECTION("no rows still yields one piece")
+    {
+        // A payload with no rows is still a payload: its sender has state to deliver, and a
+        // caller that emits one PDU per span must emit exactly one.
+        auto const spans = partitionSnapshotRows({}, 1024);
+        REQUIRE(spans.size() == 1);
+        CHECK(spans.front().count == 0);
+    }
 }


### PR DESCRIPTION
A daemon holding more than one pane with real scrollback could not be attached to, and stayed that way. `contour client` reported "connection closed during attach" while the daemon logged `send queue overflow (… 0 in flight); disconnecting`, and because nothing on the daemon changed between attempts, every reconnect failed identically — the sessions kept running, but nothing could reach them again.

`completeHandshake` pushed one full-grid snapshot per leaf pane synchronously, inside the PDU pump's non-suspending handler. `EventLoop::spawn` only queues the drain coroutine, so it could not run until that handler returned — the `0 in flight` in the log is precisely that: not one byte was ever written. The send queue was therefore never empty after its first frame, which is exactly what the never-refuse-a-lone-frame rule needs to protect a large snapshot, and the whole attach payload had to fit the 4 MiB bound at once. At ~24 wire bytes per cell the default 1000-line scrollback is ~1.8 MB per pane, so two busy panes were already too many. `dropTagged` could not help either: on attach each session is pushed exactly once under its own tag, so there is never anything to supersede.

There was a second cliff underneath: one pane's snapshot is the whole grid including all scrollback, built into a single PDU, which past `MaxFrameSize` the client's own decoder rejects. Pacing alone would not have delivered that.

## Changes

- `net::WriteQueue` gains `waitUntilBacklogBelow`, so a producer that can pace itself does that instead of being refused. It also takes a caller stop predicate, because a connection cannot use the queue's close as its signal — an owner that waits for its producers before closing, and producers that wait for the close, wait for each other.
- Snapshots go through one streamer coroutine per connection that waits for room before every piece. The watermark is deliberately a *low*-water mark: pacing to `bound − piece` delivers the snapshot just as well, but rides the backlog just under the bound for the whole run and leaves a single piece of headroom for every producer that cannot pace itself.
- `proto::Delta` gains a `SnapshotPart` marker so an oversized snapshot can be split. Each piece names its place rather than the receiver inferring it, which is what keeps a run correct when a superseding snapshot drops the tail of the one in flight. Zero is `Whole`, so the field is inert for a producer that never splits.
- Resize is routed through the same path, not just attach. One client's resize re-projects every pane of every window, arriving once per pane inside a single callback — the identical burst, which could drop an already-attached client.
- An increment for a session mid-run is held back rather than wedged between its pieces; the client publishes a snapshot only once the run completes, so no frontend needs to know runs exist. The same applies to an `ImageData`/`ImageGone` reply, which carries no run marker of its own and *can* land between two pieces — the client asks for it on seeing a new image id in an early piece, and the server answers into the stream the run is still using.
- `docs/internals/vthost.md` gains the third send-queue rule, and records that the same burst shape is still open in `tmux::ControlSession` and `tmux::TmuxGateway`.

Rows and the hyperlink/status side tables are now moved into the piece that carries them rather than deep-copied per piece, which removes roughly 4000 allocations and ~14 MB of copying for a 4000-row grid.
