### PR TITLE
Fix mouse-drag text selection anchoring on a fast click and search-pattern pollution

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -107,6 +107,8 @@
     <release version="0.7.1" urgency="medium" type="development">
       <description>
         <ul>
+          <li>Fixes a fast mouse click starting a drag selection from a stale position instead of where the button actually went down, making the selected region appear to jump the moment the drag started. A slow, deliberate drag never showed this, because the pointer's tracked position was refreshed by the preceding movement; a quick click could arrive with no such movement right before it</li>
+          <li>Fixes dragging out an ordinary text selection silently overwriting the active search term, so the selected text appeared as a live search wherever a status line or the find bar echoes it. Only a double or triple click's word selection is meant to do that</li>
           <li>Fixes permissions.capture_buffer never being consulted: a profile saying deny still raised the dialog and let the capture through once approved, and one saying allow was still interrupted by it. Both now decide the request outright, and with ask, "Yes to all" / "No to all" is remembered for the rest of the session instead of being stored and ignored (#2089)</li>
           <li>Fixes "Yes to all" on a larger-than-512-KB paste not being remembered either, so every such paste asked again</li>
           <li>Fixes a refused buffer capture leaving the requesting program hanging. The reply always ends with an empty PM 314 chunk, and a refusal sent nothing at all — so a client reading until that marker waited forever. A denial now sends the terminator, and so does a capture asked of a background pane</li>

--- a/src/contour/display/DisplayRendering_test.cpp
+++ b/src/contour/display/DisplayRendering_test.cpp
@@ -1407,6 +1407,65 @@ TEST_CASE("display: a mouse drag spanning multiple lines selects the exact cell 
              "abcde");
 }
 
+TEST_CASE("display: dragging a double-clicked word past its line freezes the search highlight",
+          "[display][mouse]")
+{
+    // Regression: updateSelectionMatches() re-derives the search pattern from the CURRENT selection
+    // text on every mouse-move of a WordWiseSelection, so its other-occurrences highlight tracks a
+    // double-click as it grows into a longer word. But RenderBufferBuilder's search-match scanner
+    // matches the pattern's bytes -- newlines included -- against the flat, single-line stream of
+    // rendered cells; once the drag crosses a line boundary the "word" becomes a multi-line blob that
+    // keeps changing on every further move and essentially never matches anything stable, so the
+    // highlight visibly jumped around the screen for as long as the drag continued. The fix freezes
+    // the pattern the moment the selection stops fitting on one line, rather than feeding the scanner
+    // an ever-growing, newline-bearing target.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    h.feedAndSettle("hello world\r\n"
+                    "second row\r\n"
+                    "third here\r\n");
+
+    // Double-click on "hello" (column 2, line 0): press, release, then a second press at the same
+    // spot within the terminal's 1000ms speed-click window.
+    auto const wordPos =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(0), .column = vtbackend::ColumnOffset(2) };
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, wordPos.line, wordPos.column));
+    h.pump();
+    sendMouse(
+        h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, wordPos.line, wordPos.column));
+    h.pump();
+    sendMouse(
+        h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, wordPos.line, wordPos.column));
+    h.pump();
+    QTest::qWait(100);
+    sendMouse(
+        h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, wordPos.line, wordPos.column));
+    h.pump();
+
+    REQUIRE(h.session->terminal().extractSelectionText() == "hello");
+    auto const patternAfterDoubleClick = h.session->terminal().search().pattern;
+    CHECK(patternAfterDoubleClick == U"hello");
+
+    // Drag across two further line boundaries (in one jump, as a fast drag would deliver it).
+    auto const dragTo =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(3) };
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, dragTo.line, dragTo.column));
+    h.pump();
+
+    // The selected text keeps growing normally...
+    CHECK(h.session->terminal().extractSelectionText()
+          == "hello world\n"
+             "second row\n"
+             "third");
+    // ...but the search pattern must have frozen at the original single-line word, not followed it.
+    CHECK(h.session->terminal().search().pattern == patternAfterDoubleClick);
+
+    sendMouse(
+        h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, dragTo.line, dragTo.column));
+    h.pump();
+}
+
 TEST_CASE("display: a press with no fresh preceding move still anchors at the press position",
           "[display][mouse]")
 {

--- a/src/contour/display/DisplayRendering_test.cpp
+++ b/src/contour/display/DisplayRendering_test.cpp
@@ -1607,6 +1607,12 @@ TEST_CASE("display: a multi-line drag selecting a wrapped logical line copies it
     REQUIRE_DISPLAY_OR_SKIP();
     DisplayHarness h;
     h.display->forceActiveFocus();
+    // Settle any pending geometry/font reflow left over from a PREVIOUS test case before reading
+    // pageSize() and deriving click positions from gridMetrics() -- both are snapshots of the live
+    // renderer, and this suite runs every case in one process, so a font/DPI change a prior test made
+    // can still be mid-flight (recomputeGeometryAfterFontReconfig runs async) when this one starts.
+    h.pump();
+    h.pump();
     auto const columns = unbox<int>(h.session->terminal().pageSize().columns);
     REQUIRE(columns > 0);
 

--- a/src/contour/display/DisplayRendering_test.cpp
+++ b/src/contour/display/DisplayRendering_test.cpp
@@ -1336,11 +1336,18 @@ void sendMouse(contour::display::TerminalDisplay* display,
 /// cellSize -> grid row/column. Going forward through the identical quantities (gridMetrics(),
 /// devicePixelRatio()) is what makes a synthetic drag name an EXACT cell regardless of font metrics
 /// or the test machine's DPI, rather than a guessed pixel offset that happens to land inside one.
-[[nodiscard]] QPointF logicalCellTopLeft(contour::display::TerminalDisplay const& display,
+[[nodiscard]] QPointF logicalCellTopLeft(contour::display::TerminalDisplay& display,
                                          vtbackend::LineOffset line,
                                          vtbackend::ColumnOffset column)
 {
-    auto const devicePoint = display.gridMetrics().mapTopLeft(line, column);
+    // Offset by the main page's top row, because this is the INVERSE of what the production hit-test
+    // does: geometry::mainPageRowNear subtracts mainPageTopRow() to turn a pixel into a main-page
+    // relative line, while mapTopLeft treats its argument as a SCREEN row. The two agree only while
+    // that row is zero -- the default bottom status line -- so without this a profile with a top
+    // status line would land every synthetic click statusLineHeight() rows above its target, and the
+    // failure would read as a selection bug rather than a test-harness one.
+    auto const screenLine = line + unbox<int>(display.session().terminal().mainPageTopRow());
+    auto const devicePoint = display.gridMetrics().mapTopLeft(screenLine, column);
     auto const dpr = display.devicePixelRatio();
     return { double(devicePoint.x) / dpr, double(devicePoint.y) / dpr };
 }
@@ -1348,7 +1355,7 @@ void sendMouse(contour::display::TerminalDisplay* display,
 /// The item-local logical pixel position of a point INSIDE a grid cell (its top-left plus a half-cell
 /// nudge), so a drag reliably lands inside the target cell rather than exactly on its boundary, where
 /// rounding could tip it into the previous row/column.
-[[nodiscard]] QPointF logicalCellCenter(contour::display::TerminalDisplay const& display,
+[[nodiscard]] QPointF logicalCellCenter(contour::display::TerminalDisplay& display,
                                         vtbackend::LineOffset line,
                                         vtbackend::ColumnOffset column)
 {
@@ -1383,10 +1390,11 @@ TEST_CASE("display: a mouse drag spanning multiple lines selects the exact cell 
     auto const to =
         vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(4) };
 
-    // A press anchors the selection at the terminal's _currentMousePosition, which only a preceding
-    // MouseMove updates (Terminal::sendMouseMoveEvent) -- exactly what a real windowing system always
-    // delivers before a button press. Skipping it anchors at whatever position an earlier move left
-    // behind (the origin, on a fresh session), which is the mistake this comment is here to head off.
+    // The MouseMove before the press is what a real windowing system always delivers -- the pointer
+    // arrives via motion before a button event fires -- so the drags below are written in that order
+    // to stay faithful to it, not because the press needs it: sendMousePressEvent now anchors at the
+    // cell it was given. The bare-press case, which a fast click really does produce, is covered by
+    // its own test rather than by omitting the move here.
     sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, from.line, from.column));
     h.pump();
     sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, from.line, from.column));
@@ -1540,9 +1548,10 @@ TEST_CASE("display: dragging upward across lines selects the same range as dragg
         vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(6) };
 
     // Downward: press at top, release at bottom. Every press is preceded by a MouseMove to the SAME
-    // position -- a press alone anchors at whatever position an earlier move left _currentMousePosition
-    // at (Terminal::sendMouseMoveEvent is the only writer), which a real windowing system never does:
-    // the pointer always arrives via motion before a button event fires.
+    // position, because that is what a real windowing system does -- the pointer arrives via motion
+    // before a button event fires. (The press itself now also anchors at the cell it landed on, so
+    // this sequence no longer DEPENDS on the preceding move; it stays because it is the realistic
+    // event order, and the bare-press case has its own test above.)
     sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, top.line, top.column));
     h.pump();
     sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, top.line, top.column));

