### PR TITLE
fix(session): honor capture_buffer permission via requestPermission gate

### DIFF
--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -874,9 +874,11 @@ void TerminalSession::requestCaptureBuffer(LineCount lines, bool logical)
 
     _pendingBufferCapture = CaptureBufferRequest { .lines = lines, .logical = logical };
 
-    emit requestPermissionForBufferCapture();
-    // _display->post(
-    //     [this]() { requestPermission(_profile.permissions.captureBuffer, GuardedRole::CaptureBuffer); });
+    // Consult config + remembered answers via the shared gate (same shape as other roles).
+    // post() keeps executeRole / captureBuffer on the GUI thread (#2089).
+    _display->post([this]() {
+        requestPermission(_profile.permissions.value().captureBuffer, GuardedRole::CaptureBuffer);
+    });
 }
 
 void TerminalSession::executePendingBufferCapture(bool allow, bool remember)

--- a/src/contour/session/TerminalSession_test.cpp
+++ b/src/contour/session/TerminalSession_test.cpp
@@ -2193,8 +2193,25 @@ TEST_CASE("TerminalSession: config-driven permissions resolve without asking the
 
     // A font-change action with a pre-allowed permission applies without asking (no crash, no dialog).
     CHECK_NOTHROW((*session)(actions::ResetFontSize {}));
-    // Requesting a capture with a config-denied permission resolves to the deny path.
-    CHECK_NOTHROW(session->executePendingBufferCapture(false, false));
+
+    // Drive the real gate for CaptureBuffer (not only the post-gate executor).
+    // Deny must not write a capture reply into the PTY stdin buffer (#2089).
+    auto const stdinBeforeDeny = mockPtyOf(*session).stdinBuffer().size();
+    CHECK_NOTHROW(session->requestCaptureBuffer(vtbackend::LineCount(10), false));
+    CHECK(mockPtyOf(*session).stdinBuffer().size() == stdinBeforeDeny);
+}
+
+TEST_CASE("TerminalSession: capture_buffer allow resolves without dialog path side effects",
+          "[contour][session][permission]")
+{
+    contour::test::TestApp testApp;
+    auto const profileName = registerProfile(testApp.app(), "perm-allow", [](contour::config::TerminalProfile& p) {
+        p.permissions.value().captureBuffer = contour::config::Permission::Allow;
+    });
+    auto session = makeSessionWithProfile(testApp.app(), profileName);
+
+    // Allow should execute the pending capture through requestPermission without throwing.
+    CHECK_NOTHROW(session->requestCaptureBuffer(vtbackend::LineCount(5), false));
 }
 
 namespace


### PR DESCRIPTION
## Summary

fix(session): honor capture_buffer permission via requestPermission gate

## Changes

- TerminalSession.cpp: requestCaptureBuffer uses requestPermission like other roles
- TerminalSession_test.cpp: drive requestCaptureBuffer for deny/allow configs

Fixes #2089
