### PR TITLE
fix(Image): exclude libc++ from experimental/simd usage via _LIBCPP_V…

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -134,6 +134,7 @@
           <li>Fixes an SSH connection attempt skipping every other address a host name resolved to, so a host reachable only at its second address appeared to be down</li>
           <li>Fixes Contour hanging when an SSH handshake failed: the failure path took a lock the calling thread already held</li>
           <li>Fixes Contour spinning when the SSH agent could not be reached — the normal case inside a Flatpak, where $SSH_AUTH_SOCK names a host path the sandbox does not mount — instead of falling through to the next authentication method</li>
+          <li>Fixes the build on Linux with Clang and libc++, which selected the broken &lt;experimental/simd&gt;. The guard excluded it by platform — Apple and FreeBSD — but the header belongs to libc++, not to those systems, so any libc++ build reached it; it is now excluded by _LIBCPP_VERSION instead (#2087)</li>
         </ul>
       </description>
     </release>

--- a/src/vtbackend/core/Image.cpp
+++ b/src/vtbackend/core/Image.cpp
@@ -14,7 +14,7 @@
     #include <simd>
     namespace simd = std;
     #define VTBACKEND_SIMD_FOUND 1
-#elif __has_include(<experimental/simd>) && !defined(__APPLE__) && !defined(__FreeBSD__)
+#elif __has_include(<experimental/simd>) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(_LIBCPP_VERSION)
     #include <experimental/simd>
     namespace simd = std::experimental;
     #define VTBACKEND_SIMD_FOUND 1


### PR DESCRIPTION
…ERSION

On Linux + Clang + libc++, __APPLE__ and __FreeBSD__ guards were insufficient to prevent use of broken <experimental/simd>. Adding !defined(_LIBCPP_VERSION) catches all libc++-based builds regardless of platform.

## Description

<!-- Describe your changes: what and why. -->

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!-- Describe how you tested your changes and what scenarios were covered. -->

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] Breaking changes (if any) are documented