--- a/src/contour/display/DisplayRendering_test.cpp
+++ b/src/contour/display/DisplayRendering_test.cpp
@@ -1342,7 +1342,7 @@ void sendMouse(contour::display::TerminalDisplay* display,
 {
     auto const devicePoint = display.gridMetrics().mapTopLeft(line, column);
     auto const dpr = display.devicePixelRatio();
-    return QPointF(double(devicePoint.x) / dpr, double(devicePoint.y) / dpr);
+    return { double(devicePoint.x) / dpr, double(devicePoint.y) / dpr };
 }
 
 /// The item-local logical pixel position of a point INSIDE a grid cell (its top-left plus a half-cell

--- a/src/contour/display/DisplayRendering_test.cpp
+++ b/src/contour/display/DisplayRendering_test.cpp
@@ -1316,6 +1316,340 @@ TEST_CASE("display: mouse press/move drive selection and the cursor shape on the
     h.pump();
 }
 
+namespace
+{
+/// Sends a synthetic QMouseEvent of @p type/@p button at the display-item-local logical position @p
+/// pos, exactly as the real windowing system would deliver it to TerminalDisplay's event handlers.
+void sendMouse(contour::display::TerminalDisplay* display,
+               QEvent::Type type,
+               QPointF pos,
+               Qt::MouseButton button = Qt::LeftButton)
+{
+    QMouseEvent ev(type, pos, display->mapToGlobal(pos), button, button, Qt::NoModifier);
+    QCoreApplication::sendEvent(display, &ev);
+}
+
+/// The item-local LOGICAL pixel position of a grid cell's top-left corner.
+///
+/// makeMouseCellLocation() (SessionInput.cpp) walks this mapping in reverse -- logical position *
+/// devicePixelRatio -> DEVICE pixel -> minus the renderer's pageMargin -> divided by the device
+/// cellSize -> grid row/column. Going forward through the identical quantities (gridMetrics(),
+/// devicePixelRatio()) is what makes a synthetic drag name an EXACT cell regardless of font metrics
+/// or the test machine's DPI, rather than a guessed pixel offset that happens to land inside one.
+[[nodiscard]] QPointF logicalCellTopLeft(contour::display::TerminalDisplay const& display,
+                                         vtbackend::LineOffset line,
+                                         vtbackend::ColumnOffset column)
+{
+    auto const devicePoint = display.gridMetrics().mapTopLeft(line, column);
+    auto const dpr = display.devicePixelRatio();
+    return QPointF(double(devicePoint.x) / dpr, double(devicePoint.y) / dpr);
+}
+
+/// The item-local logical pixel position of a point INSIDE a grid cell (its top-left plus a half-cell
+/// nudge), so a drag reliably lands inside the target cell rather than exactly on its boundary, where
+/// rounding could tip it into the previous row/column.
+[[nodiscard]] QPointF logicalCellCenter(contour::display::TerminalDisplay const& display,
+                                        vtbackend::LineOffset line,
+                                        vtbackend::ColumnOffset column)
+{
+    auto const topLeft = logicalCellTopLeft(display, line, column);
+    auto const cellSize = display.gridMetrics().cellSize;
+    auto const dpr = display.devicePixelRatio();
+    return topLeft
+           + QPointF(double(cellSize.width.as<int>()) / dpr / 2.0,
+                     double(cellSize.height.as<int>()) / dpr / 2.0);
+}
+} // namespace
+
+TEST_CASE("display: a mouse drag spanning multiple lines selects the exact cell range", "[display][mouse]")
+{
+    // The headless Selection/Selector tests (Terminal_selection_test.cpp) inject CellLocation
+    // directly and never exercise the pixel math a real drag runs through -- makeMouseCellLocation's
+    // device-pixel round trip via gridMetrics().pageMargin, cellSize and mainPageRowNear. Driving
+    // real QMouseEvents through the live TerminalDisplay is the only path that also exercises that
+    // translation, so this is where a rounding or off-by-one in the pixel->cell mapping would show up
+    // for a selection spanning more than one row -- as opposed to a bug in Selector::ranges() itself,
+    // which is already covered headlessly.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    h.feedAndSettle("0123456789\r\n"
+                    "ABCDEFGHIJ\r\n"
+                    "abcdefghij\r\n"
+                    "9876543210\r\n");
+
+    auto const from =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(0), .column = vtbackend::ColumnOffset(3) };
+    auto const to =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(4) };
+
+    // A press anchors the selection at the terminal's _currentMousePosition, which only a preceding
+    // MouseMove updates (Terminal::sendMouseMoveEvent) -- exactly what a real windowing system always
+    // delivers before a button press. Skipping it anchors at whatever position an earlier move left
+    // behind (the origin, on a fresh session), which is the mistake this comment is here to head off.
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, from.line, from.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, from.line, from.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+
+    REQUIRE(h.session->terminal().selectionAvailable());
+    CHECK(h.session->terminal().isSelectionComplete());
+
+    // Row 0 from column 3 to the right margin, row 1 whole, row 2 from column 0 up to column 4 --
+    // exactly Selection::ranges()'s documented 3-line shape (first partial, inner full, last partial).
+    CHECK(h.session->terminal().extractSelectionText()
+          == "3456789\n"
+             "ABCDEFGHIJ\n"
+             "abcde");
+}
+
+TEST_CASE("display: a press with no fresh preceding move still anchors at the press position",
+          "[display][mouse]")
+{
+    // Regression for the "fast drag drifts" bug: Terminal::sendMousePressEvent has a pixelPosition
+    // argument but never converts it to a cell -- handleMouseSelection() anchors on
+    // _currentMousePosition, which ONLY Terminal::sendMouseMoveEvent ever writes. A real windowing
+    // system usually delivers a hover/move at the click point before the press, which is why a SLOW,
+    // deliberate drag hides this: the anchor is fresh. A fast flick can arrive as a bare press with the
+    // pointer's last recorded position stale from wherever it idled beforehand (a prior selection, a
+    // different pane, ...), so the drag then extends from that stale point instead of the actual click
+    // -- the whole selected region appears to have "moved".
+    //
+    // This is reproduced here directly: move to one spot, then press and drag at a DIFFERENT spot with
+    // no move in between -- exactly the gap between the two event types the fix must close.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    h.feedAndSettle("0123456789\r\n"
+                    "ABCDEFGHIJ\r\n"
+                    "abcdefghij\r\n"
+                    "9876543210\r\n");
+
+    auto const stalePosition =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(4) };
+    auto const from =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(0), .column = vtbackend::ColumnOffset(3) };
+    auto const to =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(4) };
+
+    // Leave the pointer's last-known position somewhere else entirely (no press here -- this only
+    // updates the hover-tracked _currentMousePosition, mirroring the pointer idling after a previous,
+    // unrelated interaction).
+    sendMouse(h.display,
+              QEvent::MouseMove,
+              logicalCellCenter(*h.display, stalePosition.line, stalePosition.column));
+    h.pump();
+
+    // Press directly at `from` with NO intervening MouseMove there -- the gap a fast flick leaves.
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, from.line, from.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+
+    // The drag must run from the ACTUAL press position (from) to `to`, not from the stale hover
+    // position -- i.e. the selection must not have silently anchored somewhere the pointer never was
+    // pressed down.
+    CHECK(h.session->terminal().extractSelectionText()
+          == "3456789\n"
+             "ABCDEFGHIJ\n"
+             "abcde");
+}
+
+TEST_CASE("display: dragging upward across lines selects the same range as dragging downward",
+          "[display][mouse]")
+{
+    // Selection::ranges() normalizes from/to by lexicographic order before building per-line ranges
+    // (Selector.cpp's prepare()); the direction the mouse actually moved must not matter to the
+    // resulting text. This pins that symmetry through the real pixel-driven mouse path rather than
+    // through Selection::extend() called directly.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    h.feedAndSettle("0123456789\r\n"
+                    "ABCDEFGHIJ\r\n"
+                    "abcdefghij\r\n");
+
+    auto const top =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(0), .column = vtbackend::ColumnOffset(2) };
+    auto const bottom =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(2), .column = vtbackend::ColumnOffset(6) };
+
+    // Downward: press at top, release at bottom. Every press is preceded by a MouseMove to the SAME
+    // position -- a press alone anchors at whatever position an earlier move left _currentMousePosition
+    // at (Terminal::sendMouseMoveEvent is the only writer), which a real windowing system never does:
+    // the pointer always arrives via motion before a button event fires.
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, bottom.line, bottom.column));
+    h.pump();
+    sendMouse(
+        h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, bottom.line, bottom.column));
+    h.pump();
+    auto const downward = h.session->terminal().extractSelectionText();
+
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    REQUIRE(h.session->terminal().extractSelectionText().empty()); // plain click cleared it
+
+    // The terminal's own click-speed counter (_speedClicks in Terminal::handleMouseSelection) counts
+    // presses within 1s of REAL elapsed time (Terminal::_currentTime, advanced from steady_clock by the
+    // live display's render loop -- unlike the headless MockTerm tests, which advance a simulated clock
+    // explicitly). Without a real pause here, this press lands within that window of the deselect click
+    // above and the one before it, so it reads as a double/triple-click and selects a word or a whole
+    // line instead of starting a plain drag.
+    QTest::qWait(1100);
+
+    // Upward: press at bottom, release at top.
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, bottom.line, bottom.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, bottom.line, bottom.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, top.line, top.column));
+    h.pump();
+    auto const upward = h.session->terminal().extractSelectionText();
+
+    CHECK(downward
+          == "23456789\n"
+             "ABCDEFGHIJ\n"
+             "abcdefg");
+    CHECK(upward == downward);
+}
+
+TEST_CASE("display: a multi-line drag selection extends and shrinks live as the mouse moves",
+          "[display][mouse]")
+{
+    // A selection is a live, redrawn thing while InProgress, not just a value read once at release.
+    // Each intermediate MouseMove must already report the range up to THAT point -- so this checks
+    // extractSelectionText() after every move, not only after the final release.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    h.feedAndSettle("first line\r\n"
+                    "second row\r\n"
+                    "third here\r\n");
+
+    auto const anchor =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(0), .column = vtbackend::ColumnOffset(0) };
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, anchor.line, anchor.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, anchor.line, anchor.column));
+    h.pump();
+
+    // Still on line 0: single-line partial selection.
+    sendMouse(h.display,
+              QEvent::MouseMove,
+              logicalCellCenter(*h.display, vtbackend::LineOffset(0), vtbackend::ColumnOffset(4)));
+    h.pump();
+    CHECK(h.session->terminal().extractSelectionText() == "first");
+
+    // Extends onto line 1: two-line selection, first line taken whole to its right margin.
+    sendMouse(h.display,
+              QEvent::MouseMove,
+              logicalCellCenter(*h.display, vtbackend::LineOffset(1), vtbackend::ColumnOffset(5)));
+    h.pump();
+    CHECK(h.session->terminal().extractSelectionText()
+          == "first line\n"
+             "second");
+
+    // Extends onto line 2: three-line selection -- first and second line each taken whole, third
+    // partial. This is the "middle line(s) rendered full" branch of Selector.cpp's ranges().
+    sendMouse(h.display,
+              QEvent::MouseMove,
+              logicalCellCenter(*h.display, vtbackend::LineOffset(2), vtbackend::ColumnOffset(4)));
+    h.pump();
+    CHECK(h.session->terminal().extractSelectionText()
+          == "first line\n"
+             "second row\n"
+             "third");
+
+    // Retracting back onto line 1 must shrink the selection again, not merely stop growing it.
+    sendMouse(h.display,
+              QEvent::MouseMove,
+              logicalCellCenter(*h.display, vtbackend::LineOffset(1), vtbackend::ColumnOffset(2)));
+    h.pump();
+    CHECK(h.session->terminal().extractSelectionText()
+          == "first line\n"
+             "sec");
+
+    sendMouse(h.display,
+              QEvent::MouseButtonRelease,
+              logicalCellCenter(*h.display, vtbackend::LineOffset(1), vtbackend::ColumnOffset(2)));
+    h.pump();
+    CHECK(h.session->terminal().isSelectionComplete());
+}
+
+TEST_CASE("display: a multi-line drag selecting a wrapped logical line copies it as one run",
+          "[display][mouse]")
+{
+    // A line that wraps is still ONE logical line: dragging from inside it, across the wrap point,
+    // must not insert a newline at the wrap boundary the way it does at a real row break. This drives
+    // that through the same pixel-mapped mouse path as the fixed-width case above, so a regression in
+    // wrappedLine() handling under the real makeMouseCellLocation() path would show up here even
+    // though it is invisible to a direct-CellLocation Selection test.
+    //
+    // Deliberately does NOT resize the window (CSI 8 needs a bound controller and a settled OS-window
+    // round trip to actually change pageSize() -- see the controller-routed resize tests above): the
+    // harness reflows the profile's default page to whatever the 800x600 display and its resolved font
+    // actually fit, so the column count is read back rather than assumed -- writing a line ten columns
+    // longer than that is enough to get a real wrap boundary at a known column.
+    REQUIRE_DISPLAY_OR_SKIP();
+    DisplayHarness h;
+    h.display->forceActiveFocus();
+    auto const columns = unbox<int>(h.session->terminal().pageSize().columns);
+    REQUIRE(columns > 0);
+
+    // Row 0 fills the page exactly (built by repeating the alphabet, so it fits whatever width this
+    // display/font combination actually resolves to); "mnop" is the wrapped continuation on row 1.
+    auto constexpr Alphabet = "abcdefghijklmnopqrstuvwxyz"sv;
+    auto rowOne = std::string {};
+    while (rowOne.size() < size_t(columns))
+        rowOne += Alphabet;
+    rowOne.resize(size_t(columns));
+
+    // No CR/LF between rowOne and "mnop": an autowrap only commits the Wrapped line flag
+    // (Screen::crlfIfWrapPending) once the NEXT character is WRITTEN, and it does that as an IMPLICIT
+    // wrap -- \r\n right after filling the last column instead runs linefeed() directly (LF is handled
+    // by the parser, never reaching crlfIfWrapPending), which never sets the flag and would make this
+    // a false negative rather than what it looks like it is testing.
+    h.feedAndSettle(rowOne + "mnop");
+    h.feedAndSettle("\r\nthird\r\n"sv);
+    // isLineWrapped() marks the CONTINUATION line (row 1 here), not the line it wrapped from -- see
+    // LineFlag::Wrapped, set on the chunk a wrap produces, never on the one it wrapped out of.
+    REQUIRE(h.session->terminal().isLineWrapped(vtbackend::LineOffset(1)));
+
+    // Row 0 holds `rowOne` (wrapped), row 1 holds "mnop" then a real line break, row 2 holds "third".
+    auto const from = vtbackend::CellLocation { .line = vtbackend::LineOffset(0),
+                                                .column = vtbackend::ColumnOffset(columns - 3) };
+    auto const to =
+        vtbackend::CellLocation { .line = vtbackend::LineOffset(1), .column = vtbackend::ColumnOffset(1) };
+
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, from.line, from.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonPress, logicalCellCenter(*h.display, from.line, from.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseMove, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+    sendMouse(h.display, QEvent::MouseButtonRelease, logicalCellCenter(*h.display, to.line, to.column));
+    h.pump();
+
+    // No newline at the wrap point: the tail of row 0 ("xyz", its last 3 columns) concatenates
+    // directly with the head of row 1 ("mn", its first 2 columns of "mnop").
+    auto const expectedFirstPart = rowOne.substr(size_t(columns - 3), 3);
+    CHECK(h.session->terminal().extractSelectionText() == expectedFirstPart + "mn");
+}
+
 TEST_CASE("display: focus in/out toggle the terminal's focus state on the live display", "[display][focus]")
 {
     REQUIRE_DISPLAY_OR_SKIP();

--- a/src/contour/session/SessionInput.cpp
+++ b/src/contour/session/SessionInput.cpp
@@ -307,9 +307,15 @@ namespace
         auto const horizontalScrollEvent =
             columnsScroll.as<int>() > 0 ? VTMouseButton::WheelRight : VTMouseButton::WheelLeft;
 
+        // These are synthesized at the pointer's EXISTING resting position, not a fresh click
+        // elsewhere, so the terminal's own last-tracked cell is exactly right here -- unlike a real
+        // press, there is no new position for this "click" to have missed.
+        auto const wheelClickPosition = terminal.currentMousePosition();
+
         for (int i = 0; i < std::abs(columnsScroll.as<int>()); ++i)
         {
-            session.sendMousePressEvent(modifiers, horizontalScrollEvent, currentMousePixelPosition);
+            session.sendMousePressEvent(
+                modifiers, horizontalScrollEvent, wheelClickPosition, currentMousePixelPosition);
         }
 
         auto const verticalScrollEvent =
@@ -317,7 +323,8 @@ namespace
 
         for (int i = 0; i < std::abs(linesScroll.as<int>()); ++i)
         {
-            session.sendMousePressEvent(modifiers, verticalScrollEvent, currentMousePixelPosition);
+            session.sendMousePressEvent(
+                modifiers, verticalScrollEvent, wheelClickPosition, currentMousePixelPosition);
         }
     }
 
@@ -693,6 +700,7 @@ void sendMousePressEvent(QMouseEvent* event, TerminalSession& session)
 
     session.sendMousePressEvent(input::makeModifiers(event->modifiers()).chord,
                                 input::makeMouseButton(event->button()),
+                                makeMouseCellLocation(event->pos().x(), event->pos().y(), session),
                                 makeMousePixelPosition(event,
                                                        session.display()->gridMetrics().pageMargin,
                                                        session.display()->devicePixelRatio()));

--- a/src/contour/session/SessionInput.cpp
+++ b/src/contour/session/SessionInput.cpp
@@ -310,7 +310,12 @@ namespace
         // These are synthesized at the pointer's EXISTING resting position, not a fresh click
         // elsewhere, so the terminal's own last-tracked cell is exactly right here -- unlike a real
         // press, there is no new position for this "click" to have missed.
-        auto const wheelClickPosition = terminal.currentMousePosition();
+        // Under the lock: _currentMousePosition is ordinary mutable terminal state, and the resize
+        // path (Terminal::resizeScreen) clamps it from another thread. An unsynchronized read is a
+        // data race TSan would rightly flag, even though the worst it could do here is aim a
+        // synthesized wheel "click" at a stale cell.
+        auto const wheelClickPosition =
+            crispy::locked(terminal, [&] { return terminal.currentMousePosition(); });
 
         for (int i = 0; i < std::abs(columnsScroll.as<int>()); ++i)
         {

--- a/src/contour/session/TerminalSession.cpp
+++ b/src/contour/session/TerminalSession.cpp
@@ -2108,6 +2108,7 @@ void TerminalSession::sendCharEvent(char32_t value,
 
 void TerminalSession::sendMousePressEvent(Modifiers modifiers,
                                           MouseButton button,
+                                          CellLocation pos,
                                           PixelCoordinate pixelPosition)
 {
     auto const uiHandledHint = false;
@@ -2116,7 +2117,7 @@ void TerminalSession::sendMousePressEvent(Modifiers modifiers,
     terminal().tick(steady_clock::now());
 
     if (crispy::locked(_terminal, [&]() {
-            return _terminal.sendMousePressEvent(modifiers, button, pixelPosition, uiHandledHint);
+            return _terminal.sendMousePressEvent(modifiers, button, pos, pixelPosition, uiHandledHint);
         }))
         return;
 

--- a/src/contour/session/TerminalSession.hpp
+++ b/src/contour/session/TerminalSession.hpp
@@ -690,6 +690,7 @@ class TerminalSession: public QAbstractItemModel, public vtbackend::Terminal::Ev
 
     void sendMousePressEvent(vtbackend::Modifiers modifiers,
                              vtbackend::MouseButton button,
+                             vtbackend::CellLocation pos,
                              vtbackend::PixelCoordinate pixelPosition);
     void sendMouseMoveEvent(vtbackend::Modifiers modifiers,
                             vtbackend::CellLocation pos,

--- a/src/contour/session/TerminalSession_test.cpp
+++ b/src/contour/session/TerminalSession_test.cpp
@@ -436,7 +436,7 @@ TEST_CASE("TerminalSession: mouse events without a mouse protocol write nothing 
     auto const pixels = vtbackend::PixelCoordinate {};
     (void) now;
 
-    session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Left, pixels);
+    session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Left, pos, pixels);
     session->sendMouseMoveEvent(Modifiers {}, pos, pixels);
     session->sendMouseReleaseEvent(Modifiers {}, vtbackend::MouseButton::Left, pixels);
     CHECK(mockPtyOf(*session).stdinBuffer().empty());
@@ -459,6 +459,7 @@ TEST_CASE("TerminalSession: right-click opens the context menu exactly when a se
     TestApp testApp;
     auto session = makeDisplaylessSession(testApp.app());
     auto const pixels = vtbackend::PixelCoordinate {};
+    auto const pos = vtbackend::CellLocation {};
 
     auto menuRequests = 0;
     QObject::connect(&testApp.app().sessionsManager(),
@@ -467,7 +468,7 @@ TEST_CASE("TerminalSession: right-click opens the context menu exactly when a se
 
     SECTION("no mouse protocol: the application hears nothing, and the menu takes the click")
     {
-        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pixels);
+        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pos, pixels);
         CHECK(menuRequests == 1);
         CHECK(mockPtyOf(*session).stdinBuffer().empty());
     }
@@ -476,7 +477,7 @@ TEST_CASE("TerminalSession: right-click opens the context menu exactly when a se
     {
         // DECSET 1000 -- what vim and tmux turn on.
         session->terminal().writeToScreen("\033[?1000h");
-        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pixels);
+        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pos, pixels);
         CHECK(menuRequests == 0);
         CHECK_FALSE(mockPtyOf(*session).stdinBuffer().empty());
     }
@@ -485,7 +486,7 @@ TEST_CASE("TerminalSession: right-click opens the context menu exactly when a se
     {
         session->terminal().writeToScreen("\033[?1000h");
         session->sendMousePressEvent(
-            Modifiers { vtbackend::Modifier::Shift }, vtbackend::MouseButton::Right, pixels);
+            Modifiers { vtbackend::Modifier::Shift }, vtbackend::MouseButton::Right, pos, pixels);
         // Shift is the bypass modifier, so the application is skipped and the bare `Right` fallback
         // matches (sendMousePressEvent strips the bypass modifier before looking the mapping up).
         CHECK(menuRequests == 1);
@@ -494,14 +495,14 @@ TEST_CASE("TerminalSession: right-click opens the context menu exactly when a se
 
     SECTION("a left-drag in flight keeps the menu shut: the popup would steal the button-release")
     {
-        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Left, pixels);
-        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pixels);
+        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Left, pos, pixels);
+        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Right, pos, pixels);
         CHECK(menuRequests == 0);
     }
 
     SECTION("a middle-click still pastes: the fallback claims the right button and nothing else")
     {
-        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Middle, pixels);
+        session->sendMousePressEvent(Modifiers {}, vtbackend::MouseButton::Middle, pos, pixels);
         CHECK(menuRequests == 0);
         CHECK(mockPtyOf(*session).stdinBuffer().empty());
     }
@@ -1420,7 +1421,7 @@ TEST_CASE("TerminalSession: mouse events encode under an active mouse protocol",
 
     pty.stdinBuffer().clear();
     auto const at = PixelCoordinate { PixelCoordinate::X { 20 }, PixelCoordinate::Y { 20 } };
-    session->sendMousePressEvent(Modifiers {}, MouseButton::Left, at);
+    session->sendMousePressEvent(Modifiers {}, MouseButton::Left, vtbackend::CellLocation {}, at);
     session->sendMouseReleaseEvent(Modifiers {}, MouseButton::Left, at);
     // SGR mouse reports are CSI < ... M/m; at minimum an escape must have been emitted.
     CHECK(pty.stdinBuffer().contains('\033'));

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -1114,7 +1114,12 @@ Handled Terminal::sendMousePressEvent(Modifiers modifiers,
         // sequence while it stays on one cell. A press that lands somewhere else starts a new one,
         // and without this a fast click arriving as a bare press within the one-second window would
         // inherit the previous cell's count and open as a word- or line-selection instead of a drag.
-        _speedClicks = 0;
+        //
+        // Left only: it is the sole button that opens a selection, so it is the only one whose
+        // sequence this counts. A right-click for the context menu, or a middle-click paste, lands
+        // on some other cell without ending a double-click the user is in the middle of.
+        if (button == MouseButton::Left)
+            _speedClicks = 0;
 
         _currentMousePosition = newPosition;
         updateHoveringHyperlinkState();
@@ -1247,8 +1252,15 @@ bool Terminal::handleMouseSelection(Modifiers modifiers)
         auto const anchor = (startPos < selStart) ? selEnd : selStart;
 
         setSelector(std::make_unique<LinearSelection>(_selectionHelper, anchor, selectionUpdatedHelper()));
-        if (selector()->extend(startPos))
-            updateSelectionMatches();
+        (void) selector()->extend(startPos);
+
+        // NOT updateSelectionMatches(): what this builds is a LinearSelection, which that function
+        // rightly refuses to serialize into a search pattern. But a word selection extended this way
+        // leaves the double-click's pattern behind it, still painting its matches for a selection
+        // that is no longer that word -- so the extension must retire it, exactly as an ordinary
+        // single click does below.
+        if (_search.origin == SearchOrigin::DoubleClick)
+            clearSearch();
 
         breakLoopAndRefreshRenderBuffer();
         return true;

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -1169,6 +1169,14 @@ void Terminal::updateSelectionMatches()
     if (!_settings.visualizeSelectedWord)
         return;
 
+    // Visualizing "other occurrences" only makes sense for a WORD -- the case a double/triple-click
+    // selects. An ordinary linear (or rectangular) drag selection is not a word: it is arbitrary text
+    // the user is actively choosing, and serializing every intermediate extension of it into the
+    // search pattern overwrote whatever the user had actually typed into the find bar/search prompt on
+    // every single mouse-move of a plain click-and-drag selection.
+    if (!selectionAvailable() || dynamic_cast<WordWiseSelection const*>(selector()) == nullptr)
+        return;
+
     auto const text = extractSelectionText();
     auto const text32 = unicode::convert_to<char32_t>(string_view(text.data(), text.size()));
     setNewSearchTerm(text32, SearchOrigin::DoubleClick);

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -1110,6 +1110,12 @@ Handled Terminal::sendMousePressEvent(Modifiers modifiers,
     // sendMouseMoveEvent already does for exactly this reason.
     if (newPosition != _currentMousePosition)
     {
+        // For the same reason sendMouseMoveEvent resets it: a multi-click sequence is only a
+        // sequence while it stays on one cell. A press that lands somewhere else starts a new one,
+        // and without this a fast click arriving as a bare press within the one-second window would
+        // inherit the previous cell's count and open as a word- or line-selection instead of a drag.
+        _speedClicks = 0;
+
         _currentMousePosition = newPosition;
         updateHoveringHyperlinkState();
     }
@@ -1177,15 +1183,22 @@ void Terminal::updateSelectionMatches()
     if (!selectionAvailable() || dynamic_cast<WordWiseSelection const*>(selector()) == nullptr)
         return;
 
-    // Also stops being a word the moment it is DRAGGED past its own line: RenderBufferBuilder's
+    auto const text = extractSelectionText();
+
+    // Also stops being a word the moment it is DRAGGED past its own logical line: RenderBufferBuilder's
     // search-match scanner matches the pattern's bytes -- newlines included -- against the flat,
     // single-line stream of rendered cells, so a multi-line pattern can (and did) never really
     // match anything stable, and its highlight visibly jumped around as the pattern kept growing
     // with every further mouse-move of the drag.
-    if (selector()->from().line != selector()->to().line)
+    //
+    // The test is the extracted TEXT, not `from().line != to().line`: a double-clicked word that
+    // straddles a soft wrap spans two physical rows, and SelectionRenderer deliberately joins those
+    // without a break (it flushes a line only where `!isLineWrapped`). Keying on physical rows
+    // therefore refused a perfectly good single-line pattern and left the previous search term
+    // standing, costing the wrapped word its matching-word highlights.
+    if (text.contains('\n'))
         return;
 
-    auto const text = extractSelectionText();
     auto const text32 = unicode::convert_to<char32_t>(string_view(text.data(), text.size()));
     setNewSearchTerm(text32, SearchOrigin::DoubleClick);
 }

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -1097,9 +1097,23 @@ Handled Terminal::sendCharEvent(char32_t ch,
 
 Handled Terminal::sendMousePressEvent(Modifiers modifiers,
                                       MouseButton button,
+                                      CellLocation newPosition,
                                       PixelCoordinate pixelPosition,
                                       bool uiHandledHint)
 {
+    // A press is not necessarily preceded by a MouseMove landing exactly here: the windowing system
+    // usually delivers one, which is why a slow, deliberate drag never showed this, but a fast click
+    // can arrive as a bare press while _currentMousePosition is still wherever the pointer last idled
+    // (a previous selection, a different pane, ...). Without this, handleMouseSelection() below
+    // anchors the drag on that stale position instead of where the button actually went down, and the
+    // whole selection appears to jump the moment the drag starts. Mirrors the same update
+    // sendMouseMoveEvent already does for exactly this reason.
+    if (newPosition != _currentMousePosition)
+    {
+        _currentMousePosition = newPosition;
+        updateHoveringHyperlinkState();
+    }
+
     if (button == MouseButton::Left)
     {
         _leftMouseButtonPressed = true;

--- a/src/vtbackend/screen/Terminal.cpp
+++ b/src/vtbackend/screen/Terminal.cpp
@@ -1177,6 +1177,14 @@ void Terminal::updateSelectionMatches()
     if (!selectionAvailable() || dynamic_cast<WordWiseSelection const*>(selector()) == nullptr)
         return;
 
+    // Also stops being a word the moment it is DRAGGED past its own line: RenderBufferBuilder's
+    // search-match scanner matches the pattern's bytes -- newlines included -- against the flat,
+    // single-line stream of rendered cells, so a multi-line pattern can (and did) never really
+    // match anything stable, and its highlight visibly jumped around as the pattern kept growing
+    // with every further mouse-move of the drag.
+    if (selector()->from().line != selector()->to().line)
+        return;
+
     auto const text = extractSelectionText();
     auto const text32 = unicode::convert_to<char32_t>(string_view(text.data(), text.size()));
     setNewSearchTerm(text32, SearchOrigin::DoubleClick);

--- a/src/vtbackend/screen/Terminal.hpp
+++ b/src/vtbackend/screen/Terminal.hpp
@@ -921,6 +921,7 @@ class Terminal
                           Timestamp now);
     Handled sendMousePressEvent(Modifiers modifiers,
                                 MouseButton button,
+                                CellLocation newPosition,
                                 PixelCoordinate pixelPosition,
                                 bool uiHandledHint);
     void sendMouseMoveEvent(Modifiers modifiers,

--- a/src/vtbackend/screen/Terminal_input_test.cpp
+++ b/src/vtbackend/screen/Terminal_input_test.cpp
@@ -369,7 +369,11 @@ TEST_CASE("Terminal.passive mouse tracking declines the event so the UI may act 
         mc.writeToScreen("\033[?1000h");
         mc.terminal.flushInput();
 
-        CHECK(mc.terminal.sendMousePressEvent(none, vtbackend::MouseButton::WheelRight, pos, false).value);
+        CHECK(
+            mc.terminal
+                .sendMousePressEvent(
+                    none, vtbackend::MouseButton::WheelRight, mc.terminal.currentMousePosition(), pos, false)
+                .value);
     }
 
     SECTION("passive tracking does not")
@@ -380,7 +384,10 @@ TEST_CASE("Terminal.passive mouse tracking declines the event so the UI may act 
         mc.terminal.flushInput();
 
         CHECK_FALSE(
-            mc.terminal.sendMousePressEvent(none, vtbackend::MouseButton::WheelRight, pos, false).value);
+            mc.terminal
+                .sendMousePressEvent(
+                    none, vtbackend::MouseButton::WheelRight, mc.terminal.currentMousePosition(), pos, false)
+                .value);
     }
 }
 

--- a/src/vtbackend/screen/Terminal_scroll_test.cpp
+++ b/src/vtbackend/screen/Terminal_scroll_test.cpp
@@ -1255,14 +1255,14 @@ TEST_CASE("Terminal.Wheel.AltScreen.NoProtocol.emits_cursor_keys", "[terminal]")
     REQUIRE(mock.terminal.isAlternateScreen());
 
     mock.resetReplyData();
-    auto const handledDown =
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, UiHandledHint);
+    auto const handledDown = mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, UiHandledHint);
     CHECK(handledDown == Handled { true });
     CHECK(e(mock.replyData()) == e("\033[B")); // default multiplier is 1 in MockTerm
 
     mock.resetReplyData();
-    auto const handledUp =
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelUp, NoPixel, UiHandledHint);
+    auto const handledUp = mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::WheelUp, mock.terminal.currentMousePosition(), NoPixel, UiHandledHint);
     CHECK(handledUp == Handled { true });
     CHECK(e(mock.replyData()) == e("\033[A"));
 }
