### PR TITLE
chore: drop the last fmtlib references

### DIFF
--- a/docs/internals/software-architecture/index.md
+++ b/docs/internals/software-architecture/index.md
@@ -61,7 +61,7 @@ graph TD
     *   Logging (`logstore`).
     *   Data structures (`Trie`, `LRUCache`, `RingBuffer`).
     *   Utilities (`base64`, `file_descriptor`, `signals`).
-*   **Key Dependencies:** `fmt`, `range-v3`, `GSL`.
+*   **Key Dependencies:** `range-v3`, `GSL`.
 
 ### 2. `vtparser` (ANSI Parser)
 **Location:** `src/vtparser/`

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -574,7 +574,6 @@ install_deps_darwin() {
         cairo \
         catch2 \
         cpp-gsl \
-        fmt \
         fontconfig \
         freetype \
         harfbuzz \

--- a/src/contour/cli/ContourApp.cpp
+++ b/src/contour/cli/ContourApp.cpp
@@ -253,8 +253,7 @@ ContourApp::ContourApp(crispy::Environment const& env):
         // Project{"Catch2", "BSL-1.0", "https://github.com/catchorg/Catch2"},
         Project { "libunicode", "Apache-2.0", "https://github.com/contour-terminal/libunicode" },
         Project { "yaml-cpp", "MIT", "https://github.com/jbeder/yaml-cpp" },
-        Project { "termbench-pro", "Apache-2.0", "https://github.com/contour-terminal/termbench-pro" },
-        Project { "fmt", "MIT", "https://github.com/fmtlib/fmt" });
+        Project { "termbench-pro", "Apache-2.0", "https://github.com/contour-terminal/termbench-pro" });
 
 #ifdef __linux__
     auto crashLogDirPath = crispy::App::instance()->localStateDir() / "crash";

--- a/src/contour/config/Actions.hpp
+++ b/src/contour/config/Actions.hpp
@@ -842,7 +842,7 @@ static_assert(std::tuple_size_v<std::remove_cvref_t<decltype(actionCatalog())>>
 
 } // namespace contour::actions
 
-// {{{ fmtlib custom formatters
+// {{{ fmt custom formatters
 
 template <>
 struct std::formatter<contour::actions::Direction>: std::formatter<std::string_view>

--- a/src/contour/config/Config.hpp
+++ b/src/contour/config/Config.hpp
@@ -2319,7 +2319,7 @@ std::string documentationProfileConfig();
 
 } // namespace contour::config
 
-// {{{ fmtlib custom formatter support
+// {{{ fmt custom formatter support
 
 template <>
 struct std::formatter<contour::config::Permission>: formatter<std::string_view>

--- a/src/crispy/CLI.hpp
+++ b/src/crispy/CLI.hpp
@@ -245,4 +245,4 @@ struct std::formatter<crispy::cli::Value>
         // return std::format_to(ctx.out(), "{}..{}", range.from, range.to);
     }
 };
-// }}} namespace fmt
+// }}}

--- a/src/text_shaper/Shaper.hpp
+++ b/src/text_shaper/Shaper.hpp
@@ -172,7 +172,7 @@ class Shaper
 
 } // end namespace text
 
-// {{{ fmtlib support
+// {{{ fmt support
 template <>
 struct std::formatter<text::BitmapFormat>: std::formatter<std::string_view>
 {

--- a/src/vtbackend/bench-headless.cpp
+++ b/src/vtbackend/bench-headless.cpp
@@ -188,8 +188,7 @@ class ContourHeadlessBench: public crispy::App
             Project { "mimalloc", "", "" },
 #endif
             Project { "yaml-cpp", "MIT", "https://github.com/jbeder/yaml-cpp" },
-            Project { "termbench-pro", "Apache-2.0", "https://github.com/contour-terminal/termbench-pro" },
-            Project { "fmt", "MIT", "https://github.com/fmtlib/fmt" });
+            Project { "termbench-pro", "Apache-2.0", "https://github.com/contour-terminal/termbench-pro" });
         link("bench-headless.parser", bind(&ContourHeadlessBench::benchParserOnly, this));
         link("bench-headless.grid", bind(&ContourHeadlessBench::benchGrid, this));
         link("bench-headless.sixel", bind(&ContourHeadlessBench::benchSixel, this));

--- a/src/vtbackend/core/Color.hpp
+++ b/src/vtbackend/core/Color.hpp
@@ -505,7 +505,7 @@ constexpr Opacity& operator--(Opacity& value) noexcept
 
 } // namespace vtbackend
 
