### PR TITLE
Fix contour_gui_test not starting on Windows (missing Qt DLLs)

### DIFF
--- a/cmake/StageRuntimeDeps.cmake
+++ b/cmake/StageRuntimeDeps.cmake
@@ -1,0 +1,52 @@
+# Staging a build-tree executable's runtime dependencies beside it.
+#
+# Windows has no RPATH: the loader finds a DLL next to the executable, in the system directories, or
+# on PATH -- and PATH is machine-global, so a Qt bin directory on it aims every other program on the
+# machine at that Qt too. windeployqt covers the application target (see DeployQt.cmake); these
+# cover the test executables it is not run for. Both are no-ops off Windows.
+
+include_guard(GLOBAL)
+
+# Copies the DLLs `target` links into its own output directory, after every build of it.
+function(contour_stage_runtime_dlls target)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    # `cmake -E copy_if_different` with no source is an error rather than a no-op, and a target
+    # linking nothing shared has an empty TARGET_RUNTIME_DLLS -- so emptiness selects the command.
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E
+                "$<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:${target}>>,copy_if_different,true>"
+                "$<TARGET_RUNTIME_DLLS:${target}>"
+                "$<TARGET_FILE_DIR:${target}>"
+        COMMAND_EXPAND_LISTS
+        VERBATIM
+        COMMENT "Staging linked DLLs beside ${target} ...")
+endfunction()
+
+# Copies imported Qt plugin targets into `<output dir>/<category>`, which is where Qt looks for them
+# relative to the executable. Nothing links a plugin, so TARGET_RUNTIME_DLLS cannot see one: which
+# are needed follows from how the program is run, and so is named here. One this Qt does not provide
+# is reported and skipped.
+function(contour_stage_qt_plugins target category)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    foreach(plugin IN LISTS ARGN)
+        if(NOT TARGET ${plugin})
+            message(STATUS "Qt plugin ${plugin} not provided: not staged beside ${target}")
+            continue()
+        endif()
+
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E make_directory
+                    "$<TARGET_FILE_DIR:${target}>/${category}"
+            COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+                    "$<TARGET_FILE:${plugin}>"
+                    "$<TARGET_FILE_DIR:${target}>/${category}"
+            VERBATIM
+            COMMENT "Staging ${plugin} beside ${target} ...")
+    endforeach()
+endfunction()

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -657,6 +657,17 @@ if(CONTOUR_FRONTEND_GUI)
         if(NOT WIN32)
             target_compile_options(contour_gui_test PRIVATE -Wno-c2y-extensions)
         endif()
+
+        # Windows found neither Qt6Test, the one Qt library `contour` does not link, nor the
+        # offscreen QPA the registration below selects, so windeployqt's staging for the application
+        # covers neither and the suite died in the loader before main(). The Windows plugin as well,
+        # so that running the executable by hand needs no more than having built it.
+        include(StageRuntimeDeps)
+        contour_stage_runtime_dlls(contour_gui_test)
+        contour_stage_qt_plugins(contour_gui_test platforms
+                                 Qt6::QOffscreenIntegrationPlugin
+                                 Qt6::QWindowsIntegrationPlugin)
+
         add_test(NAME contour_gui_test COMMAND $<TARGET_FILE:contour_gui_test>)
 
         # The offscreen QPA, because this suite constructs a QGuiApplication and its QML trees: without


### PR DESCRIPTION
`contour_gui_test` never ran on Windows: it exited with `0xC0000135` — the loader's "DLL not found" — before reaching `main()`, and with no output of its own, so `ctest` reported the bare exit code and nothing else.

Two libraries were missing, and neither is one `windeployqt` can be asked for. It runs for the `contour` target, so what it stages beside the executables is the *application's* closure: `Qt6Test` is the one Qt library the application does not itself link, and the platform plugin it deploys is the Windows one, while this suite's `add_test` registration selects the offscreen QPA. The second failure was therefore waiting behind the first — "Available platform plugins are: windows."

Putting Qt's `bin` directory on `PATH` would answer both, and is the wrong answer: `PATH` is machine-global, so it aims every other program on the system at this Qt as well. Windows has no RPATH, which leaves the directory holding the executable as the only place the loader looks that is still inside the build tree. So a new `StageRuntimeDeps` module copies the DLLs a target links there after each build, via CMake's own `TARGET_RUNTIME_DLLS`, and copies named Qt plugins into the `platforms/` subdirectory Qt searches relative to the executable. Plugins have to be named explicitly because nothing links them — which ones are needed is a property of how the program is run, not of what it links — so the offscreen and Windows plugins are both staged, the latter so that running the executable by hand needs no more than having built it.

No effect off Windows: both functions return early there, the build tree's RPATH already resolving everything.