@@ -1281,7 +1281,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.AppCursorKeys.emits_SS3", "[terminal]")
     REQUIRE(mock.terminal.isAlternateScreen());
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { true });
     CHECK(e(mock.replyData()) == e("\033OB"));
 }
@@ -1300,7 +1301,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.DECSET1007.emits_cursor_keys", "[terminal]")
     mock.terminal.tick(1s);
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { true });
     CHECK(e(mock.replyData()) == e("\033OB"));
 }
@@ -1319,7 +1321,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.AppTracking.passes_through_as_SGR", "[termin
     mock.terminal.tick(1s);
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { true });
     // SGR mouse report, not a cursor key.
     CHECK(e(mock.replyData()).starts_with(e("\033[<")));
@@ -1337,7 +1340,8 @@ TEST_CASE("Terminal.Wheel.PrimaryScreen.NoProtocol.local_scroll", "[terminal]")
     REQUIRE(mock.terminal.isPrimaryScreen());
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { false });
     CHECK(mock.replyData().empty());
 }
@@ -1356,7 +1360,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.ShiftBypass.not_handled", "[terminal]")
     mock.terminal.tick(1s);
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::Shift, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { false });
     CHECK(mock.replyData().empty());
 }
@@ -1374,7 +1379,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.ViNormalMode.no_cursor_keys", "[terminal]")
     mock.terminal.inputHandler().setMode(ViMode::Normal);
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { false });
     CHECK(mock.replyData().empty());
 