-// {{{ fmtlib custom formatter
+// {{{ fmt custom formatter
 template <>
 struct std::formatter<vtbackend::Color>: std::formatter<std::string>
 {

--- a/src/vtbackend/core/ColorPalette.hpp
+++ b/src/vtbackend/core/ColorPalette.hpp
@@ -492,7 +492,7 @@ RGBColor apply(ColorPalette const& colorPalette, Color color, ColorTarget target
 
 } // namespace vtbackend
 
-// {{{ fmtlib custom formatter support
+// {{{ fmt custom formatter support
 template <>
 struct std::formatter<vtbackend::ColorPreference>: std::formatter<std::string_view>
 {

--- a/src/vtbackend/core/Image.hpp
+++ b/src/vtbackend/core/Image.hpp
@@ -415,7 +415,7 @@ class ImagePool
 
 } // namespace vtbackend
 
-// {{{ fmtlib support
+// {{{ fmt support
 template <>
 struct std::formatter<vtbackend::ImageFormat>: formatter<std::string_view>
 {

--- a/src/vtbackend/input/InputGenerator.hpp
+++ b/src/vtbackend/input/InputGenerator.hpp
@@ -846,7 +846,7 @@ inline std::string toString(InputGenerator::MouseEventType value)
 
 } // namespace vtbackend
 
-// {{{ fmtlib custom formatter support
+// {{{ fmt custom formatter support
 
 template <>
 struct std::formatter<vtbackend::KeyboardEventType>: formatter<std::string_view>

--- a/src/vtbackend/input/MatchModes.hpp
+++ b/src/vtbackend/input/MatchModes.hpp
@@ -105,7 +105,7 @@ constexpr bool operator!=(MatchModes a, MatchModes b) noexcept
 
 } // namespace vtbackend
 
-// {{{ fmtlib support
+// {{{ fmt support
 template <>
 struct std::formatter<vtbackend::MatchModes>: formatter<std::string>
 {

--- a/src/vtbackend/input/vi/Selector.hpp
+++ b/src/vtbackend/input/vi/Selector.hpp
@@ -184,7 +184,7 @@ void renderSelection(Selection const& selection, Renderer&& render)
 
 } // namespace vtbackend
 
-// {{{ fmtlib custom formatter support
+// {{{ fmt custom formatter support
 template <>
 struct std::formatter<vtbackend::Selection::State>: formatter<std::string_view>
 {

--- a/src/vtbackend/input/vi/ViInputHandler.hpp
+++ b/src/vtbackend/input/vi/ViInputHandler.hpp
@@ -250,7 +250,7 @@ class ViInputHandler: public InputHandler
 
 } // namespace vtbackend
 
-// {{{ fmtlib custom formatters
+// {{{ fmt custom formatters
 template <>
 struct std::formatter<vtbackend::TextObjectScope>: formatter<std::string_view>
 {

--- a/src/vtbackend/vt/Functions.hpp
+++ b/src/vtbackend/vt/Functions.hpp
@@ -1328,7 +1328,7 @@ struct std::hash<vtbackend::Function>
     constexpr uint32_t operator()(vtbackend::Function const& fun) const noexcept { return fun.id(); }
 };
 
-// {{{ fmtlib support
+// {{{ fmt support
 template <>
 struct std::formatter<vtbackend::FunctionCategory>: std::formatter<std::string_view>
 {

--- a/src/vtbackend/vt/VTType.hpp
+++ b/src/vtbackend/vt/VTType.hpp
@@ -163,7 +163,7 @@ std::string toParams(DeviceAttributes v);
 
 } // namespace vtbackend
 
-// {{{ fmtlib support
+// {{{ fmt support
 template <>
 struct std::formatter<vtbackend::VTType>: std::formatter<std::string_view>
 {

--- a/src/vtparser/Parser.hpp
+++ b/src/vtparser/Parser.hpp
@@ -464,7 +464,7 @@ struct numeric_limits<vtparser::Action>
 };
 } // namespace std
 
-// {{{ fmtlib custom formatter specializations
+// {{{ fmt custom formatter specializations
 template <>
 struct std::formatter<vtparser::State>: formatter<std::string_view>
 {


### PR DESCRIPTION
Follow-up to 87bde6b2 (Use C++20 formatting API rather than fmtlib).

## Description

:)
<!-- Describe your changes: what and why. -->

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/contour-terminal/contour/blob/master/docs/CONTRIBUTING.md) guide
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] Breaking changes (if any) are documented