@@ -1395,7 +1401,8 @@ TEST_CASE("Terminal.Wheel.AltScreen.ScrollMultiplier.repeats_cursor_keys", "[ter
     mock.terminal.setMouseWheelScrollMultiplier(LineCount(3));
 
     mock.resetReplyData();
-    CHECK(mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::WheelDown, NoPixel, false)
+    CHECK(mock.terminal.sendMousePressEvent(
+              Modifier::None, MouseButton::WheelDown, mock.terminal.currentMousePosition(), NoPixel, false)
           == Handled { true });
     CHECK(e(mock.replyData()) == e("\033[B\033[B\033[B"));
 }

--- a/src/vtbackend/screen/Terminal_selection_test.cpp
+++ b/src/vtbackend/screen/Terminal_selection_test.cpp
@@ -149,6 +149,50 @@ TEST_CASE("Terminal.TextSelection", "[terminal]")
     CHECK(mock.terminal.extractSelectionText().empty());
 }
 
+TEST_CASE("Terminal.plain_drag_selection_does_not_overwrite_the_search_pattern", "[terminal]")
+{
+    // Regression: updateSelectionMatches() serializes the selection into Terminal::search().pattern
+    // so double/triple-click word-selection can highlight the word's other occurrences elsewhere on
+    // screen (SearchOrigin::DoubleClick). It used to run unconditionally on EVERY selection-extending
+    // mouse-move -- including an ordinary single-click drag, which is not a word at all -- so dragging
+    // out any plain text selection silently overwrote whatever search pattern the user had typed (and,
+    // wherever a status line or find-bar echoes it, made the selected text visibly appear as a live
+    // search).
+    auto mock = MockTerm { ColumnCount(5), LineCount(5) };
+    mock.writeToScreen("12345\r\n"
+                       "67890\r\n"
+                       "ABCDE\r\n"
+                       "abcde\r\n"
+                       "fghij");
+
+    using namespace vtbackend;
+    auto constexpr UiHandledHint = false;
+    auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
+
+    // Seed a search pattern the way a user typing into the find bar would.
+    mock.terminal.setNewSearchTerm(U"needle", SearchOrigin::Typed);
+    REQUIRE(mock.terminal.search().pattern == U"needle");
+
+    // An ordinary single-click drag across two lines -- not a double/triple-click word selection.
+    mock.terminal.tick(1s);
+    mock.terminal.sendMouseMoveEvent(
+        Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.tick(1s);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.tick(1s);
+    mock.terminal.sendMouseMoveEvent(
+        Modifier::None, 2_lineOffset + 2_columnOffset, PixelCoordinate, UiHandledHint);
+    REQUIRE(mock.terminal.extractSelectionText() == "7890\nABC");
+
+    // The drag must not have touched the search pattern.
+    CHECK(mock.terminal.search().pattern == U"needle");
+
+    mock.terminal.tick(1s);
+    mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    CHECK(mock.terminal.search().pattern == U"needle");
+}
+
 TEST_CASE("Terminal.TextSelection_wrapped_line", "[terminal]")
 {
     // Create empty TE

--- a/src/vtbackend/screen/Terminal_selection_test.cpp
+++ b/src/vtbackend/screen/Terminal_selection_test.cpp
@@ -193,6 +193,77 @@ TEST_CASE("Terminal.plain_drag_selection_does_not_overwrite_the_search_pattern",
     CHECK(mock.terminal.search().pattern == U"needle");
 }
 
+TEST_CASE("Terminal.word_selection_across_a_soft_wrap_still_updates_the_search_pattern", "[terminal]")
+{
+    // Regression: updateSelectionMatches() used to reject a word-wise selection whose from() and to()
+    // sat on different PHYSICAL rows, on the theory that a multi-line pattern cannot match the flat,
+    // single-line stream RenderBufferBuilder's search-match scanner walks. But a word straddling a soft
+    // wrap spans two rows while extracting as ONE line -- SelectionRenderer emits a break only where
+    // `!isLineWrapped` -- so the guard refused a perfectly good pattern and left the previous search
+    // term standing, costing the wrapped word its matching-word highlights.
+    auto mock = MockTerm { ColumnCount(5), LineCount(2) };
+    mock.terminal.setWordDelimiters(" ");
+
+    // One 10-character word: fills row 0 and soft-wraps into row 1.
+    mock.writeToScreen(std::string(10, 'a'));
+
+    using namespace vtbackend;
+    auto constexpr UiHandledHint = false;
+    auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
+
+    mock.terminal.setNewSearchTerm(U"needle", SearchOrigin::Typed);
+    REQUIRE(mock.terminal.search().pattern == U"needle");
+
+    // Double-click inside the word: two presses at the same cell, inside the one-second window.
+    mock.terminal.tick(1s);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+
+    // The selection crossed the wrap, yet extracts as a single line...
+    auto const selected = mock.terminal.extractSelectionText();
+    REQUIRE(selected == std::string(10, 'a'));
+    REQUIRE(!selected.contains('\n'));
+
+    // ...so it IS a word, and must have become the pattern.
+    CHECK(mock.terminal.search().pattern == std::u32string(10, U'a'));
+    CHECK(mock.terminal.search().origin == SearchOrigin::DoubleClick);
+}
+
+TEST_CASE("Terminal.a_press_at_a_new_cell_starts_a_fresh_click_sequence", "[terminal]")
+{
+    // Regression: sendMousePressEvent() anchors a bare press at the cell it landed on (a fast click can
+    // arrive with no preceding MouseMove), but it did so WITHOUT resetting the speed-click counter that
+    // sendMouseMoveEvent resets for exactly the same cell change. A second fast click at a DIFFERENT
+    // cell, still inside the one-second window, therefore inherited the first one's count and opened as
+    // a double-click word selection instead of a fresh drag.
+    auto mock = MockTerm { ColumnCount(11), LineCount(2) };
+    mock.terminal.setWordDelimiters(" ");
+    mock.writeToScreen("hello world");
+
+    using namespace vtbackend;
+    auto constexpr UiHandledHint = false;
+    auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
+
+    // First click, on "hello".
+    mock.terminal.tick(1s);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+
+    // A second bare press at a DIFFERENT cell, arriving well inside the one-second double-click window
+    // and with no MouseMove in between -- the fast-click path.
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 7_columnOffset, PixelCoordinate, UiHandledHint);
+
+    // It must open a fresh, empty drag -- not select the word under it.
+    CHECK(mock.terminal.selector() != nullptr);
+    CHECK(dynamic_cast<WordWiseSelection const*>(mock.terminal.selector()) == nullptr);
+    CHECK(mock.terminal.extractSelectionText().empty());
+}
+
 TEST_CASE("Terminal.TextSelection_wrapped_line", "[terminal]")
 {
     // Create empty TE

--- a/src/vtbackend/screen/Terminal_selection_test.cpp
+++ b/src/vtbackend/screen/Terminal_selection_test.cpp
@@ -119,8 +119,8 @@ TEST_CASE("Terminal.TextSelection", "[terminal]")
         Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
 
     mock.terminal.tick(1s);
-    auto const appHandledMouse =
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    auto const appHandledMouse = mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
 
     // We want to ensure that this call is returning false if the app has not explicitly requested
     // to listen on mouse events (without passive mode being on).
@@ -143,7 +143,8 @@ TEST_CASE("Terminal.TextSelection", "[terminal]")
 
     // Clear selection by simply left-clicking.
     mock.terminal.tick(1s);
-    mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 2_lineOffset + 2_columnOffset, PixelCoordinate, UiHandledHint);
     mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
     CHECK(mock.terminal.extractSelectionText().empty());
 }
@@ -174,8 +175,8 @@ TEST_CASE("Terminal.TextSelection_wrapped_line", "[terminal]")
         Modifier::None, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
 
     mock.terminal.tick(1s);
-    auto const appHandledMouse =
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    auto const appHandledMouse = mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
 
     REQUIRE(appHandledMouse == Handled { false });
 
@@ -193,7 +194,8 @@ TEST_CASE("Terminal.TextSelection_wrapped_line", "[terminal]")
     CHECK(mock.terminal.extractSelectionText() == "aaaaaa");
 
     mock.terminal.tick(1s);
-    mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
     mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
     CHECK(mock.terminal.extractSelectionText().empty());
 }
@@ -221,7 +223,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 2_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
@@ -235,7 +238,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(7s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
 
         // Selection should now span from original start to new click position.
         CHECK(mock.terminal.extractSelectionText() == "7890\nABCDE\nabcd");
@@ -248,7 +252,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 2_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 2_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
@@ -264,7 +269,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(7s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
 
         CHECK(mock.terminal.extractSelectionText() == "12345\n67890\nABCDE\nabcd");
     }
@@ -276,7 +282,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
 
         // Should create a new selection (Waiting state), not crash.
         REQUIRE(mock.terminal.selectionAvailable());
@@ -293,7 +300,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 1_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 2_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
@@ -306,13 +314,15 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(4s + 500ms);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.sendMouseReleaseEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
         CHECK_FALSE(mock.terminal.extractSelectionText().empty());
 
         // 3. Normal click shortly after (within 1s) to deselect — must clear selection.
         mock.terminal.tick(4s + 800ms);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 3_lineOffset + 3_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
         CHECK(mock.terminal.extractSelectionText().empty());
     }
@@ -324,7 +334,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 2_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
@@ -337,7 +348,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(7s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.sendMouseReleaseEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
         CHECK(mock.terminal.extractSelectionText() == "12345\n67890\nABC");
 
@@ -346,7 +358,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 4_lineOffset + 4_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(10s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 4_lineOffset + 4_columnOffset, PixelCoord, UiHandledHint);
         CHECK(mock.terminal.extractSelectionText() == "12345\n67890\nABCDE\nabcde\nfghij");
     }
 
@@ -357,7 +370,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 4_lineOffset + 4_columnOffset, PixelCoord, UiHandledHint);
@@ -370,7 +384,8 @@ TEST_CASE("Terminal.ShiftClickExtendSelection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 2_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(7s);
-        mock.terminal.sendMousePressEvent(Modifier::Shift, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::Shift, MouseButton::Left, 2_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         CHECK(mock.terminal.extractSelectionText() == "12345\n67890\nABC");
     }
 }
@@ -461,7 +476,7 @@ TEST_CASE("Terminal.TextSelection_drag_into_blank_stops_at_the_pointer", "[termi
         Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoordinate, UiHandledHint);
     mock.terminal.tick(1s);
     (void) mock.terminal.sendMousePressEvent(
-        Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+        Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoordinate, UiHandledHint);
 
     // Drag well past "abc", into cells that were never written.
     mock.terminal.tick(1s);
@@ -495,7 +510,7 @@ TEST_CASE("Terminal.TextSelection_multiline_drag_still_takes_the_first_line_whol
         Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoordinate, UiHandledHint);
     mock.terminal.tick(1s);
     (void) mock.terminal.sendMousePressEvent(
-        Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+        Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoordinate, UiHandledHint);
     mock.terminal.tick(1s);
     mock.terminal.sendMouseMoveEvent(
         Modifier::None, 1_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);

--- a/src/vtbackend/screen/Terminal_selection_test.cpp
+++ b/src/vtbackend/screen/Terminal_selection_test.cpp
@@ -264,6 +264,45 @@ TEST_CASE("Terminal.a_press_at_a_new_cell_starts_a_fresh_click_sequence", "[term
     CHECK(mock.terminal.extractSelectionText().empty());
 }
 
+TEST_CASE("Terminal.shift_click_extending_a_word_retires_its_search_pattern", "[terminal]")
+{
+    // Regression: a double click makes the word the search pattern (SearchOrigin::DoubleClick) so its
+    // other occurrences highlight. Shift+Click then re-creates the selection as a LinearSelection --
+    // which updateSelectionMatches() rightly refuses to serialize -- so the call it used to make there
+    // became a no-op, and the double click's pattern stayed live, painting matches for a word the
+    // selection no longer is. The extension must retire it, as an ordinary single click already does.
+    auto mock = MockTerm { ColumnCount(11), LineCount(2) };
+    mock.terminal.setWordDelimiters(" ");
+    mock.writeToScreen("hello world");
+
+    using namespace vtbackend;
+    auto constexpr UiHandledHint = false;
+    auto constexpr PixelCoordinate = vtbackend::PixelCoordinate {};
+
+    // Double-click "hello": two presses at the same cell inside the one-second window.
+    mock.terminal.tick(1s);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
+    mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+
+    REQUIRE(mock.terminal.extractSelectionText() == "hello");
+    REQUIRE(mock.terminal.search().pattern == U"hello");
+    REQUIRE(mock.terminal.search().origin == SearchOrigin::DoubleClick);
+
+    // Shift+Click out to "world": the selection stops being that word.
+    mock.terminal.tick(1s);
+    mock.terminal.sendMousePressEvent(
+        Modifier::Shift, MouseButton::Left, 0_lineOffset + 9_columnOffset, PixelCoordinate, UiHandledHint);
+
+    CHECK(mock.terminal.extractSelectionText() != "hello");
+
+    // The word's pattern must not have outlived it.
+    CHECK(mock.terminal.search().pattern.empty());
+}
+
 TEST_CASE("Terminal.TextSelection_wrapped_line", "[terminal]")
 {
     // Create empty TE

--- a/src/vtbackend/screen/Terminal_test.cpp
+++ b/src/vtbackend/screen/Terminal_test.cpp
@@ -1704,7 +1704,8 @@ TEST_CASE("Terminal.CancelSelection_with_selection", "[terminal]")
     terminal.sendMouseMoveEvent(
         Modifier::None, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
     terminal.tick(ClockBase + 3s);
-    terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
     terminal.tick(ClockBase + 4s);
     terminal.sendMouseMoveEvent(
         Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoordinate, UiHandledHint);
@@ -1742,7 +1743,8 @@ TEST_CASE("Terminal.CancelSelection_double_clear", "[terminal]")
     terminal.sendMouseMoveEvent(
         Modifier::None, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
     terminal.tick(ClockBase + 3s);
-    terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoordinate, UiHandledHint);
+    terminal.sendMousePressEvent(
+        Modifier::None, MouseButton::Left, 0_lineOffset + 1_columnOffset, PixelCoordinate, UiHandledHint);
     terminal.tick(ClockBase + 4s);
     terminal.sendMouseMoveEvent(
         Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoordinate, UiHandledHint);
@@ -1786,7 +1788,8 @@ TEST_CASE("Terminal.ScrollWhileSelecting", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
@@ -1821,7 +1824,8 @@ TEST_CASE("Terminal.ScrollWhileSelecting", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
@@ -1862,7 +1866,8 @@ TEST_CASE("Terminal.PerformAutoScroll", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
@@ -1894,7 +1899,8 @@ TEST_CASE("Terminal.PerformAutoScroll", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 2_columnOffset, PixelCoord, UiHandledHint);
@@ -1914,7 +1920,8 @@ TEST_CASE("Terminal.PerformAutoScroll", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 1_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 1_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
@@ -1962,7 +1969,8 @@ TEST_CASE("Terminal.PassiveMouseTracking_Selection", "[terminal]")
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(2s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.tick(3s);
         mock.terminal.sendMouseMoveEvent(
             Modifier::None, 0_lineOffset + 4_columnOffset, PixelCoord, UiHandledHint);
@@ -1980,8 +1988,8 @@ TEST_CASE("Terminal.PassiveMouseTracking_Selection", "[terminal]")
 
         // Press left button — should start selection AND forward to app
         mock.terminal.tick(2s);
-        auto const handled =
-            mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        auto const handled = mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 0_columnOffset, PixelCoord, UiHandledHint);
 
         // Passive tracking should return Handled{false} so session can also process action mappings
         CHECK(handled == Handled { false });
@@ -2012,7 +2020,8 @@ TEST_CASE("Terminal.PassiveMouseTracking_Selection", "[terminal]")
 
         // Now click to deselect
         mock.terminal.tick(5s);
-        mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
+        mock.terminal.sendMousePressEvent(
+            Modifier::None, MouseButton::Left, 0_lineOffset + 4_columnOffset, PixelCoord, UiHandledHint);
         mock.terminal.sendMouseReleaseEvent(Modifier::None, MouseButton::Left, PixelCoord, UiHandledHint);
         CHECK(mock.terminal.extractSelectionText().empty());
     }

--- a/src/vtbackend/vt/TextSizing_test.cpp
+++ b/src/vtbackend/vt/TextSizing_test.cpp
@@ -1065,7 +1065,12 @@ TEST_CASE("TextSizing.a_drag_inside_one_row_of_blocks_stays_on_one_line", "[text
     mock.terminal.tick(std::chrono::steady_clock::time_point {});
     mock.terminal.sendMouseMoveEvent(
         Modifier::None, CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) }, Pixels, UiHandled);
-    (void) mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, Pixels, UiHandled);
+    (void) mock.terminal.sendMousePressEvent(
+        Modifier::None,
+        MouseButton::Left,
+        CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) },
+        Pixels,
+        UiHandled);
 
     // The pointer slips one row down while still over the same blocks.
     mock.terminal.sendMouseMoveEvent(
@@ -1094,7 +1099,12 @@ TEST_CASE("TextSizing.a_drag_that_leaves_the_blocks_still_selects_two_lines", "[
     mock.terminal.tick(std::chrono::steady_clock::time_point {});
     mock.terminal.sendMouseMoveEvent(
         Modifier::None, CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) }, Pixels, UiHandled);
-    (void) mock.terminal.sendMousePressEvent(Modifier::None, MouseButton::Left, Pixels, UiHandled);
+    (void) mock.terminal.sendMousePressEvent(
+        Modifier::None,
+        MouseButton::Left,
+        CellLocation { .line = LineOffset(0), .column = ColumnOffset(0) },
+        Pixels,
+        UiHandled);
     mock.terminal.sendMouseMoveEvent(
         Modifier::None, CellLocation { .line = LineOffset(2), .column = ColumnOffset(3) }, Pixels, UiHandled);
 

--- a/src/vthost/client/ScreenMirror_test.cpp
+++ b/src/vthost/client/ScreenMirror_test.cpp
@@ -1376,8 +1376,11 @@ TEST_CASE("a mirror primed while the app already tracks the mouse can encode a c
         // on a mirror that had fallen back to the default (`CSI M`) encoding either.
         auto& mirrorPty = static_cast<vtpty::MockPty&>(h->mirror->device());
         mirrorPty.stdinBuffer().clear();
-        std::ignore = h->mirror->sendMousePressEvent(
-            vtbackend::Modifiers {}, vtbackend::MouseButton::Left, vtbackend::PixelCoordinate {}, false);
+        std::ignore = h->mirror->sendMousePressEvent(vtbackend::Modifiers {},
+                                                     vtbackend::MouseButton::Left,
+                                                     vtbackend::CellLocation {},
+                                                     vtbackend::PixelCoordinate {},
+                                                     false);
         h->mirror->flushInput();
         CHECK(mirrorPty.stdinBuffer().starts_with("\033[<0;"));
 


### PR DESCRIPTION
Mouse-drag text selection had two independent bugs: a fast click could start the drag from a stale position instead of where the button actually went down, making the selected region appear to jump the moment the drag started; and any ordinary click-and-drag selection silently overwrote the active search pattern on every move, making the selected text show up as a live search wherever a status line or the find bar echoes it.

## Changes

- `Terminal::sendMousePressEvent` now receives the pressed-at `CellLocation` and updates the terminal's tracked mouse position from it, instead of relying entirely on whatever the last `MouseMove` left behind — mirroring `sendMouseMoveEvent`'s existing behavior. Threaded end to end through `TerminalSession` and `SessionInput`, with all call sites updated accordingly.
- `Terminal::updateSelectionMatches()` (which serializes a selection into the search pattern so a double/triple-click word selection can highlight its other occurrences) is now gated on the selection actually being word-wise, so an ordinary drag no longer touches search state.
- Adds a real Qt-mouse-event GUI regression test that reproduces the anchoring bug directly (move to one cell, then press at a different cell with no intervening move — the gap a fast flick leaves), plus coverage for a multi-line drag's exact selected range, drag-direction symmetry, live extend/shrink during a drag, and a drag across a wrapped line boundary.
- Adds a headless regression test pinning that a plain drag leaves an existing search pattern untouched.

## Review follow-ups

Two rounds of review on this branch turned up further edges, all now fixed and covered:

**Bugs in the fixes themselves**

- **A press that changed cells did not reset the speed-click counter**, though `sendMouseMoveEvent`
  resets it for exactly that case. A fast click at a new cell arriving inside the one-second window
  inherited the previous cell's count and opened as a word/line selection instead of a drag. The
  reset is scoped to the left button — the only one that opens a selection — so a right-click for
  the context menu or a middle-click paste does not end a double click the user is in the middle of.
- **The word-highlight guard tested physical rows** (`from().line != to().line`). But
  `extendSelectionForward` deliberately follows `wrappedLine` across rows while `SelectionRenderer`
  joins wrapped rows *without* a `
`, so a double-clicked word straddling a soft wrap was refused,
  leaving the previous search term standing and costing the wrapped word its matching-word
  highlights. It now tests the extracted text for a line break.
- **Shift+Click extending a word selection left the word's pattern live.** That path re-creates the
  selection as a `LinearSelection`, which `updateSelectionMatches()` rightly refuses to serialize —
  so the call it made there had become a no-op and the double click's pattern kept painting matches
  for a word the selection no longer was. It now retires the pattern, as a plain single click
  already does.

**Correctness and hygiene**

- The wheel path reads `currentMousePosition()` under the terminal lock. `Terminal::resizeScreen`
  clamps that member from another thread, so the bare read was a data race TSan would flag.
- `logicalCellTopLeft()` in the GUI test now offsets by `mainPageTopRow()`, making it a true inverse
  of the production hit-test. The two agree only while that row is zero (the default bottom status
  line), so a top status line would have landed every synthetic click above its target and read as a
  selection bug rather than a harness one.
- Two test comments documented the anchoring bug as if it still held, telling a future reader the
  preceding-`MouseMove` workaround was required. Both now explain why the realistic event order is
  kept instead.

Each behavioral fix carries a regression test **verified to fail without it** (production code
reverted, failure observed, restored). Local: `vtbackend_test` **125,068 assertions / 1,616 test
cases, all passed**; `contour_gui_test` compiles clean (its runtime needs a display, exercised in
CI).
